### PR TITLE
Splitting/sqlite storage writer integration

### DIFF
--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -95,6 +95,11 @@ public:
    */
   virtual void write(std::shared_ptr<SerializedBagMessage> message);
 
+  /**
+   * Check if the current recording database file needs to be split and rolled over to new file.
+   */
+  virtual bool should_split_database() const;
+
 private:
   std::string uri_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
@@ -102,6 +107,7 @@ private:
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_;
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
   std::unique_ptr<Converter> converter_;
+  uint64_t max_bagfile_size_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -102,7 +102,7 @@ public:
 
 private:
   void initialize_metadata_();
-  void aggregate_metadata_(rosbag2_storage::BagMetadata metadata);
+  void aggregate_metadata_(rosbag2_storage::BagMetadata&& metadata);
 
   std::string uri_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -101,6 +101,9 @@ public:
   virtual bool should_split_database() const;
 
 private:
+  void initialize_metadata_();
+  void aggregate_metadata_(rosbag2_storage::BagMetadata metadata);
+
   std::string uri_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
@@ -108,6 +111,7 @@ private:
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
   std::unique_ptr<Converter> converter_;
   uint64_t max_bagfile_size_;
+  rosbag2_storage::BagMetadata metadata_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -98,7 +98,7 @@ void Writer::write(std::shared_ptr<SerializedBagMessage> message)
 bool Writer::should_split_database() const
 {
   return (max_bagfile_size_ != rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT) &&
-         (storage_->get_bagfile_size() > max_bagfile_size_);
+         (storage_->get_current_bagfile_size() > max_bagfile_size_);
 }
 
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -119,7 +119,7 @@ void Writer::initialize_metadata_()
   metadata_.bag_size = 0;
 }
 
-void Writer::aggregate_metadata_(rosbag2_storage::BagMetadata metadata)
+void Writer::aggregate_metadata_(rosbag2_storage::BagMetadata&& metadata)
 {
   metadata_.storage_identifier = metadata.storage_identifier;
   metadata_.relative_file_paths.swap(metadata.relative_file_paths);

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -38,6 +38,7 @@ public:
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
   MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
+  MOCK_METHOD0(split_database, void());
 };
 
 #endif  // ROSBAG2__MOCK_STORAGE_HPP_

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -37,6 +37,7 @@ public:
   MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
+  MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
 };
 
 #endif  // ROSBAG2__MOCK_STORAGE_HPP_

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -37,7 +37,7 @@ public:
   MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
-  MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
+  MOCK_CONST_METHOD0(get_current_bagfile_size, uint64_t());
   MOCK_METHOD0(split_database, void());
 };
 

--- a/rosbag2/test/rosbag2/test_writer.cpp
+++ b/rosbag2/test/rosbag2/test_writer.cpp
@@ -121,3 +121,45 @@ TEST_F(WriterTest, open_throws_error_if_converter_plugin_does_not_exist) {
 
   EXPECT_ANY_THROW(writer_->open(storage_options_, {input_format, output_format}));
 }
+
+TEST_F(WriterTest, bagfile_size_is_checked_on_every_write) {
+  const int counter = 10;
+  const uint64_t max_bagfile_size = 100;
+  EXPECT_CALL(*storage_, get_current_bagfile_size()).Times(counter);
+
+  writer_ = std::make_unique<rosbag2::Writer>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+
+  std::string rmw_format = "rmw_format";
+
+  auto message = std::make_shared<rosbag2::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+  storage_options_.max_bagfile_size = max_bagfile_size;
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", ""});
+
+  for (auto i = 0; i < counter; i++) {
+    writer_->write(message);
+  }
+}
+
+TEST_F(WriterTest, get_metadata_gets_called_from_write_when_splitting_and_destructor) {
+  const uint64_t max_bagfile_size = 1;
+  EXPECT_CALL(*storage_, get_metadata()).Times(2);
+  EXPECT_CALL(*storage_, split_database()).Times(1);
+  EXPECT_CALL(*storage_, get_current_bagfile_size())
+  .Times(AtLeast(1)).WillRepeatedly(Return(max_bagfile_size + 1));
+
+  writer_ = std::make_unique<rosbag2::Writer>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+
+  std::string rmw_format = "rmw_format";
+
+  auto message = std::make_shared<rosbag2::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+  storage_options_.max_bagfile_size = max_bagfile_size;
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", ""});
+
+  writer_->write(message);
+}

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(
   SHARED
   src/rosbag2_storage/metadata_io.cpp
   src/rosbag2_storage/ros_helper.cpp
-  src/rosbag2_storage/storage_factory.cpp)
+  src/rosbag2_storage/storage_factory.cpp
+  src/rosbag2_storage/base_io_interface.cpp)
 target_include_directories(rosbag2_storage PUBLIC include)
 ament_target_dependencies(
   rosbag2_storage

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -31,6 +31,10 @@ enum class IOFlag : uint8_t
   APPEND = 2
 };
 
