### PR TITLE
Add error checking on SqliteWrapper deconstructor

### DIFF
--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -47,6 +47,7 @@ public:
 
 private:
   DBPtr db_ptr;
+  std::string uri_;
 };
 
 

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -47,7 +47,6 @@ public:
 
 private:
   DBPtr db_ptr;
-  std::string uri_;
 };
 
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -31,8 +31,7 @@ namespace rosbag2_storage_plugins
 
 SqliteWrapper::SqliteWrapper(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
-: db_ptr(nullptr),
-  uri_(uri)
+: db_ptr(nullptr)
 {
   if (io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     int rc = sqlite3_open_v2(uri.c_str(), &db_ptr,
@@ -60,7 +59,7 @@ SqliteWrapper::~SqliteWrapper()
   const int rc = sqlite3_close(db_ptr);
   if (rc != SQLITE_OK) {
     ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR_STREAM(
-      "Could not close open database: " << uri_ << ". Error code: " << rc <<
+      "Could not close open database. Error code: " << rc <<
         " Error message: " << sqlite3_errstr(rc));
   }
 }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -31,7 +31,8 @@ namespace rosbag2_storage_plugins
 
 SqliteWrapper::SqliteWrapper(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
-: db_ptr(nullptr)
+: db_ptr(nullptr),
+  uri_(uri)
 {
   if (io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     int rc = sqlite3_open_v2(uri.c_str(), &db_ptr,
@@ -59,7 +60,7 @@ SqliteWrapper::~SqliteWrapper()
   const int rc = sqlite3_close(db_ptr);
   if (rc != SQLITE_OK) {
     ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR_STREAM(
-            "Could not close open database. Error code: " << rc <<
+            "Could not close open database: " << uri_ << ". Error code: " << rc <<
             " Error message: " << sqlite3_errstr(rc));
   }
 }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -56,11 +56,11 @@ SqliteWrapper::SqliteWrapper()
 
 SqliteWrapper::~SqliteWrapper()
 {
-  int rc = sqlite3_close(db_ptr);
+  const int rc = sqlite3_close(db_ptr);
   if (rc != SQLITE_OK) {
     ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR_STREAM(
-            "Could not close open database. Error code: " + std::to_string(rc) +
-            " Error message: " + sqlite3_errstr(rc));
+            "Could not close open database. Error code: " << rc <<
+            " Error message: " << sqlite3_errstr(rc));
   }
 }
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -24,6 +24,8 @@
 
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_exception.hpp"
 
+#include "../logging.hpp"
+
 namespace rosbag2_storage_plugins
 {
 
@@ -54,7 +56,12 @@ SqliteWrapper::SqliteWrapper()
 
 SqliteWrapper::~SqliteWrapper()
 {
-  sqlite3_close(db_ptr);
+  int rc = sqlite3_close(db_ptr);
+  if (rc != SQLITE_OK) {
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR_STREAM(
+            "Could not close open database. Error code: " + std::to_string(rc) +
+            " Error message: " + sqlite3_errstr(rc));
+  }
 }
 
 SqliteStatement SqliteWrapper::prepare_statement(const std::string & query)

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -60,8 +60,8 @@ SqliteWrapper::~SqliteWrapper()
   const int rc = sqlite3_close(db_ptr);
   if (rc != SQLITE_OK) {
     ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR_STREAM(
-            "Could not close open database: " << uri_ << ". Error code: " << rc <<
-            " Error message: " << sqlite3_errstr(rc));
+      "Could not close open database: " << uri_ << ". Error code: " << rc <<
+        " Error message: " << sqlite3_errstr(rc));
   }
 }
 


### PR DESCRIPTION
Check the return code for sqlite3_close and log to error.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>