### PR TITLE
enforce unique node names

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
@@ -33,14 +33,21 @@ using CountFunction = std::function<size_t(const std::string &)>;
 class PublisherManager
 {
 public:
+  ~PublisherManager()
+  {
+    publishers_.clear();
+    publisher_nodes_.clear();
+  }
+
   template<class T>
   void add_publisher(
     const std::string & topic_name, std::shared_ptr<T> message, size_t expected_messages = 0)
   {
-    static int counter = 0;
-    auto publisher_node = std::make_shared<rclcpp::Node>("publisher" + std::to_string(counter++));
+    auto node_name = std::string("publisher") + std::to_string(counter_++);
+    auto publisher_node = std::make_shared<rclcpp::Node>(node_name);
     auto publisher = publisher_node->create_publisher<T>(topic_name);
 
+    publisher_nodes_.push_back(publisher_node);
     publishers_.push_back([publisher, topic_name, message, expected_messages](
         CountFunction count_stored_messages) {
         if (expected_messages != 0) {
@@ -72,6 +79,8 @@ public:
   }
 
 private:
+  int counter_ = 1;
+  std::vector<std::shared_ptr<rclcpp::Node>> publisher_nodes_;
   std::vector<std::function<void(CountFunction)>> publishers_;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "rclcpp/any_subscription_callback.hpp"
+#include "rclcpp/macros.hpp"
 #include "rclcpp/subscription.hpp"
 
 namespace rosbag2_transport


### PR DESCRIPTION
fixes the unique node problem referred to in https://github.com/ros2/rcl/issues/375

the template function indeed creates a new `static int counter` per type and thus non-unique node names when different types are used.