### PR TITLE
Add compatibility with new IPC implementation

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
@@ -70,21 +70,6 @@ void GenericSubscription::return_serialized_message(
   message.reset();
 }
 
-void GenericSubscription::handle_intra_process_message(
-  rcl_interfaces::msg::IntraProcessMessage & ipm,
-  const rmw_message_info_t & message_info)
-{
-  (void) ipm;
-  (void) message_info;
-  throw std::runtime_error("Intra process is not supported");
-}
-
-const std::shared_ptr<rcl_subscription_t>
-GenericSubscription::get_intra_process_subscription_handle() const
-{
-  return nullptr;
-}
-
 std::shared_ptr<rmw_serialized_message_t>
 GenericSubscription::borrow_serialized_message(size_t capacity)
 {

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
@@ -64,15 +64,6 @@ public:
 
   void return_serialized_message(std::shared_ptr<rmw_serialized_message_t> & message) override;
 
-  // Intra-process message handling is not supported by this publisher
-  void handle_intra_process_message(
-    rcl_interfaces::msg::IntraProcessMessage & ipm,
-    const rmw_message_info_t & message_info) override;
-
-  // Intra-process message handling is not supported by this publisher (returns nullptr always)
-  const std::shared_ptr<rcl_subscription_t>
-  get_intra_process_subscription_handle() const override;
-
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -56,7 +56,9 @@ std::shared_ptr<GenericSubscription> Rosbag2Node::create_generic_subscription(
       topic,
       callback);
 
-    get_node_topics_interface()->add_subscription(subscription, nullptr);
+    // Intra-process message handling is not supported.
+    bool use_intra_process = false;
+    get_node_topics_interface()->add_subscription(subscription, use_intra_process, nullptr);
   } catch (const std::runtime_error & ex) {
     ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
       "Error subscribing to topic '" << topic << "'. Error: " << ex.what());


### PR DESCRIPTION
This PR is intended to follow https://github.com/ros2/rclcpp/pull/778 where a new IPC implementation is created.

The new IPC implementation introduces some changes to the `Subscription` and `SubscriptionBase` classes that affect this repository.