### PR TITLE
clean up test dependencies for rosbag2_test_common

### DIFF
--- a/rosbag2_test_common/CMakeLists.txt
+++ b/rosbag2_test_common/CMakeLists.txt
@@ -16,26 +16,25 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-
-find_package(ament_cmake_gmock REQUIRED)
-find_package(ament_lint_auto REQUIRED)
 find_package(rclcpp REQUIRED)
-
-ament_lint_auto_find_test_dependencies()
+find_package(rcutils REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
-
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-
 target_link_libraries(${PROJECT_NAME} INTERFACE rclcpp rcutils)
-
-ament_export_dependencies(rclcpp)
 
 install(
   DIRECTORY include/
   DESTINATION include)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_dependencies(rclcpp rcutils)
 
 ament_export_include_directories(include)
 ament_package()

--- a/rosbag2_test_common/package.xml
+++ b/rosbag2_test_common/package.xml
@@ -9,12 +9,11 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_cmake_gmock</test_depend>
+  <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>rcutils</build_export_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>rclcpp</test_depend>
-  <test_depend>rcutils</test_depend>
-  <build_export_depend>rclcpp</build_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosbag2_test_common/package.xml
+++ b/rosbag2_test_common/package.xml
@@ -9,8 +9,11 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_export_depend>rclcpp</build_export_depend>
-  <build_export_depend>rcutils</build_export_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rcutils</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcutils</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Tackles dev job: http://build.ros2.org/job/Ddev__rosbag2__ubuntu_bionic_amd64/4/consoleFull#console-section-12

Signed-off-by: Karsten Knese <karsten@openrobotics.org>