### PR TITLE
disable plugins/tests which need rmw_fastrtps_cpp if unavailable

### DIFF
--- a/rosbag2_converter_default_plugins/CMakeLists.txt
+++ b/rosbag2_converter_default_plugins/CMakeLists.txt
@@ -24,44 +24,44 @@ find_package(rosbag2 REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
+find_package(rmw_fastrtps_cpp QUIET)
 
-add_library(${PROJECT_NAME} SHARED
-  src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp)
+if(rmw_fastrtps_cpp_FOUND)
+  add_library(${PROJECT_NAME} SHARED
+    src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}
-  ament_index_cpp
-  pluginlib
-  Poco
-  rosbag2
-  rcutils
-  rmw
-  rosidl_generator_cpp)
+  ament_target_dependencies(${PROJECT_NAME}
+    ament_index_cpp
+    pluginlib
+    Poco
+    rosbag2
+    rcutils
+    rmw
+    rosidl_generator_cpp)
 
-target_include_directories(${PROJECT_NAME}
-  PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  target_include_directories(${PROJECT_NAME}
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 
-pluginlib_export_plugin_description_file(rosbag2 plugin_description.xml)
+  pluginlib_export_plugin_description_file(rosbag2 plugin_description.xml)
 
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
+  install(
+    TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_gmock REQUIRED)
-  find_package(ament_lint_auto REQUIRED)
-  find_package(rcutils REQUIRED)
-  find_package(rmw_fastrtps_cpp QUIET)
-  find_package(rosbag2 REQUIRED)
-  find_package(rosbag2_test_common REQUIRED)
-  find_package(test_msgs REQUIRED)
+  if(BUILD_TESTING)
+    find_package(ament_cmake_gmock REQUIRED)
+    find_package(ament_lint_auto REQUIRED)
+    find_package(rcutils REQUIRED)
+    find_package(rosbag2 REQUIRED)
+    find_package(rosbag2_test_common REQUIRED)
+    find_package(test_msgs REQUIRED)
 
-  ament_lint_auto_find_test_dependencies()
+    ament_lint_auto_find_test_dependencies()
 
-  if(rmw_fastrtps_cpp_FOUND)
     ament_add_gmock(test_cdr_converter
       test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
       src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp

--- a/rosbag2_converter_default_plugins/CMakeLists.txt
+++ b/rosbag2_converter_default_plugins/CMakeLists.txt
@@ -76,6 +76,8 @@ if(rmw_fastrtps_cpp_FOUND)
         test_msgs)
     endif()
   endif()
+else()
+  message(STATUS "Skipping [${PROJECT_NAME}]. rmw_fastrtps_cpp isn't available.")
 endif()
 
 ament_package()

--- a/rosbag2_converter_default_plugins/CMakeLists.txt
+++ b/rosbag2_converter_default_plugins/CMakeLists.txt
@@ -54,25 +54,27 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(rcutils REQUIRED)
-  find_package(rmw_fastrtps_cpp REQUIRED)
+  find_package(rmw_fastrtps_cpp QUIET)
   find_package(rosbag2 REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   find_package(test_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gmock(test_cdr_converter
-    test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
-    src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_cdr_converter)
-    ament_target_dependencies(test_cdr_converter
-      pluginlib
-      rosbag2
-      rosbag2_test_common
-      rcutils
-      rmw_fastrtps_cpp
-      test_msgs)
+  if(rmw_fastrtps_cpp_FOUND)
+    ament_add_gmock(test_cdr_converter
+      test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
+      src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    if(TARGET test_cdr_converter)
+      ament_target_dependencies(test_cdr_converter
+        pluginlib
+        rosbag2
+        rosbag2_test_common
+        rcutils
+        rmw_fastrtps_cpp
+        test_msgs)
+    endif()
   endif()
 endif()
 

--- a/rosbag2_converter_default_plugins/package.xml
+++ b/rosbag2_converter_default_plugins/package.xml
@@ -17,7 +17,6 @@
   <depend>rmw_fastrtps_cpp</depend>
   <depend>rosbag2</depend>
 
-
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_converter_default_plugins/package.xml
+++ b/rosbag2_converter_default_plugins/package.xml
@@ -14,7 +14,9 @@
   <depend>rosidl_generator_cpp</depend>
   <depend>rcutils</depend>
   <depend>rmw</depend>
+  <depend>rmw_fastrtps_cpp</depend>
   <depend>rosbag2</depend>
+
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -34,7 +34,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   # disable tests that depends on rosbag2_converter_default_plugins at runtime
-  if (rmw_fastrtps_cpp_FOUND)
+  if(rmw_fastrtps_cpp_FOUND)
     ament_add_gmock(test_rosbag2_record_end_to_end
       test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -47,17 +47,17 @@ if(BUILD_TESTING)
         test_msgs)
     endif()
 
-   # ament_add_gmock(test_rosbag2_play_end_to_end
-   #   test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
-   #   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-   # if(TARGET test_rosbag2_play_end_to_end)
-   #   ament_target_dependencies(test_rosbag2_play_end_to_end
-   #     rclcpp
-   #     rosbag2_storage
-   #     rosbag2_storage_default_plugins
-   #     rosbag2_test_common
-   #     test_msgs)
-   # endif()
+    # ament_add_gmock(test_rosbag2_play_end_to_end
+    #   test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+    #   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    # if(TARGET test_rosbag2_play_end_to_end)
+    #   ament_target_dependencies(test_rosbag2_play_end_to_end
+    #     rclcpp
+    #     rosbag2_storage
+    #     rosbag2_storage_default_plugins
+    #     rosbag2_test_common
+    #     test_msgs)
+    # endif()
 
     ament_add_gmock(test_rosbag2_info_end_to_end
       test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -26,53 +26,57 @@ if(BUILD_TESTING)
   find_package(rclcpp REQUIRED)
   find_package(std_msgs REQUIRED)
   find_package(test_msgs REQUIRED)
+  find_package(rmw_fastrtps_cpp QUIET)
   find_package(rosbag2_storage REQUIRED)
   find_package(rosbag2_storage_default_plugins REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gmock(test_rosbag2_record_end_to_end
-    test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_rosbag2_record_end_to_end)
-    ament_target_dependencies(test_rosbag2_record_end_to_end
-      rclcpp
-      rosbag2_storage
-      rosbag2_storage_default_plugins
-      rosbag2_test_common
-      test_msgs)
-  endif()
+  # disable tests that depends on rosbag2_converter_default_plugins at runtime
+  if (rmw_fastrtps_cpp_FOUND)
+    ament_add_gmock(test_rosbag2_record_end_to_end
+      test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    if(TARGET test_rosbag2_record_end_to_end)
+      ament_target_dependencies(test_rosbag2_record_end_to_end
+        rclcpp
+        rosbag2_storage
+        rosbag2_storage_default_plugins
+        rosbag2_test_common
+        test_msgs)
+    endif()
 
-#  ament_add_gmock(test_rosbag2_play_end_to_end
-#    test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
-#    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-#  if(TARGET test_rosbag2_play_end_to_end)
-#    ament_target_dependencies(test_rosbag2_play_end_to_end
-#      rclcpp
-#      rosbag2_storage
-#      rosbag2_storage_default_plugins
-#      rosbag2_test_common
-#      test_msgs)
-#  endif()
+   # ament_add_gmock(test_rosbag2_play_end_to_end
+   #   test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+   #   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+   # if(TARGET test_rosbag2_play_end_to_end)
+   #   ament_target_dependencies(test_rosbag2_play_end_to_end
+   #     rclcpp
+   #     rosbag2_storage
+   #     rosbag2_storage_default_plugins
+   #     rosbag2_test_common
+   #     test_msgs)
+   # endif()
 
-  ament_add_gmock(test_rosbag2_info_end_to_end
-    test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_rosbag2_info_end_to_end)
-    ament_target_dependencies(test_rosbag2_info_end_to_end
-      rosbag2_storage
-      rosbag2_test_common)
-  endif()
+    ament_add_gmock(test_rosbag2_info_end_to_end
+      test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    if(TARGET test_rosbag2_info_end_to_end)
+      ament_target_dependencies(test_rosbag2_info_end_to_end
+        rosbag2_storage
+        rosbag2_test_common)
+    endif()
 
-  ament_add_gmock(test_converter
-    test/rosbag2_tests/test_converter.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_converter)
-    ament_target_dependencies(test_converter
-      rosbag2
-      rosbag2_test_common
-      test_msgs)
+    ament_add_gmock(test_converter
+      test/rosbag2_tests/test_converter.cpp
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    if(TARGET test_converter)
+      ament_target_dependencies(test_converter
+        rosbag2
+        rosbag2_test_common
+        test_msgs)
+    endif()
   endif()
 endif()
 

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -77,6 +77,7 @@ ament_export_dependencies(rosbag2)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(test_msgs REQUIRED)
   find_package(rosbag2_test_common REQUIRED)

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -14,6 +14,7 @@
   <depend>rmw</depend>
   <depend>shared_queues_vendor</depend>
 
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -14,8 +14,8 @@
   <depend>rmw</depend>
   <depend>shared_queues_vendor</depend>
 
-  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>test_msgs</test_depend>


### PR DESCRIPTION
Fixes https://github.com/ros2/rosbag2/issues/136.