### PR TITLE
Export ament_index and class_loader dependencies

### DIFF
--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -73,7 +73,11 @@ install(
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(rosbag2_storage rosidl_typesupport_introspection_cpp)
+ament_export_dependencies(
+  ament_index_cpp
+  class_loader
+  rosbag2_storage
+  rosidl_typesupport_introspection_cpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -56,7 +56,7 @@ install(
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(yaml_cpp_vendor)
+ament_export_dependencies(ament_index_cpp yaml_cpp_vendor)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rosbag2_storage_default_plugins/CMakeLists.txt
+++ b/rosbag2_storage_default_plugins/CMakeLists.txt
@@ -58,7 +58,12 @@ install(
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(rosbag2_storage rcutils sqlite3_vendor SQLite3)
+ament_export_dependencies(
+  class_loader
+  rosbag2_storage
+  rcutils
+  sqlite3_vendor
+  SQLite3)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)


### PR DESCRIPTION
Fixes missing exported dependencies:
 - ament_index_cpp and class_loader for rosbag2
 - ament_index_cpp for rosbag2_storage
 - class_loader for rosbag2_storage_default_plugins

Signed-off-by: Kurtis Charnock <kurtis.charnock@arm.com>