### PR TITLE
Add support for parsing middle module name from type

### DIFF
--- a/rosbag2/include/rosbag2/typesupport_helpers.hpp
+++ b/rosbag2/include/rosbag2/typesupport_helpers.hpp
@@ -29,7 +29,7 @@ const rosidl_message_type_support_t *
 get_typesupport(const std::string & type, const std::string & typesupport_identifier);
 
 ROSBAG2_PUBLIC
-const std::pair<std::string, std::string> extract_type_and_package(const std::string & full_type);
+const std::tuple<std::string, std::string, std::string> extract_type_and_package(const std::string & full_type);
 
 }  // namespace rosbag2
 

--- a/rosbag2/include/rosbag2/typesupport_helpers.hpp
+++ b/rosbag2/include/rosbag2/typesupport_helpers.hpp
@@ -29,9 +29,13 @@ ROSBAG2_PUBLIC
 const rosidl_message_type_support_t *
 get_typesupport(const std::string & type, const std::string & typesupport_identifier);
 
+[[deprecated("use extract_type_identifier(const std::string & full_type) instead")]]
+ROSBAG2_PUBLIC
+const std::pair<std::string, std::string> extract_type_and_package(const std::string & full_type);
+
 ROSBAG2_PUBLIC
 const std::tuple<std::string, std::string, std::string>
-extract_type_and_package(const std::string & full_type);
+extract_type_identifier(const std::string & full_type);
 
 }  // namespace rosbag2
 

--- a/rosbag2/src/rosbag2/typesupport_helpers.cpp
+++ b/rosbag2/src/rosbag2/typesupport_helpers.cpp
@@ -61,7 +61,7 @@ std::string get_typesupport_library_path(
   return library_path;
 }
 
