### PR TITLE
[dashing backport] enable address sanitizers only on 64bit machines (#149)

### DIFF
--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -16,6 +16,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 option(DISABLE_SANITIZERS "disables the use of gcc saniztizers")
+# Only enable sanitizers on x64 architectures
+# https://github.com/google/sanitizers/issues/794
+if(NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+  set(DISABLE_SANITIZERS ON)
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)


### PR DESCRIPTION
CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8169)](http://ci.ros2.org/job/ci_linux/8169/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4150)](http://ci.ros2.org/job/ci_linux-aarch64/4150/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6653)](http://ci.ros2.org/job/ci_osx/6653/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8048)](http://ci.ros2.org/job/ci_windows/8048/)

armhf32:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-armhf&build=68)](https://ci.ros2.org/job/ci_linux-armhf/68/)