### PR TITLE
Fix issue with ros2bag record python frontend

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -48,7 +48,7 @@ class RecordVerb(VerbExtension):
             help='disables topic auto discovery during recording: only topics present at '
              'startup will be recorded')
         parser.add_argument(
-            '-p', '--polling-interval', default=100,
+            '-p', '--polling-interval', type=int, default=100,
             help='time in ms to wait between querying available topics for recording. It has no '
              'effect if --no-discovery is enabled.'
         )

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -52,6 +52,8 @@ class RecordVerb(VerbExtension):
             help='time in ms to wait between querying available topics for recording. It has no '
              'effect if --no-discovery is enabled.'
         )
+        self._subparser = parser
+
 
     def create_bag_directory(self, uri):
         try:


### PR DESCRIPTION
Currently "ros2 bag record" command causes crashes when used with arguments. The PR fixes it.
@Karsten1987 review and get back to me. 