### PR TITLE
[WIP] Add C Interface to rosbag2

### DIFF
--- a/rosbag2/include/rosbag2/rosbag2.h
+++ b/rosbag2/include/rosbag2/rosbag2.h
@@ -1,0 +1,33 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__ROSBAG2_H_
+#define ROSBAG2__ROSBAG2_H_
+
+#include "rcutils/types.h"
+#include "rmw/names_and_types.h"
+#include "rosbag2/types/bag_handle.h"
+#include "rosbag2/types/bag_metadata.h"
+#include "rosbag2/types/serialized_bag_message.h"
+#include "rosbag2/types/sequential_reader.h"
+#include "rosbag2/types/writer.h"
+
+extern "C"
+{
+
+int rosbag2_info(rcutils_char_array_t * uri, rosbag2_bag_metadata_t * bag_metadata);
+
+};
+
+#endif  // ROSBAG2__ROSBAG2_H_

--- a/rosbag2/include/rosbag2/types/bag_handle.h
+++ b/rosbag2/include/rosbag2/types/bag_handle.h
@@ -1,0 +1,49 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__BAG_HANDLE_H_
+#define ROSBAG2__BAG_HANDLE_H_
+
+#include "rcutils/types.h"
+#include "rosbag2/visibility_control.hpp"
+
+extern "C"
+{
+
+typedef struct rosbag2_bag_handle_t
+{
+  rcutils_char_array_t uri;
+  rcutils_char_array_t storage_identifier;
+  rcutils_char_array_t storage_format;
+  rcutils_allocator_t allocator;
+} rosbag2_bag_handle_t;
+
+rosbag2_bag_handle_t get_zero_initialized_bag_handle();
+
+RCUTILS_WARN_UNUSED
+ROSBAG2_PUBLIC
+int rosbag2_bag_handle_init(
+  rosbag2_bag_handle_t * bag_handle,
+  char * uri,
+  char * storage_identifier,
+  char * storage_format,
+  const rcutils_allocator_t * allocator);
+
+RCUTILS_WARN_UNUSED
+ROSBAG2_PUBLIC
+int rosbag2_bag_handle_fini(rosbag2_bag_handle_t * bag_handle);
+
+};
+
+#endif //ROSBAG2__BAG_HANDLE_H_

--- a/rosbag2/include/rosbag2/types/bag_handle.h
+++ b/rosbag2/include/rosbag2/types/bag_handle.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__BAG_HANDLE_H_
-#define ROSBAG2__BAG_HANDLE_H_
+#ifndef ROSBAG2__TYPES__BAG_HANDLE_H_
+#define ROSBAG2__TYPES__BAG_HANDLE_H_
 
 #include "rcutils/types.h"
 #include "rosbag2/visibility_control.hpp"
@@ -46,4 +46,4 @@ int rosbag2_bag_handle_fini(rosbag2_bag_handle_t * bag_handle);
 
 };
 
-#endif //ROSBAG2__BAG_HANDLE_H_
+#endif // ROSBAG2__TYPES__BAG_HANDLE_H_

--- a/rosbag2/include/rosbag2/types/bag_metadata.h
+++ b/rosbag2/include/rosbag2/types/bag_metadata.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__TYPES_HPP_
-#define ROSBAG2__TYPES_HPP_
+#ifndef ROSBAG2__TYPES__BAG_METADATA_H_
+#define ROSBAG2__TYPES__BAG_METADATA_H_
 
 #include "rcutils/strdup.h"
 
@@ -90,4 +90,4 @@ int rosbag2_topic_metadata_array_fini(rosbag2_topic_metadata_array_t * topic_met
 
 };
 
-#endif  // ROSBAG2__TYPES_HPP_
+#endif  // ROSBAG2__TYPES_BAG_METADATA_H_