-const std::pair<std::string, std::string> extract_type_and_package(const std::string & full_type)
+const std::tuple<std::string, std::string, std::string> extract_type_and_package(const std::string & full_type)
 {
   char type_separator = '/';
   auto sep_position_back = full_type.find_last_of(type_separator);
@@ -75,17 +75,19 @@ const std::pair<std::string, std::string> extract_type_and_package(const std::st
   }
 
   std::string package_name = full_type.substr(0, sep_position_front);
+  std::string middle_module = full_type.substr(sep_position_front + 1, sep_position_back - sep_position_front - 1);
   std::string type_name = full_type.substr(sep_position_back + 1);
 
-  return {package_name, type_name};
+  return std::make_tuple(package_name, middle_module, type_name);
 }
 
 const rosidl_message_type_support_t *
 get_typesupport(const std::string & type, const std::string & typesupport_identifier)
 {
   std::string package_name;
+  std::string middle_module;
   std::string type_name;
-  std::tie(package_name, type_name) = extract_type_and_package(type);
+  std::tie(package_name, middle_module, type_name) = extract_type_and_package(type);
 
   std::string poco_dynamic_loading_error = "Something went wrong loading the typesupport library "
     "for message type " + package_name + "/" + type_name + ".";
@@ -96,7 +98,7 @@ get_typesupport(const std::string & type, const std::string & typesupport_identi
     auto typesupport_library = std::make_shared<Poco::SharedLibrary>(library_path);
 
     auto symbol_name = typesupport_identifier + "__get_message_type_support_handle__" +
-      package_name + "__msg__" + type_name;
+      package_name + "__" + middle_module + "__" + type_name;
 
     if (!typesupport_library->hasSymbol(symbol_name)) {
       throw std::runtime_error(poco_dynamic_loading_error + " Symbol not found.");

--- a/rosbag2/src/rosbag2/typesupport_helpers.cpp
+++ b/rosbag2/src/rosbag2/typesupport_helpers.cpp
@@ -62,8 +62,18 @@ std::string get_typesupport_library_path(
   return library_path;
 }
 
+const std::pair<std::string, std::string> extract_type_and_package(const std::string & full_type)
+{
+  std::string package_name;
+  std::string type_name;
+
+  std::tie(package_name, std::ignore, type_name) = extract_type_identifier(full_type);
+
+  return {package_name, type_name};
+}
+
 const std::tuple<std::string, std::string, std::string>
-extract_type_and_package(const std::string & full_type)
+extract_type_identifier(const std::string & full_type)
 {
   char type_separator = '/';
   auto sep_position_back = full_type.find_last_of(type_separator);
@@ -93,7 +103,7 @@ get_typesupport(const std::string & type, const std::string & typesupport_identi
   std::string package_name;
   std::string middle_module;
   std::string type_name;
-  std::tie(package_name, middle_module, type_name) = extract_type_and_package(type);
+  std::tie(package_name, middle_module, type_name) = extract_type_identifier(type);
 
   std::string poco_dynamic_loading_error = "Something went wrong loading the typesupport library "
     "for message type " + package_name + "/" + type_name + ".";

--- a/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
+++ b/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
@@ -35,11 +35,30 @@ TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_slash_at_the_end_o
   EXPECT_ANY_THROW(rosbag2::extract_type_and_package("name_with_slash_at_end/"));
 }
 
+TEST(TypesupportHelpersTest, separates_into_package_and_name_for_correct_package_legacy) {
+  std::string package;
+  std::string name;
+  std::tie(package, name) = rosbag2::extract_type_and_package("package/name");
+
+  EXPECT_THAT(package, StrEq("package"));
+  EXPECT_THAT(name, StrEq("name"));
+}
+
+TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashes_legacy) {
+  std::string package;
+  std::string name;
+  std::tie(package, name) =
+    rosbag2::extract_type_and_package("package/middle_module/name");
+
+  EXPECT_THAT(package, StrEq("package"));
+  EXPECT_THAT(name, StrEq("name"));
+}
+
 TEST(TypesupportHelpersTest, separates_into_package_and_name_for_correct_package) {
   std::string package;
   std::string middle_module;
   std::string name;
-  std::tie(package, middle_module, name) = rosbag2::extract_type_and_package("package/name");
+  std::tie(package, middle_module, name) = rosbag2::extract_type_identifier("package/name");
 
   EXPECT_THAT(package, StrEq("package"));
   EXPECT_THAT(middle_module, StrEq(""));
@@ -51,7 +70,7 @@ TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashe
   std::string middle_module;
   std::string name;
   std::tie(package, middle_module, name) =
-    rosbag2::extract_type_and_package("package/middle_module/name");
+    rosbag2::extract_type_identifier("package/middle_module/name");
 
   EXPECT_THAT(package, StrEq("package"));
   EXPECT_THAT(middle_module, StrEq("middle_module"));

--- a/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
+++ b/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
@@ -24,17 +24,24 @@
 using namespace ::testing;  // NOLINT
 
 TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_no_type) {
-  EXPECT_ANY_THROW(rosbag2::extract_type_and_package("just_a_package_name"));
+  EXPECT_ANY_THROW(rosbag2::extract_type_identifier("just_a_package_name"));
 }
 
 TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_slash_at_the_start_only) {
-  EXPECT_ANY_THROW(rosbag2::extract_type_and_package("/name_with_slash_at_start"));
+  EXPECT_ANY_THROW(rosbag2::extract_type_identifier("/name_with_slash_at_start"));
 }
 
 TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_slash_at_the_end_only) {
-  EXPECT_ANY_THROW(rosbag2::extract_type_and_package("name_with_slash_at_end/"));
+  EXPECT_ANY_THROW(rosbag2::extract_type_identifier("name_with_slash_at_end/"));
 }
 
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
 TEST(TypesupportHelpersTest, separates_into_package_and_name_for_correct_package_legacy) {
   std::string package;
   std::string name;
@@ -53,6 +60,11 @@ TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashe
   EXPECT_THAT(package, StrEq("package"));
   EXPECT_THAT(name, StrEq("name"));
 }
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
 
 TEST(TypesupportHelpersTest, separates_into_package_and_name_for_correct_package) {
   std::string package;

--- a/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
+++ b/rosbag2/test/rosbag2/test_typesupport_helpers.cpp
@@ -37,20 +37,24 @@ TEST(TypesupportHelpersTest, throws_exception_if_filetype_has_slash_at_the_end_o
 
 TEST(TypesupportHelpersTest, separates_into_package_and_name_for_correct_package) {
   std::string package;
+  std::string middle_module;
   std::string name;
-  std::tie(package, name) = rosbag2::extract_type_and_package("package/name");
+  std::tie(package, middle_module, name) = rosbag2::extract_type_and_package("package/name");
 
   EXPECT_THAT(package, StrEq("package"));
+  EXPECT_THAT(middle_module, StrEq(""));
   EXPECT_THAT(name, StrEq("name"));
 }
 
 TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashes) {
   std::string package;
+  std::string middle_module;
   std::string name;
-  std::tie(package, name) = rosbag2::extract_type_and_package("name/with/multiple_slashes");
+  std::tie(package, middle_module, name) = rosbag2::extract_type_and_package("package/middle_module/name");
 
-  EXPECT_THAT(package, StrEq("name"));
-  EXPECT_THAT(name, StrEq("multiple_slashes"));
+  EXPECT_THAT(package, StrEq("package"));
+  EXPECT_THAT(middle_module, StrEq("middle_module"));
+  EXPECT_THAT(name, StrEq("name"));
 }
 
 TEST(TypesupportHelpersTest, throws_exception_if_library_cannot_be_found) {


### PR DESCRIPTION
Allows support for message types generated from both msg and idl files.  Attempts to solve #127.  I'm making the assumption that all type names are of the form package_name/middle_module (i.e. idl or msg)/type.  