### PR TITLE
Fix master build and small renamings

### DIFF
--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2/serialization_format_converter_factory.cpp
   src/rosbag2/typesupport_helpers.cpp
   src/rosbag2/writer.cpp
-  src/rosbag2/types/ros2_message.cpp)
+  src/rosbag2/types/introspection_message.cpp)
 
 ament_target_dependencies(${PROJECT_NAME}
   ament_index_cpp
@@ -125,7 +125,7 @@ if(BUILD_TESTING)
   ament_add_gmock(test_ros2_message
     test/rosbag2/types/test_ros2_message.cpp
     src/rosbag2/typesupport_helpers.cpp
-    src/rosbag2/types/ros2_message.cpp)
+    src/rosbag2/types/introspection_message.cpp)
   if(TARGET test_ros2_message)
     target_compile_definitions(test_ros2_message PRIVATE "ROSBAG2_BUILDING_DLL")
     if(NOT DISABLE_SANITIZERS)

--- a/rosbag2/include/rosbag2/converter.hpp
+++ b/rosbag2/include/rosbag2/converter.hpp
@@ -42,7 +42,7 @@ namespace rosbag2
 // Only used internally.
 struct ConverterTypeSupport
 {
-  const rosidl_message_type_support_t * cpp_type_support;
+  const rosidl_message_type_support_t * rmw_type_support;
   const rosidl_message_type_support_t * introspection_type_support;
 };
 

--- a/rosbag2/include/rosbag2/serialization_format_converter_interface.hpp
+++ b/rosbag2/include/rosbag2/serialization_format_converter_interface.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <string>
 
-#include "rosbag2/types/ros2_message.hpp"
+#include "rosbag2/types/introspection_message.hpp"
 #include "rosbag2/types.hpp"
 #include "rcutils/types.h"
 #include "rosbag2_storage/serialized_bag_message.hpp"
@@ -35,10 +35,10 @@ public:
   virtual void deserialize(
     std::shared_ptr<const rosbag2::SerializedBagMessage> serialized_message,
     const rosidl_message_type_support_t * type_support,
-    std::shared_ptr<rosbag2_ros2_message_t> ros_message) = 0;
+    std::shared_ptr<rosbag2_introspection_message_t> ros_message) = 0;
 
   virtual void serialize(
-    std::shared_ptr<const rosbag2_ros2_message_t> ros_message,
+    std::shared_ptr<const rosbag2_introspection_message_t> ros_message,
     const rosidl_message_type_support_t * type_support,
     std::shared_ptr<rosbag2::SerializedBagMessage> serialized_message) = 0;
 };

--- a/rosbag2/include/rosbag2/types/introspection_message.hpp
+++ b/rosbag2/include/rosbag2/types/introspection_message.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__TYPES__ROS2_MESSAGE_HPP_
-#define ROSBAG2__TYPES__ROS2_MESSAGE_HPP_
+#ifndef ROSBAG2__TYPES__INTROSPECTION_MESSAGE_HPP_
+#define ROSBAG2__TYPES__INTROSPECTION_MESSAGE_HPP_
 
 #include <memory>
 
@@ -23,7 +23,7 @@
 #include "rcutils/allocator.h"
 #include "rosbag2/visibility_control.hpp"
 
