### PR TITLE
Handle message type name with multiple namespace parts

### DIFF
--- a/rosbag2/src/rosbag2/typesupport_helpers.cpp
+++ b/rosbag2/src/rosbag2/typesupport_helpers.cpp
@@ -67,7 +67,6 @@ const std::pair<std::string, std::string> extract_type_and_package(const std::st
   auto sep_position_back = full_type.find_last_of(type_separator);
   auto sep_position_front = full_type.find_first_of(type_separator);
   if (sep_position_back == std::string::npos ||
-    sep_position_back != sep_position_front ||
     sep_position_back == 0 ||
     sep_position_back == full_type.length() - 1)
   {
@@ -76,7 +75,7 @@ const std::pair<std::string, std::string> extract_type_and_package(const std::st
   }
 
   std::string package_name = full_type.substr(0, sep_position_front);
-  std::string type_name = full_type.substr(sep_position_front + 1);
+  std::string type_name = full_type.substr(sep_position_back + 1);
 
   return {package_name, type_name};
 }

--- a/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
+++ b/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
@@ -53,7 +53,6 @@ TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashe
   EXPECT_THAT(name, StrEq("multiple_slashes"));
 }
 
-
 TEST(TypesupportHelpersTest, throws_exception_if_library_cannot_be_found) {
   EXPECT_THROW(
     rosbag2::get_typesupport("invalid/message", "rosidl_typesupport_cpp"), std::runtime_error);

--- a/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
+++ b/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
@@ -27,10 +27,6 @@ TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_no_type) {
   EXPECT_ANY_THROW(rosbag2::extract_type_and_package("just_a_package_name"));
 }
 
-TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_multiple_slashes) {
-  EXPECT_ANY_THROW(rosbag2::extract_type_and_package("name/with/multiple_slashes"));
-}
-
 TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_slash_at_the_start_only) {
   EXPECT_ANY_THROW(rosbag2::extract_type_and_package("/name_with_slash_at_start"));
 }
@@ -47,6 +43,16 @@ TEST(TypesupportHelpersTest, separates_into_package_and_name_for_correct_package
   EXPECT_THAT(package, StrEq("package"));
   EXPECT_THAT(name, StrEq("name"));
 }
+
+TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashes) {
+  std::string package;
+  std::string name;
+  std::tie(package, name) = rosbag2::extract_type_and_package("name/with/multiple_slashes");
+
+  EXPECT_THAT(package, StrEq("name"));
+  EXPECT_THAT(name, StrEq("multiple_slashes"));
+}
+
 
 TEST(TypesupportHelpersTest, throws_exception_if_library_cannot_be_found) {
   EXPECT_THROW(

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -134,7 +134,7 @@ TEST_F(RosBag2NodeFixture,
   auto topics_and_types = node_->get_topics_with_types({"string_topic"});
 
   ASSERT_THAT(topics_and_types, SizeIs(1));
-  EXPECT_THAT(topics_and_types.begin()->second, StrEq("test_msgs/Strings"));
+  EXPECT_THAT(topics_and_types.begin()->second, StrEq("test_msgs/msg/Strings"));
 }
 
 TEST_F(RosBag2NodeFixture,
@@ -146,7 +146,7 @@ TEST_F(RosBag2NodeFixture,
   auto topics_and_types = node_->get_topics_with_types({"/string_topic"});
 
   ASSERT_THAT(topics_and_types, SizeIs(1));
-  EXPECT_THAT(topics_and_types.begin()->second, StrEq("test_msgs/Strings"));
+  EXPECT_THAT(topics_and_types.begin()->second, StrEq("test_msgs/msg/Strings"));
 }
 
 TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_only_specified_topics) {
@@ -162,8 +162,8 @@ TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_only_specified_topics) 
   auto topics_and_types = node_->get_topics_with_types({first_topic, second_topic});
 
   ASSERT_THAT(topics_and_types, SizeIs(2));
-  EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/Strings"));
-  EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/Strings"));
+  EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/msg/Strings"));
+  EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/msg/Strings"));
 }
 
 TEST_F(RosBag2NodeFixture, get_all_topics_with_types_returns_all_topics)
@@ -180,7 +180,7 @@ TEST_F(RosBag2NodeFixture, get_all_topics_with_types_returns_all_topics)
   auto topics_and_types = node_->get_all_topics_with_types();
 
   ASSERT_THAT(topics_and_types, SizeIs(Ge(3u)));
-  EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/Strings"));
-  EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/Strings"));
-  EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/Strings"));
+  EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/msg/Strings"));
+  EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/msg/Strings"));
+  EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/msg/Strings"));
 }


### PR DESCRIPTION
For now, it is okay to ignore the middle parts of the namespace, but this should be updated in the future.

Connects to https://github.com/ros2/ros2/issues/677