### PR TITLE
Change storage interfaces for bagfile splitting feature

### DIFF
--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -37,6 +37,7 @@ public:
   MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
+  MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
 };
 
 #endif  // ROSBAG2__MOCK_STORAGE_HPP_

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -38,6 +38,10 @@ public:
 
   virtual void open(const std::string & uri, IOFlag io_flag) = 0;
 
+  /**
+   * Returns the size of the bagfile.
+   * \returns the size of the bagfile in bytes.
+   */
   virtual uint64_t get_bagfile_size() const = 0;
 };
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -37,6 +37,8 @@ public:
   virtual ~BaseIOInterface() = default;
 
   virtual void open(const std::string & uri, IOFlag io_flag) = 0;
+
+  virtual uint64_t get_bagfile_size() const = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
@@ -34,6 +34,8 @@ public:
   virtual ~ReadOnlyInterface() = default;
 
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_ONLY) override = 0;
+
+  uint64_t get_bagfile_size() const override = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
@@ -33,6 +33,8 @@ public:
   ~ReadWriteInterface() override = default;
 
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_WRITE) override = 0;
+
+  uint64_t get_bagfile_size() const override = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -85,5 +85,4 @@ uint64_t TestPlugin::get_bagfile_size() const
   return default_max_bagfile_size;
 }
 
-
 PLUGINLIB_EXPORT_CLASS(TestPlugin, rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -79,4 +79,11 @@ rosbag2_storage::BagMetadata TestPlugin::get_metadata()
   return rosbag2_storage::BagMetadata();
 }
 
+uint64_t TestPlugin::get_bagfile_size() const
+{
+  std::cout << "\nreturning bagfile size\n";
+  return default_max_bagfile_size;
+}
+
+
 PLUGINLIB_EXPORT_CLASS(TestPlugin, rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -44,6 +44,11 @@ public:
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   rosbag2_storage::BagMetadata get_metadata() override;
+
+  uint64_t get_bagfile_size() const override;
+
+private:
+  const uint64_t default_max_bagfile_size = 0;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_PLUGIN_HPP_

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -59,4 +59,10 @@ rosbag2_storage::BagMetadata TestReadOnlyPlugin::get_metadata()
   return rosbag2_storage::BagMetadata();
 }
 
+uint64_t TestReadOnlyPlugin::get_bagfile_size() const
+{
+  std::cout << "\nreturning bagfile size\n";
+  return default_max_bagfile_size;
+}
+
 PLUGINLIB_EXPORT_CLASS(TestReadOnlyPlugin, rosbag2_storage::storage_interfaces::ReadOnlyInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -35,6 +35,11 @@ public:
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   rosbag2_storage::BagMetadata get_metadata() override;
+
+  uint64_t get_bagfile_size() const override;
+
+private:
+  const uint64_t default_max_bagfile_size = 0;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_READ_ONLY_PLUGIN_HPP_

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -42,7 +42,7 @@ class ROSBAG2_STORAGE_DEFAULT_PLUGINS_PUBLIC SqliteStorage
   : public rosbag2_storage::storage_interfaces::ReadWriteInterface
 {
 public:
-  SqliteStorage();
+  SqliteStorage() = default;
   ~SqliteStorage() override = default;
 
   void open(
@@ -64,6 +64,8 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
+  uint64_t get_bagfile_size() const override;
+
 private:
   void initialize();
   void prepare_for_writing();
@@ -79,12 +81,14 @@ private:
 
   std::shared_ptr<SqliteWrapper> database_;
   std::string database_name_;
-  SqliteStatement write_statement_;
-  SqliteStatement read_statement_;
-  ReadQueryResult message_result_;
-  ReadQueryResult::Iterator current_message_row_;
+  SqliteStatement write_statement_ {};
+  SqliteStatement read_statement_ {};
+  ReadQueryResult message_result_ {nullptr};
+  ReadQueryResult::Iterator current_message_row_ {
+    nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END};
   std::unordered_map<std::string, int> topics_;
   std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
+  std::string uri_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -36,14 +36,6 @@
 namespace rosbag2_storage_plugins
 {
 
-SqliteStorage::SqliteStorage()
-: database_(),
-  write_statement_(nullptr),
-  read_statement_(nullptr),
-  message_result_(nullptr),
-  current_message_row_(nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END)
-{}
-
 void SqliteStorage::open(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
@@ -82,6 +74,7 @@ void SqliteStorage::open(
     initialize();
   }
 
+  uri_ = uri;
   ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opened database '" << uri << "'.");
 }
 
@@ -131,6 +124,12 @@ std::vector<rosbag2_storage::TopicMetadata> SqliteStorage::get_all_topics_and_ty
   }
 
   return all_topics_and_types_;
+}
+
+uint64_t SqliteStorage::get_bagfile_size() const
+{
+  return rosbag2_storage::FilesystemHelper::get_file_size(
+    rosbag2_storage::FilesystemHelper::concat({uri_, database_name_}));
 }
 
 void SqliteStorage::initialize()


### PR DESCRIPTION
This PR is a rework of PR #158 into smaller PRs as per https://github.com/ros2/rosbag2/pull/158#issuecomment-537111547_

### Changes
* Add support for rosbag splitting to IO interfaces
* Implement support for rosbag splitting in default plugin: sqlite_storage