### PR TITLE
remove disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # rosbag2
 
-THIS IS WORK IN PROGRESS AND SHOULD BE USED WITH CARE
-
 Repository for implementing rosbag2 as described in its corresponding [design article](https://github.com/ros2/design/blob/f69fbbd11848e3dd6866b71a158a1902e31e92f1/articles/rosbags.md)
 
 ## Installation instructions

--- a/ros2bag/ros2bag/command/bag.py
+++ b/ros2bag/ros2bag/command/bag.py
@@ -36,7 +36,5 @@ class BagCommand(CommandExtension):
 
         extension = getattr(args, '_verb')
 
-        print('DISCLAIMER')
-        print('ros2 bag is currently under development and not ready to use yet')
         # call the verb's main method
         return extension.main(args=args)


### PR DESCRIPTION
for visibility only. Removing the disclaimer info given that rosbag2 is now part of the official ros2 repos file.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7178)](http://ci.ros2.org/job/ci_linux/7178/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3389)](http://ci.ros2.org/job/ci_linux-aarch64/3389/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5885)](https://ci.ros2.org/job/ci_osx/5885/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7013)](https://ci.ros2.org/job/ci_windows/7013/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>