### PR TITLE
Use unordered map instead of map

### DIFF
--- a/rosbag2/include/rosbag2/converter.hpp
+++ b/rosbag2/include/rosbag2/converter.hpp
@@ -15,9 +15,9 @@
 #ifndef ROSBAG2__CONVERTER_HPP_
 #define ROSBAG2__CONVERTER_HPP_
 
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rosbag2/serialization_format_converter_factory.hpp"
@@ -74,7 +74,7 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
   std::unique_ptr<SerializationFormatConverterInterface> input_converter_;
   std::unique_ptr<SerializationFormatConverterInterface> output_converter_;
-  std::map<std::string, ConverterTypeSupport> topics_and_types_;
+  std::unordered_map<std::string, ConverterTypeSupport> topics_and_types_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -16,7 +16,6 @@
 #define ROSBAG2_STORAGE__BAG_METADATA_HPP_
 
 #include <chrono>
-#include <map>
 #include <string>
 #include <vector>
 #include <utility>

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 #include <iostream>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -16,7 +16,6 @@
 #ifndef ROSBAG2_STORAGE__TEST_PLUGIN_HPP_
 #define ROSBAG2_STORAGE__TEST_PLUGIN_HPP_
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <iostream>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -15,7 +15,6 @@
 #ifndef ROSBAG2_STORAGE__TEST_READ_ONLY_PLUGIN_HPP_
 #define ROSBAG2_STORAGE__TEST_READ_ONLY_PLUGIN_HPP_
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -15,9 +15,9 @@
 #ifndef ROSBAG2_STORAGE_DEFAULT_PLUGINS__SQLITE__SQLITE_STORAGE_HPP_
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS__SQLITE__SQLITE_STORAGE_HPP_
 
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rcutils/types.h"
@@ -81,7 +81,7 @@ private:
   SqliteStatement read_statement_;
   ReadQueryResult message_result_;
   ReadQueryResult::Iterator current_message_row_;
-  std::map<std::string, int> topics_;
+  std::unordered_map<std::string, int> topics_;
   std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
 };
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -20,7 +20,6 @@
 #include <cstring>
 #include <iostream>
 #include <fstream>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -16,9 +16,9 @@
 #define ROSBAG2_TEST_COMMON__SUBSCRIPTION_MANAGER_HPP_
 
 #include <future>
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"  // rclcpp must be included before the Windows specific includes.
@@ -77,7 +77,7 @@ public:
   }
 
 private:
