### PR TITLE
ignore cast function type warning

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Wno-cast-function-type -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-cast-function-type -Werror)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -155,6 +155,9 @@ rosbag2_transport_info(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
 }
 
 /// Define the public methods of this module
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wcast-function-type"
 static PyMethodDef rosbag2_transport_methods[] = {
   {
     "record", reinterpret_cast<PyCFunction>(rosbag2_transport_record), METH_VARARGS | METH_KEYWORDS,
@@ -170,6 +173,8 @@ static PyMethodDef rosbag2_transport_methods[] = {
   },
   {nullptr, nullptr, 0, nullptr}  /* sentinel */
 };
+# pragma GCC diagnostic pop
+#endif
 
 PyDoc_STRVAR(rosbag2_transport__doc__,
   "Python module for rosbag2 transport");

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -158,6 +158,7 @@ rosbag2_transport_info(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
 #if !defined(_WIN32)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 static PyMethodDef rosbag2_transport_methods[] = {
   {
     "record", reinterpret_cast<PyCFunction>(rosbag2_transport_record), METH_VARARGS | METH_KEYWORDS,
@@ -173,6 +174,7 @@ static PyMethodDef rosbag2_transport_methods[] = {
   },
   {nullptr, nullptr, 0, nullptr}  /* sentinel */
 };
+#if !defined(_WIN32)
 # pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
This fixes the warning shown in CentOS. According to https://docs.python.org/3/c-api/structures.html#c.PyMethodDef this cast is correct and necessary. Thus suppress the warning for this package.

CentOS CI: https://ci.ros2.org/job/ci_linux-centos/7/
Warning is unrelated

Signed-off-by: Karsten Knese <karsten@openrobotics.org>