### PR TITLE
Release fixups

### DIFF
--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 
 from ros2bag.verb import VerbExtension
 
@@ -30,6 +29,6 @@ class InfoVerb(VerbExtension):
     def main(self, *, args):  # noqa: D102
         bag_file = args.bag_file
         if not os.path.exists(bag_file):
-            return "Error: bag file '{}' does not exist!".format(bag_file)
+            return "[ERROR] [ros2bag]: bag file '{}' does not exist!".format(bag_file)
 
         rosbag2_transport_py.info(uri=bag_file)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -26,10 +26,28 @@ class PlayVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(
             'bag_file', help='bag file to replay')
+        parser.add_argument(
+            '-s', '--storage', default='sqlite3',
+            help='storage identifier to be used, defaults to "sqlite3"')
+        parser.add_argument(
+            '-r', '--read-ahead-queue-size', default = 1000,
+            help='size of message queue rosbag tries to hold in memory to help deterministic '
+                 'playback. Larger size will result in larger memory needs but might prevent '
+                 'delay of message playback.')
 
     def main(self, *, args):  # noqa: D102
         bag_file = args.bag_file
         if not os.path.exists(bag_file):
             return "Error: bag file '{}' does not exist!".format(bag_file)
 
-        rosbag2_transport_py.play(uri=bag_file, storage_id='sqlite3')
+        read_ahead_queue_size = 1000
+        try:
+            read_ahead_queue_size = int(args.read_ahead_queue_size)
+        except:
+            print("[ERROR] [ros2bag] read ahead queue size must be an integer")
+            exit(0)
+
+        rosbag2_transport_py.play(
+            uri=bag_file,
+            storage_id=args.storage,
+            read_ahead_queue_size=read_ahead_queue_size)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 
 from ros2bag.verb import VerbExtension
 
@@ -30,7 +29,7 @@ class PlayVerb(VerbExtension):
             '-s', '--storage', default='sqlite3',
             help='storage identifier to be used, defaults to "sqlite3"')
         parser.add_argument(
-            '-r', '--read-ahead-queue-size', default = 1000,
+            '-r', '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
                  'playback. Larger size will result in larger memory needs but might prevent '
                  'delay of message playback.')
@@ -38,16 +37,9 @@ class PlayVerb(VerbExtension):
     def main(self, *, args):  # noqa: D102
         bag_file = args.bag_file
         if not os.path.exists(bag_file):
-            return "Error: bag file '{}' does not exist!".format(bag_file)
-
-        read_ahead_queue_size = 1000
-        try:
-            read_ahead_queue_size = int(args.read_ahead_queue_size)
-        except:
-            print("[ERROR] [ros2bag] read ahead queue size must be an integer")
-            exit(0)
+            return "[ERROR] [ros2bag] bag file '{}' does not exist!".format(bag_file)
 
         rosbag2_transport_py.play(
             uri=bag_file,
             storage_id=args.storage,
-            read_ahead_queue_size=read_ahead_queue_size)
+            read_ahead_queue_size=args.read_ahead_queue_size)

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -14,7 +14,6 @@
 
 import datetime
 import os
-import sys
 
 from ros2bag.verb import VerbExtension
 
@@ -30,7 +29,7 @@ class RecordVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(
             '-a', '--all', action='store_true',
-            help='recording all topics, required if no topics are listed explicitely.')
+            help='recording all topics, required if no topics are listed explicitly.')
         parser.add_argument(
             'topics', nargs='*', help='topics to be recorded')
         parser.add_argument(
@@ -57,7 +56,7 @@ class RecordVerb(VerbExtension):
     def create_bag_directory(self, uri):
         try:
             os.makedirs(uri)
-        except:
+        except OSError:
             return "[ERROR] [ros2bag]: Could not create bag folder '{}'.".format(uri)
 
     def main(self, *, args):  # noqa: D102

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -28,9 +28,6 @@ class RecordVerb(VerbExtension):
     """ros2 bag record."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        self._subparser = parser
-
-        add_arguments(parser)
         parser.add_argument(
             '-a', '--all', action='store_true',
             help='recording all topics, required if no topics are listed explicitely.')

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -32,7 +32,8 @@ class RecordVerb(VerbExtension):
 
         add_arguments(parser)
         parser.add_argument(
-            '-a', '--all', action='store_true', help='recording all topics')
+            '-a', '--all', action='store_true',
+            help='recording all topics, required if no topics are listed explicitely.')
         parser.add_argument(
             'topics', nargs='*', help='topics to be recorded')
         parser.add_argument(

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -60,7 +60,7 @@ class RecordVerb(VerbExtension):
         try:
             os.makedirs(uri)
         except:
-            return "Error: Could not create bag folder '{}'.".format(uri)
+            return "[ERROR] [ros2bag]: Could not create bag folder '{}'.".format(uri)
 
     def main(self, *, args):  # noqa: D102
         if args.all and args.topics:
@@ -69,7 +69,7 @@ class RecordVerb(VerbExtension):
         uri = args.output if args.output else datetime.datetime.now().strftime("rosbag2_%Y_%m_%d-%H_%M_%S")
 
         if os.path.isdir(uri):
-            return "Error: Output folder '{}' already exists.".format(uri)
+            return "[ERROR] [ros2bag]: Output folder '{}' already exists.".format(uri)
 
         self.create_bag_directory(uri)
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -107,7 +107,8 @@ void Rosbag2Transport::print_bag_info(const std::string & uri)
   } catch (std::runtime_error & e) {
     (void) e;
     ROSBAG2_TRANSPORT_LOG_ERROR_STREAM("Could not read metadata for " << uri << ". Please specify "
-      "the path to the folder containing an existing 'metadata.yaml' file");
+      "the path to the folder containing an existing 'metadata.yaml' file and make sure that the "
+      "file 'metadata.yaml' exists and has the correct format.");
     return;
   }
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -109,7 +109,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   storage_options.uri = std::string(uri);
   storage_options.storage_id = std::string(storage_id);
 
-  play_options.read_ahead_queue_size = read_ahead_queue_size ? read_ahead_queue_size : 1000;
+  play_options.read_ahead_queue_size = read_ahead_queue_size;
 
   rosbag2_transport::Rosbag2Transport transport;
   transport.init();


### PR DESCRIPTION
This pr improves few minor cosmetic issues:
- Use consistent format for error messages (even those from the python layer)
- Improve error message for `info` when the metadata file can not be read.
- Improve help text for `--all` option of `record`.
- Get rid of `--spin-time` cli option
- Expose `read_ahead_queue_size` as cli option
- Improve handling of `Ctrl-C`