--- a/rosbag2/include/rosbag2/types/bag_metadata.h
+++ b/rosbag2/include/rosbag2/types/bag_metadata.h
@@ -1,0 +1,93 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__TYPES_HPP_
+#define ROSBAG2__TYPES_HPP_
+
+#include "rcutils/strdup.h"
+
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/topic_with_type.hpp"
+#include "rosbag2/visibility_control.hpp"
+
+extern "C" {
+
+typedef struct rosbag2_topic_metadata_t
+{
+  size_t message_count;
+  rcutils_char_array_t topic_name;
+  rcutils_char_array_t topic_type;
+} rosbag2_topic_metadata_t;
+
+typedef struct rosbag2_topic_metadata_array_t
+{
+  size_t size;
+  rosbag2_topic_metadata_t * data;
+  rcutils_allocator_t allocator;
+} rosbag2_topic_metadata_array_t;
+
+typedef struct rosbag2_bag_metadata_t
+{
+  int version = 1;
+  size_t bag_size;
+  rcutils_char_array_t storage_identifier;
+  rcutils_char_array_t storage_format;
+  rcutils_string_array_t relative_file_paths;
+  rcutils_time_point_value_t duration;
+  rcutils_time_point_value_t starting_time;
+  size_t message_count;
+  rosbag2_topic_metadata_array_t topics_with_message_count;
+} rosbag2_bag_metadata_t;
+
+ROSBAG2_PUBLIC
+rosbag2_bag_metadata_t get_zero_initialized_bag_metadata();
+
+ROSBAG2_PUBLIC
+RCUTILS_WARN_UNUSED
+int rosbag2_bag_metadata_init(
+  rosbag2_bag_metadata_t * bag_metadata, const rcutils_allocator_t * allocator);
+
+ROSBAG2_PUBLIC
+RCUTILS_WARN_UNUSED
+int rosbag2_bag_metadata_fini(rosbag2_bag_metadata_t * bag_metadata);
+
+ROSBAG2_PUBLIC
+rosbag2_topic_metadata_t get_zero_initialized_topic_metadata();
+
+ROSBAG2_PUBLIC
+RCUTILS_WARN_UNUSED
+int rosbag2_topic_metadata_init(
+  rosbag2_topic_metadata_t * metadata, const rcutils_allocator_t * allocator);
+
+ROSBAG2_PUBLIC
+RCUTILS_WARN_UNUSED
+int rosbag2_topic_metadata_fini(rosbag2_topic_metadata_t * topic_metadata);
+
+rosbag2_topic_metadata_array_t get_zero_initialized_topic_metadata_array();
+
+ROSBAG2_PUBLIC
+RCUTILS_WARN_UNUSED
+int rosbag2_topic_metadata_array_init(
+  rosbag2_topic_metadata_array_t * topic_metadata_array,
+  size_t size,
+  const rcutils_allocator_t * allocator);
+
+ROSBAG2_PUBLIC
+RCUTILS_WARN_UNUSED
+int rosbag2_topic_metadata_array_fini(rosbag2_topic_metadata_array_t * topic_metadata_array);
+
+};
+
+#endif  // ROSBAG2__TYPES_HPP_

--- a/rosbag2/include/rosbag2/types/sequential_reader.h
+++ b/rosbag2/include/rosbag2/types/sequential_reader.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__SEQUENTIAL_READER_H_
-#define ROSBAG2__SEQUENTIAL_READER_H_
+#ifndef ROSBAG2__TYPES__SEQUENTIAL_READER_H_
+#define ROSBAG2__TYPES__SEQUENTIAL_READER_H_
 
 #include "rosbag2/types/bag_handle.h"
 #include "rosbag2/types/serialized_bag_message.h"
@@ -48,4 +48,4 @@ int rosbag2_read_all_topics_and_types(
   rosbag2_sequential_reader_t * reader, rmw_names_and_types_t * topics_and_types);
 };
 
-#endif  // ROSBAG2__SEQUENTIAL_READER_H_
+#endif  // ROSBAG2__TYPES__SEQUENTIAL_READER_H_

--- a/rosbag2/include/rosbag2/types/sequential_reader.h
+++ b/rosbag2/include/rosbag2/types/sequential_reader.h
@@ -1,0 +1,51 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__SEQUENTIAL_READER_H_
+#define ROSBAG2__SEQUENTIAL_READER_H_
+
+#include "rosbag2/types/bag_handle.h"
+#include "rosbag2/types/serialized_bag_message.h"
+
+extern "C"
+{
+
+// internal struct with c++ data members
+// contains std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage;
+// contains std::unique_ptr<rosbag2_storage::Rosbag2StorageFactory> factory;
+struct SequentialReaderImpl;
+
+typedef struct rosbag2_sequential_reader_t
+{
+  SequentialReaderImpl * impl;
+} rosbag2_sequential_reader_t;
+
+rosbag2_sequential_reader_t get_zero_initalized_sequential_reader();
+
+RCUTILS_WARN_UNUSED
+int rosbag2_sequential_reader_init(rosbag2_bag_handle_t * bag_handle);
+
+RCUTILS_WARN_UNUSED
+int rosbag2_sequential_reader_fini(rosbag2_sequential_reader_t * reader);
+
+bool rosbag2_has_next(rosbag2_sequential_reader_t * reader);
+
+int rosbag2_read_next(
+  rosbag2_sequential_reader_t * reader, rosbag2_serialized_bag_message_t * message);
+
+int rosbag2_read_all_topics_and_types(
+  rosbag2_sequential_reader_t * reader, rmw_names_and_types_t * topics_and_types);
+};
+
+#endif  // ROSBAG2__SEQUENTIAL_READER_H_

