### PR TITLE
Dnae adas/sequential writing

### DIFF
--- a/rosbag2_storage_default_plugins/CMakeLists.txt
+++ b/rosbag2_storage_default_plugins/CMakeLists.txt
@@ -90,6 +90,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_sqlite_storage ${TEST_LINK_LIBRARIES})
     ament_target_dependencies(test_sqlite_storage rosbag2_test_common)
   endif()
+
+  ament_add_gmock(test_sqlite_sequential_storage
+    test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_sqlite_sequential_storage)
+    target_link_libraries(test_sqlite_sequential_storage ${TEST_LINK_LIBRARIES})
+    ament_target_dependencies(test_sqlite_sequential_storage rosbag2_test_common)
+  endif()
 endif()
 
 ament_package()

--- a/rosbag2_storage_default_plugins/CMakeLists.txt
+++ b/rosbag2_storage_default_plugins/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(SQLite3 REQUIRED)  # provided by sqlite3_vendor
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
   src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+  src/rosbag2_storage_default_plugins/sqlite/sqlite_sequential_storage.cpp
   src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp)
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_sequential_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_sequential_storage.hpp
@@ -1,0 +1,88 @@
+// Copyright 2019, Denso ADAS Engineering Services GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_STORAGE_DEFAULT_PLUGINS__SQLITE__SQLITE_SEQUENTIAL_STORAGE_HPP_
+#define ROSBAG2_STORAGE_DEFAULT_PLUGINS__SQLITE__SQLITE_SEQUENTIAL_STORAGE_HPP_
+
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "sqlite_storage.hpp"
+
+// This is necessary because of using stl types here. It is completely safe, because
+// a) the member is not accessible from the outside
+// b) there are no inline functions.
+#ifdef _WIN32
+# pragma warning(push)
+# pragma warning(disable:4251)
+#endif
+
+namespace rosbag2_storage_plugins
+{
+
+class ROSBAG2_STORAGE_DEFAULT_PLUGINS_PUBLIC SqliteSequentialStorage
+  : public SqliteStorage
+{
+public:
+  SqliteSequentialStorage() = default;
+  ~SqliteSequentialStorage() override = default;
+
+  void open(
+    const std::string & uri,
+    rosbag2_storage::storage_interfaces::IOFlag io_flag =
+    rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
+
+  rosbag2_storage::BagMetadata get_metadata() override;
+
+  const std::string get_storage_identifier() const override;
+
+protected:
+  std::shared_ptr<rcutils_uint8_array_t> read_data() override;
+  std::shared_ptr<rcutils_uint8_array_t> get_serialized_data(
+    std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message) override;
+
+private:
+#pragma pack(push, 1)
+  struct MetaInformation
+  {
+    uint64_t offset;
+    uint64_t size;
+    uint32_t file_index;
+  };
+#pragma pack(pop)  // back to whatever the previous packing mode was
+
+  struct BinarySequentialFile
+  {
+    std::string path;
+    std::fstream file_stream;
+    std::mutex lock;
+
+    explicit BinarySequentialFile(const std::string & _path)
+    : path(_path)
+    {
+    }
+  };
+
+  std::vector<std::unique_ptr<BinarySequentialFile>> data_files_;
+};
+
+}  // namespace rosbag2_storage_plugins
+
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
+
+#endif  // ROSBAG2_STORAGE_DEFAULT_PLUGINS__SQLITE__SQLITE_SEQUENTIAL_STORAGE_HPP_

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -86,7 +86,7 @@ private:
     uint64_t size;
     uint32_t file_index;
   };
-#pragma pack(pop) //back to whatever the previous packing mode was
+#pragma pack(pop)  // back to whatever the previous packing mode was
 
   struct BinarySequentialFile
   {
@@ -94,7 +94,8 @@ private:
     std::fstream file_stream;
     std::mutex lock;
 
-    BinarySequentialFile(const std::string &_path) : path(_path)
+    explicit BinarySequentialFile(const std::string & _path)
+    : path(_path)
     {
     }
   };

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <fstream>
 
 #include "rcutils/types.h"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
