### PR TITLE
Renaming struct members for consistency

### DIFF
--- a/rosbag2/include/rosbag2/converter.hpp
+++ b/rosbag2/include/rosbag2/converter.hpp
@@ -43,7 +43,7 @@ public:
   Converter(
     const std::string & input_format,
     const std::string & output_format,
-    const std::vector<TopicWithType> & topics_and_types,
+    const std::vector<TopicMetadata> & topics_and_types,
     std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory =
     std::make_shared<SerializationFormatConverterFactory>());
 

--- a/rosbag2/include/rosbag2/sequential_reader.hpp
+++ b/rosbag2/include/rosbag2/sequential_reader.hpp
@@ -94,7 +94,7 @@ public:
    * \return vector of topics with topic name and type as std::string
    * \throws runtime_error if the Reader is not open.
    */
-  virtual std::vector<TopicWithType> get_all_topics_and_types();
+  virtual std::vector<TopicMetadata> get_all_topics_and_types();
 
 private:
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;

--- a/rosbag2/include/rosbag2/types.hpp
+++ b/rosbag2/include/rosbag2/types.hpp
@@ -23,8 +23,8 @@ namespace rosbag2
 {
 using BagMetadata = rosbag2_storage::BagMetadata;
 using SerializedBagMessage = rosbag2_storage::SerializedBagMessage;
+using TopicInformation = rosbag2_storage::TopicInformation;
 using TopicMetadata = rosbag2_storage::TopicMetadata;
-using TopicWithType = rosbag2_storage::TopicWithType;
 }  // namespace rosbag2
 
 #endif  // ROSBAG2__TYPES_HPP_

--- a/rosbag2/include/rosbag2/types/ros2_message.hpp
+++ b/rosbag2/include/rosbag2/types/ros2_message.hpp
@@ -27,7 +27,7 @@ typedef struct rosbag2_ros2_message_t
 {
   void * message;
   const char * topic_name;
-  rcutils_time_point_value_t timestamp;
+  rcutils_time_point_value_t time_stamp;
   rcutils_allocator_t allocator;
 } rosbag2_ros2_message_t;
 

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -64,7 +64,7 @@ public:
    * \param topic_with_type name and type identifier of topic to be created
    * \throws runtime_error if the Writer is not open.
    */
