### PR TITLE
Auto discovery of new topics

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -48,10 +48,12 @@ class RecordVerb(VerbExtension):
              ' rmw currently in use')
         parser.add_argument(
             '--no-discovery', action='store_true',
-            help='disables topic auto discovery during recording')
+            help='disables topic auto discovery during recording: only topics present at '
+             'startup will be recorded')
         parser.add_argument(
             '-p', '--polling-interval', default=100,
-            help='time in ms to wait between querying available topics for recording'
+            help='time in ms to wait between querying available topics for recording. It has no '
+             'effect if --no-discovery is enabled.'
         )
 
     def create_bag_directory(self, uri):

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -46,6 +46,9 @@ class RecordVerb(VerbExtension):
             '-f', '--serialization-format', default='',
             help='rmw serialization format in which the messages are saved, defaults to the'
              ' rmw currently in use')
+        parser.add_argument(
+            '--no-discovery', action='store_true',
+            help='disables topic auto discovery during recording')
 
     def create_bag_directory(self, uri):
         try:
@@ -69,12 +72,14 @@ class RecordVerb(VerbExtension):
                 uri=uri,
                 storage_id=args.storage,
                 serialization_format=args.serialization_format,
-                all=True)
+                all=True,
+                no_discovery=args.no_discovery)
         elif args.topics and len(args.topics) > 0:
             rosbag2_transport_py.record(
                 uri=uri,
                 storage_id=args.storage,
                 serialization_format=args.serialization_format,
+                no_discovery=args.no_discovery,
                 topics=args.topics)
         else:
             self._subparser.print_help()

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -49,6 +49,10 @@ class RecordVerb(VerbExtension):
         parser.add_argument(
             '--no-discovery', action='store_true',
             help='disables topic auto discovery during recording')
+        parser.add_argument(
+            '-p', '--polling-interval', default=100,
+            help='time in ms to wait between querying available topics for recording'
+        )
 
     def create_bag_directory(self, uri):
         try:
@@ -73,13 +77,15 @@ class RecordVerb(VerbExtension):
                 storage_id=args.storage,
                 serialization_format=args.serialization_format,
                 all=True,
-                no_discovery=args.no_discovery)
+                no_discovery=args.no_discovery,
+                polling_interval=args.polling_interval)
         elif args.topics and len(args.topics) > 0:
             rosbag2_transport_py.record(
                 uri=uri,
                 storage_id=args.storage,
                 serialization_format=args.serialization_format,
                 no_discovery=args.no_discovery,
+                polling_interval=args.polling_interval,
                 topics=args.topics)
         else:
             self._subparser.print_help()

--- a/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
@@ -41,9 +41,6 @@ public:
     auto publisher_node = std::make_shared<rclcpp::Node>("publisher" + std::to_string(counter++));
     auto publisher = publisher_node->create_publisher<T>(topic_name);
 
