### PR TITLE
disable cppcheck

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -80,6 +80,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(test_msgs REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
+  # explicitly disable cppcheck
+  set(ament_cmake_cppcheck_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gmock(test_info


### PR DESCRIPTION
due to an update of the ROS2 CI machines (OSX, Windows) cppcheck currently fails because we're using a rclcpp macro which is not verified by cppcheck.

the patch for cppcheck is here: https://github.com/ament/ament_lint/pull/125
given that this patch most likely won't be backported to crystal, this PR explicitly disables cppcheck. 

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6163)](http://ci.ros2.org/job/ci_linux/6163/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2629)](http://ci.ros2.org/job/ci_linux-aarch64/2629/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5083)](http://ci.ros2.org/job/ci_osx/5083/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6024)](http://ci.ros2.org/job/ci_windows/6024/)