### PR TITLE
Build sqlite3 as shared library

### DIFF
--- a/sqlite3_vendor/sqlite3_cmakelists.txt
+++ b/sqlite3_vendor/sqlite3_cmakelists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-add_library(sqlite3 sqlite3.c)
+add_library(sqlite3 SHARED sqlite3.c)
 set_target_properties(sqlite3 PROPERTIES
   INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 


### PR DESCRIPTION
This PR fixes the following problem:

When sqlite3 is not installed on Linux, it is built via the vendor package as static library. However, the sqlite3 plugin is a shared library and it cannot be built against a static library which was not explicitly built with -fPIC (that's how ELF works, for Windows, there is no problem).

Solution:
Build a shared library, since this is also the default for Linux systems where usually sqlite3 is already installed, so the resulting system will more closely resemble a system where sqlite3 is already installed.