### PR TITLE
Improve sqlite iterator interface

### DIFF
--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
@@ -177,7 +177,7 @@ private:
 
 private:
   bool step();
-  bool isQueryOk(int return_code);
+  bool is_query_ok(int return_code);
 
   void obtain_column_value(size_t index, int & value) const;
   void obtain_column_value(size_t index, rcutils_time_point_value_t & value) const;

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
@@ -72,8 +72,8 @@ public:
       Iterator(const Iterator &) = delete;
       Iterator & operator=(const Iterator &) = delete;
 
-      Iterator(Iterator &&) noexcept = default;
-      Iterator & operator=(Iterator &&) noexcept = default;
+      Iterator(Iterator &&) = default;
+      Iterator & operator=(Iterator &&) = default;
 
       Iterator & operator++()
       {

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
@@ -69,6 +69,12 @@ public:
         }
       }
 
+      Iterator(const Iterator &) = delete;
+      Iterator & operator=(const Iterator &) = delete;
+
+      Iterator(Iterator &&) noexcept = default;
+      Iterator & operator=(Iterator &&) noexcept = default;
+
       Iterator & operator++()
       {
         if (next_row_idx_ != POSITION_END) {
@@ -102,11 +108,11 @@ public:
         return row;
       }
 
-      bool operator==(Iterator other) const
+      bool operator==(const Iterator & other) const
       {
         return statement_ == other.statement_ && next_row_idx_ == other.next_row_idx_;
       }
-      bool operator!=(Iterator other) const
+      bool operator!=(const Iterator & other) const
       {
         return !(*this == other);
       }
@@ -140,11 +146,12 @@ private:
     };
 
     explicit QueryResult(std::shared_ptr<SqliteStatementWrapper> statement)
-    : statement_(statement)
+    : statement_(statement), is_already_accessed_(false)
     {}
 
     Iterator begin()
     {
+      try_access_data();
       return Iterator(statement_, 0);
     }
     Iterator end()
@@ -158,7 +165,16 @@ private:
     }
 
 private:
+    void try_access_data()
+    {
+      if (is_already_accessed_) {
+        throw SqliteException("Only one iterator per query result is supported!");
+      }
+      is_already_accessed_ = true;
+    }
+
     std::shared_ptr<SqliteStatementWrapper> statement_;
+    bool is_already_accessed_;
   };
 
   std::shared_ptr<SqliteStatementWrapper> execute_and_reset();

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp
@@ -51,14 +51,14 @@ SqliteStatementWrapper::~SqliteStatementWrapper()
 std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_reset()
 {
   int return_code = sqlite3_step(statement_);
-  if (!isQueryOk(return_code)) {
+  if (!is_query_ok(return_code)) {
     throw SqliteException("Error processing SQLite statement. Return code: " +
             std::to_string(return_code));
   }
   return reset();
 }
 
-bool SqliteStatementWrapper::isQueryOk(int return_code)
+bool SqliteStatementWrapper::is_query_ok(int return_code)
 {
   return return_code == SQLITE_OK || return_code == SQLITE_DONE || return_code == SQLITE_ROW;
 }


### PR DESCRIPTION
The `SqliteStatementWrapper::QueryResult::Iterator` represents the result set of a sqlite query that needs to be stepped. Using a copy of such a iterator would also step the statement and looping the original iterator would "miss" result rows. To avoid this surprising behavior this PR changes the iterator interface to disable copies.