### PR TITLE
Build sqlite3 with position independent flags

### DIFF
--- a/sqlite3_vendor/sqlite3_cmakelists.txt
+++ b/sqlite3_vendor/sqlite3_cmakelists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
-add_library(sqlite3 SHARED sqlite3.c)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # for Linux, since the library will be used in a shared lib
+add_library(sqlite3 sqlite3.c)
 set_target_properties(sqlite3 PROPERTIES
   INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 


### PR DESCRIPTION
It turns out that SQLite3 does not export symbols on Windows when built as shared library.
The easiest way to fix this is revert to building a static library and doing so as position independent code.