### PR TITLE
Splitting/writer changes

### DIFF
--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -98,7 +98,7 @@ public:
   /**
    * Check if the current recording database file needs to be split and rolled over to new file.
    */
-  virtual bool should_split_database() const;
+  virtual bool should_split_bagfile() const;
 
 private:
   std::string uri_;

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -95,6 +95,11 @@ public:
    */
   virtual void write(std::shared_ptr<SerializedBagMessage> message);
 
+  /**
+   * Check if the current recording database file needs to be split and rolled over to new file.
+   */
+  virtual bool should_split_database() const;
+
 private:
   std::string uri_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
@@ -102,6 +107,7 @@ private:
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_;
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
   std::unique_ptr<Converter> converter_;
+  uint64_t max_bagfile_size_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -96,7 +96,9 @@ public:
   virtual void write(std::shared_ptr<SerializedBagMessage> message);
 
   /**
-   * Check if the current recording database file needs to be split and rolled over to new file.
+   * Check if the current recording bagfile needs to be split and rolled over to new file.
+   *
+   * \return true if the bagfile should be split.
    */
   virtual bool should_split_bagfile() const;
 

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -95,7 +95,7 @@ void Writer::write(std::shared_ptr<SerializedBagMessage> message)
   storage_->write(converter_ ? converter_->convert(message) : message);
 }
 
-bool Writer::should_split_database() const
+bool Writer::should_split_bagfile() const
 {
   return (max_bagfile_size_ != rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT) &&
          (storage_->get_bagfile_size() > max_bagfile_size_);

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -38,6 +38,7 @@ public:
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
   MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
+  MOCK_METHOD0(split_database, void());
 };
 
 #endif  // ROSBAG2__MOCK_STORAGE_HPP_

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -38,7 +38,6 @@ public:
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
   MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
-  MOCK_METHOD0(split_database, void());
 };
 
 #endif  // ROSBAG2__MOCK_STORAGE_HPP_

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(
   SHARED
   src/rosbag2_storage/metadata_io.cpp
   src/rosbag2_storage/ros_helper.cpp
-  src/rosbag2_storage/storage_factory.cpp)
+  src/rosbag2_storage/storage_factory.cpp
+  src/rosbag2_storage/base_io_interface.cpp)
 target_include_directories(rosbag2_storage PUBLIC include)
 ament_target_dependencies(
   rosbag2_storage

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -31,6 +31,10 @@ enum class IOFlag : uint8_t
   APPEND = 2
 };
 
+// When bagfile splitting feature is not enabled or applicable,
+// use 0 as the default maximum bagfile size value.
+extern const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT;
+
 class ROSBAG2_STORAGE_PUBLIC BaseIOInterface
 {
 public:

--- a/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018, Bosch Software Innovations GmbH.
+// Copyright 2019 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__STORAGE_OPTIONS_HPP_
-#define ROSBAG2__STORAGE_OPTIONS_HPP_
+#include "rosbag2_storage/storage_interfaces/base_io_interface.hpp"
 
-#include <string>
-
-namespace rosbag2
+namespace rosbag2_storage
 {
-
-struct StorageOptions
+namespace storage_interfaces
 {
-public:
-  std::string uri;
-  std::string storage_id;
-  uint64_t max_bagfile_size;
-};
-
-}  // namespace rosbag2
-
-#endif  // ROSBAG2__STORAGE_OPTIONS_HPP_
+const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT = 0;
+}
+}

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -56,7 +56,7 @@ class Rosbag2TransportTestFixture : public Test
 {
 public:
   Rosbag2TransportTestFixture()
-  : storage_options_({"uri", "storage_id"}), play_options_({1000}),
+  : storage_options_({"uri", "storage_id", 0}), play_options_({1000}),
     reader_(std::make_shared<MockSequentialReader>()),
     writer_(std::make_shared<MockWriter>()),
     info_(std::make_shared<MockInfo>()) {}


### PR DESCRIPTION
This PR is a rework of PR #158 into smaller PRs as per https://github.com/ros2/rosbag2/pull/158#issuecomment-537111547_

### Changes
* Add `should_split_database` to `Writer`
* Add `get_bagfile_size` to `ReadWriteInterface`
* Implement `get_bagfile_size` in `SqliteStorage`

This PR is dependent on PR #170 