-  bool continue_spinning(std::map<std::string, size_t> expected_topics_with_sizes)
+  bool continue_spinning(std::unordered_map<std::string, size_t> expected_topics_with_sizes)
   {
     for (const auto & topic_expected : expected_topics_with_sizes) {
       if (subscribed_messages_[topic_expected.first].size() < topic_expected.second) {
@@ -88,9 +88,9 @@ private:
   }
 
   std::vector<rclcpp::SubscriptionBase::SharedPtr> subscriptions_;
-  std::map<std::string,
+  std::unordered_map<std::string,
     std::vector<std::shared_ptr<rmw_serialized_message_t>>> subscribed_messages_;
-  std::map<std::string, size_t> expected_topics_with_size_;
+  std::unordered_map<std::string, size_t> expected_topics_with_size_;
   rclcpp::Node::SharedPtr subscriber_node_;
   MemoryManagement memory_management_;
 };

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -17,7 +17,6 @@
 #include <cstdlib>
 #include <future>
 #include <iostream>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
@@ -16,7 +16,6 @@
 #define ROSBAG2_TRANSPORT__ROSBAG2_TRANSPORT_HPP_
 
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_transport/src/rosbag2_transport/formatter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.cpp
@@ -16,9 +16,9 @@
 
 #include <chrono>
 #include <iomanip>
-#include <map>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #ifdef _WIN32
@@ -28,10 +28,10 @@
 namespace rosbag2_transport
 {
 
-std::map<std::string, std::string> Formatter::format_duration(
+std::unordered_map<std::string, std::string> Formatter::format_duration(
   std::chrono::high_resolution_clock::duration duration)
 {
-  std::map<std::string, std::string> formatted_duration;
+  std::unordered_map<std::string, std::string> formatted_duration;
   auto m_seconds = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
   auto seconds = std::chrono::duration_cast<std::chrono::seconds>(m_seconds);
   std::string fractional_seconds = std::to_string(m_seconds.count() % 1000);

--- a/rosbag2_transport/src/rosbag2_transport/formatter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.hpp
@@ -16,9 +16,9 @@
 #define ROSBAG2_TRANSPORT__FORMATTER_HPP_
 
 #include <chrono>
-#include <map>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rosbag2/types.hpp"
@@ -29,7 +29,7 @@ namespace rosbag2_transport
 class Formatter
 {
 public:
-  static std::map<std::string, std::string> format_duration(
+  static std::unordered_map<std::string, std::string> format_duration(
     std::chrono::high_resolution_clock::duration duration);
 
   static std::string format_time_point(std::chrono::high_resolution_clock::duration time_point);

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -15,7 +15,6 @@
 #include "player.hpp"
 
 #include <chrono>
-#include <map>
 #include <memory>
 #include <queue>
 #include <string>

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -17,10 +17,10 @@
 
 #include <chrono>
 #include <future>
-#include <map>
 #include <memory>
 #include <queue>
 #include <string>
+#include <unordered_map>
 
 #include "moodycamel/readerwriterqueue.h"
 #include "replayable_message.hpp"
@@ -64,7 +64,7 @@ private:
   moodycamel::ReaderWriterQueue<ReplayableMessage> message_queue_;
   mutable std::future<void> storage_loading_future_;
   std::shared_ptr<Rosbag2Node> rosbag2_transport_;
-  std::map<std::string, std::shared_ptr<GenericPublisher>> publishers_;
+  std::unordered_map<std::string, std::shared_ptr<GenericPublisher>> publishers_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <utility>
 
 #include "rcl/expand_topic_name.h"
@@ -117,7 +118,7 @@ std::string Rosbag2Node::expand_topic_name(const std::string & topic_name)
   return expanded_topic_name_std;
 }
 
-std::map<std::string, std::string> Rosbag2Node::get_topics_with_types(
+std::unordered_map<std::string, std::string> Rosbag2Node::get_topics_with_types(
   const std::vector<std::string> & topic_names)
 {
   std::vector<std::string> sanitized_topic_names;
@@ -145,7 +146,7 @@ std::map<std::string, std::string> Rosbag2Node::get_topics_with_types(
   return filter_topics_with_more_than_one_type(filtered_topics_and_types);
 }
 
-std::map<std::string, std::string>
+std::unordered_map<std::string, std::string>
 Rosbag2Node::get_all_topics_with_types()
 {
   // TODO(Martin-Idel-SI): This is a short sleep to allow the node some time to discover the topic
@@ -154,10 +155,10 @@ Rosbag2Node::get_all_topics_with_types()
   return filter_topics_with_more_than_one_type(this->get_topic_names_and_types());
 }
 
-std::map<std::string, std::string> Rosbag2Node::filter_topics_with_more_than_one_type(
+std::unordered_map<std::string, std::string> Rosbag2Node::filter_topics_with_more_than_one_type(
   std::map<std::string, std::vector<std::string>> topics_and_types)
 {
-  std::map<std::string, std::string> filtered_topics_and_types;
+  std::unordered_map<std::string, std::string> filtered_topics_and_types;
   for (const auto & topic_and_type : topics_and_types) {
     if (topic_and_type.second.size() > 1) {
       ROSBAG2_TRANSPORT_LOG_ERROR_STREAM("Topic '" << topic_and_type.first <<

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rclcpp/node.hpp"
@@ -43,14 +44,14 @@ public:
     const std::string & type,
     std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback);
 
-  std::map<std::string, std::string>
+  std::unordered_map<std::string, std::string>
   get_topics_with_types(const std::vector<std::string> & topic_names);
 
   std::string expand_topic_name(const std::string & topic_name);
 
-  std::map<std::string, std::string> get_all_topics_with_types();
+  std::unordered_map<std::string, std::string> get_all_topics_with_types();
 
-  std::map<std::string, std::string> filter_topics_with_more_than_one_type(
+  std::unordered_map<std::string, std::string> filter_topics_with_more_than_one_type(
     std::map<std::string, std::vector<std::string>> topics_and_types);
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -14,7 +14,6 @@
 
 #include "rosbag2_transport/rosbag2_transport.hpp"
 
-#include <map>
 #include <memory>
 #include <queue>
 #include <string>

--- a/rosbag2_transport/test/rosbag2_transport/mock_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_writer.hpp
@@ -15,9 +15,9 @@
 #ifndef ROSBAG2_TRANSPORT__MOCK_WRITER_HPP_
 #define ROSBAG2_TRANSPORT__MOCK_WRITER_HPP_
 
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rosbag2/writer.hpp"
@@ -51,20 +51,20 @@ public:
     return messages_;
   }
 
-  std::map<std::string, size_t> messages_per_topic()
+  std::unordered_map<std::string, size_t> messages_per_topic()
   {
     return messages_per_topic_;
   }
 
-  std::map<std::string, rosbag2::TopicMetadata> get_topics()
+  std::unordered_map<std::string, rosbag2::TopicMetadata> get_topics()
   {
     return topics_;
   }
 
 private:
-  std::map<std::string, rosbag2::TopicMetadata> topics_;
+  std::unordered_map<std::string, rosbag2::TopicMetadata> topics_;
   std::vector<std::shared_ptr<rosbag2::SerializedBagMessage>> messages_;
-  std::map<std::string, size_t> messages_per_topic_;
+  std::unordered_map<std::string, size_t> messages_per_topic_;
 };
 
 #endif  // ROSBAG2_TRANSPORT__MOCK_WRITER_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
@@ -15,7 +15,6 @@
 #include <gmock/gmock.h>
 
 #include <future>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 
 #include <cstdio>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
@@ -14,7 +14,6 @@
 
 #include <gmock/gmock.h>
 
-#include <map>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/rosbag2_transport/test/rosbag2_transport/test_info.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_info.cpp
@@ -15,7 +15,6 @@
 #include <gmock/gmock.h>
 
 #include <future>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -16,7 +16,6 @@
 
 #include <chrono>
 #include <future>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -15,7 +15,6 @@
 #include <gmock/gmock.h>
 
 #include <chrono>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -15,7 +15,6 @@
 #include <gmock/gmock.h>
 
 #include <future>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Replaces the usage of `std::map` with `std::unordered_map` where possible.

This pr is based on #57.

Only the last commit is actually part of this pr.