### PR TITLE
Fix logging warnings introduced by ros2/rcutils#154

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/logging.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/logging.hpp
@@ -28,7 +28,7 @@
 #define ROSBAG2_STORAGE_LOG_INFO_STREAM(args) do { \
     std::stringstream __ss; \
     __ss << args; \
-    RCUTILS_LOG_INFO_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __ss.str().c_str()); \
+    RCUTILS_LOG_INFO_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_LOG_ERROR(...) \
@@ -37,7 +37,7 @@
 #define ROSBAG2_STORAGE_LOG_ERROR_STREAM(args) do { \
     std::stringstream __ss; \
     __ss << args; \
-    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __ss.str().c_str()); \
+    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_LOG_WARN(...) \
@@ -46,7 +46,7 @@
 #define ROSBAG2_STORAGE_LOG_WARN_STREAM(args) do { \
     std::stringstream __ss; \
     __ss << args; \
-    RCUTILS_LOG_WARN_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __ss.str().c_str()); \
+    RCUTILS_LOG_WARN_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_LOG_DEBUG(...) \
@@ -55,7 +55,7 @@
 #define ROSBAG2_STORAGE_LOG_DEBUG_STREAM(args) do { \
     std::stringstream __ss; \
     __ss << args; \
-    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __ss.str().c_str()); \
+    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #endif  // ROSBAG2_STORAGE__LOGGING_HPP_


### PR DESCRIPTION
GCC now warns us that log message should not be passed
as format string. This is a dangerous pattern because
if the log message contains a sequence of characters
printf will interpret such as "%d", the program may crash.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>