### PR TITLE
Add support for parsing middle module name from type (#128)

### DIFF
--- a/rosbag2/include/rosbag2/typesupport_helpers.hpp
+++ b/rosbag2/include/rosbag2/typesupport_helpers.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2__TYPESUPPORT_HELPERS_HPP_
 
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "rosidl_generator_cpp/message_type_support_decl.hpp"
@@ -28,8 +29,13 @@ ROSBAG2_PUBLIC
 const rosidl_message_type_support_t *
 get_typesupport(const std::string & type, const std::string & typesupport_identifier);
 
+[[deprecated("use extract_type_identifier(const std::string & full_type) instead")]]
 ROSBAG2_PUBLIC
 const std::pair<std::string, std::string> extract_type_and_package(const std::string & full_type);
+
+ROSBAG2_PUBLIC
+const std::tuple<std::string, std::string, std::string>
+extract_type_identifier(const std::string & full_type);
 
 }  // namespace rosbag2
 

--- a/rosbag2/src/rosbag2/typesupport_helpers.cpp
+++ b/rosbag2/src/rosbag2/typesupport_helpers.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "ament_index_cpp/get_resources.hpp"
@@ -63,6 +64,17 @@ std::string get_typesupport_library_path(
 
 const std::pair<std::string, std::string> extract_type_and_package(const std::string & full_type)
 {
+  std::string package_name;
+  std::string type_name;
+
+  std::tie(package_name, std::ignore, type_name) = extract_type_identifier(full_type);
+
+  return {package_name, type_name};
+}
+
+const std::tuple<std::string, std::string, std::string>
+extract_type_identifier(const std::string & full_type)
+{
   char type_separator = '/';
   auto sep_position_back = full_type.find_last_of(type_separator);
   auto sep_position_front = full_type.find_first_of(type_separator);
@@ -75,17 +87,23 @@ const std::pair<std::string, std::string> extract_type_and_package(const std::st
   }
 
   std::string package_name = full_type.substr(0, sep_position_front);
+  std::string middle_module = "";
+  if (sep_position_back - sep_position_front > 0) {
+    middle_module =
+      full_type.substr(sep_position_front + 1, sep_position_back - sep_position_front - 1);
+  }
   std::string type_name = full_type.substr(sep_position_back + 1);
 
-  return {package_name, type_name};
+  return std::make_tuple(package_name, middle_module, type_name);
 }
 
 const rosidl_message_type_support_t *
 get_typesupport(const std::string & type, const std::string & typesupport_identifier)
 {
   std::string package_name;
+  std::string middle_module;
   std::string type_name;
-  std::tie(package_name, type_name) = extract_type_and_package(type);
+  std::tie(package_name, middle_module, type_name) = extract_type_identifier(type);
 
   std::string poco_dynamic_loading_error = "Something went wrong loading the typesupport library "
     "for message type " + package_name + "/" + type_name + ".";
@@ -96,7 +114,7 @@ get_typesupport(const std::string & type, const std::string & typesupport_identi
     auto typesupport_library = std::make_shared<Poco::SharedLibrary>(library_path);
 
     auto symbol_name = typesupport_identifier + "__get_message_type_support_handle__" +
-      package_name + "__msg__" + type_name;
+      package_name + "__" + (middle_module.empty() ? "msg" : middle_module) + "__" + type_name;
 
     if (!typesupport_library->hasSymbol(symbol_name)) {
       throw std::runtime_error(poco_dynamic_loading_error + " Symbol not found.");


### PR DESCRIPTION
* Add support for parsing middle module name from type
Allows support for message types generated from both msg and idl files.

Signed-off-by: David Hodo <david.hodo@is4s.com>

* test fixups and default behavior

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

* deprecate legacy type extraction and add new

Signed-off-by: David Hodo <david.hodo@is4s.com>

* use pragma to avoid deprecation in test

Signed-off-by: Karsten Knese <karsten@openrobotics.org>