-typedef struct rosbag2_ros2_message_t
+typedef struct rosbag2_introspection_message_t
 {
   void * message;
   char * topic_name;
@@ -35,12 +35,13 @@ namespace rosbag2
 {
 
 ROSBAG2_PUBLIC
-std::shared_ptr<rosbag2_ros2_message_t>
-allocate_ros2_message(
+std::shared_ptr<rosbag2_introspection_message_t>
+allocate_introspection_message(
   const rosidl_message_type_support_t * introspection_ts, const rcutils_allocator_t * allocator);
 
 ROSBAG2_PUBLIC
-void ros2_message_set_topic_name(rosbag2_ros2_message_t * msg, const char * topic_name);
+void introspection_message_set_topic_name(
+  rosbag2_introspection_message_t * msg, const char * topic_name);
 
 ROSBAG2_PUBLIC
 void allocate_internal_types(
@@ -59,8 +60,8 @@ void allocate_vector(
   void * data, const rosidl_typesupport_introspection_cpp::MessageMember & member);
 
 ROSBAG2_PUBLIC
-void deallocate_ros2_message(
-  rosbag2_ros2_message_t * msg,
+void deallocate_introspection_message(
+  rosbag2_introspection_message_t * msg,
   const rosidl_typesupport_introspection_cpp::MessageMembers * members);
 
 ROSBAG2_PUBLIC
@@ -81,4 +82,4 @@ void cleanup_vector(
 
 }  // namespace rosbag2
 
-#endif  // ROSBAG2__TYPES__ROS2_MESSAGE_HPP_
+#endif  // ROSBAG2__TYPES__INTROSPECTION_MESSAGE_HPP_

--- a/rosbag2/src/rosbag2/converter.cpp
+++ b/rosbag2/src/rosbag2/converter.cpp
@@ -64,7 +64,7 @@ Converter::~Converter()
 std::shared_ptr<SerializedBagMessage> Converter::convert(
   std::shared_ptr<const rosbag2::SerializedBagMessage> message)
 {
-  auto ts = topics_and_types_.at(message->topic_name).cpp_type_support;
+  auto ts = topics_and_types_.at(message->topic_name).rmw_type_support;
   auto introspection_ts = topics_and_types_.at(message->topic_name).introspection_type_support;
   auto allocator = rcutils_get_default_allocator();
   std::shared_ptr<rosbag2_ros2_message_t> allocated_ros_message =
@@ -80,7 +80,7 @@ std::shared_ptr<SerializedBagMessage> Converter::convert(
 void Converter::add_topic(const std::string & topic, const std::string & type)
 {
   ConverterTypeSupport type_support;
-  type_support.cpp_type_support = get_typesupport(type, "rosidl_typesupport_cpp");
+  type_support.rmw_type_support = get_typesupport(type, "rosidl_typesupport_cpp");
   type_support.introspection_type_support =
     get_typesupport(type, "rosidl_typesupport_introspection_cpp");
 

--- a/rosbag2/src/rosbag2/converter.cpp
+++ b/rosbag2/src/rosbag2/converter.cpp
@@ -67,8 +67,8 @@ std::shared_ptr<SerializedBagMessage> Converter::convert(
   auto ts = topics_and_types_.at(message->topic_name).rmw_type_support;
   auto introspection_ts = topics_and_types_.at(message->topic_name).introspection_type_support;
   auto allocator = rcutils_get_default_allocator();
-  std::shared_ptr<rosbag2_ros2_message_t> allocated_ros_message =
-    allocate_ros2_message(introspection_ts, &allocator);
+  std::shared_ptr<rosbag2_introspection_message_t> allocated_ros_message =
+    allocate_introspection_message(introspection_ts, &allocator);
 
   input_converter_->deserialize(message, ts, allocated_ros_message);
   auto output_message = std::make_shared<rosbag2::SerializedBagMessage>();

--- a/rosbag2/src/rosbag2/types/introspection_message.cpp
+++ b/rosbag2/src/rosbag2/types/introspection_message.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rosbag2/types/ros2_message.hpp"
+#include "rosbag2/types/introspection_message.hpp"
 
 #include <memory>
 #include <string>
@@ -26,13 +26,13 @@
 namespace rosbag2
 {
 
-std::shared_ptr<rosbag2_ros2_message_t>
-allocate_ros2_message(
+std::shared_ptr<rosbag2_introspection_message_t>
+allocate_introspection_message(
   const rosidl_message_type_support_t * introspection_ts, const rcutils_allocator_t * allocator)
 {
   auto intro_ts_members = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
     introspection_ts->data);
-  auto raw_ros2_message = new rosbag2_ros2_message_t();
+  auto raw_ros2_message = new rosbag2_introspection_message_t();
   raw_ros2_message->allocator = *allocator;
   raw_ros2_message->topic_name = nullptr;
   raw_ros2_message->message = raw_ros2_message->allocator.zero_allocate(
@@ -40,13 +40,14 @@ allocate_ros2_message(
   // TODO(Martin-Idel-SI): Use custom allocator to make sure all memory is obtained that way
   allocate_internal_types(raw_ros2_message->message, intro_ts_members);
 
-  auto deleter = [intro_ts_members](rosbag2_ros2_message_t * msg) {
-      deallocate_ros2_message(msg, intro_ts_members);
+  auto deleter = [intro_ts_members](rosbag2_introspection_message_t * msg) {
+      deallocate_introspection_message(msg, intro_ts_members);
     };
-  return std::shared_ptr<rosbag2_ros2_message_t>(raw_ros2_message, deleter);
+  return std::shared_ptr<rosbag2_introspection_message_t>(raw_ros2_message, deleter);
 }
 
-void ros2_message_set_topic_name(rosbag2_ros2_message_t * msg, const char * topic_name)
+void introspection_message_set_topic_name(
+  rosbag2_introspection_message_t * msg, const char * topic_name)
 {
   if (msg->topic_name) {
     msg->allocator.deallocate(msg->topic_name, msg->allocator.state);
@@ -55,8 +56,8 @@ void ros2_message_set_topic_name(rosbag2_ros2_message_t * msg, const char * topi
   msg->topic_name = rcutils_strdup(topic_name, msg->allocator);
 }
 
-void deallocate_ros2_message(
-  rosbag2_ros2_message_t * msg,
+void deallocate_introspection_message(
+  rosbag2_introspection_message_t * msg,
   const rosidl_typesupport_introspection_cpp::MessageMembers * members)
 {
   deallocate_internal_types(msg->message, members);

--- a/rosbag2/test/rosbag2/converter_test_plugin.cpp
+++ b/rosbag2/test/rosbag2/converter_test_plugin.cpp
@@ -21,7 +21,7 @@
 void ConverterTestPlugin::deserialize(
   const std::shared_ptr<const rosbag2::SerializedBagMessage> serialized_message,
   const rosidl_message_type_support_t * type_support,
-  std::shared_ptr<rosbag2_ros2_message_t> ros_message)
+  std::shared_ptr<rosbag2_introspection_message_t> ros_message)
 {
   (void) ros_message;
   (void) serialized_message;
@@ -29,7 +29,7 @@ void ConverterTestPlugin::deserialize(
 }
 
 void ConverterTestPlugin::serialize(
-  const std::shared_ptr<const rosbag2_ros2_message_t> ros_message,
+  const std::shared_ptr<const rosbag2_introspection_message_t> ros_message,
   const rosidl_message_type_support_t * type_support,
   std::shared_ptr<rosbag2::SerializedBagMessage> serialized_message)
 {

--- a/rosbag2/test/rosbag2/converter_test_plugin.hpp
+++ b/rosbag2/test/rosbag2/converter_test_plugin.hpp
@@ -27,10 +27,10 @@ public:
   void deserialize(
     std::shared_ptr<const rosbag2::SerializedBagMessage> serialized_message,
     const rosidl_message_type_support_t * type_support,
-    std::shared_ptr<rosbag2_ros2_message_t> ros_message) override;
+    std::shared_ptr<rosbag2_introspection_message_t> ros_message) override;
 
   void serialize(
-    std::shared_ptr<const rosbag2_ros2_message_t> ros_message,
+    std::shared_ptr<const rosbag2_introspection_message_t> ros_message,
     const rosidl_message_type_support_t * type_support,
     std::shared_ptr<rosbag2::SerializedBagMessage> serialized_message) override;
 };

--- a/rosbag2/test/rosbag2/mock_converter.hpp
+++ b/rosbag2/test/rosbag2/mock_converter.hpp
@@ -33,7 +33,7 @@ public:
 
   MOCK_METHOD3(serialize,
     void(
-      std::shared_ptr<const rosbag2_ros2_message_t>,
+      std::shared_ptr<const rosbag2_introspection_message_t>,
       const rosidl_message_type_support_t *,
       std::shared_ptr<rosbag2::SerializedBagMessage>));
 };

--- a/rosbag2/test/rosbag2/types/test_ros2_message.cpp
+++ b/rosbag2/test/rosbag2/types/test_ros2_message.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "rosbag2/typesupport_helpers.hpp"
-#include "rosbag2/types/ros2_message.hpp"
+#include "rosbag2/types/introspection_message.hpp"
 #include "test_msgs/msg/bounded_array_nested.hpp"
 #include "test_msgs/msg/bounded_array_primitives_nested.hpp"
 #include "test_msgs/msg/bounded_array_primitives.hpp"
@@ -52,7 +52,7 @@ public:
     auto introspection_ts =
       rosbag2::get_typesupport(message_type, "rosidl_typesupport_introspection_cpp");
 
-    return rosbag2::allocate_ros2_message(introspection_ts, &allocator_);
+    return rosbag2::allocate_introspection_message(introspection_ts, &allocator_);
   }
 
   rcutils_allocator_t allocator_;
@@ -208,7 +208,7 @@ TEST_F(Ros2MessageTest, allocate_ros2_message_allocates_nested_bounded_array_nes
 TEST_F(Ros2MessageTest, allocate_ros2_message_cleans_up_topic_name_on_shutdown) {
   auto message = get_allocated_message("test_msgs/BoundedArrayNested");
 
-  rosbag2::ros2_message_set_topic_name(message.get(), "Topic name");
+  rosbag2::introspection_message_set_topic_name(message.get(), "Topic name");
 
   EXPECT_THAT(message->topic_name, StrEq("Topic name"));
 }
@@ -216,8 +216,8 @@ TEST_F(Ros2MessageTest, allocate_ros2_message_cleans_up_topic_name_on_shutdown) 
 TEST_F(Ros2MessageTest, duplicate_set_topic_does_not_leak) {
   auto message = get_allocated_message("test_msgs/BoundedArrayNested");
 
-  rosbag2::ros2_message_set_topic_name(message.get(), "Topic name");
-  rosbag2::ros2_message_set_topic_name(message.get(), "Topic name");
+  rosbag2::introspection_message_set_topic_name(message.get(), "Topic name");
+  rosbag2::introspection_message_set_topic_name(message.get(), "Topic name");
 
   EXPECT_THAT(message->topic_name, StrEq("Topic name"));
 }

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
@@ -23,6 +23,8 @@
 #include "Poco/SharedLibrary.h"
 
 #include "rcutils/strdup.h"
+#include "rosbag2/types/introspection_message.hpp"
+#include "rosidl_generator_cpp/message_type_support_decl.hpp"
 
 #include "../logging.hpp"
 
@@ -96,28 +98,29 @@ CdrConverter::CdrConverter()
 void CdrConverter::deserialize(
   const std::shared_ptr<const rosbag2::SerializedBagMessage> serialized_message,
   const rosidl_message_type_support_t * type_support,
-  std::shared_ptr<rosbag2_ros2_message_t> ros_message)
+  std::shared_ptr<rosbag2_introspection_message_t> introspection_message)
 {
-  rosbag2::ros2_message_set_topic_name(ros_message.get(), serialized_message->topic_name.c_str());
-  ros_message->time_stamp = serialized_message->time_stamp;
+  rosbag2::introspection_message_set_topic_name(
+    introspection_message.get(), serialized_message->topic_name.c_str());
+  introspection_message->time_stamp = serialized_message->time_stamp;
 
-  auto ret =
-    deserialize_fcn_(serialized_message->serialized_data.get(), type_support, ros_message->message);
+  auto ret = deserialize_fcn_(
+    serialized_message->serialized_data.get(), type_support, introspection_message->message);
   if (ret != RMW_RET_OK) {
     ROSBAG2_CONVERTER_DEFAULT_PLUGINS_LOG_ERROR("Failed to deserialize message.");
   }
 }
 
 void CdrConverter::serialize(
-  const std::shared_ptr<const rosbag2_ros2_message_t> ros_message,
+  const std::shared_ptr<const rosbag2_introspection_message_t> introspection_message,
   const rosidl_message_type_support_t * type_support,
   std::shared_ptr<rosbag2::SerializedBagMessage> serialized_message)
 {
-  serialized_message->topic_name = std::string(ros_message->topic_name);
-  serialized_message->time_stamp = ros_message->time_stamp;
+  serialized_message->topic_name = std::string(introspection_message->topic_name);
+  serialized_message->time_stamp = introspection_message->time_stamp;
 
   auto ret = serialize_fcn_(
-    ros_message->message, type_support, serialized_message->serialized_data.get());
+    introspection_message->message, type_support, serialized_message->serialized_data.get());
   if (ret != RMW_RET_OK) {
     ROSBAG2_CONVERTER_DEFAULT_PLUGINS_LOG_ERROR("Failed to serialize message.");
   }

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.hpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.hpp
@@ -20,7 +20,9 @@
 
 #include "rmw/types.h"
 
+#include "rosidl_generator_cpp/message_type_support_decl.hpp"
 #include "rosbag2/serialization_format_converter_interface.hpp"
+#include "rosbag2/types/introspection_message.hpp"
 
 namespace rosbag2_converter_default_plugins
 {
@@ -33,10 +35,10 @@ public:
   void deserialize(
     std::shared_ptr<const rosbag2::SerializedBagMessage> serialized_message,
     const rosidl_message_type_support_t * type_support,
-    std::shared_ptr<rosbag2_ros2_message_t> ros_message) override;
+    std::shared_ptr<rosbag2_introspection_message_t> introspection_message) override;
 
   void serialize(
-    std::shared_ptr<const rosbag2_ros2_message_t> ros_message,
+    std::shared_ptr<const rosbag2_introspection_message_t> introspection_message,
     const rosidl_message_type_support_t * type_support,
     std::shared_ptr<rosbag2::SerializedBagMessage> serialized_message) override;
 

--- a/rosbag2_converter_default_plugins/test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
@@ -22,6 +22,7 @@
 #include "rcutils/strdup.h"
 #include "rosbag2/serialization_format_converter_interface.hpp"
 #include "rosbag2/typesupport_helpers.hpp"
+#include "rosbag2/types/introspection_message.hpp"
 #include "rosbag2_test_common/memory_management.hpp"
 #include "test_msgs/message_fixtures.hpp"
 
@@ -40,16 +41,16 @@ public:
     allocator_ = rcutils_get_default_allocator();
   }
 
-  std::shared_ptr<rosbag2_ros2_message_t> make_shared_ros_message(
+  std::shared_ptr<rosbag2_introspection_message_t> make_shared_ros_message(
     const std::string & topic_name = "")
   {
-    auto ros_message = std::make_shared<rosbag2_ros2_message_t>();
+    auto ros_message = std::make_shared<rosbag2_introspection_message_t>();
     ros_message->time_stamp = 0;
     ros_message->message = nullptr;
     ros_message->allocator = allocator_;
 
     if (!topic_name.empty()) {
-      rosbag2::ros2_message_set_topic_name(ros_message.get(), topic_name.c_str());
+      rosbag2::introspection_message_set_topic_name(ros_message.get(), topic_name.c_str());
     }
 
     return ros_message;

--- a/rosbag2_tests/test/rosbag2_tests/test_converter.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_converter.cpp
@@ -20,7 +20,7 @@
 #include "rcutils/strdup.h"
 #include "rosbag2/serialization_format_converter_factory.hpp"
 #include "rosbag2/typesupport_helpers.hpp"
-#include "rosbag2/types/ros2_message.hpp"
+#include "rosbag2/types/introspection_message.hpp"
 #include "rosbag2_test_common/memory_management.hpp"
 #include "test_msgs/message_fixtures.hpp"
 
@@ -42,17 +42,18 @@ public:
       rosbag2::get_typesupport("test_msgs/DynamicArrayNested", "rosidl_typesupport_cpp");
   }
 
-  std::shared_ptr<rosbag2_ros2_message_t> allocate_empty_dynamic_array_message()
+  std::shared_ptr<rosbag2_introspection_message_t> allocate_empty_dynamic_array_message()
   {
     auto introspection_type_support = rosbag2::get_typesupport(
       "test_msgs/DynamicArrayNested", "rosidl_typesupport_introspection_cpp");
-    auto ros_message = rosbag2::allocate_ros2_message(introspection_type_support, &allocator_);
-    ros_message->time_stamp = 1;
-    rosbag2::ros2_message_set_topic_name(ros_message.get(), topic_name_.c_str());
-    return ros_message;
+    auto introspection_message =
+      rosbag2::allocate_introspection_message(introspection_type_support, &allocator_);
+    introspection_message->time_stamp = 1;
+    rosbag2::introspection_message_set_topic_name(introspection_message.get(), topic_name_.c_str());
+    return introspection_message;
   }
 
-  void fill_dynamic_array_message(std::shared_ptr<rosbag2_ros2_message_t> message)
+  void fill_dynamic_array_message(std::shared_ptr<rosbag2_introspection_message_t> message)
   {
     auto correctly_typed_ros_message =
       reinterpret_cast<test_msgs::msg::DynamicArrayNested *>(message->message);

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -45,14 +45,15 @@ TEST_F(InfoEndToEndTestFixture, info_end_to_end_test) {
       "\nBag size:          .*B"
       "\nStorage id:        sqlite3"
       "\nDuration:          0\\.155s"
-      "\nStart:             Sep .+ 2018 .+:.+:44\\.241 \\(1537282604\\.241\\)"
-      "\nEnd                Sep .+ 2018 .+:.+:44\\.397 \\(1537282604\\.397\\)"
+      "\nStart:             Sep 18 2018 .*:.*:44.241 \\(1537282604\\.241\\)"
+      "\nEnd                Sep 18 2018 .*:.*:44.397 \\(1537282604\\.397\\)"
       "\nMessages:          7"
-      "\nTopic information: "
-      "Topic: /test_topic | Type: test_msgs/Primitives | Count:  3 | Serialization Format: cdr\n"
-      "                   "
-      "Topic: /array_topic | Type: test_msgs/StaticArrayPrimitives | "
-      "Count: 4 | Serialization Format: cdr"));
+      "\nTopic information: "));
+  EXPECT_THAT(output, HasSubstr(
+      "Topic: /test_topic | Type: test_msgs/Primitives | Count: 3 | Serialization Format: cdr\n"));
+  EXPECT_THAT(output, HasSubstr(
+      "Topic: /array_topic | Type: test_msgs/StaticArrayPrimitives | Count: 4 | "
+      "Serialization Format: cdr"));
 }
 
 // TODO(Martin-Idel-SI): Revisit exit code non-zero here, gracefully should be exit code zero

--- a/rosbag2_transport/src/rosbag2_transport/formatter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.cpp
@@ -136,7 +136,7 @@ void Formatter::format_topics_with_type(
   }
 
   auto print_topic_info =
-    [&info_stream, &indentation_spaces](const rosbag2::TopicInformation & ti) -> void {
+    [&info_stream](const rosbag2::TopicInformation & ti) -> void {
       info_stream << "Topic: " << ti.topic_metadata.name << " | ";
       info_stream << "Type: " << ti.topic_metadata.type << " | ";
       info_stream << "Count: " << ti.message_count << " | ";

--- a/rosbag2_transport/src/rosbag2_transport/formatter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.hpp
@@ -29,7 +29,6 @@ namespace rosbag2_transport
 class Formatter
 {
 public:
-=======
   static void format_bag_meta_data(const rosbag2::BagMetadata & metadata);
 
   static std::unordered_map<std::string, std::string> format_duration(

--- a/rosbag2_transport/test/rosbag2_transport/test_info.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_info.cpp
@@ -44,18 +44,20 @@ TEST_F(Rosbag2TransportTestFixture, info_pretty_prints_information_from_bagfile)
   // the expected output uses a regex to handle different time zones.
   rosbag2_transport::Rosbag2Transport transport(reader_, writer_, info_);
   transport.print_bag_info("test");
-  std::string expected_output(
-    "\nFiles:             some_relative_path\n"
-    "                   some_other_relative_path\n"
-    "Bag size:          0 B\n"
-    "Storage id:        sqlite3\n"
-    "Duration:          0\\.50s\n"
-    "Start:             Sep .+ 2018 .+:.+:45\\.348 \\(1538051985\\.348\\)\n"
-    "End                Sep .+ 2018 .+:.+:45\\.398 \\(1538051985\\.398\\)\n"
-    "Messages:          50\n"
-    "Topics with Type:  Topic: topic1 | Type: type1 | Count: 100 | Serialization Format: rmw1\n"
-    "                   Topic: topic2 | Type: type2 | Count: 200 | Serialization Format: rmw2\n\n");
 
   std::string output = internal::GetCapturedStdout();
-  EXPECT_THAT(output, ContainsRegex(expected_output));
+  EXPECT_THAT(output, ContainsRegex(
+      "\nFiles:             some_relative_path\n"
+      "                   some_other_relative_path\n"
+      "Bag size:          0 B\n"
+      "Storage id:        sqlite3\n"
+      "Duration:          0\\.50s\n"
+      "Start:             Sep 27 2018 .*:.*:45.348 \\(1538051985\\.348\\)\n"
+      "End                Sep 27 2018 .*:.*:45.398 \\(1538051985\\.398\\)\n"
+      "Messages:          50\n"
+      "Topic information: "));
+  EXPECT_THAT(output, HasSubstr(
+      "Topic: topic1 | Type: type1 | Count: 100 | Serialization Format: rmw1"));
+  EXPECT_THAT(output, HasSubstr(
+      "Topic: topic2 | Type: type2 | Count: 200 | Serialization Format: rmw2\n\n"));
 }


### PR DESCRIPTION
Renames `ros2_message_t` to `introspection_message_t` and `cpp_type_support` to `rmw_type_support`. Fixes build issues from #66.