### PR TITLE
Fix test failures on armhf

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -33,13 +33,13 @@ struct TopicInformation
 
 struct BagMetadata
 {
-  int version = 1;  // upgrade this number when changing the content of the struct
-  size_t bag_size = 0;  // Will not be serialized
+  int version = 2;  // upgrade this number when changing the content of the struct
+  uint64_t bag_size = 0;  // Will not be serialized
   std::string storage_identifier;
   std::vector<std::string> relative_file_paths;
   std::chrono::nanoseconds duration;
   std::chrono::time_point<std::chrono::high_resolution_clock> starting_time;
-  size_t message_count;
+  uint64_t message_count;
   std::vector<TopicInformation> topics_with_message_count;
 };
 

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -72,7 +72,7 @@ struct convert<rosbag2_storage::TopicInformation>
   static bool decode(const Node & node, rosbag2_storage::TopicInformation & metadata)
   {
     metadata.topic_metadata = node["topic_metadata"].as<rosbag2_storage::TopicMetadata>();
-    metadata.message_count = node["message_count"].as<size_t>();
+    metadata.message_count = node["message_count"].as<uint64_t>();
     return true;
   }
 };
@@ -89,7 +89,7 @@ struct convert<std::chrono::nanoseconds>
 
   static bool decode(const Node & node, std::chrono::nanoseconds & time_in_ns)
   {
-    time_in_ns = std::chrono::nanoseconds(node["nanoseconds"].as<size_t>());
+    time_in_ns = std::chrono::nanoseconds(node["nanoseconds"].as<uint64_t>());
     return true;
   }
 };
@@ -108,7 +108,7 @@ struct convert<std::chrono::time_point<std::chrono::high_resolution_clock>>
     const Node & node, std::chrono::time_point<std::chrono::high_resolution_clock> & start_time)
   {
     start_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
-      std::chrono::nanoseconds(node["nanoseconds_since_epoch"].as<size_t>()));
+      std::chrono::nanoseconds(node["nanoseconds_since_epoch"].as<uint64_t>()));
     return true;
   }
 };
@@ -137,7 +137,7 @@ struct convert<rosbag2_storage::BagMetadata>
     metadata.duration = node["duration"].as<std::chrono::nanoseconds>();
     metadata.starting_time = node["starting_time"]
       .as<std::chrono::time_point<std::chrono::high_resolution_clock>>();
-    metadata.message_count = node["message_count"].as<size_t>();
+    metadata.message_count = node["message_count"].as<uint64_t>();
     metadata.topics_with_message_count =
       node["topics_with_message_count"].as<std::vector<rosbag2_storage::TopicInformation>>();
     return true;

--- a/rosbag2_transport/src/rosbag2_transport/formatter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.cpp
@@ -90,7 +90,7 @@ std::string Formatter::format_time_point(
          " (" + formatted_duration["time_in_sec"] + ")";
 }
 
-std::string Formatter::format_file_size(size_t file_size)
+std::string Formatter::format_file_size(uint64_t file_size)
 {
   double size = static_cast<double>(file_size);
   static const char * units[] = {"B", "KiB", "MiB", "GiB", "TiB"};

--- a/rosbag2_transport/src/rosbag2_transport/formatter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/formatter.hpp
@@ -36,7 +36,7 @@ public:
 
   static std::string format_time_point(std::chrono::high_resolution_clock::duration time_point);
 
-  static std::string format_file_size(size_t file_size);
+  static std::string format_file_size(uint64_t file_size);
 
   static void format_file_paths(
     const std::vector<std::string> & paths,

--- a/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_formatter.cpp
@@ -35,13 +35,13 @@ public:
 };
 
 TEST_F(FormatterTestFixture, format_file_size_returns_correct_format) {
-  size_t zero_bytes = 0;
-  size_t thirty_bytes = 30;
-  size_t two_kibibytes = 2048;
-  size_t two_point_twelve_kibibytes = 3195;
-  size_t one_and_a_half_mebibytes = 1536 * 1024;
-  size_t one_tebibite = static_cast<size_t>(pow(1024, 4));
-  size_t one_pebibyte = static_cast<size_t>(pow(1024, 5));
+  uint64_t zero_bytes = 0;
+  uint64_t thirty_bytes = 30;
+  uint64_t two_kibibytes = 2048;
+  uint64_t two_point_twelve_kibibytes = 3195;
+  uint64_t one_and_a_half_mebibytes = 1536 * 1024;
+  uint64_t one_tebibite = static_cast<uint64_t>(pow(1024, 4));
+  uint64_t one_pebibyte = static_cast<uint64_t>(pow(1024, 5));
 
   EXPECT_THAT(formatter_->format_file_size(zero_bytes), Eq("0 B"));
   EXPECT_THAT(formatter_->format_file_size(thirty_bytes), Eq("30 B"));


### PR DESCRIPTION
Fix rosbag2_transport unit test failures on armhf.

Related to armhf tier-2 support fixes: https://github.com/ros2/ros2/issues/721
Fixes unit test failure reported [here](https://ci.ros2.org/job/ci_linux-armhf/16/testReport/rosbag2_transport/FormatterTestFixture/format_file_size_returns_correct_format/).

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>