@@ -85,6 +86,8 @@ private:
   ReadQueryResult::Iterator current_message_row_;
   std::unordered_map<std::string, int> topics_;
   std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
+  bool extra_file_;
+  std::fstream data_file_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <fstream>
 #include <mutex>
 
 #include "rcutils/types.h"
@@ -66,7 +65,13 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
-private:
+  virtual const std::string get_storage_identifier() const;
+
+protected:
+  virtual std::shared_ptr<rcutils_uint8_array_t> read_data();
+  virtual std::shared_ptr<rcutils_uint8_array_t>
+  get_serialized_data(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message);
+
   void initialize();
   void prepare_for_writing();
   void prepare_for_reading();
@@ -79,27 +84,6 @@ private:
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string>;
 
-#pragma pack(push, 1)
-  struct MetaInformation
-  {
-    uint64_t offset;
-    uint64_t size;
-    uint32_t file_index;
-  };
-#pragma pack(pop)  // back to whatever the previous packing mode was
-
-  struct BinarySequentialFile
-  {
-    std::string path;
-    std::fstream file_stream;
-    std::mutex lock;
-
-    explicit BinarySequentialFile(const std::string & _path)
-    : path(_path)
-    {
-    }
-  };
-
   std::shared_ptr<SqliteWrapper> database_;
   std::string database_name_;
   SqliteStatement write_statement_;
@@ -108,8 +92,6 @@ private:
   ReadQueryResult::Iterator current_message_row_;
   std::unordered_map<std::string, int> topics_;
   std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
-  bool extra_file_;
-  std::vector<std::unique_ptr<BinarySequentialFile>> data_files_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/plugin_description.xml
+++ b/rosbag2_storage_default_plugins/plugin_description.xml
@@ -6,4 +6,11 @@
   >
     <description>Plugin to write to SQLite3 databases</description>
   </class>