+// When bagfile splitting feature is not enabled or applicable,
+// use 0 as the default maximum bagfile size value.
+extern const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT;
+
 class ROSBAG2_STORAGE_PUBLIC BaseIOInterface
 {
 public:

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -37,6 +37,8 @@ public:
   virtual ~BaseIOInterface() = default;
 
   virtual void open(const std::string & uri, IOFlag io_flag) = 0;
+
+  virtual uint64_t get_bagfile_size() const = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -42,7 +42,7 @@ public:
 
   virtual void open(const std::string & uri, IOFlag io_flag) = 0;
 
-  virtual uint64_t get_bagfile_size() const = 0;
+  virtual uint64_t get_current_bagfile_size() const = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -38,6 +38,8 @@ public:
   virtual void create_topic(const TopicMetadata & topic) = 0;
 
   virtual void remove_topic(const TopicMetadata & topic) = 0;
+
+  virtual void split_database() = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
@@ -34,6 +34,8 @@ public:
   virtual ~ReadOnlyInterface() = default;
 
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_ONLY) override = 0;
+
+  uint64_t get_bagfile_size() const override = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_only_interface.hpp
@@ -35,7 +35,7 @@ public:
 
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_ONLY) override = 0;
 
-  uint64_t get_bagfile_size() const override = 0;
+  uint64_t get_current_bagfile_size() const override = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
@@ -34,7 +34,9 @@ public:
 
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_WRITE) override = 0;
 
-  uint64_t get_bagfile_size() const override = 0;
+  uint64_t get_current_bagfile_size() const override = 0;
+
+  void split_database() override = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/read_write_interface.hpp
@@ -33,6 +33,8 @@ public:
   ~ReadWriteInterface() override = default;
 
   void open(const std::string & uri, IOFlag io_flag = IOFlag::READ_WRITE) override = 0;
+
+  uint64_t get_bagfile_size() const override = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018, Bosch Software Innovations GmbH.
+// Copyright 2019 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__STORAGE_OPTIONS_HPP_
-#define ROSBAG2__STORAGE_OPTIONS_HPP_
+#include "rosbag2_storage/storage_interfaces/base_io_interface.hpp"
 
-#include <string>
-
-namespace rosbag2
+namespace rosbag2_storage
 {
-
-struct StorageOptions
+namespace storage_interfaces
 {
-public:
-  std::string uri;
-  std::string storage_id;
-  uint64_t max_bagfile_size;
-};
-
-}  // namespace rosbag2
-
-#endif  // ROSBAG2__STORAGE_OPTIONS_HPP_
+const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT = 0;
+}
+}

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -79,4 +79,11 @@ rosbag2_storage::BagMetadata TestPlugin::get_metadata()
   return rosbag2_storage::BagMetadata();
 }
 
+uint64_t TestPlugin::get_bagfile_size() const
+{
+  std::cout << "\nreturning bagfile size\n";
+  return default_max_bagfile_size;
+}
+
+
 PLUGINLIB_EXPORT_CLASS(TestPlugin, rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -29,8 +29,7 @@ TestPlugin::~TestPlugin()
   std::cout << "\nclosing.\n";
 }
 