--- a/rosbag2/include/rosbag2/types/serialized_bag_message.h
+++ b/rosbag2/include/rosbag2/types/serialized_bag_message.h
@@ -1,0 +1,41 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__SERIALIZED_BAG_MESSAGE_H_
+#define ROSBAG2__SERIALIZED_BAG_MESSAGE_H_
+
+#include "rcutils/types.h"
+#include "rcutils/time.h"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+
+extern "C"
+{
+
+typedef rosbag2_serialized_bag_message_t rosbag2_storage_serialized_bag_message_t
+
+rosbag2_serialized_bag_message_t rosbag2_get_zero_initialized_serialized_bag_message();
+
+RCUTILS_WARN_UNUSED
+int rosbag2_serialized_bag_message_init(
+  rosbag2_serialized_bag_message_t * message,
+  int64_t time_stamp,
+  char * topic_name,
+  const rcutils_allocator_t * allocator);
+
+RCUTILS_WARN_UNUSED
+int rosbag2_serialized_bag_message_fini(rosbag2_serialized_bag_message_t * message);
+
+};
+
+#endif //ROSBAG2__SERIALIZED_BAG_MESSAGE_H_

--- a/rosbag2/include/rosbag2/types/serialized_bag_message.h
+++ b/rosbag2/include/rosbag2/types/serialized_bag_message.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__SERIALIZED_BAG_MESSAGE_H_
-#define ROSBAG2__SERIALIZED_BAG_MESSAGE_H_
+#ifndef ROSBAG2__TYPES__SERIALIZED_BAG_MESSAGE_H_
+#define ROSBAG2__TYPES__SERIALIZED_BAG_MESSAGE_H_
 
 #include "rcutils/types.h"
 #include "rcutils/time.h"
@@ -29,7 +29,7 @@ rosbag2_serialized_bag_message_t rosbag2_get_zero_initialized_serialized_bag_mes
 RCUTILS_WARN_UNUSED
 int rosbag2_serialized_bag_message_init(
   rosbag2_serialized_bag_message_t * message,
-  int64_t time_stamp,
+  rcutils_time_point_value_t time_stamp,
   char * topic_name,
   const rcutils_allocator_t * allocator);
 
@@ -38,4 +38,4 @@ int rosbag2_serialized_bag_message_fini(rosbag2_serialized_bag_message_t * messa
 
 };
 
-#endif //ROSBAG2__SERIALIZED_BAG_MESSAGE_H_
+#endif // ROSBAG2__TYPES__SERIALIZED_BAG_MESSAGE_H_

--- a/rosbag2/include/rosbag2/types/writer.h
+++ b/rosbag2/include/rosbag2/types/writer.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__WRITER_H_
-#define ROSBAG2__WRITER_H_
+#ifndef ROSBAG2__TYPES__WRITER_H_
+#define ROSBAG2__TYPES__WRITER_H_
 
 #include "rosbag2/types/bag_handle.h"
 
@@ -44,4 +44,4 @@ int rosbag2_write(
   rosbag2_writer_t * writer, rosbag2_serialized_bag_message_t * message);
 };
 
-#endif  // ROSBAG2__WRITER_H_
+#endif  // ROSBAG2__TYPES__WRITER_H_

--- a/rosbag2/include/rosbag2/types/writer.h
+++ b/rosbag2/include/rosbag2/types/writer.h
@@ -1,0 +1,47 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2__WRITER_H_
+#define ROSBAG2__WRITER_H_
+
+#include "rosbag2/types/bag_handle.h"
+
+extern "C"
+{
+// internal struct with c++ data members
+// contains std::unique_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage;
+// contains std::unique_ptr<rosbag2_storage::Rosbag2StorageFactory> factory;
+struct WriterImpl;
+
+typedef struct rosbag2_writer_t
+{
+  WriterImpl * impl;
+} rosbag2_writer_t;
+
+rosbag2_writer_t get_zero_initalized_writer();
+
+RCUTILS_WARN_UNUSED
+int rosbag2_writer_init(rosbag2_bag_handle_t * bag_handle);
+
+RCUTILS_WARN_UNUSED
+int rosbag2_writer_fini(rosbag2_writer_t * writer);
+
+int rosbag2_create_topic(
+  rosbag2_writer_t * writer, rcutils_char_array_t * topic, rcutils_string_array_t * type);
+
+int rosbag2_write(
+  rosbag2_writer_t * writer, rosbag2_serialized_bag_message_t * message);
+};
+
+#endif  // ROSBAG2__WRITER_H_