-    // We need to publish one message to set up the topic for discovery
-    publisher->publish(message);
-
     publishers_.push_back([publisher, topic_name, message, expected_messages](
         CountFunction count_stored_messages) {
         if (expected_messages != 0) {

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -25,14 +25,15 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   auto message = get_messages_primitives()[0];
   message->string_value = "test";
   size_t expected_test_messages = 3;
-  pub_man_.add_publisher("/test_topic", message, expected_test_messages);
 
   auto wrong_message = get_messages_primitives()[0];
   wrong_message->string_value = "wrong_content";
-  pub_man_.add_publisher("/wrong_topic", wrong_message);
 
   auto process_handle = start_execution("ros2 bag record --output " + bag_path_ + " /test_topic");
   wait_for_db();
+
+  pub_man_.add_publisher("/test_topic", message, expected_test_messages);
+  pub_man_.add_publisher("/wrong_topic", wrong_message);
 
   rosbag2_storage_plugins::SqliteWrapper
     db(database_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -106,6 +106,14 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_record_all test_msgs rosbag2_test_common)
   endif()
 
+  ament_add_gmock(test_record_all_no_discovery
+    test/rosbag2_transport/test_record_all_no_discovery.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_record_all_no_discovery)
+    target_link_libraries(test_record_all_no_discovery rosbag2_transport)
+    ament_target_dependencies(test_record_all_no_discovery test_msgs rosbag2_test_common)
+  endif()
+
   ament_add_gmock(test_play
     test/rosbag2_transport/test_play.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -27,7 +27,7 @@ public:
   bool all;
   std::vector<std::string> topics;
   std::string rmw_serialization_format;
-  std::chrono::milliseconds topic_polling_frequency;
+  std::chrono::milliseconds topic_polling_interval;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_TRANSPORT__RECORD_OPTIONS_HPP_
 #define ROSBAG2_TRANSPORT__RECORD_OPTIONS_HPP_
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,7 @@ public:
   bool all;
   std::vector<std::string> topics;
   std::string rmw_serialization_format;
+  std::chrono::milliseconds topic_polling_frequency;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -25,6 +25,7 @@ struct RecordOptions
 {
 public:
   bool all;
+  bool is_discovery_disabled;
   std::vector<std::string> topics;
   std::string rmw_serialization_format;
   std::chrono::milliseconds topic_polling_interval;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -74,6 +74,10 @@ std::future<void> Recorder::launch_topics_discovery(
           node_->get_all_topics_with_types() :
           node_->get_topics_with_types(topics);
 
+        if (!topics.empty() && subscriptions_.size() == topics.size()) {
+          return;
+        }
+
         for (const auto & topic_with_type : all_topics_and_types) {
           std::string topic_name = topic_with_type.first;
           bool already_subscribed = std::find(

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -16,11 +16,11 @@
 #define ROSBAG2_TRANSPORT__RECORDER_HPP_
 
 #include <future>
-#include <map>
 #include <memory>
 #include <string>
-#include <vector>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "rosbag2/types.hpp"
 #include "rosbag2/writer.hpp"
@@ -51,8 +51,8 @@ private:
     std::chrono::milliseconds topic_polling_interval,
     const std::vector<std::string> & topics_to_record = {});
   void subscribe_all_missing_topics(
-    const std::map<std::string, std::string> & all_topics_and_types);
-  void subscribe_topic(const rosbag2::TopicWithType & topic_with_type);
+    const std::unordered_map<std::string, std::string> & all_topics_and_types);
+  void subscribe_topic(const rosbag2::TopicMetadata & topic);
   bool is_every_topic_subscribed(const std::vector<std::string> & topics_to_record) const;
   void record_messages() const;
 
@@ -60,6 +60,7 @@ private:
   std::shared_ptr<Rosbag2Node> node_;
   std::vector<std::shared_ptr<GenericSubscription>> subscriptions_;
   std::vector<std::string> subscribed_topics_;
+  std::string serialization_format_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -49,8 +50,8 @@ private:
     const std::string & topic_name, const std::string & topic_type);
   std::future<void> launch_topics_discovery(
     std::chrono::milliseconds topic_polling_interval,
-    bool is_discovery_disabled,
     const std::vector<std::string> & topics_to_record = {});
+  bool subscribe_topics(const std::vector<std::string> & topics_to_record);
   void subscribe_all_missing_topics(
     const std::unordered_map<std::string, std::string> & all_topics_and_types);
   void subscribe_topic(const rosbag2::TopicMetadata & topic);
@@ -60,7 +61,7 @@ private:
   std::shared_ptr<rosbag2::Writer> writer_;
   std::shared_ptr<Rosbag2Node> node_;
   std::vector<std::shared_ptr<GenericSubscription>> subscriptions_;
-  std::vector<std::string> subscribed_topics_;
+  std::unordered_set<std::string> subscribed_topics_;
   std::string serialization_format_;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -48,14 +48,16 @@ public:
 private:
   std::future<void> launch_topics_discovery(
     std::chrono::milliseconds topic_polling_interval,
-    const std::vector<std::string> & topics_to_record = {});
-  bool subscribe_topics(const std::vector<std::string> & topics_to_record);
+    const std::vector<std::string> & requested_topics = {});
+  std::unordered_map<std::string, std::string>
+  get_requested_or_available_topics(const std::vector<std::string> & requested_topics);
+  std::unordered_map<std::string, std::string>
+  get_missing_topics(const std::unordered_map<std::string, std::string> & topics);
+  void subscribe_topics(
+    const std::unordered_map<std::string, std::string> & topics_and_types);
+  void subscribe_topic(const rosbag2::TopicMetadata & topic);
   std::shared_ptr<GenericSubscription> create_subscription(
     const std::string & topic_name, const std::string & topic_type);
-  void subscribe_all_missing_topics(
-    const std::unordered_map<std::string, std::string> & all_topics_and_types);
-  void subscribe_topic(const rosbag2::TopicMetadata & topic);
-  bool is_every_topic_subscribed(const std::vector<std::string> & topics_to_record) const;
   void record_messages() const;
 
   std::shared_ptr<rosbag2::Writer> writer_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -49,6 +49,7 @@ private:
     const std::string & topic_name, const std::string & topic_type);
   std::future<void> launch_topics_discovery(
     std::chrono::milliseconds topic_polling_interval,
+    bool is_discovery_disabled,
     const std::vector<std::string> & topics_to_record = {});
   void subscribe_all_missing_topics(
     const std::unordered_map<std::string, std::string> & all_topics_and_types);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_TRANSPORT__RECORDER_HPP_
 #define ROSBAG2_TRANSPORT__RECORDER_HPP_
 
+#include <future>
 #include <memory>
 #include <string>
 #include <vector>
@@ -42,10 +43,12 @@ public:
 private:
   std::shared_ptr<GenericSubscription> create_subscription(
     const std::string & topic_name, const std::string & topic_type);
+  std::future<void> launch_topics_discovery(std::vector<std::string> topics = {});
 
   std::shared_ptr<rosbag2::Writer> writer_;
   std::shared_ptr<Rosbag2Node> node_;
   std::vector<std::shared_ptr<GenericSubscription>> subscriptions_;
+  std::vector<std::string> subscribed_topics_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -43,7 +43,8 @@ public:
 private:
   std::shared_ptr<GenericSubscription> create_subscription(
     const std::string & topic_name, const std::string & topic_type);
-  std::future<void> launch_topics_discovery(std::vector<std::string> topics = {});
+  std::future<void> launch_topics_discovery(
+    std::chrono::milliseconds topic_polling_frequency, std::vector<std::string> topics = {});
 
   std::shared_ptr<rosbag2::Writer> writer_;
   std::shared_ptr<Rosbag2Node> node_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -16,10 +16,14 @@
 #define ROSBAG2_TRANSPORT__RECORDER_HPP_
 
 #include <future>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
+#include "rosbag2/types.hpp"
+#include "rosbag2/writer.hpp"
 #include "rosbag2_transport/record_options.hpp"
 
 namespace rosbag2
@@ -44,7 +48,13 @@ private:
   std::shared_ptr<GenericSubscription> create_subscription(
     const std::string & topic_name, const std::string & topic_type);
   std::future<void> launch_topics_discovery(
-    std::chrono::milliseconds topic_polling_frequency, std::vector<std::string> topics = {});
+    std::chrono::milliseconds topic_polling_interval,
+    const std::vector<std::string> & topics_to_record = {});
+  void subscribe_all_missing_topics(
+    const std::map<std::string, std::string> & all_topics_and_types);
+  void subscribe_topic(const rosbag2::TopicWithType & topic_with_type);
+  bool is_every_topic_subscribed(const std::vector<std::string> & topics_to_record) const;
+  void record_messages() const;
 
   std::shared_ptr<rosbag2::Writer> writer_;
   std::shared_ptr<Rosbag2Node> node_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -46,12 +46,12 @@ public:
   void record(const RecordOptions & record_options);
 
 private:
-  std::shared_ptr<GenericSubscription> create_subscription(
-    const std::string & topic_name, const std::string & topic_type);
   std::future<void> launch_topics_discovery(
     std::chrono::milliseconds topic_polling_interval,
     const std::vector<std::string> & topics_to_record = {});
   bool subscribe_topics(const std::vector<std::string> & topics_to_record);
+  std::shared_ptr<GenericSubscription> create_subscription(
+    const std::string & topic_name, const std::string & topic_type);
   void subscribe_all_missing_topics(
     const std::unordered_map<std::string, std::string> & all_topics_and_types);
   void subscribe_topic(const rosbag2::TopicMetadata & topic);

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -129,9 +129,6 @@ std::unordered_map<std::string, std::string> Rosbag2Node::get_topics_with_types(
     }
   }
 
-  // TODO(Martin-Idel-SI): This is a short sleep to allow the node some time to discover the topic
-  // This should be replaced by an auto-discovery system in the future
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
   auto topics_and_types = this->get_topic_names_and_types();
 
   std::map<std::string, std::vector<std::string>> filtered_topics_and_types;
@@ -149,9 +146,6 @@ std::unordered_map<std::string, std::string> Rosbag2Node::get_topics_with_types(
 std::unordered_map<std::string, std::string>
 Rosbag2Node::get_all_topics_with_types()
 {
-  // TODO(Martin-Idel-SI): This is a short sleep to allow the node some time to discover the topic
-  // This should be replaced by an auto-discovery system in the future
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
   return filter_topics_with_more_than_one_type(this->get_topic_names_and_types());
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -29,20 +29,29 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   rosbag2_transport::RecordOptions record_options{};
 
   static const char * kwlist[] = {
-    "uri", "storage_id", "serialization_format", "all", "no_discovery", "topics", nullptr};
+    "uri",
+    "storage_id",
+    "serialization_format",
+    "all",
+    "no_discovery",
+    "polling_interval",
+    "topics",
+    nullptr};
 
   char * uri = nullptr;
   char * storage_id = nullptr;
   char * serilization_format = nullptr;
   bool all = false;
   bool no_discovery = false;
+  uint64_t polling_interval_ms = 100;
   PyObject * topics = nullptr;
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sss|bbO", const_cast<char **>(kwlist),
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sss|bbKO", const_cast<char **>(kwlist),
     &uri,
     &storage_id,
     &serilization_format,
     &all,
     &no_discovery,
+    &polling_interval_ms,
     &topics))
   {
     return nullptr;
@@ -52,7 +61,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   storage_options.storage_id = std::string(storage_id);
   record_options.all = all;
   record_options.is_discovery_disabled = no_discovery;
-  record_options.topic_polling_interval = std::chrono::milliseconds(100);
+  record_options.topic_polling_interval = std::chrono::milliseconds(polling_interval_ms);
 
   if (topics) {
     PyObject * topic_iterator = PyObject_GetIter(topics);

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -29,18 +29,20 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   rosbag2_transport::RecordOptions record_options{};
 
   static const char * kwlist[] = {
-    "uri", "storage_id", "serialization_format", "all", "topics", nullptr};
+    "uri", "storage_id", "serialization_format", "all", "no_discovery", "topics", nullptr};
 
   char * uri = nullptr;
   char * storage_id = nullptr;
   char * serilization_format = nullptr;
   bool all = false;
+  bool no_discovery = false;
   PyObject * topics = nullptr;
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sss|bO", const_cast<char **>(kwlist),
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sss|bbO", const_cast<char **>(kwlist),
     &uri,
     &storage_id,
     &serilization_format,
     &all,
+    &no_discovery,
     &topics))
   {
     return nullptr;
@@ -49,6 +51,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   storage_options.uri = std::string(uri);
   storage_options.storage_id = std::string(storage_id);
   record_options.all = all;
+  record_options.is_discovery_disabled = no_discovery;
   record_options.topic_polling_interval = std::chrono::milliseconds(100);
 
   if (topics) {

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <Python.h>
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -48,6 +49,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   storage_options.uri = std::string(uri);
   storage_options.storage_id = std::string(storage_id);
   record_options.all = all;
+  record_options.topic_polling_frequency = std::chrono::milliseconds(100);
 
   if (topics) {
     PyObject * topic_iterator = PyObject_GetIter(topics);

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -49,7 +49,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   storage_options.uri = std::string(uri);
   storage_options.storage_id = std::string(storage_id);
   record_options.all = all;
-  record_options.topic_polling_frequency = std::chrono::milliseconds(100);
+  record_options.topic_polling_interval = std::chrono::milliseconds(100);
 
   if (topics) {
     PyObject * topic_iterator = PyObject_GetIter(topics);

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -37,7 +37,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   string_message->string_value = "Hello World";
   std::string string_topic = "/string_topic";
 
-  start_recording({false, {string_topic, array_topic}});
+  start_recording({false, {string_topic, array_topic}, 100ms});
 
   pub_man_.add_publisher<test_msgs::msg::Primitives>(
     string_topic, string_message, 2);

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -37,12 +37,12 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   string_message->string_value = "Hello World";
   std::string string_topic = "/string_topic";
 
+  start_recording({false, {string_topic, array_topic}});
+
   pub_man_.add_publisher<test_msgs::msg::Primitives>(
     string_topic, string_message, 2);
   pub_man_.add_publisher<test_msgs::msg::StaticArrayPrimitives>(
     array_topic, array_message, 2);
-
-  start_recording({false, {string_topic, array_topic}, "rmw_format"});
   run_publishers();
   stop_recording();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -37,7 +37,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   string_message->string_value = "Hello World";
   std::string string_topic = "/string_topic";
 
-  start_recording({false, {string_topic, array_topic}, "rmw_format", 100ms});
+  start_recording({false, false, {string_topic, array_topic}, "rmw_format", 100ms});
 
   pub_man_.add_publisher<test_msgs::msg::Primitives>(
     string_topic, string_message, 2);

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -37,7 +37,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   string_message->string_value = "Hello World";
   std::string string_topic = "/string_topic";
 
-  start_recording({false, {string_topic, array_topic}, 100ms});
+  start_recording({false, {string_topic, array_topic}, "rmw_format", 100ms});
 
   pub_man_.add_publisher<test_msgs::msg::Primitives>(
     string_topic, string_message, 2);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -40,7 +40,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   pub_man_.add_publisher<test_msgs::msg::Primitives>(string_topic, string_message, 2);
   pub_man_.add_publisher<test_msgs::msg::StaticArrayPrimitives>(array_topic, array_message, 2);
 
-  start_recording({true, {}, ""});
+  start_recording({true, {}, "", 100ms});
   run_publishers();
   stop_recording();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -40,7 +40,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   pub_man_.add_publisher<test_msgs::msg::Primitives>(string_topic, string_message, 2);
   pub_man_.add_publisher<test_msgs::msg::StaticArrayPrimitives>(array_topic, array_message, 2);
 
-  start_recording({true, {}, "", 100ms});
+  start_recording({true, {}, "rmw_format", 100ms});
   run_publishers();
   stop_recording();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -14,14 +14,9 @@
 
 #include <gmock/gmock.h>
 
-#include <memory>
 #include <string>
-#include <vector>
 
-#include "rclcpp/rclcpp.hpp"
 #include "record_integration_fixture.hpp"
-#include "rosbag2_transport/rosbag2_transport.hpp"
-#include "rosbag2/types.hpp"
 #include "test_msgs/msg/primitives.hpp"
 #include "test_msgs/msg/static_array_primitives.hpp"
 #include "test_msgs/message_fixtures.hpp"
@@ -40,7 +35,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   pub_man_.add_publisher<test_msgs::msg::Primitives>(string_topic, string_message, 2);
   pub_man_.add_publisher<test_msgs::msg::StaticArrayPrimitives>(array_topic, array_message, 2);
 
-  start_recording({true, {}, "rmw_format", 100ms});
+  start_recording({true, false, {}, "rmw_format", 100ms});
   run_publishers();
   stop_recording();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
@@ -1,0 +1,42 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "record_integration_fixture.hpp"
+#include "test_msgs/msg/primitives.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+TEST_F(RecordIntegrationTestFixture, record_all_without_discovery_ignores_later_announced_topics)
+{
+  auto string_message = get_messages_primitives()[0];
+  string_message->string_value = "Hello World";
+
+  start_recording({true, true, {}, "rmw_format", 1ms});
+
+  std::this_thread::sleep_for(100ms);
+  auto publisher_node = std::make_shared<rclcpp::Node>("publisher_for_test");
+  auto publisher = publisher_node->create_publisher<test_msgs::msg::Primitives>("/string_topic");
+  for (int i = 0; i < 5; ++i) {
+    std::this_thread::sleep_for(20ms);
+    publisher->publish(string_message);
+  }
+  stop_recording();
+
+  ASSERT_THAT(writer_->get_messages(), SizeIs(0));
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -79,6 +79,12 @@ public:
     return memory_management_.serialize_message(string_message);
   }
 
+  void sleep_to_allow_topics_discovery()
+  {
+    // This is a short sleep to allow the node some time to discover the topic
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
   MemoryManagement memory_management_;
   std::shared_ptr<rosbag2_transport::Rosbag2Node> node_;
   rclcpp::Node::SharedPtr publisher_node_;
@@ -113,6 +119,7 @@ TEST_F(RosBag2NodeFixture, publisher_and_subscriber_work)
 TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_empty_if_topic_does_not_exist) {
   create_publisher("string_topic");
 
+  sleep_to_allow_topics_discovery();
   auto topics_and_types = node_->get_topics_with_types({"/wrong_topic"});
 
   ASSERT_THAT(topics_and_types, IsEmpty());
@@ -123,6 +130,7 @@ TEST_F(RosBag2NodeFixture,
 {
   create_publisher("string_topic");
 
+  sleep_to_allow_topics_discovery();
   auto topics_and_types = node_->get_topics_with_types({"string_topic"});
 
   ASSERT_THAT(topics_and_types, SizeIs(1));
@@ -134,6 +142,7 @@ TEST_F(RosBag2NodeFixture,
 {
   create_publisher("string_topic");
 
+  sleep_to_allow_topics_discovery();
   auto topics_and_types = node_->get_topics_with_types({"/string_topic"});
 
   ASSERT_THAT(topics_and_types, SizeIs(1));
@@ -149,6 +158,7 @@ TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_only_specified_topics) 
   create_publisher(second_topic);
   create_publisher(third_topic);
 
+  sleep_to_allow_topics_discovery();
   auto topics_and_types = node_->get_topics_with_types({first_topic, second_topic});
 
   ASSERT_THAT(topics_and_types, SizeIs(2));
@@ -166,6 +176,7 @@ TEST_F(RosBag2NodeFixture, get_all_topics_with_types_returns_all_topics)
   create_publisher(second_topic);
   create_publisher(third_topic);
 
+  sleep_to_allow_topics_discovery();
   auto topics_and_types = node_->get_all_topics_with_types();
 
   ASSERT_THAT(topics_and_types, SizeIs(Ge(3u)));


### PR DESCRIPTION
Using `ros2 bag record`: Poll regularly for new topics if not all topics have been found yet or `ros2 bag record` is used with the `--all` option to subscribe to all topics.

The polling interval is currently set to 100ms and not exposed to the user, but this can easily be amended if necessary.

CI: 
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5648)](http://ci.ros2.org/job/ci_linux/5648/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2265)](http://ci.ros2.org/job/ci_linux-aarch64/2265/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4672)](http://ci.ros2.org/job/ci_osx/4672/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5544)](http://ci.ros2.org/job/ci_windows/5544/)