+  <class
+    name="sqlite3_sequential"
+    type="rosbag2_storage_plugins::SqliteSequentialStorage"
+    base_class_type="rosbag2_storage::storage_interfaces::ReadWriteInterface"
+  >
+    <description>Plugin to write to SQLite3 databases, serializing binary data in separate file</description>
+  </class>
 </library>

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_sequential_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_sequential_storage.cpp
@@ -1,0 +1,161 @@
+// Copyright 2019, Denso ADAS Engineering Services GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_storage_default_plugins/sqlite/sqlite_sequential_storage.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+#include "rosbag2_storage/filesystem_helper.hpp"
+#include "rosbag2_storage/ros_helper.hpp"
+
+#include "../logging.hpp"
+
+namespace rosbag2_storage_plugins
+{
+
+void SqliteSequentialStorage::open(
+  const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
+{
+  SqliteStorage::open(uri, io_flag);
+
+  const bool ro = is_read_only(io_flag);
+  auto metadata = ro ?
+    load_metadata(uri) :
+    std::unique_ptr<rosbag2_storage::BagMetadata>();
+
+  // in write mode we add at least one serialized file
+  // (it would be possible to split the data into into multiple files)
+  if (!ro) {
+    data_files_.push_back(
+      std::make_unique<BinarySequentialFile>(database_name_ + ".extra")
+    );
+  } else if (metadata->relative_file_paths.size() >= 1) {
+    std::for_each(metadata->relative_file_paths.begin() + 1,
+      metadata->relative_file_paths.end(), [this](auto & path)
+      {
+        data_files_.push_back(
+          std::make_unique<BinarySequentialFile>(path)
+        );
+      });
+  }
+
+  if (data_files_.size() == 0) {  // no serialized file
+    throw std::runtime_error("Missing binary, sequential file!");
+  } else {
+    for (auto & data_file : data_files_) {
+      data_file->file_stream.open(
+        rosbag2_storage::FilesystemHelper::concat({uri, data_file->path}),
+        std::fstream::binary | (ro ? std::fstream::in : std::fstream::out)
+      );
+
+      if (!data_file->file_stream) {
+        throw std::runtime_error("Failed to setup storage. Failed to open extra file!");
+      }
+    }
+  }
+}
+
+std::shared_ptr<rcutils_uint8_array_t> SqliteSequentialStorage::get_serialized_data(
+  std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
+{
+  constexpr uint32_t file_index = 0;  // could be changed to split data into files
+
+  // allocate array for message meta information
+  auto serialized_data = std::shared_ptr<rcutils_uint8_array_t>(new rcutils_uint8_array_t,
+      [](rcutils_uint8_array_t * msg) {
+        int error = rcutils_uint8_array_fini(msg);
+        delete msg;
+        if (error != RCUTILS_RET_OK) {
+          RCUTILS_LOG_ERROR_NAMED(
+            "rosbag2_storage_default_plugins", "Leaking memory %i", error);
+        }
+      });
+  *serialized_data = rcutils_get_zero_initialized_uint8_array();
+
+  auto allocator = rcutils_get_default_allocator();
+  auto ret = rcutils_uint8_array_init(serialized_data.get(), sizeof(MetaInformation), &allocator);
+  if (ret != RCUTILS_RET_OK) {
+    throw std::runtime_error("Error allocating resources " + std::to_string(ret));
+  }
+  MetaInformation * data = reinterpret_cast<MetaInformation *>(serialized_data->buffer);
+  serialized_data->buffer_length = sizeof(MetaInformation);
+
+  // write actual content to file and store meta information to serialized data to return
+  auto & file_handle = data_files_[file_index];
+  std::lock_guard<std::mutex>(file_handle->lock);
+
+  data->offset = static_cast<uint64_t>(file_handle->file_stream.tellg());
+  data->size = static_cast<uint64_t>(message->serialized_data->buffer_length);
+  data->file_index = file_index;
+
+  file_handle->file_stream.write(reinterpret_cast<const char *>(message->serialized_data->buffer),
+    message->serialized_data->buffer_length);
+
+  return serialized_data;
+}
+
+
+std::shared_ptr<rcutils_uint8_array_t> SqliteSequentialStorage::read_data()
+{
+  std::shared_ptr<rcutils_uint8_array_t> serialized_return_data;
+
+  MetaInformation * data;
+  std::shared_ptr<rcutils_uint8_array_t> serialized_data = std::get<0>(*current_message_row_);
+  if (serialized_data->buffer_length == sizeof(MetaInformation)) {
+    data = reinterpret_cast<MetaInformation *>(serialized_data->buffer);
+
+    if (!data || data->file_index >= data_files_.size()) {
+      throw std::runtime_error("Invalid content for extra file!");
+    }
+
+    auto & file_handle = data_files_[data->file_index];
+    std::lock_guard<std::mutex>(file_handle->lock);
+
+    serialized_return_data = rosbag2_storage::make_empty_serialized_message(data->size);
+    serialized_return_data->buffer_length = data->size;
+    file_handle->file_stream.seekg(data->offset);
+
+    file_handle->file_stream.read(reinterpret_cast<char *>(
+        serialized_return_data->buffer), data->size
+    );
+  } else {
+    throw std::runtime_error("Database entry has wrong size!");
+  }
+
+  return serialized_return_data;
+}
+
+rosbag2_storage::BagMetadata SqliteSequentialStorage::get_metadata()
+{
+  rosbag2_storage::BagMetadata metadata = SqliteStorage::get_metadata();
+  metadata.storage_identifier = get_storage_identifier();
+  for (const auto & f : data_files_) {
+    metadata.relative_file_paths.push_back(f->path);
+  }
+
+  return metadata;
+}
+
+const std::string SqliteSequentialStorage::get_storage_identifier() const
+{
+  return "sqlite3_sequential";
+}
+
+}  // namespace rosbag2_storage_plugins
+
+#include "pluginlib/class_list_macros.hpp"  // NOLINT
+PLUGINLIB_EXPORT_CLASS(rosbag2_storage_plugins::SqliteSequentialStorage,
+  rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -89,7 +89,7 @@ void SqliteStorage::open(
     const bool ro = is_read_only(io_flag);
 
     // in write mode we add at least one serialized file
-    // (it would be possible to split dante into multiple files)
+    // (it would be possible to split the data into into multiple files)
     if(!ro)
     {
       data_files_.push_back(

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -126,7 +126,7 @@ void SqliteStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMe
 
     auto serialized_data = std::make_shared<rcutils_uint8_array_t>();
     serialized_data->buffer = reinterpret_cast<uint8_t *>(data.data());
-    serialized_data->buffer_length = serialized_data->buffer_capacity = 16;
+    serialized_data->buffer_length = serialized_data->buffer_capacity = sizeof(data::value_type)*data.size();
 
     write_statement_->bind(message->time_stamp, topic_entry->second, serialized_data);
     write_statement_->execute_and_reset();
@@ -157,7 +157,7 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SqliteStorage::read_next(
   auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   if (extra_file_) {
     std::shared_ptr<rcutils_uint8_array_t> serialized_data = std::get<0>(*current_message_row_);
-    if (serialized_data->buffer_length == 16) {
+    if (serialized_data->buffer_length == 2*sizeof(uint64_t)) {
 
       uint64_t * data = reinterpret_cast<uint64_t *>(serialized_data->buffer);
 
@@ -170,7 +170,7 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SqliteStorage::read_next(
         bag_message->serialized_data->buffer_length
       );
     } else {
-      throw std::runtime_error("Database entry has wrong size! %d != 16", serialized_data->buffer_length);
+      throw std::runtime_error("Database entry has wrong size! %d != %d", serialized_data->buffer_length, 2*sizeof(uint64_t));
     }
   } else {
     bag_message->serialized_data = std::get<0>(*current_message_row_);

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -117,16 +117,15 @@ void SqliteStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMe
   }
 
   if (extra_file_) {
-    uint64_t data[2];
-
-    data[0] = data_file_.tellg();
-    data[1] = message->serialized_data->buffer_length;
+    std::array<uint64_t, 2> data = {
+      data_file_.tellg(),
+      message->serialized_data->buffer_length};
 
     data_file_.write(reinterpret_cast<const char *>(message->serialized_data->buffer),
       message->serialized_data->buffer_length);
 
     auto serialized_data = std::make_shared<rcutils_uint8_array_t>();
-    serialized_data->buffer = reinterpret_cast<uint8_t *>(&data);
+    serialized_data->buffer = reinterpret_cast<uint8_t *>(data.data());
     serialized_data->buffer_length = serialized_data->buffer_capacity = 16;
 
     write_statement_->bind(message->time_stamp, topic_entry->second, serialized_data);

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -146,7 +146,8 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
   EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
-    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
+    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3",
+    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3.extra"
   }));
   EXPECT_THAT(metadata.topics_with_message_count, ElementsAreArray({
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
@@ -171,7 +172,8 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_if_no_messages) {
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
   EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
-    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
+    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3",
+    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3.extra"
   }));
   EXPECT_THAT(metadata.topics_with_message_count, IsEmpty());
   EXPECT_THAT(metadata.message_count, Eq(0u));


### PR DESCRIPTION
Feature: Writing serialized ROS2 messages to a binary file instead of sqlite3 database.
 * speed improvement
 * allows to split big recordings
 * allows to write to multiple disks (for higher write performance)

Question: Should the identifier for the storage plugin be changed? (rosbag2 recorded with this system cannot be played by previous versions, but vice versa)