-void TestPlugin::open(
-  const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag flag)
+void TestPlugin::open(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag flag)
 {
   if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     std::cout << "opening testplugin read only: ";
@@ -79,11 +78,15 @@ rosbag2_storage::BagMetadata TestPlugin::get_metadata()
   return rosbag2_storage::BagMetadata();
 }
 
-uint64_t TestPlugin::get_bagfile_size() const
+uint64_t TestPlugin::get_current_bagfile_size() const
 {
-  std::cout << "\nreturning bagfile size\n";
-  return default_max_bagfile_size;
+  std::cout << "\nreturning current bagfile size\n";
+  return rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT;
 }
 
+void TestPlugin::split_database()
+{
+  std::cout << "\nsplitting database\n";
+}
 
 PLUGINLIB_EXPORT_CLASS(TestPlugin, rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -45,10 +45,9 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
-  uint64_t get_bagfile_size() const override;
+  uint64_t get_current_bagfile_size() const override;
 
-private:
-  const uint64_t default_max_bagfile_size = 0;
+  void split_database() override;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_PLUGIN_HPP_

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -44,6 +44,11 @@ public:
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   rosbag2_storage::BagMetadata get_metadata() override;
+
+  uint64_t get_bagfile_size() const override;
+
+private:
+  const uint64_t default_max_bagfile_size = 0;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_PLUGIN_HPP_

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -59,10 +59,9 @@ rosbag2_storage::BagMetadata TestReadOnlyPlugin::get_metadata()
   return rosbag2_storage::BagMetadata();
 }
 
-uint64_t TestReadOnlyPlugin::get_bagfile_size() const
+uint64_t TestReadOnlyPlugin::get_current_bagfile_size() const
 {
-  std::cout << "\nreturning bagfile size\n";
-  return default_max_bagfile_size;
+  return rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT;
 }
 
 PLUGINLIB_EXPORT_CLASS(TestReadOnlyPlugin, rosbag2_storage::storage_interfaces::ReadOnlyInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -59,4 +59,10 @@ rosbag2_storage::BagMetadata TestReadOnlyPlugin::get_metadata()
   return rosbag2_storage::BagMetadata();
 }
 
