### PR TITLE
disable some tests for connext

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -93,14 +93,6 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_info rosbag2_test_common)
   endif()
 
-  ament_add_gmock(test_record
-    test/rosbag2_transport/test_record.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_record)
-    target_link_libraries(test_record rosbag2_transport)
-    ament_target_dependencies(test_record test_msgs rosbag2_test_common)
-  endif()
-
   ament_add_gmock(test_record_all
     test/rosbag2_transport/test_record_all.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -115,14 +107,6 @@ if(BUILD_TESTING)
   if(TARGET test_record_all_no_discovery)
     target_link_libraries(test_record_all_no_discovery rosbag2_transport)
     ament_target_dependencies(test_record_all_no_discovery test_msgs rosbag2_test_common)
-  endif()
-
-  ament_add_gmock(test_play
-    test/rosbag2_transport/test_play.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_play)
-    target_link_libraries(test_play rosbag2_transport)
-    ament_target_dependencies(test_play test_msgs rosbag2_test_common)
   endif()
 
   ament_add_gmock(test_play_timing
@@ -159,6 +143,33 @@ if(BUILD_TESTING)
   if(TARGET test_formatter)
     target_link_libraries(test_formatter rosbag2_transport)
   endif()
+
+  # disable the following tests for connext
+  # due to slower discovery of nodes
+  get_default_rmw_implementation(rmw_default)
+  set(SKIP_TEST "")
+  if(${rmw_default} MATCHES "(.*)connext(.*)")
+    set(SKIP_TEST "SKIP_TEST")
+  endif()
+
+  ament_add_gmock(test_record
+    test/rosbag2_transport/test_record.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    ${SKIP_TEST})
+  if(TARGET test_record)
+    target_link_libraries(test_record rosbag2_transport)
+    ament_target_dependencies(test_record test_msgs rosbag2_test_common)
+  endif()
+
+  ament_add_gmock(test_play
+    test/rosbag2_transport/test_play.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    ${SKIP_TEST})
+  if(TARGET test_play)
+    target_link_libraries(test_play rosbag2_transport)
+    ament_target_dependencies(test_play test_msgs rosbag2_test_common)
+  endif()
+
 endif()
 
 ament_package()

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -67,12 +67,12 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
   };
 
   std::vector<std::shared_ptr<rosbag2::SerializedBagMessage>> messages =
-  {serialize_test_message("topic1", 0, primitive_message1),
-    serialize_test_message("topic1", 100, primitive_message1),
-    serialize_test_message("topic1", 200, primitive_message1),
-    serialize_test_message("topic2", 50, complex_message1),
-    serialize_test_message("topic2", 150, complex_message1),
-    serialize_test_message("topic2", 250, complex_message1)};
+  {serialize_test_message("topic1", 500, primitive_message1),
+    serialize_test_message("topic1", 700, primitive_message1),
+    serialize_test_message("topic1", 900, primitive_message1),
+    serialize_test_message("topic2", 550, complex_message1),
+    serialize_test_message("topic2", 750, complex_message1),
+    serialize_test_message("topic2", 950, complex_message1)};
 
   reader_->prepare(messages, topic_types);
 

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -82,7 +82,7 @@ public:
   void sleep_to_allow_topics_discovery()
   {
     // This is a short sleep to allow the node some time to discover the topic
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
 
   MemoryManagement memory_management_;


### PR DESCRIPTION
CI (only Connext):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7837)](http://ci.ros2.org/job/ci_linux/7837/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3905)](http://ci.ros2.org/job/ci_linux-aarch64/3905/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6394)](http://ci.ros2.org/job/ci_osx/6394/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7675)](http://ci.ros2.org/job/ci_windows/7675/)

CI (only FastRTPS):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7838)](http://ci.ros2.org/job/ci_linux/7838/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3906)](http://ci.ros2.org/job/ci_linux-aarch64/3906/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6395)](http://ci.ros2.org/job/ci_osx/6395/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7676)](http://ci.ros2.org/job/ci_windows/7676/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>