-  virtual void create_topic(const TopicWithType & topic_with_type);
+  virtual void create_topic(const TopicMetadata & topic_with_type);
 
   /**
    * Write a message to a bagfile. The topic needs to have been created before writing is possible.

--- a/rosbag2/src/rosbag2/converter.cpp
+++ b/rosbag2/src/rosbag2/converter.cpp
@@ -31,7 +31,7 @@ namespace rosbag2
 Converter::Converter(
   const std::string & input_format,
   const std::string & output_format,
-  const std::vector<TopicWithType> & topics_and_types,
+  const std::vector<TopicMetadata> & topics_and_types,
   std::shared_ptr<rosbag2::SerializationFormatConverterFactoryInterface> converter_factory)
 : converter_factory_(converter_factory)
 {

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -68,7 +68,7 @@ std::shared_ptr<SerializedBagMessage> SequentialReader::read_next()
   throw std::runtime_error("Bag is not open. Call open() before reading.");
 }
 
-std::vector<TopicWithType> SequentialReader::get_all_topics_and_types()
+std::vector<TopicMetadata> SequentialReader::get_all_topics_and_types()
 {
   if (storage_) {
     return storage_->get_all_topics_and_types();

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -48,7 +48,7 @@ void Writer::open(const StorageOptions & options)
   uri_ = options.uri;
 }
 
-void Writer::create_topic(const TopicWithType & topic_with_type)
+void Writer::create_topic(const TopicMetadata & topic_with_type)
 {
   if (!storage_) {
     throw std::runtime_error("Bag is not open. Call open() before writing.");

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -30,11 +30,11 @@ class MockStorage : public rosbag2_storage::storage_interfaces::ReadWriteInterfa
 {
 public:
   MOCK_METHOD2(open, void(const std::string &, rosbag2_storage::storage_interfaces::IOFlag));
-  MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicWithType &));
+  MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD0(has_next, bool());
   MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());
   MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
-  MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicWithType>());
+  MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
 };
 

--- a/rosbag2/test/rosbag2/test_info.cpp
+++ b/rosbag2/test/rosbag2/test_info.cpp
@@ -76,14 +76,14 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
   EXPECT_THAT(read_metadata.topics_with_message_count,
     SizeIs(2u));
   auto actual_first_topic = read_metadata.topics_with_message_count[0];
-  rosbag2_storage::TopicMetadata expected_first_topic = {{"topic1", "type1"}, 100};
+  rosbag2_storage::TopicInformation expected_first_topic = {{"topic1", "type1"}, 100};
   EXPECT_THAT(actual_first_topic.topic_with_type.name,
     Eq(expected_first_topic.topic_with_type.name));
   EXPECT_THAT(actual_first_topic.topic_with_type.type,
     Eq(expected_first_topic.topic_with_type.type));
   EXPECT_THAT(actual_first_topic.message_count, Eq(expected_first_topic.message_count));
   auto actual_second_topic = read_metadata.topics_with_message_count[1];
-  rosbag2_storage::TopicMetadata expected_second_topic = {{"topic2", "type2"}, 200};
+  rosbag2_storage::TopicInformation expected_second_topic = {{"topic2", "type2"}, 200};
   EXPECT_THAT(actual_second_topic.topic_with_type.name,
     Eq(expected_second_topic.topic_with_type.name));
   EXPECT_THAT(actual_second_topic.topic_with_type.type,

--- a/rosbag2/test/rosbag2/test_sequential_reader.cpp
+++ b/rosbag2/test/rosbag2/test_sequential_reader.cpp
@@ -39,10 +39,10 @@ public:
     storage_ = std::make_shared<NiceMock<MockStorage>>();
     converter_factory_ = std::make_shared<StrictMock<MockConverterFactory>>();
 
-    rosbag2_storage::TopicWithType topic_with_type;
+    rosbag2_storage::TopicMetadata topic_with_type;
     topic_with_type.name = "topic";
     topic_with_type.type = "test_msgs/Primitives";
-    auto topics_and_types = std::vector<rosbag2_storage::TopicWithType>{topic_with_type};
+    auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));
 

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
@@ -99,7 +99,7 @@ void CdrConverter::deserialize(
   std::shared_ptr<rosbag2_ros2_message_t> ros_message)
 {
   ros_message->topic_name = serialized_message->topic_name.c_str();
-  ros_message->timestamp = serialized_message->time_stamp;
+  ros_message->time_stamp = serialized_message->time_stamp;
 
   printf("this should be a call to FASTRTPS\n");
   auto ret =
@@ -115,7 +115,7 @@ void CdrConverter::serialize(
   std::shared_ptr<rosbag2::SerializedBagMessage> serialized_message)
 {
   serialized_message->topic_name = std::string(ros_message->topic_name);
-  serialized_message->time_stamp = ros_message->timestamp;
+  serialized_message->time_stamp = ros_message->time_stamp;
 
   auto ret = serialize_fcn_(
     ros_message->message, type_support, serialized_message->serialized_data.get());

--- a/rosbag2_converter_default_plugins/test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
@@ -44,7 +44,7 @@ public:
     const std::string & topic_name = "")
   {
     auto ros_message = std::make_shared<rosbag2_ros2_message_t>();
-    ros_message->timestamp = 0;
+    ros_message->time_stamp = 0;
     ros_message->message = nullptr;
     ros_message->allocator = allocator_;
 
@@ -81,13 +81,13 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_pr
 
   auto cast_message = static_cast<test_msgs::msg::Primitives *>(ros_message->message);
   EXPECT_THAT(*cast_message, Eq(*message));
-  EXPECT_THAT(ros_message->timestamp, Eq(serialized_message->time_stamp));
+  EXPECT_THAT(ros_message->time_stamp, Eq(serialized_message->time_stamp));
   EXPECT_THAT(ros_message->topic_name, StrEq(serialized_message->topic_name));
 }
 
 TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_primitives) {
   auto ros_message = make_shared_ros_message(topic_name_);
-  ros_message->timestamp = 1;
+  ros_message->time_stamp = 1;
   auto message = get_messages_primitives()[0];
   message->string_value = "test_serialize";
   message->float64_value = 102.34;
@@ -104,7 +104,7 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_prim
     serialized_message->serialized_data);
   EXPECT_THAT(*deserialized_msg, Eq(*message));
   EXPECT_THAT(serialized_message->topic_name, StrEq(topic_name_));
-  EXPECT_THAT(serialized_message->time_stamp, Eq(ros_message->timestamp));
+  EXPECT_THAT(serialized_message->time_stamp, Eq(ros_message->time_stamp));
 }
 
 TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_static_array) {
@@ -128,13 +128,13 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_st
 
   auto cast_message = static_cast<test_msgs::msg::StaticArrayPrimitives *>(ros_message->message);
   EXPECT_THAT(*cast_message, Eq(*message));
-  EXPECT_THAT(ros_message->timestamp, Eq(serialized_message->time_stamp));
+  EXPECT_THAT(ros_message->time_stamp, Eq(serialized_message->time_stamp));
   EXPECT_THAT(ros_message->topic_name, StrEq(serialized_message->topic_name));
 }
 
 TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_static_array) {
   auto ros_message = make_shared_ros_message(topic_name_);
-  ros_message->timestamp = 1;
+  ros_message->time_stamp = 1;
   auto message = get_messages_static_array_primitives()[0];
   message->string_values = {{"test_deserialize", "another string", "the third one"}};
   message->float64_values = {{102.34, 1.9, 1236.011}};
@@ -152,7 +152,7 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_stat
     deserialize_message<test_msgs::msg::StaticArrayPrimitives>(serialized_message->serialized_data);
   EXPECT_THAT(*deserialized_msg, Eq(*message));
   EXPECT_THAT(serialized_message->topic_name, StrEq(topic_name_));
-  EXPECT_THAT(serialized_message->time_stamp, Eq(ros_message->timestamp));
+  EXPECT_THAT(serialized_message->time_stamp, Eq(ros_message->time_stamp));
 }
 
 TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_dynamic_array_nest) {
@@ -181,13 +181,13 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_dy
 
   auto cast_message = static_cast<test_msgs::msg::DynamicArrayNested *>(ros_message->message);
   EXPECT_THAT(*cast_message, Eq(*message));
-  EXPECT_THAT(ros_message->timestamp, Eq(serialized_message->time_stamp));
+  EXPECT_THAT(ros_message->time_stamp, Eq(serialized_message->time_stamp));
   EXPECT_THAT(ros_message->topic_name, StrEq(serialized_message->topic_name));
 }
 
 TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_dynamic_array_nest) {
   auto ros_message = make_shared_ros_message(topic_name_);
-  ros_message->timestamp = 1;
+  ros_message->time_stamp = 1;
   auto message = get_messages_dynamic_array_nested()[0];
   test_msgs::msg::Primitives first_primitive_message;
   first_primitive_message.string_value = "I am the first";
@@ -210,5 +210,5 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_dyna
     deserialize_message<test_msgs::msg::DynamicArrayNested>(serialized_message->serialized_data);
   EXPECT_THAT(*deserialized_msg, Eq(*message));
   EXPECT_THAT(serialized_message->topic_name, StrEq(topic_name_));
-  EXPECT_THAT(serialized_message->time_stamp, Eq(ros_message->timestamp));
+  EXPECT_THAT(serialized_message->time_stamp, Eq(ros_message->time_stamp));
 }

--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -26,9 +26,9 @@
 namespace rosbag2_storage
 {
 
-struct TopicMetadata
+struct TopicInformation
 {
-  TopicWithType topic_with_type;
+  TopicMetadata topic_with_type;
   size_t message_count;
 };
 
@@ -42,7 +42,7 @@ struct BagMetadata
   std::chrono::nanoseconds duration;
   std::chrono::time_point<std::chrono::high_resolution_clock> starting_time;
   size_t message_count;
-  std::vector<TopicMetadata> topics_with_message_count;
+  std::vector<TopicInformation> topics_with_message_count;
 };
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
@@ -37,7 +37,7 @@ public:
 
   virtual std::shared_ptr<SerializedBagMessage> read_next() = 0;
 
-  virtual std::vector<TopicWithType> get_all_topics_and_types() = 0;
+  virtual std::vector<TopicMetadata> get_all_topics_and_types() = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -35,7 +35,7 @@ public:
 
   virtual void write(std::shared_ptr<const SerializedBagMessage> msg) = 0;
 
-  virtual void create_topic(const TopicWithType & topic) = 0;
+  virtual void create_topic(const TopicMetadata & topic) = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/topic_with_type.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/topic_with_type.hpp
@@ -20,7 +20,7 @@
 namespace rosbag2_storage
 {
 
-struct TopicWithType
+struct TopicMetadata
 {
   std::string name;
   std::string type;

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -36,9 +36,9 @@
 namespace YAML
 {
 template<>
-struct convert<rosbag2_storage::TopicWithType>
+struct convert<rosbag2_storage::TopicMetadata>
 {
-  static Node encode(const rosbag2_storage::TopicWithType & topic)
+  static Node encode(const rosbag2_storage::TopicMetadata & topic)
   {
     Node node;
     node["name"] = topic.name;
@@ -46,7 +46,7 @@ struct convert<rosbag2_storage::TopicWithType>
     return node;
   }
 
-  static bool decode(const Node & node, rosbag2_storage::TopicWithType & topic)
+  static bool decode(const Node & node, rosbag2_storage::TopicMetadata & topic)
   {
     topic.name = node["name"].as<std::string>();
     topic.type = node["type"].as<std::string>();
@@ -55,9 +55,9 @@ struct convert<rosbag2_storage::TopicWithType>
 };
 
 template<>
-struct convert<rosbag2_storage::TopicMetadata>
+struct convert<rosbag2_storage::TopicInformation>
 {
-  static Node encode(const rosbag2_storage::TopicMetadata & metadata)
+  static Node encode(const rosbag2_storage::TopicInformation & metadata)
   {
     Node node;
     node["topic_and_type"] = metadata.topic_with_type;
@@ -65,9 +65,9 @@ struct convert<rosbag2_storage::TopicMetadata>
     return node;
   }
 
-  static bool decode(const Node & node, rosbag2_storage::TopicMetadata & metadata)
+  static bool decode(const Node & node, rosbag2_storage::TopicInformation & metadata)
   {
-    metadata.topic_with_type = node["topic_and_type"].as<rosbag2_storage::TopicWithType>();
+    metadata.topic_with_type = node["topic_and_type"].as<rosbag2_storage::TopicMetadata>();
     metadata.message_count = node["message_count"].as<size_t>();
     return true;
   }
@@ -137,7 +137,7 @@ struct convert<rosbag2_storage::BagMetadata>
       .as<std::chrono::time_point<std::chrono::high_resolution_clock>>();
     metadata.message_count = node["message_count"].as<size_t>();
     metadata.topics_with_message_count =
-      node["topics_with_message_count"].as<std::vector<rosbag2_storage::TopicMetadata>>();
+      node["topics_with_message_count"].as<std::vector<rosbag2_storage::TopicInformation>>();
     return true;
   }
 };

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> TestPlugin::read_next()
   return std::shared_ptr<rosbag2_storage::SerializedBagMessage>();
 }
 
-void TestPlugin::create_topic(const rosbag2_storage::TopicWithType & topic)
+void TestPlugin::create_topic(const rosbag2_storage::TopicMetadata & topic)
 {
   std::cout << "Created topic with name =" << topic.name << " and type =" << topic.type << ".\n";
 }
@@ -63,10 +63,10 @@ void TestPlugin::write(const std::shared_ptr<const rosbag2_storage::SerializedBa
   std::cout << "\nwriting\n";
 }
 
-std::vector<rosbag2_storage::TopicWithType> TestPlugin::get_all_topics_and_types()
+std::vector<rosbag2_storage::TopicMetadata> TestPlugin::get_all_topics_and_types()
 {
   std::cout << "\nreading topics and types\n";
-  return std::vector<rosbag2_storage::TopicWithType>();
+  return std::vector<rosbag2_storage::TopicMetadata>();
 }
 
 rosbag2_storage::BagMetadata TestPlugin::get_metadata()

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -32,7 +32,7 @@ public:
 
   void open(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag flag) override;
 
-  void create_topic(const rosbag2_storage::TopicWithType & topic) override;
+  void create_topic(const rosbag2_storage::TopicMetadata & topic) override;
 
   bool has_next() override;
 
@@ -40,7 +40,7 @@ public:
 
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
 
-  std::vector<rosbag2_storage::TopicWithType> get_all_topics_and_types() override;
+  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   rosbag2_storage::BagMetadata get_metadata() override;
 };

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -49,10 +49,10 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> TestReadOnlyPlugin::read_
   return std::shared_ptr<rosbag2_storage::SerializedBagMessage>();
 }
 
-std::vector<rosbag2_storage::TopicWithType> TestReadOnlyPlugin::get_all_topics_and_types()
+std::vector<rosbag2_storage::TopicMetadata> TestReadOnlyPlugin::get_all_topics_and_types()
 {
   std::cout << "\nreading topics and types\n";
-  return std::vector<rosbag2_storage::TopicWithType>();
+  return std::vector<rosbag2_storage::TopicMetadata>();
 }
 
 rosbag2_storage::BagMetadata TestReadOnlyPlugin::get_metadata()

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -33,7 +33,7 @@ public:
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
 
-  std::vector<rosbag2_storage::TopicWithType> get_all_topics_and_types() override;
+  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   rosbag2_storage::BagMetadata get_metadata() override;
 };

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -50,7 +50,7 @@ public:
     rosbag2_storage::storage_interfaces::IOFlag io_flag =
     rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
 
-  void create_topic(const rosbag2_storage::TopicWithType & topic) override;
+  void create_topic(const rosbag2_storage::TopicMetadata & topic) override;
 
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message) override;
 
@@ -58,7 +58,7 @@ public:
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
 
-  std::vector<rosbag2_storage::TopicWithType> get_all_topics_and_types() override;
+  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
@@ -82,7 +82,7 @@ private:
   ReadQueryResult message_result_;
   ReadQueryResult::Iterator current_message_row_;
   std::map<std::string, int> topics_;
-  std::vector<rosbag2_storage::TopicWithType> all_topics_and_types_;
+  std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -125,7 +125,7 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SqliteStorage::read_next(
   return bag_message;
 }
 
-std::vector<rosbag2_storage::TopicWithType> SqliteStorage::get_all_topics_and_types()
+std::vector<rosbag2_storage::TopicMetadata> SqliteStorage::get_all_topics_and_types()
 {
   if (all_topics_and_types_.empty()) {
     fill_topics_and_types();
@@ -149,7 +149,7 @@ void SqliteStorage::initialize()
   database_->prepare_statement(create_table)->execute_and_reset();
 }
 
-void SqliteStorage::create_topic(const rosbag2_storage::TopicWithType & topic)
+void SqliteStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
 {
   if (topics_.find(topic.name) == std::end(topics_)) {
     auto insert_topic =

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -30,23 +30,23 @@ using namespace ::testing;  // NOLINT
 namespace rosbag2_storage
 {
 
-bool operator==(const TopicWithType & lhs, const TopicWithType & rhs)
+bool operator==(const TopicMetadata & lhs, const TopicMetadata & rhs)
 {
   return lhs.name == rhs.name && lhs.type == rhs.type;
 }
 
-bool operator!=(const TopicWithType & lhs, const TopicWithType & rhs)
+bool operator!=(const TopicMetadata & lhs, const TopicMetadata & rhs)
 {
   return !(lhs == rhs);
 }
 
-bool operator==(const TopicMetadata & lhs, const TopicMetadata & rhs)
+bool operator==(const TopicInformation & lhs, const TopicInformation & rhs)
 {
   return lhs.topic_with_type == rhs.topic_with_type &&
          lhs.message_count == rhs.message_count;
 }
 
-bool operator!=(const TopicMetadata & lhs, const TopicMetadata & rhs)
+bool operator!=(const TopicInformation & lhs, const TopicInformation & rhs)
 {
   return !(lhs == rhs);
 }
@@ -121,8 +121,8 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
   auto topics_and_types = readable_storage->get_all_topics_and_types();
 
   EXPECT_THAT(topics_and_types, ElementsAreArray({
-    rosbag2_storage::TopicWithType{"topic1", "type1"},
-    rosbag2_storage::TopicWithType{"topic2", "type2"}
+    rosbag2_storage::TopicMetadata{"topic1", "type1"},
+    rosbag2_storage::TopicMetadata{"topic2", "type2"}
   }));
 }
 
@@ -147,8 +147,8 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
     rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
   }));
   EXPECT_THAT(metadata.topics_with_message_count, ElementsAreArray({
-    rosbag2_storage::TopicMetadata{rosbag2_storage::TopicWithType{"topic1", "type1"}, 2u},
-    rosbag2_storage::TopicMetadata{rosbag2_storage::TopicWithType{"topic2", "type2"}, 1u}
+    rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{"topic1", "type1"}, 2u},
+    rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{"topic2", "type2"}, 1u}
   }));
   EXPECT_THAT(metadata.message_count, Eq(3u));
   EXPECT_THAT(metadata.starting_time, Eq(

--- a/rosbag2_transport/src/rosbag2_transport/formatter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.cpp
@@ -99,7 +99,7 @@ void Formatter::format_file_paths(
 }
 
 void Formatter::format_topics_with_type(
-  std::vector<rosbag2::TopicMetadata> topics,
+  std::vector<rosbag2::TopicInformation> topics,
   std::stringstream & info_stream,
   int indentation_spaces)
 {

--- a/rosbag2_transport/src/rosbag2_transport/formatter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.cpp
@@ -80,7 +80,9 @@ std::string Formatter::format_file_size(size_t file_size)
 }
 
 void Formatter::format_file_paths(
-  std::vector<std::string> paths, std::stringstream & info_stream, int indentation_spaces)
+  const std::vector<std::string> & paths,
+  std::stringstream & info_stream,
+  int indentation_spaces)
 {
   if (paths.empty()) {
     info_stream << std::endl;
@@ -99,7 +101,7 @@ void Formatter::format_file_paths(
 }
 
 void Formatter::format_topics_with_type(
-  std::vector<rosbag2::TopicInformation> topics,
+  const std::vector<rosbag2::TopicInformation> & topics,
   std::stringstream & info_stream,
   int indentation_spaces)
 {

--- a/rosbag2_transport/src/rosbag2_transport/formatter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.hpp
@@ -37,10 +37,12 @@ public:
   static std::string format_file_size(size_t file_size);
 
   static void format_file_paths(
-    std::vector<std::string> paths, std::stringstream & info_stream, int indentation_spaces);
+    const std::vector<std::string> & paths,
+    std::stringstream & info_stream,
+    int indentation_spaces);
 
   static void format_topics_with_type(
-    std::vector<rosbag2::TopicInformation>,
+    const std::vector<rosbag2::TopicInformation> & topics,
     std::stringstream & info_stream,
     int indentation_spaces);
 

--- a/rosbag2_transport/src/rosbag2_transport/formatter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.hpp
@@ -31,12 +31,17 @@ class Formatter
 public:
   static std::map<std::string, std::string> format_duration(
     std::chrono::high_resolution_clock::duration duration);
+
   static std::string format_time_point(std::chrono::high_resolution_clock::duration time_point);
+
   static std::string format_file_size(size_t file_size);
+
   static void format_file_paths(
     std::vector<std::string> paths, std::stringstream & info_stream, int indentation_spaces);
+
   static void format_topics_with_type(
-    std::vector<rosbag2::TopicInformation>, std::stringstream & info_stream,
+    std::vector<rosbag2::TopicInformation>,
+    std::stringstream & info_stream,
     int indentation_spaces);
 
 private:

--- a/rosbag2_transport/src/rosbag2_transport/formatter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.hpp
@@ -36,7 +36,8 @@ public:
   static void format_file_paths(
     std::vector<std::string> paths, std::stringstream & info_stream, int indentation_spaces);
   static void format_topics_with_type(
-    std::vector<rosbag2::TopicMetadata>, std::stringstream & info_stream, int indentation_spaces);
+    std::vector<rosbag2::TopicInformation>, std::stringstream & info_stream,
+    int indentation_spaces);
 
 private:
   static void indent(std::stringstream & info_stream, int number_of_spaces);

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -41,14 +41,14 @@ public:
     return messages_[num_read_++];
   }
 
-  std::vector<rosbag2::TopicWithType> get_all_topics_and_types() override
+  std::vector<rosbag2::TopicMetadata> get_all_topics_and_types() override
   {
     return topics_;
   }
 
   void prepare(
     std::vector<std::shared_ptr<rosbag2::SerializedBagMessage>> messages,
-    std::vector<rosbag2::TopicWithType> topics)
+    std::vector<rosbag2::TopicMetadata> topics)
   {
     messages_ = std::move(messages);
     topics_ = std::move(topics);
@@ -56,7 +56,7 @@ public:
 
 private:
   std::vector<std::shared_ptr<rosbag2::SerializedBagMessage>> messages_;
-  std::vector<rosbag2::TopicWithType> topics_;
+  std::vector<rosbag2::TopicMetadata> topics_;
   size_t num_read_;
 };
 

--- a/rosbag2_transport/test/rosbag2_transport/mock_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_writer.hpp
@@ -30,7 +30,7 @@ public:
     (void) options;
   }
 
-  void create_topic(const rosbag2::TopicWithType & topic_with_type) override
+  void create_topic(const rosbag2::TopicMetadata & topic_with_type) override
   {
     topics_.emplace(topic_with_type.name, topic_with_type);
   }
@@ -51,13 +51,13 @@ public:
     return messages_per_topic_;
   }
 
-  std::map<std::string, rosbag2::TopicWithType> get_topics()
+  std::map<std::string, rosbag2::TopicMetadata> get_topics()
   {
     return topics_;
   }
 
 private:
-  std::map<std::string, rosbag2::TopicWithType> topics_;
+  std::map<std::string, rosbag2::TopicMetadata> topics_;
   std::vector<std::shared_ptr<rosbag2::SerializedBagMessage>> messages_;
   std::map<std::string, size_t> messages_per_topic_;
 };

--- a/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
@@ -73,7 +73,7 @@ TEST_F(FormatterTestFixture, format_files_prints_newline_if_there_are_no_paths) 
 }
 
 TEST_F(FormatterTestFixture, format_topics_with_type_correctly_layouts_more_topics) {
-  std::vector<rosbag2::TopicMetadata> topics;
+  std::vector<rosbag2::TopicInformation> topics;
   topics.push_back({{"topic1", "type1"}, 100});
   topics.push_back({{"topic2", "type2"}, 200});
   std::stringstream formatted_output;
@@ -84,7 +84,7 @@ TEST_F(FormatterTestFixture, format_topics_with_type_correctly_layouts_more_topi
 }
 
 TEST_F(FormatterTestFixture, format_topics_with_type_prints_newline_if_there_are_no_topics) {
-  std::vector<rosbag2::TopicMetadata> topics = {};
+  std::vector<rosbag2::TopicInformation> topics = {};
   std::stringstream formatted_output;
 
   formatter_->format_topics_with_type(topics, formatted_output, 0);

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -62,7 +62,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
   complex_message1->string_values = {{"Complex Hello1", "Complex Hello2", "Complex Hello3"}};
   complex_message1->bool_values = {{true, false, true}};
 
-  auto topic_types = std::vector<rosbag2::TopicWithType>{
+  auto topic_types = std::vector<rosbag2::TopicMetadata>{
     {"topic1", "test_msgs/Primitives"},
     {"topic2", "test_msgs/StaticArrayPrimitives"},
   };

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -39,7 +39,7 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_relative_timing_of_stored_m
   primitive_message2->string_value = "Hello World 2";
 
   auto message_time_difference = std::chrono::seconds(1);
-  auto topics_and_types = std::vector<rosbag2::TopicWithType>{{"topic1", "test_msgs/Primitives"}};
+  auto topics_and_types = std::vector<rosbag2::TopicMetadata>{{"topic1", "test_msgs/Primitives"}};
   std::vector<std::shared_ptr<rosbag2::SerializedBagMessage>> messages =
   {serialize_test_message("topic1", 0, primitive_message1),
     serialize_test_message("topic1", 0, primitive_message2)};


### PR DESCRIPTION
Extracted from #57:
- Both the ros2 message and the serialized bag message now contain a field `time_stamp`
- TopicWithType will be changed to incorporate more fields

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5650)](http://ci.ros2.org/job/ci_linux/5650/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2266)](http://ci.ros2.org/job/ci_linux-aarch64/2266/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4673)](http://ci.ros2.org/job/ci_osx/4673/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5545)](http://ci.ros2.org/job/ci_windows/5545/)