### PR TITLE
Disable parameter event publishers on test nodes

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
@@ -44,7 +44,9 @@ public:
     const std::string & topic_name, std::shared_ptr<T> message, size_t expected_messages = 0)
   {
     auto node_name = std::string("publisher") + std::to_string(counter_++);
-    auto publisher_node = std::make_shared<rclcpp::Node>(node_name);
+    auto publisher_node = std::make_shared<rclcpp::Node>(
+      node_name,
+      rclcpp::NodeOptions().start_parameter_event_publisher(false));
     auto publisher = publisher_node->create_publisher<T>(topic_name, 10);
 
     publisher_nodes_.push_back(publisher_node);

--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -33,7 +33,10 @@ class SubscriptionManager
 public:
   SubscriptionManager()
   {
-    subscriber_node_ = std::make_shared<rclcpp::Node>("subscriber_node");
+    subscriber_node_ = std::make_shared<rclcpp::Node>(
+      "subscriber_node",
+      rclcpp::NodeOptions().start_parameter_event_publisher(false)
+    );
   }
 
   template<typename MessageT>

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
@@ -27,7 +27,9 @@ TEST_F(RecordIntegrationTestFixture, record_all_without_discovery_ignores_later_
   auto string_message = get_messages_strings()[0];
   string_message->string_value = "Hello World";
 
-  auto publisher_node = std::make_shared<rclcpp::Node>("publisher_for_test");
+  auto publisher_node = std::make_shared<rclcpp::Node>(
+    "publisher_for_test",
+    rclcpp::NodeOptions().start_parameter_event_publisher(false));
 
   start_recording({true, true, {}, "rmw_format", 1ms});
 

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -34,7 +34,9 @@ public:
   RosBag2NodeFixture()
   {
     node_ = std::make_shared<rosbag2_transport::Rosbag2Node>("rosbag2");
-    publisher_node_ = std::make_shared<rclcpp::Node>("publisher_node");
+    publisher_node_ = std::make_shared<rclcpp::Node>(
+      "publisher_node",
+      rclcpp::NodeOptions().start_parameter_event_publisher(false));
   }
 
   static void SetUpTestCase()


### PR DESCRIPTION
This suppresses one of the root causes of ci failures - the implicitly created parameter event publisher in rclcpp.