### PR TITLE
Change plugin_development documentation to reflect interface change

### DIFF
--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -5,15 +5,15 @@ There are different interfaces for storage plugins depending on your need: The g
 ## Writing a general plugin
 
 Assume you write a plugin `MyStorage` which can both save messages and read messages.
-Its header file could be `my_storage.hpp` and it would derive from `rosbag2_storage::ReadWriteStorage`.
-While implementing the interface provided by `rosbag2_storage::ReadWriteStorage`, make sure that all resources such as file handles or database connections are closed or destroyed in the destructor, no additional `close` call should be necessary.
+Its header file could be `my_storage.hpp` and `MyStorage` will derive from `rosbag2_storage::storage_interfaces::ReadWriteInterface`.
+**Important:** While implementing the interface provided by `rosbag2_storage::storage_interfaces::ReadWriteInterface`, make sure that all resources such as file handles or database connections are closed or destroyed in the destructor, no additional `close` call should be necessary.
 
 In order to find the plugin at runtime, it needs to be exported to the pluginlib.
 Add the following lines to `my_storage.cpp`:
 
 ```
 #include "pluginlib/class_list_macros.hpp"
-PLUGINLIB_EXPORT_CLASS(MyStorage, rosbag2_storage::ReadWriteStorage)
+PLUGINLIB_EXPORT_CLASS(MyStorage, rosbag2_storage::storage_interfaces::ReadWriteInterface)
 ```
 
 Furthermore, we need some meta-information in the form of a `plugin_description.xml` file.
@@ -21,32 +21,32 @@ Here, it contains
 
 ```
 <library path="my_storage_lib">
-  <class name="my_storage" type="MyStorage" base_class_type="rosbag2_storage::ReadWriteStorage">
+  <class name="my_storage" type="MyStorage" base_class_type="rosbag2_storage::storage_interfaces::ReadWriteInterface">
   </class>
 </library>
 ```
-Here, `my_storage_lib` is the name of the library while `my_storage` is an identifier used by the pluginlib to load it.
+`my_storage_lib` is the name of the library (ament package) while `my_storage` is an identifier used by the pluginlib to load it.
 
-In addition, in the `CMakeLists.txt` plugins and `plugin_description` file need to be added to the index to be found at runtime:
+In addition, in the `CMakeLists.txt` the `plugin_description.xml` file needs to be added to the index to be found at runtime:
 
 `pluginlib_export_plugin_description_file(rosbag2_storage plugin_description.xml)`
 
-The first argument `rosbag2_storage` denotes the library we add our plugin to, while the second argument is the path to the plugin description file.
+The first argument `rosbag2_storage` denotes the library we add our plugin to (this will always be `rosbag2_storage`), while the second argument is the path to the plugin description file.
 
 ## Writing a plugin for reading only
 
-When writing plugins to only provide functionality for reading, derive from `rosbag2_storage::ReadableStorage`.
+When writing plugins to only provide functionality for reading, derive from `rosbag2_storage::storage_interfaces::ReadOnlyInterface`.
 
-If the read-only plugin is called `my_readonly_storage` in a library `my_storage_lib`, it will be registered using 
+If the read-only plugin is called `my_readonly_storage` in a library `my_storage_lib`, it will be registered using
 
 ```
 #include "pluginlib/class_list_macros.hpp"
-PLUGINLIB_EXPORT_CLASS(MyReadonlyStorage, rosbag2_storage::ReadableStorage)
+PLUGINLIB_EXPORT_CLASS(MyReadonlyStorage, rosbag2_storage::storage_interfaces::ReadOnlyInterface)
 ```
 with the plugin description
 ```
 <library path="my_storage_lib">
-  <class name="my_readonly_storage" type="MyReadonlyStorage" base_class_type="rosbag2_storage::ReadableStorage">
+  <class name="my_readonly_storage" type="MyReadonlyStorage" base_class_type="rosbag2_storage::storage_interfaces::ReadOnlyInterface">
   </class>
 </library>
 ```


### PR DESCRIPTION
In our branch, we initially added some documentation on how to write storage plugins.

This PR updates the documentation with all changes pushed to master.