### PR TITLE
 Display bag summary using `ros2 bag info` (reduced size)

### DIFF
--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -12,18 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
 from ros2bag.verb import VerbExtension
+
+from rosbag2_transport import rosbag2_transport_py
 
 
 class InfoVerb(VerbExtension):
     """ros2 bag info."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        arg = parser.add_argument(
+        parser.add_argument(
             'bag_file', help='bag file to introspect')
 
     def main(self, *, args):  # noqa: D102
         bag_file = args.bag_file
-        print('calling ros2 bag info on', bag_file)
+        if not os.path.exists(bag_file):
+            return "Error: bag file '{}' does not exist!".format(bag_file)
+
+        rosbag2_transport_py.info(uri=bag_file)

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -43,6 +43,12 @@ class RecordVerb(VerbExtension):
             '-s', '--storage', default='sqlite3',
             help='storage identifier to be used, defaults to "sqlite3"')
 
+    def create_bag_directory(self, uri):
+        try:
+            os.makedirs(uri)
+        except:
+            return "Error: Could not create bag folder '{}'.".format(uri)
+
     def main(self, *, args):  # noqa: D102
         if args.all and args.topics:
             return 'Invalid choice: Can not specify topics and -a at the same time.'
@@ -52,10 +58,7 @@ class RecordVerb(VerbExtension):
         if os.path.isdir(uri):
             return "Error: Output folder '{}' already exists.".format(uri)
 
-        try:
-            os.makedirs(uri)
-        except:
-            return "Error: Could not create bag folder '{}'.".format(uri)
+        self.create_bag_directory(uri)
 
         if args.all:
             rosbag2_transport_py.record(uri=uri, storage_id=args.storage, all=True)
@@ -63,3 +66,6 @@ class RecordVerb(VerbExtension):
             rosbag2_transport_py.record(uri=uri, storage_id=args.storage, topics=args.topics)
         else:
             self._subparser.print_help()
+
+        if os.path.isdir(uri) and not os.listdir(uri):
+            os.rmdir(uri)

--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(rosbag2_storage REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
+  src/rosbag2/info.cpp
   src/rosbag2/sequential_reader.cpp
   src/rosbag2/serialization_format_converter_factory.cpp
   src/rosbag2/typesupport_helpers.cpp
@@ -71,13 +72,6 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gmock(test_typesupport_helpers
-    test/rosbag2/test_typesupport_helpers.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_typesupport_helpers)
-    target_link_libraries(test_typesupport_helpers rosbag2)
-  endif()
-
   add_library(
     converter_test_plugin
     SHARED
@@ -95,6 +89,22 @@ if(BUILD_TESTING)
   if(TARGET test_converter_factory)
     target_include_directories(test_converter_factory PRIVATE include)
     target_link_libraries(test_converter_factory rosbag2)
+  endif()
+
+  ament_add_gmock(test_typesupport_helpers
+    test/rosbag2/test_typesupport_helpers.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_typesupport_helpers)
+    target_link_libraries(test_typesupport_helpers rosbag2)
+  endif()
+
+  ament_add_gmock(test_info
+    test/rosbag2/test_info.cpp
+    test/rosbag2/mock_metadata_io.hpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_info)
+    target_link_libraries(test_info rosbag2)
+    ament_target_dependencies(test_info rosbag2_test_common)
   endif()
 endif()
 

--- a/rosbag2/include/rosbag2/info.hpp
+++ b/rosbag2/include/rosbag2/info.hpp
@@ -12,19 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__TYPES_HPP_
-#define ROSBAG2__TYPES_HPP_
+#ifndef ROSBAG2__INFO_HPP_
+#define ROSBAG2__INFO_HPP_
 
-#include "rosbag2_storage/bag_metadata.hpp"
-#include "rosbag2_storage/serialized_bag_message.hpp"
-#include "rosbag2_storage/topic_with_type.hpp"
+#include <string>
+
+#include "rosbag2/types.hpp"
+#include "visibility_control.hpp"
 
 namespace rosbag2
 {
-using BagMetadata = rosbag2_storage::BagMetadata;
-using SerializedBagMessage = rosbag2_storage::SerializedBagMessage;
-using TopicMetadata = rosbag2_storage::TopicMetadata;
-using TopicWithType = rosbag2_storage::TopicWithType;
+
+class ROSBAG2_PUBLIC Info
+{
+public:
+  virtual ~Info() = default;
+
+  virtual rosbag2::BagMetadata read_metadata(const std::string & uri);
+};
+
 }  // namespace rosbag2
 
-#endif  // ROSBAG2__TYPES_HPP_
+#endif  // ROSBAG2__INFO_HPP_

--- a/rosbag2/include/rosbag2/info.hpp
+++ b/rosbag2/include/rosbag2/info.hpp
@@ -28,7 +28,8 @@ class ROSBAG2_PUBLIC Info
 public:
   virtual ~Info() = default;
 
-  virtual rosbag2::BagMetadata read_metadata(const std::string & uri);
+  virtual rosbag2::BagMetadata read_metadata(
+    const std::string & uri, const std::string & storage_id = "");
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -70,6 +70,7 @@ public:
   virtual void write(std::shared_ptr<SerializedBagMessage> message);
 
 private:
+  std::string uri_;
   rosbag2_storage::StorageFactory factory_;
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_;
 };

--- a/rosbag2/package.xml
+++ b/rosbag2/package.xml
@@ -20,6 +20,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>test_msgs</test_depend>
+  <test_depend>rosbag2_test_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosbag2/src/rosbag2/info.cpp
+++ b/rosbag2/src/rosbag2/info.cpp
@@ -14,17 +14,35 @@
 
 #include "rosbag2/info.hpp"
 
+#include <memory>
 #include <string>
 
+#include "rosbag2_storage/filesystem_helper.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
+#include "rosbag2_storage/storage_factory.hpp"
 
 namespace rosbag2
 {
 
-rosbag2::BagMetadata Info::read_metadata(const std::string & uri)
+rosbag2::BagMetadata Info::read_metadata(const std::string & uri, const std::string & storage_id)
 {
   rosbag2_storage::MetadataIo metadata_io;
-  return metadata_io.read_metadata(uri);
+  if (metadata_io.metadata_file_exists(uri)) {
+    return metadata_io.read_metadata(uri);
+  }
+  if (!storage_id.empty()) {
+    rosbag2_storage::StorageFactory factory;
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage;
+    storage = factory.open_read_only(uri, storage_id);
+    if (!storage) {
+      throw std::runtime_error("The metadata.yaml file does not exist and the bag could not be "
+              "opened.");
+    }
+    auto bag_metadata = storage->get_metadata();
+    bag_metadata.bag_size = rosbag2_storage::FilesystemHelper::calculate_directory_size(uri);
+    return bag_metadata;
+  }
+  throw std::runtime_error("The metadata.yaml file does not exist. Please specify a the "
+          "storage id of the bagfile to query it directly");
 }
-
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/info.cpp
+++ b/rosbag2/src/rosbag2/info.cpp
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__TYPES_HPP_
-#define ROSBAG2__TYPES_HPP_
+#include "rosbag2/info.hpp"
 
-#include "rosbag2_storage/bag_metadata.hpp"
-#include "rosbag2_storage/serialized_bag_message.hpp"
-#include "rosbag2_storage/topic_with_type.hpp"
+#include <string>
+
+#include "rosbag2_storage/metadata_io.hpp"
 
 namespace rosbag2
 {
-using BagMetadata = rosbag2_storage::BagMetadata;
-using SerializedBagMessage = rosbag2_storage::SerializedBagMessage;
-using TopicMetadata = rosbag2_storage::TopicMetadata;
-using TopicWithType = rosbag2_storage::TopicWithType;
-}  // namespace rosbag2
 
-#endif  // ROSBAG2__TYPES_HPP_
+rosbag2::BagMetadata Info::read_metadata(const std::string & uri)
+{
+  rosbag2_storage::MetadataIo metadata_io;
+  return metadata_io.read_metadata(uri);
+}
+
+}  // namespace rosbag2

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -16,7 +16,10 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
+#include "rosbag2_storage/metadata_io.hpp"
+#include "rosbag2/info.hpp"
 #include "rosbag2/storage_options.hpp"
 
 namespace rosbag2
@@ -24,6 +27,11 @@ namespace rosbag2
 
 Writer::~Writer()
 {
+  if (!uri_.empty()) {
+    rosbag2_storage::MetadataIo metadata_io;
+    metadata_io.write_metadata(uri_, storage_->get_metadata());
+  }
+
   storage_.reset();  // Necessary to ensure that the writer is destroyed before the factory
 }
 
@@ -33,6 +41,7 @@ void Writer::open(const StorageOptions & options)
   if (!storage_) {
     throw std::runtime_error("No storage could be initialized. Abort");
   }
+  uri_ = options.uri;
 }
 
 void Writer::create_topic(const TopicWithType & topic_with_type)

--- a/rosbag2/test/rosbag2/mock_metadata_io.hpp
+++ b/rosbag2/test/rosbag2/mock_metadata_io.hpp
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2_STORAGE__BAG_INFO_HPP_
-#define ROSBAG2_STORAGE__BAG_INFO_HPP_
+#ifndef ROSBAG2__MOCK_METADATA_IO_HPP_
+#define ROSBAG2__MOCK_METADATA_IO_HPP_
 
+#include <gmock/gmock.h>
+
+#include <memory>
 #include <string>
+#include <vector>
 
-namespace rosbag2_storage
-{
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
 
-/**
- * Struct to hold the storage information.
- */
-struct BagInfo
+class MockMetadataIo : public rosbag2_storage::MetadataIo
 {
-  std::string uri;
-  // TODO(greimela-si/botteroa-si): Add remaining info fields.
+public:
+  MOCK_METHOD2(write_metadata, void(const std::string &, rosbag2_storage::BagMetadata));
+  MOCK_METHOD1(read_metadata, rosbag2_storage::BagMetadata(const std::string &));
 };
 
-}  // namespace rosbag2_storage
-
-#endif  // ROSBAG2_STORAGE__BAG_INFO_HPP_
+#endif  // ROSBAG2__MOCK_METADATA_IO_HPP_

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -1,0 +1,63 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__MOCK_STORAGE_HPP_
+#define ROSBAG2__MOCK_STORAGE_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/topic_with_type.hpp"
+#include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
+
+class MockStorage : public rosbag2_storage::storage_interfaces::ReadWriteInterface
+{
+public:
+  ~MockStorage() override = default;
+
+  void open(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag flag) override
+  {
+    (void) uri;
+    (void) flag;
+  }
+
+  void create_topic(const rosbag2_storage::TopicWithType & topic) override
+  {
+    (void) topic;
+  }
+
+  bool has_next() override {return true;}
+
+  std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override {return nullptr;}
+
+  void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override
+  {
+    (void) msg;
+  }
+
+  std::vector<rosbag2_storage::TopicWithType> get_all_topics_and_types() override
+  {
+    return std::vector<rosbag2_storage::TopicWithType>();
+  }
+
+  rosbag2_storage::BagMetadata get_metadata() override
+  {
+    return rosbag2_storage::BagMetadata();
+  }
+};
+
+#endif  // ROSBAG2__MOCK_STORAGE_HPP_

--- a/rosbag2/test/rosbag2/test_info.cpp
+++ b/rosbag2/test/rosbag2/test_info.cpp
@@ -34,7 +34,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
     "rosbag2_bagfile_information:\n"
     "  version: 1\n"
     "  storage_identifier: sqlite3\n"
-    "  storage_format: cdr\n"
+    "  serialization_format: cdr\n"
     "  relative_file_paths:\n"
     "    - some_relative_path\n"
     "    - some_other_relative_path\n"
@@ -65,7 +65,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
   auto read_metadata = info.read_metadata(temporary_dir_path_);
 
   EXPECT_THAT(read_metadata.storage_identifier, Eq("sqlite3"));
-  EXPECT_THAT(read_metadata.storage_format, Eq("cdr"));
+  EXPECT_THAT(read_metadata.serialization_format, Eq("cdr"));
   EXPECT_THAT(read_metadata.relative_file_paths,
     Eq(std::vector<std::string>({"some_relative_path", "some_other_relative_path"})));
   EXPECT_THAT(read_metadata.duration, Eq(std::chrono::nanoseconds(100)));

--- a/rosbag2/test/rosbag2/test_info.cpp
+++ b/rosbag2/test/rosbag2/test_info.cpp
@@ -24,6 +24,7 @@
 #include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/filesystem_helper.hpp"
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
+#include "rosbag2/writer.hpp"
 
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT

--- a/rosbag2/test/rosbag2/test_info.cpp
+++ b/rosbag2/test/rosbag2/test_info.cpp
@@ -1,0 +1,91 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "mock_metadata_io.hpp"
+#include "rosbag2/info.hpp"
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/filesystem_helper.hpp"
+#include "rosbag2_test_common/temporary_directory_fixture.hpp"
+
+using namespace ::testing;  // NOLINT
+using namespace rosbag2_test_common;  // NOLINT
+
+TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metadata_io_method) {
+  std::string bagfile(
+    "rosbag2_bagfile_information:\n"
+    "  version: 1\n"
+    "  storage_identifier: sqlite3\n"
+    "  storage_format: cdr\n"
+    "  relative_file_paths:\n"
+    "    - some_relative_path\n"
+    "    - some_other_relative_path\n"
+    "  combined_bag_size: 10\n"
+    "  duration:\n"
+    "    nanoseconds: 100\n"
+    "  starting_time:\n"
+    "    nanoseconds_since_epoch: 1000000\n"
+    "  message_count: 50\n"
+    "  topics_with_message_count:\n"
+    "    - topic_and_type:\n"
+    "        name: topic1\n"
+    "        type: type1\n"
+    "      message_count: 100\n"
+    "    - topic_and_type:\n"
+    "        name: topic2\n"
+    "        type: type2\n"
+    "      message_count: 200");
+
+  std::ofstream fout(
+    rosbag2_storage::FilesystemHelper::concat({
+    temporary_dir_path_, rosbag2_storage::MetadataIo::metadata_filename
+  }));
+  fout << bagfile;
+  fout.close();
+
+  rosbag2::Info info;
+  auto read_metadata = info.read_metadata(temporary_dir_path_);
+
+  EXPECT_THAT(read_metadata.storage_identifier, Eq("sqlite3"));
+  EXPECT_THAT(read_metadata.storage_format, Eq("cdr"));
+  EXPECT_THAT(read_metadata.relative_file_paths,
+    Eq(std::vector<std::string>({"some_relative_path", "some_other_relative_path"})));
+  EXPECT_THAT(read_metadata.duration, Eq(std::chrono::nanoseconds(100)));
+  EXPECT_THAT(read_metadata.starting_time,
+    Eq(std::chrono::time_point<std::chrono::high_resolution_clock>(
+      std::chrono::nanoseconds(1000000))));
+  EXPECT_THAT(read_metadata.message_count, Eq(50u));
+  EXPECT_THAT(read_metadata.topics_with_message_count,
+    SizeIs(2u));
+  auto actual_first_topic = read_metadata.topics_with_message_count[0];
+  rosbag2_storage::TopicMetadata expected_first_topic = {{"topic1", "type1"}, 100};
+  EXPECT_THAT(actual_first_topic.topic_with_type.name,
+    Eq(expected_first_topic.topic_with_type.name));
+  EXPECT_THAT(actual_first_topic.topic_with_type.type,
+    Eq(expected_first_topic.topic_with_type.type));
+  EXPECT_THAT(actual_first_topic.message_count, Eq(expected_first_topic.message_count));
+  auto actual_second_topic = read_metadata.topics_with_message_count[1];
+  rosbag2_storage::TopicMetadata expected_second_topic = {{"topic2", "type2"}, 200};
+  EXPECT_THAT(actual_second_topic.topic_with_type.name,
+    Eq(expected_second_topic.topic_with_type.name));
+  EXPECT_THAT(actual_second_topic.topic_with_type.type,
+    Eq(expected_second_topic.topic_with_type.type));
+  EXPECT_THAT(actual_second_topic.message_count, Eq(expected_second_topic.message_count));
+}

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -18,17 +18,20 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 
 add_library(
   rosbag2_storage
   SHARED
+  src/rosbag2_storage/metadata_io.cpp
   src/rosbag2_storage/ros_helper.cpp
   src/rosbag2_storage/storage_factory.cpp)
 target_include_directories(rosbag2_storage PUBLIC include)
 ament_target_dependencies(
   rosbag2_storage
   pluginlib
-  rcutils)
+  rcutils
+  yaml_cpp_vendor)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -86,6 +89,14 @@ if(BUILD_TESTING)
   if(TARGET test_ros_helper)
     target_include_directories(test_ros_helper PRIVATE include)
     target_link_libraries(test_ros_helper rosbag2_storage)
+  endif()
+
+  ament_add_gmock(test_metadata_serialization
+    test/rosbag2_storage/test_metadata_serialization.cpp)
+  if(TARGET test_metadata_serialization)
+    target_include_directories(test_metadata_serialization PRIVATE include)
+    target_link_libraries(test_metadata_serialization rosbag2_storage)
+    ament_target_dependencies(test_metadata_serialization rosbag2_test_common)
   endif()
 
   ament_add_gmock(test_filesystem_helper

--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -37,7 +37,7 @@ struct BagMetadata
   int version = 1;  // upgrade this number when changing the content of the struct
   size_t bag_size = 0;  // Will not be serialized
   std::string storage_identifier;
-  std::string storage_format;
+  std::string serialization_format;
   std::vector<std::string> relative_file_paths;
   std::chrono::nanoseconds duration;
   std::chrono::time_point<std::chrono::high_resolution_clock> starting_time;

--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -1,0 +1,50 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_STORAGE__BAG_METADATA_HPP_
+#define ROSBAG2_STORAGE__BAG_METADATA_HPP_
+
+#include <chrono>
+#include <map>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "rosbag2_storage/topic_with_type.hpp"
+
+namespace rosbag2_storage
+{
+
+struct TopicMetadata
+{
+  TopicWithType topic_with_type;
+  size_t message_count;
+};
+
+struct BagMetadata
+{
+  int version = 1;
+  size_t bag_size = 0;  // Will not be serialized
+  std::string storage_identifier;
+  std::string storage_format;
+  std::vector<std::string> relative_file_paths;
+  std::chrono::nanoseconds duration;
+  std::chrono::time_point<std::chrono::high_resolution_clock> starting_time;
+  size_t message_count;
+  std::vector<TopicMetadata> topics_with_message_count;
+};
+
+}  // namespace rosbag2_storage
+
+#endif  // ROSBAG2_STORAGE__BAG_METADATA_HPP_

--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -34,7 +34,7 @@ struct TopicMetadata
 
 struct BagMetadata
 {
-  int version = 1;
+  int version = 1;  // upgrade this number when changing the content of the struct
   size_t bag_size = 0;  // Will not be serialized
   std::string storage_identifier;
   std::string storage_format;

--- a/rosbag2_storage/include/rosbag2_storage/filesystem_helper.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/filesystem_helper.hpp
@@ -118,6 +118,12 @@ public:
     int rc = stat(file_path.c_str(), &stat_buffer);
     return rc == 0 ? static_cast<size_t>(stat_buffer.st_size) : 0;
   }
+
+  static bool file_exists(const std::string & file_path)
+  {
+    struct stat stat_buffer {};
+    return stat(file_path.c_str(), &stat_buffer) == 0;
+  }
 };
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
@@ -29,8 +29,10 @@ class MetadataIo
 public:
   static constexpr const char * const metadata_filename = "metadata.yaml";
 
-  ROSBAG2_STORAGE_PUBLIC void write_metadata(const std::string & uri, BagMetadata metadata);
-  ROSBAG2_STORAGE_PUBLIC BagMetadata read_metadata(const std::string & uri);
+  ROSBAG2_STORAGE_PUBLIC
+  void write_metadata(const std::string & uri, const BagMetadata & metadata);
+  ROSBAG2_STORAGE_PUBLIC
+  BagMetadata read_metadata(const std::string & uri);
 
 private:
   std::string get_metadata_file_name(const std::string & uri);

--- a/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2018, Bosch Software Innovations GmbH.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_INFO_INTERFACE_HPP_
-#define ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_INFO_INTERFACE_HPP_
+#ifndef ROSBAG2_STORAGE__METADATA_IO_HPP_
+#define ROSBAG2_STORAGE__METADATA_IO_HPP_
 
-#include "rosbag2_storage/bag_info.hpp"
+#include <string>
+
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/topic_with_type.hpp"
 #include "rosbag2_storage/visibility_control.hpp"
 
 namespace rosbag2_storage
 {
-namespace storage_interfaces
-{
 
-class ROSBAG2_STORAGE_PUBLIC BaseInfoInterface
+class MetadataIo
 {
 public:
-  virtual ~BaseInfoInterface() = default;
-  virtual BagInfo info() = 0;
+  static constexpr const char * const metadata_filename = "metadata.yaml";
+
+  ROSBAG2_STORAGE_PUBLIC void write_metadata(const std::string & uri, BagMetadata metadata);
+  ROSBAG2_STORAGE_PUBLIC BagMetadata read_metadata(const std::string & uri);
+
+private:
+  std::string get_metadata_file_name(const std::string & uri);
 };
 
-}  // namespace storage_interfaces
 }  // namespace rosbag2_storage
 
-#endif  // ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_INFO_INTERFACE_HPP_
+#endif  // ROSBAG2_STORAGE__METADATA_IO_HPP_

--- a/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/filesystem_helper.hpp"
 #include "rosbag2_storage/topic_with_type.hpp"
 #include "rosbag2_storage/visibility_control.hpp"
 
@@ -31,8 +32,12 @@ public:
 
   ROSBAG2_STORAGE_PUBLIC
   void write_metadata(const std::string & uri, const BagMetadata & metadata);
+
   ROSBAG2_STORAGE_PUBLIC
   BagMetadata read_metadata(const std::string & uri);
+
+  ROSBAG2_STORAGE_PUBLIC
+  bool metadata_file_exists(const std::string & uri);
 
 private:
   std::string get_metadata_file_name(const std::string & uri);

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
@@ -1,4 +1,5 @@
 // Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2018 Bosch Software Innovations, GmbH.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_WRITE_INTERFACE_HPP_
-#define ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_WRITE_INTERFACE_HPP_
+#ifndef ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_INFO_INTERFACE_HPP_
+#define ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_INFO_INTERFACE_HPP_
 
-#include <memory>
-#include <string>
-
-#include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
-#include "rosbag2_storage/topic_with_type.hpp"
 #include "rosbag2_storage/visibility_control.hpp"
 
 namespace rosbag2_storage
@@ -28,17 +24,15 @@ namespace rosbag2_storage
 namespace storage_interfaces
 {
 
-class ROSBAG2_STORAGE_PUBLIC BaseWriteInterface
+class ROSBAG2_STORAGE_PUBLIC BaseInfoInterface
 {
 public:
-  virtual ~BaseWriteInterface() = default;
+  virtual ~BaseInfoInterface() = default;
 
-  virtual void write(std::shared_ptr<const SerializedBagMessage> msg) = 0;
-
-  virtual void create_topic(const TopicWithType & topic) = 0;
+  virtual BagMetadata get_metadata() = 0;
 };
 
 }  // namespace storage_interfaces
 }  // namespace rosbag2_storage
 
-#endif  // ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_WRITE_INTERFACE_HPP_
+#endif  // ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_INFO_INTERFACE_HPP_

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -35,6 +35,7 @@ class ROSBAG2_STORAGE_PUBLIC BaseIOInterface
 {
 public:
   virtual ~BaseIOInterface() = default;
+
   virtual void open(const std::string & uri, IOFlag io_flag) = 0;
 };
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "rosbag2_storage/serialized_bag_message.hpp"
-#include "rosbag2_storage/bag_info.hpp"
+#include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/topic_with_type.hpp"
 #include "rosbag2_storage/visibility_control.hpp"
 
@@ -36,6 +36,8 @@ public:
   virtual void write(std::shared_ptr<const SerializedBagMessage> msg) = 0;
 
   virtual void create_topic(const TopicWithType & topic) = 0;
+
+  virtual BagMetadata get_metadata() = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include "rosbag2_storage/storage_interfaces/base_info_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/base_io_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/base_read_interface.hpp"
 #include "rosbag2_storage/visibility_control.hpp"
@@ -27,10 +28,11 @@ namespace storage_interfaces
 {
 
 class ROSBAG2_STORAGE_PUBLIC ReadOnlyInterface
-  : public BaseIOInterface, public BaseReadInterface
+  : public BaseInfoInterface, public BaseIOInterface, public BaseReadInterface
 {
 public:
   virtual ~ReadOnlyInterface() = default;
+
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_ONLY) override = 0;
 };
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
@@ -17,7 +17,6 @@
 
 #include <string>
 
-#include "rosbag2_storage/storage_interfaces/base_info_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/base_io_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/base_read_interface.hpp"
 #include "rosbag2_storage/visibility_control.hpp"
@@ -28,7 +27,7 @@ namespace storage_interfaces
 {
 
 class ROSBAG2_STORAGE_PUBLIC ReadOnlyInterface
-  : public BaseInfoInterface, public BaseIOInterface, public BaseReadInterface
+  : public BaseIOInterface, public BaseReadInterface
 {
 public:
   virtual ~ReadOnlyInterface() = default;

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
@@ -31,6 +31,7 @@ class ROSBAG2_STORAGE_PUBLIC ReadWriteInterface
 {
 public:
   ~ReadWriteInterface() override = default;
+
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_WRITE) override = 0;
 };
 

--- a/rosbag2_storage/package.xml
+++ b/rosbag2_storage/package.xml
@@ -10,6 +10,7 @@
 
   <depend>pluginlib</depend>
   <depend>rcutils</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -147,7 +147,7 @@ struct convert<rosbag2_storage::BagMetadata>
 namespace rosbag2_storage
 {
 
-void MetadataIo::write_metadata(const std::string & uri, BagMetadata metadata)
+void MetadataIo::write_metadata(const std::string & uri, const BagMetadata & metadata)
 {
   YAML::Node metadata_node;
   metadata_node["rosbag2_bagfile_information"] = metadata;

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -1,0 +1,177 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_storage/metadata_io.hpp"
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "rosbag2_storage/filesystem_helper.hpp"
+
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
+
+namespace YAML
+{
+template<>
+struct convert<rosbag2_storage::TopicWithType>
+{
+  static Node encode(const rosbag2_storage::TopicWithType & topic)
+  {
+    Node node;
+    node["name"] = topic.name;
+    node["type"] = topic.type;
+    return node;
+  }
+
+  static bool decode(const Node & node, rosbag2_storage::TopicWithType & topic)
+  {
+    topic.name = node["name"].as<std::string>();
+    topic.type = node["type"].as<std::string>();
+    return true;
+  }
+};
+
+template<>
+struct convert<rosbag2_storage::TopicMetadata>
+{
+  static Node encode(const rosbag2_storage::TopicMetadata & metadata)
+  {
+    Node node;
+    node["topic_and_type"] = metadata.topic_with_type;
+    node["message_count"] = metadata.message_count;
+    return node;
+  }
+
+  static bool decode(const Node & node, rosbag2_storage::TopicMetadata & metadata)
+  {
+    metadata.topic_with_type = node["topic_and_type"].as<rosbag2_storage::TopicWithType>();
+    metadata.message_count = node["message_count"].as<size_t>();
+    return true;
+  }
+};
+
+template<>
+struct convert<std::chrono::nanoseconds>
+{
+  static Node encode(const std::chrono::nanoseconds & time_in_ns)
+  {
+    Node node;
+    node["nanoseconds"] = time_in_ns.count();
+    return node;
+  }
+
+  static bool decode(const Node & node, std::chrono::nanoseconds & time_in_ns)
+  {
+    time_in_ns = std::chrono::nanoseconds(node["nanoseconds"].as<size_t>());
+    return true;
+  }
+};
+
+template<>
+struct convert<std::chrono::time_point<std::chrono::high_resolution_clock>>
+{
+  static Node encode(const std::chrono::time_point<std::chrono::high_resolution_clock> & start_time)
+  {
+    Node node;
+    node["nanoseconds_since_epoch"] = start_time.time_since_epoch().count();
+    return node;
+  }
+
+  static bool decode(
+    const Node & node, std::chrono::time_point<std::chrono::high_resolution_clock> & start_time)
+  {
+    start_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
+      std::chrono::nanoseconds(node["nanoseconds_since_epoch"].as<size_t>()));
+    return true;
+  }
+};
+
+template<>
+struct convert<rosbag2_storage::BagMetadata>
+{
+  static Node encode(const rosbag2_storage::BagMetadata & metadata)
+  {
+    Node node;
+    node["version"] = metadata.version;
+    node["storage_identifier"] = metadata.storage_identifier;
+    node["storage_format"] = metadata.storage_format;
+    node["relative_file_paths"] = metadata.relative_file_paths;
+    node["duration"] = metadata.duration;
+    node["starting_time"] = metadata.starting_time;
+    node["message_count"] = metadata.message_count;
+    node["topics_with_message_count"] = metadata.topics_with_message_count;
+    return node;
+  }
+
+  static bool decode(const Node & node, rosbag2_storage::BagMetadata & metadata)
+  {
+    metadata.version = node["version"].as<int>();
+    metadata.storage_identifier = node["storage_identifier"].as<std::string>();
+    metadata.storage_format = node["storage_format"].as<std::string>();
+    metadata.relative_file_paths = node["relative_file_paths"].as<std::vector<std::string>>();
+    metadata.duration = node["duration"].as<std::chrono::nanoseconds>();
+    metadata.starting_time = node["starting_time"]
+      .as<std::chrono::time_point<std::chrono::high_resolution_clock>>();
+    metadata.message_count = node["message_count"].as<size_t>();
+    metadata.topics_with_message_count =
+      node["topics_with_message_count"].as<std::vector<rosbag2_storage::TopicMetadata>>();
+    return true;
+  }
+};
+
+}  // namespace YAML
+
+namespace rosbag2_storage
+{
+
+void MetadataIo::write_metadata(const std::string & uri, BagMetadata metadata)
+{
+  YAML::Node metadata_node;
+  metadata_node["rosbag2_bagfile_information"] = metadata;
+  std::ofstream fout(get_metadata_file_name(uri));
+  fout << metadata_node;
+}
+
+BagMetadata MetadataIo::read_metadata(const std::string & uri)
+{
+  try {
+    YAML::Node yaml_file = YAML::LoadFile(get_metadata_file_name(uri));
+    auto metadata = yaml_file["rosbag2_bagfile_information"].as<rosbag2_storage::BagMetadata>();
+    metadata.bag_size = FilesystemHelper::calculate_directory_size(uri);
+    return metadata;
+  } catch (const YAML::Exception & ex) {
+    throw std::runtime_error(std::string("Exception on parsing info file: ") + ex.what());
+  }
+}
+
+std::string MetadataIo::get_metadata_file_name(const std::string & uri)
+{
+  std::string metadata_file = rosbag2_storage::FilesystemHelper::concat({uri, metadata_filename});
+
+  return metadata_file;
+}
+
+}  // namespace rosbag2_storage

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -174,4 +174,10 @@ std::string MetadataIo::get_metadata_file_name(const std::string & uri)
   return metadata_file;
 }
 
+bool MetadataIo::metadata_file_exists(const std::string & uri)
+{
+  return rosbag2_storage::FilesystemHelper::file_exists(
+    rosbag2_storage::FilesystemHelper::concat({uri, metadata_filename}));
+}
+
 }  // namespace rosbag2_storage

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -117,7 +117,7 @@ struct convert<rosbag2_storage::BagMetadata>
     Node node;
     node["version"] = metadata.version;
     node["storage_identifier"] = metadata.storage_identifier;
-    node["storage_format"] = metadata.storage_format;
+    node["serialization_format"] = metadata.serialization_format;
     node["relative_file_paths"] = metadata.relative_file_paths;
     node["duration"] = metadata.duration;
     node["starting_time"] = metadata.starting_time;
@@ -130,7 +130,7 @@ struct convert<rosbag2_storage::BagMetadata>
   {
     metadata.version = node["version"].as<int>();
     metadata.storage_identifier = node["storage_identifier"].as<std::string>();
-    metadata.storage_format = node["storage_format"].as<std::string>();
+    metadata.serialization_format = node["serialization_format"].as<std::string>();
     metadata.relative_file_paths = node["relative_file_paths"].as<std::vector<std::string>>();
     metadata.duration = node["duration"].as<std::chrono::nanoseconds>();
     metadata.starting_time = node["starting_time"]

--- a/rosbag2_storage/test/rosbag2_storage/test_filesystem_helper.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_filesystem_helper.cpp
@@ -41,6 +41,18 @@ TEST_F(FilesystemHelperFixture, calculate_directory_size_adds_size_of_two_direct
   EXPECT_THAT(size, Eq(13u));
 }
 
+TEST_F(FilesystemHelperFixture, file_exists_shows_whether_file_exists)
+{
+  std::ofstream out(FilesystemHelper::concat({temporary_dir_path_, "file1.txt"}));
+  out << "test";
+  out.close();
+
+  EXPECT_TRUE(FilesystemHelper::file_exists(
+      FilesystemHelper::concat({temporary_dir_path_, "file1.txt"})));
+  EXPECT_FALSE(FilesystemHelper::file_exists(
+      FilesystemHelper::concat({temporary_dir_path_, "file2.txt"})));
+}
+
 TEST(FilesystemHelper, concat_joins_string_list_with_directory_separators)
 {
   auto sep = std::string(FilesystemHelper::separator);

--- a/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
@@ -48,7 +48,7 @@ TEST_F(MetadataFixture, test_writing_and_reading_yaml)
   BagMetadata metadata{};
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
-  metadata.storage_format = "cdr";
+  metadata.serialization_format = "cdr";
   metadata.relative_file_paths.emplace_back("some_relative_path");
   metadata.relative_file_paths.emplace_back("some_other_relative_path");
   metadata.duration = std::chrono::nanoseconds(100);
@@ -63,7 +63,7 @@ TEST_F(MetadataFixture, test_writing_and_reading_yaml)
 
   EXPECT_THAT(read_metadata.version, Eq(metadata.version));
   EXPECT_THAT(read_metadata.storage_identifier, Eq(metadata.storage_identifier));
-  EXPECT_THAT(read_metadata.storage_format, Eq(metadata.storage_format));
+  EXPECT_THAT(read_metadata.serialization_format, Eq(metadata.serialization_format));
   EXPECT_THAT(read_metadata.relative_file_paths, Eq(metadata.relative_file_paths));
   EXPECT_THAT(read_metadata.duration, Eq(metadata.duration));
   EXPECT_THAT(read_metadata.starting_time, Eq(metadata.starting_time));

--- a/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
@@ -1,0 +1,87 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+# include <direct.h>
+# include <Windows.h>
+#endif
+
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
+#include "rosbag2_storage/filesystem_helper.hpp"
+#include "rosbag2_test_common/temporary_directory_fixture.hpp"
+
+using namespace ::testing;  // NOLINT
+using namespace rosbag2_storage;  // NOLINT
+using namespace rosbag2_test_common;  // NOLINT
+
+class MetadataFixture : public TemporaryDirectoryFixture
+{
+public:
+  MetadataFixture()
+  : metadata_io_(std::make_shared<MetadataIo>()) {}
+
+  std::shared_ptr<MetadataIo> metadata_io_;
+};
+
+TEST_F(MetadataFixture, test_writing_and_reading_yaml)
+{
+  BagMetadata metadata{};
+  metadata.version = 1;
+  metadata.storage_identifier = "sqlite3";
+  metadata.storage_format = "cdr";
+  metadata.relative_file_paths.emplace_back("some_relative_path");
+  metadata.relative_file_paths.emplace_back("some_other_relative_path");
+  metadata.duration = std::chrono::nanoseconds(100);
+  metadata.starting_time =
+    std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(1000000));
+  metadata.message_count = 50;
+  metadata.topics_with_message_count.push_back({{"topic1", "type1"}, 100});
+  metadata.topics_with_message_count.push_back({{"topic2", "type2"}, 200});
+
+  metadata_io_->write_metadata(temporary_dir_path_, metadata);
+  auto read_metadata = metadata_io_->read_metadata(temporary_dir_path_);
+
+  EXPECT_THAT(read_metadata.version, Eq(metadata.version));
+  EXPECT_THAT(read_metadata.storage_identifier, Eq(metadata.storage_identifier));
+  EXPECT_THAT(read_metadata.storage_format, Eq(metadata.storage_format));
+  EXPECT_THAT(read_metadata.relative_file_paths, Eq(metadata.relative_file_paths));
+  EXPECT_THAT(read_metadata.duration, Eq(metadata.duration));
+  EXPECT_THAT(read_metadata.starting_time, Eq(metadata.starting_time));
+  EXPECT_THAT(read_metadata.message_count, Eq(metadata.message_count));
+  EXPECT_THAT(read_metadata.topics_with_message_count,
+    SizeIs(metadata.topics_with_message_count.size()));
+  auto actual_first_topic = read_metadata.topics_with_message_count[0];
+  auto expected_first_topic = metadata.topics_with_message_count[0];
+  EXPECT_THAT(actual_first_topic.topic_with_type.name,
+    Eq(expected_first_topic.topic_with_type.name));
+  EXPECT_THAT(actual_first_topic.topic_with_type.type,
+    Eq(expected_first_topic.topic_with_type.type));
+  EXPECT_THAT(actual_first_topic.message_count, Eq(expected_first_topic.message_count));
+  auto actual_second_topic = read_metadata.topics_with_message_count[1];
+  auto expected_second_topic = metadata.topics_with_message_count[1];
+  EXPECT_THAT(actual_second_topic.topic_with_type.name,
+    Eq(expected_second_topic.topic_with_type.name));
+  EXPECT_THAT(actual_second_topic.topic_with_type.type,
+    Eq(expected_second_topic.topic_with_type.type));
+  EXPECT_THAT(actual_second_topic.message_count, Eq(expected_second_topic.message_count));
+}

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -21,7 +21,6 @@
 
 #include "pluginlib/class_list_macros.hpp"
 
-#include "rosbag2_storage/bag_info.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
 #include "test_plugin.hpp"
@@ -40,11 +39,6 @@ void TestPlugin::open(
     std::cout << "opening testplugin read write: ";
   }
   std::cout << uri << ".\n";
-}
-
-rosbag2_storage::BagInfo TestPlugin::info()
-{
-  return rosbag2_storage::BagInfo();
 }
 
 bool TestPlugin::has_next()
@@ -73,6 +67,12 @@ std::vector<rosbag2_storage::TopicWithType> TestPlugin::get_all_topics_and_types
 {
   std::cout << "\nreading topics and types\n";
   return std::vector<rosbag2_storage::TopicWithType>();
+}
+
+rosbag2_storage::BagMetadata TestPlugin::get_metadata()
+{
+  std::cout << "\nreturning metadata\n";
+  return rosbag2_storage::BagMetadata();
 }
 
 PLUGINLIB_EXPORT_CLASS(TestPlugin, rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>
 
-#include "rosbag2_storage/bag_info.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_storage/topic_with_type.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
@@ -33,8 +32,6 @@ public:
 
   void open(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag flag) override;
 
-  rosbag2_storage::BagInfo info() override;
-
   void create_topic(const rosbag2_storage::TopicWithType & topic) override;
 
   bool has_next() override;
@@ -44,6 +41,8 @@ public:
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
 
   std::vector<rosbag2_storage::TopicWithType> get_all_topics_and_types() override;
+
+  rosbag2_storage::BagMetadata get_metadata() override;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_PLUGIN_HPP_

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -38,11 +38,6 @@ void TestReadOnlyPlugin::open(
   std::cout << uri << ".\n";
 }
 
-rosbag2_storage::BagInfo TestReadOnlyPlugin::info()
-{
-  return rosbag2_storage::BagInfo();
-}
-
 bool TestReadOnlyPlugin::has_next()
 {
   return true;

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -55,4 +55,9 @@ std::vector<rosbag2_storage::TopicWithType> TestReadOnlyPlugin::get_all_topics_a
   return std::vector<rosbag2_storage::TopicWithType>();
 }
 
+rosbag2_storage::BagMetadata TestReadOnlyPlugin::get_metadata()
+{
+  return rosbag2_storage::BagMetadata();
+}
+
 PLUGINLIB_EXPORT_CLASS(TestReadOnlyPlugin, rosbag2_storage::storage_interfaces::ReadOnlyInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -29,8 +29,6 @@ public:
 
   void open(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag flag) override;
 
-  rosbag2_storage::BagInfo info() override;
-
   bool has_next() override;
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -34,6 +34,8 @@ public:
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
 
   std::vector<rosbag2_storage::TopicWithType> get_all_topics_and_types() override;
+
+  rosbag2_storage::BagMetadata get_metadata() override;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_READ_ONLY_PLUGIN_HPP_

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -60,7 +60,7 @@ public:
 
   std::vector<rosbag2_storage::TopicWithType> get_all_topics_and_types() override;
 
-  rosbag2_storage::BagInfo info() override;
+  rosbag2_storage::BagMetadata get_metadata() override;
 
 private:
   void initialize();
@@ -74,7 +74,7 @@ private:
     std::shared_ptr<rcutils_char_array_t>, rcutils_time_point_value_t, std::string>;
 
   std::shared_ptr<SqliteWrapper> database_;
-  rosbag2_storage::BagInfo bag_info_;
+  rosbag2_storage::BagMetadata metadata_;
   SqliteStatement write_statement_;
   SqliteStatement read_statement_;
   ReadQueryResult message_result_;

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -67,14 +67,16 @@ private:
   void prepare_for_writing();
   void prepare_for_reading();
   void fill_topics_and_types();
-  std::string get_database_name(const std::string & uri);
+
+  std::unique_ptr<rosbag2_storage::BagMetadata> load_metadata(const std::string & uri);
   bool database_exists(const std::string & uri);
+  bool is_read_only(const rosbag2_storage::storage_interfaces::IOFlag & io_flag) const;
 
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_char_array_t>, rcutils_time_point_value_t, std::string>;
 
   std::shared_ptr<SqliteWrapper> database_;
-  rosbag2_storage::BagMetadata metadata_;
+  std::string database_name_;
   SqliteStatement write_statement_;
   SqliteStatement read_statement_;
   ReadQueryResult message_result_;

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -191,7 +191,7 @@ std::unique_ptr<rosbag2_storage::BagMetadata> SqliteStorage::load_metadata(const
     rosbag2_storage::MetadataIo metadata_io;
     return std::make_unique<rosbag2_storage::BagMetadata>(metadata_io.read_metadata(uri));
   } catch (std::exception & e) {
-    (void) e;
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR("Failed to load metadata: %s", e.what());
     return std::unique_ptr<rosbag2_storage::BagMetadata>();
   }
 }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "rosbag2_storage/filesystem_helper.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp"
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_exception.hpp"
@@ -38,36 +39,45 @@ namespace rosbag2_storage_plugins
 
 SqliteStorage::SqliteStorage()
 : database_(),
-  metadata_(),
   write_statement_(nullptr),
   read_statement_(nullptr),
   message_result_(nullptr),
   current_message_row_(nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END)
-{
-  metadata_.storage_identifier = "sqlite3";
-  metadata_.storage_format = "cdr";  // TODO(greimela) Determine format (i.e. data encoding)
-}
+{}
 
 void SqliteStorage::open(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
-  std::string database_name = get_database_name(uri);
-  std::string database_path = rosbag2_storage::FilesystemHelper::concat({uri, database_name});
+  auto metadata = load_metadata(uri);
 
-  if (io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY &&
-    !database_exists(database_path))
-  {
-    throw std::runtime_error("Failed to read from bag '" + uri + "': Folder does not exist.");
+  if (metadata) {
+    if (metadata->relative_file_paths.empty()) {
+      throw std::runtime_error(
+              "Failed to read from bag '" + uri + "': Missing database file path in metadata");
+    }
+
+    database_name_ = metadata->relative_file_paths[0];
+  } else {
+    if (is_read_only(io_flag)) {
+      throw std::runtime_error("Failed to read from bag '" + uri + "': No metadata found.");
+    }
+
+    database_name_ = rosbag2_storage::FilesystemHelper::get_folder_name(uri) + ".db3";
+  }
+
+  std::string database_path = rosbag2_storage::FilesystemHelper::concat({uri, database_name_});
+  if (is_read_only(io_flag) && !database_exists(database_path)) {
+    throw std::runtime_error(
+            "Failed to read from bag '" + uri + "': File '" + database_name_ + "' does not exist.");
   }
 
   try {
     database_ = std::make_unique<SqliteWrapper>(database_path, io_flag);
-    metadata_.relative_file_paths = {database_name};
   } catch (const SqliteException & e) {
     throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));
   }
 
-  if (io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) {
+  if (!metadata) {
     initialize();
   }
 
@@ -175,9 +185,15 @@ void SqliteStorage::fill_topics_and_types()
   }
 }
 
-std::string SqliteStorage::get_database_name(const std::string & uri)
+std::unique_ptr<rosbag2_storage::BagMetadata> SqliteStorage::load_metadata(const std::string & uri)
 {
-  return rosbag2_storage::FilesystemHelper::get_folder_name(uri) + ".db3";
+  try {
+    rosbag2_storage::MetadataIo metadata_io;
+    return std::make_unique<rosbag2_storage::BagMetadata>(metadata_io.read_metadata(uri));
+  } catch (std::exception & e) {
+    (void) e;
+    return std::unique_ptr<rosbag2_storage::BagMetadata>();
+  }
 }
 
 bool SqliteStorage::database_exists(const std::string & uri)
@@ -186,10 +202,20 @@ bool SqliteStorage::database_exists(const std::string & uri)
   return database.good();
 }
 
+bool SqliteStorage::is_read_only(const rosbag2_storage::storage_interfaces::IOFlag & io_flag) const
+{
+  return io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY;
+}
+
 rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
 {
-  metadata_.message_count = 0;
-  metadata_.topics_with_message_count = {};
+  rosbag2_storage::BagMetadata metadata;
+  metadata.storage_identifier = "sqlite3";
+  metadata.storage_format = "cdr";  // TODO(greimela) Determine format (i.e. data encoding)
+  metadata.relative_file_paths = {database_name_};
+
+  metadata.message_count = 0;
+  metadata.topics_with_message_count = {};
 
   auto statement = database_->prepare_statement(
     "SELECT name, type, COUNT(messages.id), MIN(messages.timestamp), MAX(messages.timestamp) "
@@ -201,26 +227,26 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
   rcutils_time_point_value_t min_time = INT64_MAX;
   rcutils_time_point_value_t max_time = 0;
   for (auto result : query_results) {
-    metadata_.topics_with_message_count.push_back(
+    metadata.topics_with_message_count.push_back(
       {
         {std::get<0>(result), std::get<1>(result)},
         static_cast<size_t>(std::get<2>(result))
       });
-    metadata_.message_count += std::get<2>(result);
+    metadata.message_count += std::get<2>(result);
     min_time = std::get<3>(result) < min_time ? std::get<3>(result) : min_time;
     max_time = std::get<4>(result) > max_time ? std::get<4>(result) : max_time;
   }
 
-  if (metadata_.message_count == 0) {
+  if (metadata.message_count == 0) {
     min_time = 0;
     max_time = 0;
   }
 
-  metadata_.starting_time =
+  metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(min_time));
-  metadata_.duration = std::chrono::nanoseconds(max_time) - std::chrono::nanoseconds(min_time);
+  metadata.duration = std::chrono::nanoseconds(max_time) - std::chrono::nanoseconds(min_time);
 
-  return metadata_;
+  return metadata;
 }
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -213,7 +213,7 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
 {
   rosbag2_storage::BagMetadata metadata;
   metadata.storage_identifier = "sqlite3";
-  metadata.storage_format = "cdr";  // TODO(greimela) Determine format (i.e. data encoding)
+  metadata.serialization_format = "cdr";  // TODO(greimela) Determine format (i.e. data encoding)
   metadata.relative_file_paths = {database_name_};
 
   metadata.message_count = 0;

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -48,7 +48,9 @@ SqliteStorage::SqliteStorage()
 void SqliteStorage::open(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
-  auto metadata = load_metadata(uri);
+  auto metadata = is_read_only(io_flag) ?
+    load_metadata(uri) :
+    std::unique_ptr<rosbag2_storage::BagMetadata>();
 
   if (metadata) {
     if (metadata->relative_file_paths.empty()) {

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -15,6 +15,8 @@
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp"
 
 #include <sys/stat.h>
+
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <fstream>
@@ -36,12 +38,15 @@ namespace rosbag2_storage_plugins
 
 SqliteStorage::SqliteStorage()
 : database_(),
-  bag_info_(),
+  metadata_(),
   write_statement_(nullptr),
   read_statement_(nullptr),
   message_result_(nullptr),
   current_message_row_(nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END)
-{}
+{
+  metadata_.storage_identifier = "sqlite3";
+  metadata_.storage_format = "cdr";  // TODO(greimela) Determine format (i.e. data encoding)
+}
 
 void SqliteStorage::open(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
@@ -57,7 +62,7 @@ void SqliteStorage::open(
 
   try {
     database_ = std::make_unique<SqliteWrapper>(database_path, io_flag);
-    bag_info_.uri = database_name;
+    metadata_.relative_file_paths = {database_name};
   } catch (const SqliteException & e) {
     throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));
   }
@@ -132,11 +137,6 @@ void SqliteStorage::initialize()
   database_->prepare_statement(create_table)->execute_and_reset();
 }
 
-rosbag2_storage::BagInfo SqliteStorage::info()
-{
-  return bag_info_;
-}
-
 void SqliteStorage::create_topic(const rosbag2_storage::TopicWithType & topic)
 {
   if (topics_.find(topic.name) == std::end(topics_)) {
@@ -186,8 +186,44 @@ bool SqliteStorage::database_exists(const std::string & uri)
   return database.good();
 }
 
-}  // namespace rosbag2_storage_plugins
+rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
+{
+  metadata_.message_count = 0;
+  metadata_.topics_with_message_count = {};
 
+  auto statement = database_->prepare_statement(
+    "SELECT name, type, COUNT(messages.id), MIN(messages.timestamp), MAX(messages.timestamp) "
+    "FROM messages JOIN topics on topics.id = messages.topic_id "
+    "GROUP BY topics.name;");
+  auto query_results = statement->execute_query<
+    std::string, std::string, int, rcutils_time_point_value_t, rcutils_time_point_value_t>();
+
+  rcutils_time_point_value_t min_time = INT64_MAX;
+  rcutils_time_point_value_t max_time = 0;
+  for (auto result : query_results) {
+    metadata_.topics_with_message_count.push_back(
+      {
+        {std::get<0>(result), std::get<1>(result)},
+        static_cast<size_t>(std::get<2>(result))
+      });
+    metadata_.message_count += std::get<2>(result);
+    min_time = std::get<3>(result) < min_time ? std::get<3>(result) : min_time;
+    max_time = std::get<4>(result) > max_time ? std::get<4>(result) : max_time;
+  }
+
+  if (metadata_.message_count == 0) {
+    min_time = 0;
+    max_time = 0;
+  }
+
+  metadata_.starting_time =
+    std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(min_time));
+  metadata_.duration = std::chrono::nanoseconds(max_time) - std::chrono::nanoseconds(min_time);
+
+  return metadata_;
+}
+
+}  // namespace rosbag2_storage_plugins
 
 #include "pluginlib/class_list_macros.hpp"  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rosbag2_storage_plugins::SqliteStorage,

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -27,6 +27,7 @@
 
 #include "rcutils/logging_macros.h"
 #include "rcutils/snprintf.h"
+#include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp"
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
@@ -101,6 +102,8 @@ public:
       bag_message->topic_name = topic_name;
       writable_storage->write(bag_message);
     }
+
+    metadata_io_.write_metadata(temporary_dir_path_, writable_storage->get_metadata());
   }
 
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
@@ -138,6 +141,7 @@ protected:
   }
 
   rcutils_allocator_t allocator_;
+  rosbag2_storage::MetadataIo metadata_io_;
 };
 
 #endif  // ROSBAG2_STORAGE_DEFAULT_PLUGINS__SQLITE__STORAGE_TEST_FIXTURE_HPP_

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -40,6 +40,17 @@ bool operator!=(const TopicWithType & lhs, const TopicWithType & rhs)
   return !(lhs == rhs);
 }
 
+bool operator==(const TopicMetadata & lhs, const TopicMetadata & rhs)
+{
+  return lhs.topic_with_type == rhs.topic_with_type &&
+         lhs.message_count == rhs.message_count;
+}
+
+bool operator!=(const TopicMetadata & lhs, const TopicMetadata & rhs)
+{
+  return !(lhs == rhs);
+}
+
 }  // namespace rosbag2_storage
 
 TEST_F(StorageTestFixture, string_messages_are_written_and_read_to_and_from_sqlite3_storage) {
@@ -112,4 +123,56 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
     rosbag2_storage::TopicWithType{"topic1", "type1"},
     rosbag2_storage::TopicWithType{"topic2", "type2"}
   }));
+}
+
+TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
+  std::vector<std::string> string_messages = {"first message", "second message", "third message"};
+  std::vector<std::string> topics = {"topic1", "topic2"};
+  std::vector<std::tuple<std::string, int64_t, std::string, std::string>> messages =
+  {std::make_tuple(string_messages[0], static_cast<int64_t>(1e9), topics[0], "type1"),
+    std::make_tuple(string_messages[1], static_cast<int64_t>(2e9), topics[0], "type1"),
+    std::make_tuple(string_messages[2], static_cast<int64_t>(3e9), topics[1], "type2")};
+
+  write_messages_to_sqlite(messages);
+
+  auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+  readable_storage->open(
+    temporary_dir_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+  auto metadata = readable_storage->get_metadata();
+
+  EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
+  EXPECT_THAT(metadata.storage_format, Eq("cdr"));
+  EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
+    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
+  }));
+  EXPECT_THAT(metadata.topics_with_message_count, ElementsAreArray({
+    rosbag2_storage::TopicMetadata{rosbag2_storage::TopicWithType{"topic1", "type1"}, 2u},
+    rosbag2_storage::TopicMetadata{rosbag2_storage::TopicWithType{"topic2", "type2"}, 1u}
+  }));
+  EXPECT_THAT(metadata.message_count, Eq(3u));
+  EXPECT_THAT(metadata.starting_time, Eq(
+      std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::seconds(1))
+  ));
+  EXPECT_THAT(metadata.duration, Eq(std::chrono::seconds(2)));
+}
+
+TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_if_no_messages) {
+  write_messages_to_sqlite({});
+
+  auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+  readable_storage->open(
+    temporary_dir_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+  auto metadata = readable_storage->get_metadata();
+
+  EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
+  EXPECT_THAT(metadata.storage_format, Eq("cdr"));
+  EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
+    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
+  }));
+  EXPECT_THAT(metadata.topics_with_message_count, IsEmpty());
+  EXPECT_THAT(metadata.message_count, Eq(0u));
+  EXPECT_THAT(metadata.starting_time, Eq(
+      std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::seconds(0))
+  ));
+  EXPECT_THAT(metadata.duration, Eq(std::chrono::seconds(0)));
 }

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -142,7 +142,7 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
   auto metadata = readable_storage->get_metadata();
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
-  EXPECT_THAT(metadata.storage_format, Eq("cdr"));
+  EXPECT_THAT(metadata.serialization_format, Eq("cdr"));
   EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
     rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
   }));
@@ -166,7 +166,7 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_if_no_messages) {
   auto metadata = readable_storage->get_metadata();
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
-  EXPECT_THAT(metadata.storage_format, Eq("cdr"));
+  EXPECT_THAT(metadata.serialization_format, Eq("cdr"));
   EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
     rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
   }));

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -112,6 +112,7 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
   writable_storage->open(temporary_dir_path_);
   writable_storage->create_topic({"topic1", "type1"});
   writable_storage->create_topic({"topic2", "type2"});
+  metadata_io_.write_metadata(temporary_dir_path_, writable_storage->get_metadata());
   writable_storage.reset();
 
   auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -55,6 +55,14 @@ if(BUILD_TESTING)
       test_msgs)
   endif()
 
+  ament_add_gmock(test_rosbag2_info_end_to_end
+    test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_rosbag2_info_end_to_end)
+    ament_target_dependencies(test_rosbag2_info_end_to_end
+      rosbag2_storage)
+  endif()
+
 endif()
 
 ament_package()

--- a/rosbag2_tests/resources/test/metadata.yaml
+++ b/rosbag2_tests/resources/test/metadata.yaml
@@ -1,0 +1,20 @@
+rosbag2_bagfile_information:
+  version: 1
+  storage_identifier: sqlite3
+  storage_format: cdr
+  relative_file_paths:
+    - test.db3
+  duration:
+    nanoseconds: 155979811
+  starting_time:
+    nanoseconds_since_epoch: 1537282604241440135
+  message_count: 7
+  topics_with_message_count:
+    - topic_and_type:
+        name: /test_topic
+        type: test_msgs/Primitives
+      message_count: 3
+    - topic_and_type:
+        name: /array_topic
+        type: test_msgs/StaticArrayPrimitives
+      message_count: 4

--- a/rosbag2_tests/resources/test/metadata.yaml
+++ b/rosbag2_tests/resources/test/metadata.yaml
@@ -1,7 +1,7 @@
 rosbag2_bagfile_information:
   version: 1
   storage_identifier: sqlite3
-  storage_format: cdr
+  serialization_format: cdr
   relative_file_paths:
     - test.db3
   duration:

--- a/rosbag2_tests/test/rosbag2_tests/process_execution_helpers_unix.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/process_execution_helpers_unix.hpp
@@ -30,8 +30,13 @@ using ProcessHandle = int;
 
 int execute_and_wait_until_completion(const std::string & command, const std::string & path)
 {
+  char previous_dir[PATH_MAX];
+  getcwd(previous_dir, PATH_MAX);
+
   chdir(path.c_str());
   auto exitcode = std::system(command.c_str());
+  chdir(previous_dir);
+
   return WEXITSTATUS(exitcode);
 }
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -53,6 +53,7 @@ TEST_F(InfoEndToEndTestFixture, info_end_to_end_test) {
       "\n                      /array_topic; test_msgs/StaticArrayPrimitives; 4 msgs"));
 }
 
+// TODO(Martin-Idel-SI): Revisit exit code non-zero here, gracefully should be exit code zero
 TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_bag_does_not_exist) {
   internal::CaptureStderr();
   auto exit_code =
@@ -61,4 +62,14 @@ TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_bag_does_not_exist) {
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
   EXPECT_THAT(error_output, HasSubstr("'does_not_exist' does not exist"));
+}
+
+TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_metadata_yaml_file_does_not_exist) {
+  internal::CaptureStderr();
+  auto exit_code =
+    execute_and_wait_until_completion("ros2 bag info " + database_path_, database_path_);
+  auto error_output = internal::GetCapturedStderr();
+
+  EXPECT_THAT(exit_code, Eq(EXIT_SUCCESS));
+  EXPECT_THAT(error_output, HasSubstr("Could not read metadata for " + database_path_));
 }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -41,16 +41,16 @@ TEST_F(InfoEndToEndTestFixture, info_end_to_end_test) {
   EXPECT_THAT(exit_code, Eq(EXIT_SUCCESS));
   // The bag size depends on the os and is not asserted, the time is asserted time zone independent
   EXPECT_THAT(output, ContainsRegex(
-      "\nFiles:            test\\.db3"
-      "\nBag size:         .*B"
-      "\nStorage id:       sqlite3"
-      "\nStorage format:   cdr"
-      "\nDuration:         0\\.155s"
-      "\nStart:            Sep .+ 2018 .+:.+:44\\.241 \\(1537282604\\.241\\)"
-      "\nEnd               Sep .+ 2018 .+:.+:44\\.397 \\(1537282604\\.397\\)"
-      "\nMessages:         7"
-      "\nTopics with Type: /test_topic; test_msgs/Primitives; 3 msgs"
-      "\n                  /array_topic; test_msgs/StaticArrayPrimitives; 4 msgs"));
+      "\nFiles:                test\\.db3"
+      "\nBag size:             .*B"
+      "\nStorage id:           sqlite3"
+      "\nSerialization format: cdr"
+      "\nDuration:             0\\.155s"
+      "\nStart:                Sep .+ 2018 .+:.+:44\\.241 \\(1537282604\\.241\\)"
+      "\nEnd                   Sep .+ 2018 .+:.+:44\\.397 \\(1537282604\\.397\\)"
+      "\nMessages:             7"
+      "\nTopics with Type:     /test_topic; test_msgs/Primitives; 3 msgs"
+      "\n                      /array_topic; test_msgs/StaticArrayPrimitives; 4 msgs"));
 }
 
 TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_bag_does_not_exist) {

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -1,0 +1,64 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#include "process_execution_helpers.hpp"
+
+using namespace ::testing;  // NOLINT
+
+class InfoEndToEndTestFixture : public Test
+{
+public:
+  InfoEndToEndTestFixture()
+  {
+    database_path_ = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
+  }
+
+  std::string database_path_;
+};
+
+TEST_F(InfoEndToEndTestFixture, info_end_to_end_test) {
+  internal::CaptureStdout();
+  auto exit_code = execute_and_wait_until_completion("ros2 bag info test", database_path_);
+  std::string output = internal::GetCapturedStdout();
+
+  EXPECT_THAT(exit_code, Eq(EXIT_SUCCESS));
+  // The bag size depends on the os and is not asserted, the time is asserted time zone independent
+  EXPECT_THAT(output, ContainsRegex(
+      "\nFiles:            test\\.db3"
+      "\nBag size:         .*B"
+      "\nStorage id:       sqlite3"
+      "\nStorage format:   cdr"
+      "\nDuration:         0\\.155s"
+      "\nStart:            Sep .+ 2018 .+:.+:44\\.241 \\(1537282604\\.241\\)"
+      "\nEnd               Sep .+ 2018 .+:.+:44\\.397 \\(1537282604\\.397\\)"
+      "\nMessages:         7"
+      "\nTopics with Type: /test_topic; test_msgs/Primitives; 3 msgs"
+      "\n                  /array_topic; test_msgs/StaticArrayPrimitives; 4 msgs"));
+}
+
+TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_bag_does_not_exist) {
+  internal::CaptureStderr();
+  auto exit_code =
+    execute_and_wait_until_completion("ros2 bag info does_not_exist", database_path_);
+  auto error_output = internal::GetCapturedStderr();
+
+  EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
+  EXPECT_THAT(error_output, HasSubstr("'does_not_exist' does not exist"));
+}

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -48,7 +48,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::BagMetadata metadata{};
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
-  metadata.storage_format = "cdr";
+  metadata.serialization_format = "cdr";
   metadata.relative_file_paths.emplace_back("bag.db3");
   metadata.duration = std::chrono::nanoseconds(0);
   metadata.starting_time =

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -19,6 +19,7 @@
 // rclcpp.hpp included in record_fixture.hpp must be included before process_execution_helpers.hpp
 #include "record_fixture.hpp"
 #include "process_execution_helpers.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
 
 TEST_F(RecordFixture, record_end_to_end_test) {
   auto message = get_messages_primitives()[0];
@@ -40,6 +41,22 @@ TEST_F(RecordFixture, record_end_to_end_test) {
     });
 
   stop_execution(process_handle);
+
+  // TODO(Martin-Idel-SI): Find out how to correctly send a Ctrl-C signal on Windows
+  // This is necessary as the process is killed hard on Windows and doesn't write a metadata file
+#ifdef _WIN32
+  rosbag2_storage::BagMetadata metadata{};
+  metadata.version = 1;
+  metadata.storage_identifier = "sqlite3";
+  metadata.storage_format = "cdr";
+  metadata.relative_file_paths.emplace_back("bag.db3");
+  metadata.duration = std::chrono::nanoseconds(0);
+  metadata.starting_time =
+    std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));
+  metadata.message_count = 0;
+  rosbag2_storage::MetadataIo metadata_io;
+  metadata_io.write_metadata(bag_path_, metadata);
+#endif
 
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Primitives>("/test_topic");
   EXPECT_THAT(test_topic_messages, SizeIs(Ge(expected_test_messages)));

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(shared_queues_vendor REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_transport/player.cpp
+  src/rosbag2_transport/formatter.cpp
   src/rosbag2_transport/generic_publisher.cpp
   src/rosbag2_transport/generic_subscription.cpp
   src/rosbag2_transport/recorder.cpp
@@ -79,6 +80,14 @@ if(BUILD_TESTING)
   find_package(rosbag2_test_common REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  ament_add_gmock(test_info
+    test/rosbag2_transport/test_info.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_info)
+    target_link_libraries(test_info rosbag2_transport)
+    ament_target_dependencies(test_info rosbag2_test_common)
+  endif()
+
   ament_add_gmock(test_record
     test/rosbag2_transport/test_record.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -128,6 +137,14 @@ if(BUILD_TESTING)
       rclcpp
       test_msgs
       rosbag2_test_common)
+  endif()
+
+  ament_add_gmock(test_formatter
+    test/rosbag2_transport/test_formatter.cpp
+    src/rosbag2_transport/formatter.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_formatter)
+    target_link_libraries(test_formatter rosbag2_transport)
   endif()
 endif()
 

--- a/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
@@ -32,10 +32,7 @@
 namespace rosbag2_transport
 {
 
-class GenericPublisher;
-class GenericSubscription;
 class Rosbag2Node;
-class Player;
 
 class Rosbag2Transport
 {

--- a/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include "rosbag2/info.hpp"
 #include "rosbag2/sequential_reader.hpp"
 #include "rosbag2/writer.hpp"
 #include "rosbag2_transport/play_options.hpp"
@@ -46,7 +47,9 @@ public:
   /// Constructor for testing, allows to set the reader and writer to use
   ROSBAG2_TRANSPORT_PUBLIC
   Rosbag2Transport(
-    std::shared_ptr<rosbag2::SequentialReader> reader, std::shared_ptr<rosbag2::Writer> writer);
+    std::shared_ptr<rosbag2::SequentialReader> reader,
+    std::shared_ptr<rosbag2::Writer> writer,
+    std::shared_ptr<rosbag2::Info> info);
 
   ROSBAG2_TRANSPORT_PUBLIC
   void init();
@@ -73,11 +76,20 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   void play(const StorageOptions & storage_options, const PlayOptions & play_options);
 
+  /**
+   * Print the bag info contained in the metadata yaml file.
+   *
+   * \param uri path to the metadata yaml file.
+   */
+  ROSBAG2_TRANSPORT_PUBLIC
+  void print_bag_info(const std::string & uri);
+
 private:
   std::shared_ptr<Rosbag2Node> setup_node();
 
   std::shared_ptr<rosbag2::SequentialReader> reader_;
   std::shared_ptr<rosbag2::Writer> writer_;
+  std::shared_ptr<rosbag2::Info> info_;
 
   std::shared_ptr<Rosbag2Node> transport_node_;
 };

--- a/rosbag2_transport/src/rosbag2_transport/formatter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.cpp
@@ -1,0 +1,131 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formatter.hpp"
+
+#include <chrono>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <time.h>
+#endif
+
+namespace rosbag2_transport
+{
+
+std::map<std::string, std::string> Formatter::format_duration(
+  std::chrono::high_resolution_clock::duration duration)
+{
+  std::map<std::string, std::string> formatted_duration;
+  auto m_seconds = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(m_seconds);
+  std::string fractional_seconds = std::to_string(m_seconds.count() % 1000);
+  std::time_t std_time_point = seconds.count();
+  tm time;
+#ifdef _WIN32
+  localtime_s(&time, &std_time_point);
+#else
+  localtime_r(&std_time_point, &time);
+#endif
+
+  std::stringstream formatted_date;
+  std::stringstream formatted_time;
+  formatted_date << std::put_time(&time, "%b %e %Y");
+  formatted_time << std::put_time(&time, "%H:%M:%S") << "." << fractional_seconds;
+  formatted_duration["date"] = formatted_date.str();
+  formatted_duration["time"] = formatted_time.str();
+  formatted_duration["time_in_sec"] = std::to_string(seconds.count()) + "." + fractional_seconds;
+
+  return formatted_duration;
+}
+
+std::string Formatter::format_time_point(
+  std::chrono::high_resolution_clock::duration duration)
+{
+  auto formatted_duration = format_duration(duration);
+  return formatted_duration["date"] + " " + formatted_duration["time"] +
+         " (" + formatted_duration["time_in_sec"] + ")";
+}
+
+std::string Formatter::format_file_size(size_t file_size)
+{
+  double size = static_cast<double>(file_size);
+  static const char * units[] = {"B", "KiB", "MiB", "GiB", "TiB"};
+  double reference_number_bytes = 1024;
+  int index = 0;
+  while (size >= reference_number_bytes && index < 4) {
+    size /= reference_number_bytes;
+    index++;
+  }
+
+  std::stringstream rounded_size;
+  int size_format_precision = index == 0 ? 0 : 1;
+  rounded_size << std::setprecision(size_format_precision) << std::fixed << size;
+  return rounded_size.str() + " " + units[index];
+}
+
+void Formatter::format_file_paths(
+  std::vector<std::string> paths, std::stringstream & info_stream, int indentation_spaces)
+{
+  if (paths.empty()) {
+    info_stream << std::endl;
+    return;
+  }
+
+  size_t number_of_files = paths.size();
+  for (size_t i = 0; i < number_of_files; i++) {
+    if (i == 0) {
+      info_stream << paths[i] << std::endl;
+    } else {
+      indent(info_stream, indentation_spaces);
+      info_stream << paths[i] << std::endl;
+    }
+  }
+}
+
+void Formatter::format_topics_with_type(
+  std::vector<rosbag2::TopicMetadata> topics,
+  std::stringstream & info_stream,
+  int indentation_spaces)
+{
+  if (topics.empty()) {
+    info_stream << std::endl;
+    return;
+  }
+
+  size_t number_of_topics = topics.size();
+  for (size_t j = 0; j < number_of_topics; ++j) {
+    std::string topic_with_type = topics[j].topic_with_type.name + "; " +
+      topics[j].topic_with_type.type + "; " + std::to_string(topics[j].message_count) + " msgs\n";
+    if (j == 0) {
+      info_stream << topic_with_type;
+    } else {
+      indent(info_stream, indentation_spaces);
+      info_stream << topic_with_type;
+    }
+  }
+}
+
+void Formatter::indent(std::stringstream & info_stream, int number_of_spaces)
+{
+  for (int i = 0; i < number_of_spaces; i++) {
+    info_stream << " ";
+  }
+}
+
+}  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/formatter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.hpp
@@ -1,0 +1,47 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_TRANSPORT__FORMATTER_HPP_
+#define ROSBAG2_TRANSPORT__FORMATTER_HPP_
+
+#include <chrono>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "rosbag2/types.hpp"
+
+namespace rosbag2_transport
+{
+
+class Formatter
+{
+public:
+  static std::map<std::string, std::string> format_duration(
+    std::chrono::high_resolution_clock::duration duration);
+  static std::string format_time_point(std::chrono::high_resolution_clock::duration time_point);
+  static std::string format_file_size(size_t file_size);
+  static void format_file_paths(
+    std::vector<std::string> paths, std::stringstream & info_stream, int indentation_spaces);
+  static void format_topics_with_type(
+    std::vector<rosbag2::TopicMetadata>, std::stringstream & info_stream, int indentation_spaces);
+
+private:
+  static void indent(std::stringstream & info_stream, int number_of_spaces);
+};
+
+}  // namespace rosbag2_transport
+
+#endif  // ROSBAG2_TRANSPORT__FORMATTER_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -104,21 +104,21 @@ void Rosbag2Transport::print_bag_info(const std::string & uri)
   auto end_time = start_time + metadata.duration;
   auto formatter = std::make_unique<Formatter>();
   std::stringstream info_stream;
-  int indentation_spaces = 18;  // just the longest info field (Topics with Type:) plus one space.
+  int indentation_spaces = 22;  // The longest info field (Serialization format:) plus one space.
 
   info_stream << std::endl;
-  info_stream << "Files:            ";
+  info_stream << "Files:                ";
   formatter->format_file_paths(metadata.relative_file_paths, info_stream, indentation_spaces);
-  info_stream << "Bag size:         " << formatter->format_file_size(
+  info_stream << "Bag size:             " << formatter->format_file_size(
     metadata.bag_size) << std::endl;
-  info_stream << "Storage id:       " << metadata.storage_identifier << std::endl;
-  info_stream << "Storage format:   " << metadata.storage_format << std::endl;
-  info_stream << "Duration:         " << formatter->format_duration(
+  info_stream << "Storage id:           " << metadata.storage_identifier << std::endl;
+  info_stream << "Serialization format: " << metadata.serialization_format << std::endl;
+  info_stream << "Duration:             " << formatter->format_duration(
     metadata.duration)["time_in_sec"] << "s" << std::endl;
-  info_stream << "Start:            " << formatter->format_time_point(start_time) << std::endl;
-  info_stream << "End               " << formatter->format_time_point(end_time) << std::endl;
-  info_stream << "Messages:         " << metadata.message_count << std::endl;
-  info_stream << "Topics with Type: ";
+  info_stream << "Start:                " << formatter->format_time_point(start_time) << std::endl;
+  info_stream << "End                   " << formatter->format_time_point(end_time) << std::endl;
+  info_stream << "Messages:             " << metadata.message_count << std::endl;
+  info_stream << "Topics with Type:     ";
   formatter->format_topics_with_type(
     metadata.topics_with_message_count, info_stream, indentation_spaces);
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -62,12 +62,16 @@ void Rosbag2Transport::shutdown()
 void Rosbag2Transport::record(
   const StorageOptions & storage_options, const RecordOptions & record_options)
 {
-  writer_->open(storage_options);
+  try {
+    writer_->open(storage_options);
 
-  auto transport_node = setup_node();
+    auto transport_node = setup_node();
 
-  Recorder recorder(writer_, transport_node);
-  recorder.record(record_options);
+    Recorder recorder(writer_, transport_node);
+    recorder.record(record_options);
+  } catch (std::runtime_error & e) {
+    ROSBAG2_TRANSPORT_LOG_ERROR("Failed to record: %s", e.what());
+  }
 }
 
 std::shared_ptr<Rosbag2Node> Rosbag2Transport::setup_node()
@@ -81,12 +85,16 @@ std::shared_ptr<Rosbag2Node> Rosbag2Transport::setup_node()
 void Rosbag2Transport::play(
   const StorageOptions & storage_options, const PlayOptions & play_options)
 {
-  reader_->open(storage_options);
+  try {
+    reader_->open(storage_options);
 
-  auto transport_node = setup_node();
+    auto transport_node = setup_node();
 
-  Player player(reader_, transport_node);
-  player.play(play_options);
+    Player player(reader_, transport_node);
+    player.play(play_options);
+  } catch (std::runtime_error & e) {
+    ROSBAG2_TRANSPORT_LOG_ERROR("Failed to play: %s", e.what());
+  }
 }
 
 void Rosbag2Transport::print_bag_info(const std::string & uri)

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -99,30 +99,37 @@ void Rosbag2Transport::play(
 
 void Rosbag2Transport::print_bag_info(const std::string & uri)
 {
-  auto metadata = info_->read_metadata(uri);
-  auto start_time = metadata.starting_time.time_since_epoch();
-  auto end_time = start_time + metadata.duration;
-  auto formatter = std::make_unique<Formatter>();
-  std::stringstream info_stream;
-  int indentation_spaces = 22;  // The longest info field (Serialization format:) plus one space.
+  try {
+    auto metadata = info_->read_metadata(uri);
+    auto start_time = metadata.starting_time.time_since_epoch();
+    auto end_time = start_time + metadata.duration;
+    auto formatter = std::make_unique<Formatter>();
+    std::stringstream info_stream;
+    int indentation_spaces = 22;  // The longest info field (Serialization format:) plus one space.
 
-  info_stream << std::endl;
-  info_stream << "Files:                ";
-  formatter->format_file_paths(metadata.relative_file_paths, info_stream, indentation_spaces);
-  info_stream << "Bag size:             " << formatter->format_file_size(
-    metadata.bag_size) << std::endl;
-  info_stream << "Storage id:           " << metadata.storage_identifier << std::endl;
-  info_stream << "Serialization format: " << metadata.serialization_format << std::endl;
-  info_stream << "Duration:             " << formatter->format_duration(
-    metadata.duration)["time_in_sec"] << "s" << std::endl;
-  info_stream << "Start:                " << formatter->format_time_point(start_time) << std::endl;
-  info_stream << "End                   " << formatter->format_time_point(end_time) << std::endl;
-  info_stream << "Messages:             " << metadata.message_count << std::endl;
-  info_stream << "Topics with Type:     ";
-  formatter->format_topics_with_type(
-    metadata.topics_with_message_count, info_stream, indentation_spaces);
+    info_stream << std::endl;
+    info_stream << "Files:                ";
+    formatter->format_file_paths(metadata.relative_file_paths, info_stream, indentation_spaces);
+    info_stream << "Bag size:             " << formatter->format_file_size(
+      metadata.bag_size) << std::endl;
+    info_stream << "Storage id:           " << metadata.storage_identifier << std::endl;
+    info_stream << "Serialization format: " << metadata.serialization_format << std::endl;
+    info_stream << "Duration:             " << formatter->format_duration(
+      metadata.duration)["time_in_sec"] << "s" << std::endl;
+    info_stream << "Start:                " << formatter->format_time_point(start_time) <<
+      std::endl;
+    info_stream << "End                   " << formatter->format_time_point(end_time) << std::endl;
+    info_stream << "Messages:             " << metadata.message_count << std::endl;
+    info_stream << "Topics with Type:     ";
+    formatter->format_topics_with_type(
+      metadata.topics_with_message_count, info_stream, indentation_spaces);
 
-  std::cout << info_stream.str() << std::endl;
+    std::cout << info_stream.str() << std::endl;
+  } catch (std::runtime_error & e) {
+    (void) e;
+    ROSBAG2_TRANSPORT_LOG_ERROR_STREAM("Could not read metadata for " << uri << ". Please specify "
+      "the path to the folder containing an existing 'metadata.yaml' file");
+  }
 }
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -99,37 +99,39 @@ void Rosbag2Transport::play(
 
 void Rosbag2Transport::print_bag_info(const std::string & uri)
 {
+  rosbag2::BagMetadata metadata;
   try {
-    auto metadata = info_->read_metadata(uri);
-    auto start_time = metadata.starting_time.time_since_epoch();
-    auto end_time = start_time + metadata.duration;
-    auto formatter = std::make_unique<Formatter>();
-    std::stringstream info_stream;
-    int indentation_spaces = 22;  // The longest info field (Serialization format:) plus one space.
-
-    info_stream << std::endl;
-    info_stream << "Files:                ";
-    formatter->format_file_paths(metadata.relative_file_paths, info_stream, indentation_spaces);
-    info_stream << "Bag size:             " << formatter->format_file_size(
-      metadata.bag_size) << std::endl;
-    info_stream << "Storage id:           " << metadata.storage_identifier << std::endl;
-    info_stream << "Serialization format: " << metadata.serialization_format << std::endl;
-    info_stream << "Duration:             " << formatter->format_duration(
-      metadata.duration)["time_in_sec"] << "s" << std::endl;
-    info_stream << "Start:                " << formatter->format_time_point(start_time) <<
-      std::endl;
-    info_stream << "End                   " << formatter->format_time_point(end_time) << std::endl;
-    info_stream << "Messages:             " << metadata.message_count << std::endl;
-    info_stream << "Topics with Type:     ";
-    formatter->format_topics_with_type(
-      metadata.topics_with_message_count, info_stream, indentation_spaces);
-
-    std::cout << info_stream.str() << std::endl;
+    metadata = info_->read_metadata(uri);
   } catch (std::runtime_error & e) {
     (void) e;
     ROSBAG2_TRANSPORT_LOG_ERROR_STREAM("Could not read metadata for " << uri << ". Please specify "
       "the path to the folder containing an existing 'metadata.yaml' file");
+    return;
   }
+  auto start_time = metadata.starting_time.time_since_epoch();
+  auto end_time = start_time + metadata.duration;
+  auto formatter = std::make_unique<Formatter>();
+  std::stringstream info_stream;
+  int indentation_spaces = 22;  // The longest info field (Serialization format:) plus one space.
+
+  info_stream << std::endl;
+  info_stream << "Files:                ";
+  formatter->format_file_paths(metadata.relative_file_paths, info_stream, indentation_spaces);
+  info_stream << "Bag size:             " << formatter->format_file_size(
+    metadata.bag_size) << std::endl;
+  info_stream << "Storage id:           " << metadata.storage_identifier << std::endl;
+  info_stream << "Serialization format: " << metadata.serialization_format << std::endl;
+  info_stream << "Duration:             " << formatter->format_duration(
+    metadata.duration)["time_in_sec"] << "s" << std::endl;
+  info_stream << "Start:                " << formatter->format_time_point(start_time) <<
+    std::endl;
+  info_stream << "End                   " << formatter->format_time_point(end_time) << std::endl;
+  info_stream << "Messages:             " << metadata.message_count << std::endl;
+  info_stream << "Topics with Type:     ";
+  formatter->format_topics_with_type(
+    metadata.topics_with_message_count, info_stream, indentation_spaces);
+
+  std::cout << info_stream.str() << std::endl;
 }
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -98,6 +98,24 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   Py_RETURN_NONE;
 }
 
+static PyObject *
+rosbag2_transport_info(PyObject * Py_UNUSED(self), PyObject * args, PyObject * kwargs)
+{
+  static const char * kwlist[] = {"uri", nullptr};
+
+  char * char_uri;
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s", const_cast<char **>(kwlist), &char_uri)) {
+    return nullptr;
+  }
+
+  std::string uri = std::string(char_uri);
+
+  rosbag2_transport::Rosbag2Transport transport;
+  transport.print_bag_info(uri);
+
+  Py_RETURN_NONE;
+}
+
 /// Define the public methods of this module
 static PyMethodDef rosbag2_transport_methods[] = {
   {
@@ -107,6 +125,10 @@ static PyMethodDef rosbag2_transport_methods[] = {
   {
     "play", reinterpret_cast<PyCFunction>(rosbag2_transport_play), METH_VARARGS | METH_KEYWORDS,
     "Play bag"
+  },
+  {
+    "info", reinterpret_cast<PyCFunction>(rosbag2_transport_info), METH_VARARGS | METH_KEYWORDS,
+    "Print bag info"
   },
   {nullptr, nullptr, 0, nullptr}  /* sentinel */
 };

--- a/rosbag2_transport/test/rosbag2_transport/mock_info.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_info.hpp
@@ -25,7 +25,7 @@
 class MockInfo : public rosbag2::Info
 {
 public:
-  MOCK_METHOD1(read_metadata, rosbag2::BagMetadata(const std::string &));
+  MOCK_METHOD2(read_metadata, rosbag2::BagMetadata(const std::string &, const std::string &));
 };
 
 #endif  // ROSBAG2_TRANSPORT__MOCK_INFO_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/mock_info.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_info.hpp
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__TYPES_HPP_
-#define ROSBAG2__TYPES_HPP_
+#ifndef ROSBAG2_TRANSPORT__MOCK_INFO_HPP_
+#define ROSBAG2_TRANSPORT__MOCK_INFO_HPP_
 
-#include "rosbag2_storage/bag_metadata.hpp"
-#include "rosbag2_storage/serialized_bag_message.hpp"
-#include "rosbag2_storage/topic_with_type.hpp"
+#include <gmock/gmock.h>
 
-namespace rosbag2
+#include <string>
+
+#include "rosbag2/info.hpp"
+#include "rosbag2/types.hpp"
+
+class MockInfo : public rosbag2::Info
 {
-using BagMetadata = rosbag2_storage::BagMetadata;
-using SerializedBagMessage = rosbag2_storage::SerializedBagMessage;
-using TopicMetadata = rosbag2_storage::TopicMetadata;
-using TopicWithType = rosbag2_storage::TopicWithType;
-}  // namespace rosbag2
+public:
+  MOCK_METHOD1(read_metadata, rosbag2::BagMetadata(const std::string &));
+};
 
-#endif  // ROSBAG2__TYPES_HPP_
+#endif  // ROSBAG2_TRANSPORT__MOCK_INFO_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
@@ -51,7 +51,7 @@ public:
     // the future object returned from std::async needs to be stored not to block the execution
     future_ = std::async(
       std::launch::async, [this, options]() {
-        rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_);
+        rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
         rosbag2_transport.record(storage_options_, options);
       });
   }

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -36,6 +36,8 @@
 #include "rosbag2/types.hpp"
 #include "rosbag2/writer.hpp"
 #include "rosbag2_test_common/memory_management.hpp"
+
+#include "mock_info.hpp"
 #include "mock_sequential_reader.hpp"
 #include "mock_writer.hpp"
 
@@ -57,7 +59,8 @@ public:
   Rosbag2TransportTestFixture()
   : storage_options_({"uri", "storage_id"}), play_options_({1000}),
     reader_(std::make_shared<MockSequentialReader>()),
-    writer_(std::make_shared<MockWriter>()) {}
+    writer_(std::make_shared<MockWriter>()),
+    info_(std::make_shared<MockInfo>()) {}
 
   template<typename MessageT>
   std::shared_ptr<rosbag2::SerializedBagMessage>
@@ -81,6 +84,7 @@ public:
 
   std::shared_ptr<MockSequentialReader> reader_;
   std::shared_ptr<MockWriter> writer_;
+  std::shared_ptr<MockInfo> info_;
 };
 
 #endif  // ROSBAG2_TRANSPORT__ROSBAG2_TRANSPORT_TEST_FIXTURE_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
@@ -1,0 +1,92 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "../../src/rosbag2_transport/formatter.hpp"
+
+using namespace ::testing;  // NOLINT
+using namespace std::chrono_literals;  // NOLINT
+
+class FormatterTestFixture : public Test
+{
+public:
+  FormatterTestFixture()
+  : formatter_(std::make_unique<rosbag2_transport::Formatter>()), indentation_spaces_(18) {}
+
+  std::unique_ptr<rosbag2_transport::Formatter> formatter_;
+  int indentation_spaces_;
+};
+
+TEST_F(FormatterTestFixture, format_file_size_returns_correct_format) {
+  size_t zero_bytes = 0;
+  size_t thirty_bytes = 30;
+  size_t two_kibibytes = 2048;
+  size_t two_point_twelve_kibibytes = 3195;
+  size_t one_and_a_half_mebibytes = 1536 * 1024;
+  size_t one_tebibite = static_cast<size_t>(pow(1024, 4));
+  size_t one_pebibyte = static_cast<size_t>(pow(1024, 5));
+
+  EXPECT_THAT(formatter_->format_file_size(zero_bytes), Eq("0 B"));
+  EXPECT_THAT(formatter_->format_file_size(thirty_bytes), Eq("30 B"));
+  EXPECT_THAT(formatter_->format_file_size(two_kibibytes), Eq("2.0 KiB"));
+  EXPECT_THAT(formatter_->format_file_size(two_point_twelve_kibibytes), Eq("3.1 KiB"));
+  EXPECT_THAT(formatter_->format_file_size(one_and_a_half_mebibytes), Eq("1.5 MiB"));
+  EXPECT_THAT(formatter_->format_file_size(one_tebibite), Eq("1.0 TiB"));
+  EXPECT_THAT(formatter_->format_file_size(one_pebibyte), Eq("1024.0 TiB"));
+}
+
+TEST_F(FormatterTestFixture, format_files_correctly_layouts_more_paths) {
+  std::vector<std::string> paths = {"first/file/path", "second/file", "third/path/"};
+  std::stringstream formatted_output;
+
+  formatter_->format_file_paths(paths, formatted_output, indentation_spaces_);
+  EXPECT_THAT(formatted_output.str(), Eq(
+      "first/file/path\n"
+      "                  second/file\n"
+      "                  third/path/\n"));
+}
+
+TEST_F(FormatterTestFixture, format_files_prints_newline_if_there_are_no_paths) {
+  std::vector<std::string> paths = {};
+  std::stringstream formatted_output;
+
+  formatter_->format_file_paths(paths, formatted_output, 0);
+  EXPECT_THAT(formatted_output.str(), Eq("\n"));
+}
+
+TEST_F(FormatterTestFixture, format_topics_with_type_correctly_layouts_more_topics) {
+  std::vector<rosbag2::TopicMetadata> topics;
+  topics.push_back({{"topic1", "type1"}, 100});
+  topics.push_back({{"topic2", "type2"}, 200});
+  std::stringstream formatted_output;
+
+  formatter_->format_topics_with_type(topics, formatted_output, indentation_spaces_);
+  EXPECT_THAT(formatted_output.str(), Eq("topic1; type1; 100 msgs\n"
+    "                  topic2; type2; 200 msgs\n"));
+}
+
+TEST_F(FormatterTestFixture, format_topics_with_type_prints_newline_if_there_are_no_topics) {
+  std::vector<rosbag2::TopicMetadata> topics = {};
+  std::stringstream formatted_output;
+
+  formatter_->format_topics_with_type(topics, formatted_output, 0);
+  EXPECT_THAT(formatted_output.str(), Eq("\n"));
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_info.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_info.cpp
@@ -1,0 +1,64 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <future>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosbag2/types.hpp"
+#include "rosbag2_transport/rosbag2_transport.hpp"
+#include "rosbag2_transport_test_fixture.hpp"
+
+using namespace ::testing;  // NOLINT
+
+TEST_F(Rosbag2TransportTestFixture, info_pretty_prints_information_from_bagfile)
+{
+  internal::CaptureStdout();
+
+  rosbag2::BagMetadata bagfile;
+  bagfile.storage_identifier = "sqlite3";
+  bagfile.storage_format = "cdr";
+  bagfile.relative_file_paths.emplace_back("some_relative_path");
+  bagfile.relative_file_paths.emplace_back("some_other_relative_path");
+  bagfile.starting_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
+    std::chrono::nanoseconds(1538051985348887471));    // corresponds to Sept 27 14:39:45.348
+  bagfile.duration = std::chrono::nanoseconds(50000000);
+  bagfile.message_count = 50;
+  bagfile.topics_with_message_count.push_back({{"topic1", "type1"}, 100});
+  bagfile.topics_with_message_count.push_back({{"topic2", "type2"}, 200});
+  EXPECT_CALL(*info_, read_metadata(_)).WillOnce(Return(bagfile));
+
+  // the expected output uses a regex to handle different time zones.
+  rosbag2_transport::Rosbag2Transport transport(reader_, writer_, info_);
+  transport.print_bag_info("test");
+  std::string expected_output(
+    "\nFiles:            some_relative_path\n"
+    "                  some_other_relative_path\n"
+    "Bag size:         0 B\n"
+    "Storage id:       sqlite3\n"
+    "Storage format:   cdr\n"
+    "Duration:         0\\.50s\n"
+    "Start:            Sep .+ 2018 .+:.+:45\\.348 \\(1538051985\\.348\\)\n"
+    "End               Sep .+ 2018 .+:.+:45\\.398 \\(1538051985\\.398\\)\n"
+    "Messages:         50\n"
+    "Topics with Type: topic1; type1; 100 msgs\n"
+    "                  topic2; type2; 200 msgs\n\n");
+
+  std::string output = internal::GetCapturedStdout();
+  EXPECT_THAT(output, ContainsRegex(expected_output));
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_info.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_info.cpp
@@ -41,7 +41,7 @@ TEST_F(Rosbag2TransportTestFixture, info_pretty_prints_information_from_bagfile)
   bagfile.message_count = 50;
   bagfile.topics_with_message_count.push_back({{"topic1", "type1"}, 100});
   bagfile.topics_with_message_count.push_back({{"topic2", "type2"}, 200});
-  EXPECT_CALL(*info_, read_metadata(_)).WillOnce(Return(bagfile));
+  EXPECT_CALL(*info_, read_metadata(_, _)).WillOnce(Return(bagfile));
 
   // the expected output uses a regex to handle different time zones.
   rosbag2_transport::Rosbag2Transport transport(reader_, writer_, info_);

--- a/rosbag2_transport/test/rosbag2_transport/test_info.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_info.cpp
@@ -32,7 +32,7 @@ TEST_F(Rosbag2TransportTestFixture, info_pretty_prints_information_from_bagfile)
 
   rosbag2::BagMetadata bagfile;
   bagfile.storage_identifier = "sqlite3";
-  bagfile.storage_format = "cdr";
+  bagfile.serialization_format = "cdr";
   bagfile.relative_file_paths.emplace_back("some_relative_path");
   bagfile.relative_file_paths.emplace_back("some_other_relative_path");
   bagfile.starting_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
@@ -47,17 +47,17 @@ TEST_F(Rosbag2TransportTestFixture, info_pretty_prints_information_from_bagfile)
   rosbag2_transport::Rosbag2Transport transport(reader_, writer_, info_);
   transport.print_bag_info("test");
   std::string expected_output(
-    "\nFiles:            some_relative_path\n"
-    "                  some_other_relative_path\n"
-    "Bag size:         0 B\n"
-    "Storage id:       sqlite3\n"
-    "Storage format:   cdr\n"
-    "Duration:         0\\.50s\n"
-    "Start:            Sep .+ 2018 .+:.+:45\\.348 \\(1538051985\\.348\\)\n"
-    "End               Sep .+ 2018 .+:.+:45\\.398 \\(1538051985\\.398\\)\n"
-    "Messages:         50\n"
-    "Topics with Type: topic1; type1; 100 msgs\n"
-    "                  topic2; type2; 200 msgs\n\n");
+    "\nFiles:                some_relative_path\n"
+    "                      some_other_relative_path\n"
+    "Bag size:             0 B\n"
+    "Storage id:           sqlite3\n"
+    "Serialization format: cdr\n"
+    "Duration:             0\\.50s\n"
+    "Start:                Sep .+ 2018 .+:.+:45\\.348 \\(1538051985\\.348\\)\n"
+    "End                   Sep .+ 2018 .+:.+:45\\.398 \\(1538051985\\.398\\)\n"
+    "Messages:             50\n"
+    "Topics with Type:     topic1; type1; 100 msgs\n"
+    "                      topic2; type2; 200 msgs\n\n");
 
   std::string output = internal::GetCapturedStdout();
   EXPECT_THAT(output, ContainsRegex(expected_output));

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -85,7 +85,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  Rosbag2Transport rosbag2_transport(reader_, writer_);
+  Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
   rosbag2_transport.play(storage_options_, play_options_);
 
   await_received_messages.get();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -54,7 +54,7 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_relative_timing_of_stored_m
   // we check that time elapsed during playing is at least the time difference between the two
   // messages
   auto start = std::chrono::steady_clock::now();
-  Rosbag2Transport rosbag2_transport(reader_, writer_);
+  Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
   rosbag2_transport.play(storage_options_, play_options_);
   auto replay_time = std::chrono::steady_clock::now() - start;
 


### PR DESCRIPTION
This PR adds a new ros2 bag CLI verb `info` which prints a summary of a bag content.

The printout looks like this:
```
$ ros2 bag info 2018_10_04-11_08_21

Files:            2018_10_04-11_08_21.db3
Bag size:         44.4 KiB
Storage id:       sqlite3
Storage format:   cdr
Duration:         21.3s
Start:            Oct  4 2018 11:08:21.483 (1538644101.483)
End               Oct  4 2018 11:08:42.486 (1538644122.486)
Messages:         22
Topics with Type: /string_topic; std_msgs/String; 22 msgs
```

These infos are stored in a metadata file at the end of the record process to allow getting infos about a bag without inspecting its content.
This is necessary since the user might not have access to the storage backend used to record the bagfile.
As a result, `rviz_yaml_cpp_vendor` is required as a dependency.

This PR is based on the changes introduced in #43 and contains these changes.
Therefore, this PR should be merged after #43.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5285)](http://ci.ros2.org/job/ci_linux/5285/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2039)](http://ci.ros2.org/job/ci_linux-aarch64/2039/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4401)](http://ci.ros2.org/job/ci_osx/4401/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5264)](http://ci.ros2.org/job/ci_windows/5264/)

