### PR TITLE
Enable possibility to stop execution of play using ctrl-c

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -118,7 +118,7 @@ void Player::play_messages_from_queue()
 {
   auto start_time = std::chrono::high_resolution_clock::now();
 
-  while (message_queue_.size_approx() != 0 || !is_storage_completely_loaded()) {
+  while ((message_queue_.size_approx() != 0 || !is_storage_completely_loaded()) && rclcpp::ok()) {
     ReplayableMessage message;
     if (message_queue_.try_dequeue(message)) {
       std::this_thread::sleep_until(start_time + message.time_since_start);


### PR DESCRIPTION
With the change introduced in this PR is now possible to interrupt the execution of `ros2 bag play` at any point, by pressing `Ctrl-C`.
This is achieved by checking the state of `rclcpp::ok()` in the play loop.