+uint64_t TestReadOnlyPlugin::get_bagfile_size() const
+{
+  std::cout << "\nreturning bagfile size\n";
+  return default_max_bagfile_size;
+}
+
 PLUGINLIB_EXPORT_CLASS(TestReadOnlyPlugin, rosbag2_storage::storage_interfaces::ReadOnlyInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -36,10 +36,7 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
-  uint64_t get_bagfile_size() const override;
-
-private:
-  const uint64_t default_max_bagfile_size = 0;
+  uint64_t get_current_bagfile_size() const override;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_READ_ONLY_PLUGIN_HPP_

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -35,6 +35,11 @@ public:
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   rosbag2_storage::BagMetadata get_metadata() override;
+
+  uint64_t get_bagfile_size() const override;
+
+private:
+  const uint64_t default_max_bagfile_size = 0;
 };
 
 #endif  // ROSBAG2_STORAGE__TEST_READ_ONLY_PLUGIN_HPP_

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -42,7 +42,7 @@ class ROSBAG2_STORAGE_DEFAULT_PLUGINS_PUBLIC SqliteStorage
   : public rosbag2_storage::storage_interfaces::ReadWriteInterface
 {
 public:
-  SqliteStorage();
+  SqliteStorage() = default;
   ~SqliteStorage() override = default;
 
   void open(
@@ -64,6 +64,8 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
+  uint64_t get_bagfile_size() const override;
+
 private:
   void initialize();
   void prepare_for_writing();
@@ -79,12 +81,14 @@ private:
 
   std::shared_ptr<SqliteWrapper> database_;
   std::string database_name_;
-  SqliteStatement write_statement_;
-  SqliteStatement read_statement_;
-  ReadQueryResult message_result_;
-  ReadQueryResult::Iterator current_message_row_;
+  SqliteStatement write_statement_ {};
+  SqliteStatement read_statement_ {};
+  ReadQueryResult message_result_ {nullptr};
+  ReadQueryResult::Iterator current_message_row_ {
+    nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END};
   std::unordered_map<std::string, int> topics_;
   std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
+  std::string uri_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -64,13 +64,17 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
-  uint64_t get_bagfile_size() const override;
+  uint64_t get_current_bagfile_size() const override;
+
+  void split_database() override;
 
 private:
   void initialize();
   void prepare_for_writing();
   void prepare_for_reading();
   void fill_topics_and_types();
+  std::string get_current_database_file_name() const;
+  std::string get_current_database_file_path() const;
 
   std::unique_ptr<rosbag2_storage::BagMetadata> load_metadata(const std::string & uri);
   bool database_exists(const std::string & uri);
@@ -80,7 +84,7 @@ private:
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string>;
 
   std::shared_ptr<SqliteWrapper> database_;
-  std::string database_name_;
+  std::vector<std::string> database_names_;
   SqliteStatement write_statement_ {};
   SqliteStatement read_statement_ {};
   ReadQueryResult message_result_ {nullptr};
@@ -88,7 +92,9 @@ private:
     nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END};
   std::unordered_map<std::string, int> topics_;
   std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
+  uint64_t database_file_counter_ {0};
   std::string uri_;
+  rosbag2_storage::storage_interfaces::IOFlag io_flag_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -36,14 +36,6 @@
 namespace rosbag2_storage_plugins
 {
 
-SqliteStorage::SqliteStorage()
-: database_(),
-  write_statement_(nullptr),
-  read_statement_(nullptr),
-  message_result_(nullptr),
-  current_message_row_(nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END)
-{}
-
 void SqliteStorage::open(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
@@ -82,6 +74,7 @@ void SqliteStorage::open(
     initialize();
   }
 
+  uri_ = uri;
   ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opened database '" << uri << "'.");
 }
 
@@ -131,6 +124,12 @@ std::vector<rosbag2_storage::TopicMetadata> SqliteStorage::get_all_topics_and_ty
   }
 
   return all_topics_and_types_;
+}
+
+uint64_t SqliteStorage::get_bagfile_size() const
+{
+  return rosbag2_storage::FilesystemHelper::get_file_size(
+    rosbag2_storage::FilesystemHelper::concat({uri_, database_name_}));
 }
 
 void SqliteStorage::initialize()

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -199,3 +199,17 @@ TEST_F(StorageTestFixture, remove_topics_and_types_returns_the_empty_vector) {
 
   EXPECT_THAT(topics_and_types, IsEmpty());
 }
+
+TEST_F(StorageTestFixture, split_database_creates_new_database_file) {
+  std::unique_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> writable_storage =
+    std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+  writable_storage->open(temporary_dir_path_);
+
+  auto metadata = writable_storage->get_metadata();
+  EXPECT_THAT(metadata.relative_file_paths.size(), Eq(1u));
+
+  writable_storage->split_database();
+
+  metadata = writable_storage->get_metadata();
+  EXPECT_THAT(metadata.relative_file_paths.size(), Eq(2u));
+}

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -56,7 +56,7 @@ class Rosbag2TransportTestFixture : public Test
 {
 public:
   Rosbag2TransportTestFixture()
-  : storage_options_({"uri", "storage_id"}), play_options_({1000}),
+  : storage_options_({"uri", "storage_id", 0}), play_options_({1000}),
     reader_(std::make_shared<MockSequentialReader>()),
     writer_(std::make_shared<MockWriter>()),
     info_(std::make_shared<MockInfo>()) {}


### PR DESCRIPTION
This PR is a rework of PR #158 into smaller PRs as per https://github.com/ros2/rosbag2/pull/158#issuecomment-537111547_

### Changes
* Writer now splits bagfile if it is determined that the internal interface should be split.

This PR depends on PRs #172, #171, and #170 