--- a/rosbag2_storage/include/rosbag2_storage/serialized_bag_message.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/serialized_bag_message.hpp
@@ -21,16 +21,29 @@
 #include "rcutils/types/char_array.h"
 #include "rcutils/time.h"
 
-namespace rosbag2_storage
+extern "C"
 {
 
-struct SerializedBagMessage
+typedef struct rosbag2_storage_serialized_bag_message_t
 {
-  std::shared_ptr<rcutils_char_array_t> serialized_data;
+  rcutils_char_array_t * serialized_data;
   rcutils_time_point_value_t time_stamp;
-  std::string topic_name;
-};
+  rcutils_char_array_t topic_name;
+  rcutils_allocator_t allocator;
+} rosbag2_storage_serialized_bag_message_t;
 
-}  // namespace rosbag2_storage
+rosbag2_storage_serialized_bag_message_t rosbag2_get_zero_initialized_serialized_bag_message();
+
+RCUTILS_WARN_UNUSED
+int rosbag2_serialized_bag_message_init(
+  rosbag2_storage_serialized_bag_message_t * message,
+  int64_t time_stamp,
+  char * topic_name,
+  const rcutils_allocator_t * allocator);
+
+RCUTILS_WARN_UNUSED
+int rosbag2_serialized_bag_message_fini(rosbag2_storage_serialized_bag_message_t * message);
+
+};
 
 #endif  // ROSBAG2_STORAGE__SERIALIZED_BAG_MESSAGE_HPP_

--- a/rosbag2_storage/include/rosbag2_storage/serialized_bag_message.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/serialized_bag_message.hpp
@@ -37,7 +37,7 @@ rosbag2_storage_serialized_bag_message_t rosbag2_get_zero_initialized_serialized
 RCUTILS_WARN_UNUSED
 int rosbag2_serialized_bag_message_init(
   rosbag2_storage_serialized_bag_message_t * message,
-  int64_t time_stamp,
+  rcutils_time_point_value_t time_stamp,
   char * topic_name,
   const rcutils_allocator_t * allocator);
 


### PR DESCRIPTION
This is a PR to clarify the C interface for rosbag2. The goal is to allow client libraries for different languages (e.g. `rosbag2cpp` and `rosbag2py`) to interact with rosbag2. 

I would assume the introduced classes will then constitute the only headers in `rosbag2`. All other headers will be removed (those are more or less the types I see for `rosbag2cpp`).

### Expected usage:

Record: 
- I subscribe to `rmw_serialized_message_t * `. I initialize a `rosbag2_serialized_bag_message_t *` and plug in the message handle, timestamp and topic type
- I hand the `rosbag2_serialized_bag_message_t *` to the storage layer which takes control over it (needs to be documented)
- If the storage layer is finished, it cleans everything up using the message's allocators

Play:
- I initialize a `rosbag2_serialized_bag_message_t` (in the transport layer) and hand it to the storage layer to be filled.
- I publish the message and afterwards destroy the message (in the transport layer)

Info:
- I initialize a bag handle. I fill it with the directory path and - if I know it - the storage identifier.
- I initialize a bag_metadata struct.
- I hand the bag_metadata to rosbag2, which "actually" initializes it using the information from the yaml file (if available) or reading the storage (only possible if identifier is given).
- I can then do whatever I like with the bag metadata - and when I'm finished, I delete it.

Writer/SequentialReader are used as before. Both contain an opaque struct.

### Questions:
- Should these files have ending `.h` or `.hpp`? Both are ok with me.
- I separated types, except for the subtypes of `bag_metadata` - this is something I left in the same file. If you want (or if these types will be used anywhere else), I'd separate them out. Or would you like them to be separated immediately?
- Which types should get an allocator field? Current rationale: I gave all types an allocator that would be processed from outside, i.e. the bag_metadata, the serialized_message, etc, the bag_handle, but not the writer/reader, because those are just wrappers around the true C++ type which allocates its own memory (I think it'll be difficult to work around this).
- What else do we need at this point?