### PR TITLE
Add bagfile splitting support to storage_options and Writer

### DIFF
--- a/rosbag2/include/rosbag2/storage_options.hpp
+++ b/rosbag2/include/rosbag2/storage_options.hpp
@@ -25,6 +25,11 @@ struct StorageOptions
 public:
   std::string uri;
   std::string storage_id;
+
+  /**
+   * The maximum size a bagfile can be, in bytes, before it is split.
+   * A value of 0 indicates that bagfile splitting will not be used.
+   */
   uint64_t max_bagfile_size;
 };
 

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -107,7 +107,7 @@ private:
   uint64_t max_bagfile_size_;
 
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
-  bool should_split_bagfile_() const;
+  bool should_split_bagfile() const;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -95,13 +95,6 @@ public:
    */
   virtual void write(std::shared_ptr<SerializedBagMessage> message);
 
-  /**
-   * Check if the current recording bagfile needs to be split and rolled over to new file.
-   *
-   * \return true if the bagfile should be split.
-   */
-  virtual bool should_split_bagfile() const;
-
 private:
   std::string uri_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
@@ -109,7 +102,12 @@ private:
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_;
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
   std::unique_ptr<Converter> converter_;
+
+  // Used in bagfile splitting; specifies the best-effort maximum sub-section of a bagfile in bytes.
   uint64_t max_bagfile_size_;
+
+  // Checks if the current recording bagfile needs to be split and rolled over to a new file.
+  bool should_split_bagfile_() const;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -95,6 +95,13 @@ public:
    */
   virtual void write(std::shared_ptr<SerializedBagMessage> message);
 
+  /**
+   * Check if the current recording bagfile needs to be split and rolled over to new file.
+   *
+   * \return true if the bagfile should be split.
+   */
+  virtual bool should_split_bagfile() const;
+
 private:
   std::string uri_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
@@ -102,6 +109,7 @@ private:
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_;
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
   std::unique_ptr<Converter> converter_;
+  uint64_t max_bagfile_size_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -97,7 +97,7 @@ void Writer::write(std::shared_ptr<SerializedBagMessage> message)
   storage_->write(converter_ ? converter_->convert(message) : message);
 }
 
-bool Writer::should_split_bagfile() const
+bool Writer::should_split_bagfile_() const
 {
   if (max_bagfile_size_ == rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT) {
     return false;

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -97,7 +97,7 @@ void Writer::write(std::shared_ptr<SerializedBagMessage> message)
   storage_->write(converter_ ? converter_->convert(message) : message);
 }
 
-bool Writer::should_split_bagfile_() const
+bool Writer::should_split_bagfile() const
 {
   if (max_bagfile_size_ == rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT) {
     return false;

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -51,6 +51,9 @@ void Writer::open(
   const StorageOptions & storage_options,
   const ConverterOptions & converter_options)
 {
+  
+  max_bagfile_size_ = storage_options.max_bagfile_size;
+
   if (converter_options.output_serialization_format !=
     converter_options.input_serialization_format)
   {

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -31,8 +31,10 @@ Writer::Writer(
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
 : storage_factory_(std::move(storage_factory)),
   converter_factory_(std::move(converter_factory)),
+  storage_(nullptr),
   metadata_io_(std::move(metadata_io)),
-  converter_(nullptr)
+  converter_(nullptr),
+  max_bagfile_size_(rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT)
 {}
 
 Writer::~Writer()
@@ -93,4 +95,12 @@ void Writer::write(std::shared_ptr<SerializedBagMessage> message)
   storage_->write(converter_ ? converter_->convert(message) : message);
 }
 
+bool Writer::should_split_bagfile() const
+{
+  if (max_bagfile_size_ == rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT) {
+    return false;
+  } else {
+    return storage_->get_bagfile_size() > max_bagfile_size_;
+  }
+}
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -51,7 +51,6 @@ void Writer::open(
   const StorageOptions & storage_options,
   const ConverterOptions & converter_options)
 {
-  
   max_bagfile_size_ = storage_options.max_bagfile_size;
 
   if (converter_options.output_serialization_format !=

--- a/rosbag2/test/rosbag2/test_writer.cpp
+++ b/rosbag2/test/rosbag2/test_writer.cpp
@@ -40,6 +40,7 @@ public:
     storage_ = std::make_shared<NiceMock<MockStorage>>();
     converter_factory_ = std::make_shared<StrictMock<MockConverterFactory>>();
     metadata_io_ = std::make_unique<NiceMock<MockMetadataIo>>();
+    storage_options_ = rosbag2::StorageOptions{};
     storage_options_.uri = "uri";
 
     EXPECT_CALL(
@@ -51,7 +52,7 @@ public:
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<MockMetadataIo> metadata_io_;
   std::unique_ptr<rosbag2::Writer> writer_;
-  rosbag2::StorageOptions storage_options_{};
+  rosbag2::StorageOptions storage_options_;
 };
 
 TEST_F(WriterTest,

--- a/rosbag2/test/rosbag2/test_writer.cpp
+++ b/rosbag2/test/rosbag2/test_writer.cpp
@@ -51,7 +51,7 @@ public:
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<MockMetadataIo> metadata_io_;
   std::unique_ptr<rosbag2::Writer> writer_;
-  rosbag2::StorageOptions storage_options_;
+  rosbag2::StorageOptions storage_options_{};
 };
 
 TEST_F(WriterTest,

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(
   SHARED
   src/rosbag2_storage/metadata_io.cpp
   src/rosbag2_storage/ros_helper.cpp
-  src/rosbag2_storage/storage_factory.cpp)
+  src/rosbag2_storage/storage_factory.cpp
+  src/rosbag2_storage/base_io_interface.cpp)
 target_include_directories(rosbag2_storage PUBLIC include)
 ament_target_dependencies(
   rosbag2_storage

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -33,7 +33,7 @@ enum class IOFlag : uint8_t
 
 // When bagfile splitting feature is not enabled or applicable,
 // use 0 as the default maximum bagfile size value.
-extern const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT;
+ROSBAG2_STORAGE_PUBLIC extern const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT;
 
 class ROSBAG2_STORAGE_PUBLIC BaseIOInterface
 {

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -31,6 +31,10 @@ enum class IOFlag : uint8_t
   APPEND = 2
 };
 
+// When bagfile splitting feature is not enabled or applicable,
+// use 0 as the default maximum bagfile size value.
+extern const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT;
+
 class ROSBAG2_STORAGE_PUBLIC BaseIOInterface
 {
 public:

--- a/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/base_io_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018, Bosch Software Innovations GmbH.
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSBAG2__STORAGE_OPTIONS_HPP_
-#define ROSBAG2__STORAGE_OPTIONS_HPP_
+#include "rosbag2_storage/storage_interfaces/base_io_interface.hpp"
 
-#include <string>
-
-namespace rosbag2
+namespace rosbag2_storage
 {
-
-struct StorageOptions
+namespace storage_interfaces
 {
-public:
-  std::string uri;
-  std::string storage_id;
-  uint64_t max_bagfile_size;
-};
-
-}  // namespace rosbag2
-
-#endif  // ROSBAG2__STORAGE_OPTIONS_HPP_
+const uint64_t MAX_BAGFILE_SIZE_NO_SPLIT = 0;
+}
+}

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -56,7 +56,7 @@ class Rosbag2TransportTestFixture : public Test
 {
 public:
   Rosbag2TransportTestFixture()
-  : storage_options_({"uri", "storage_id"}), play_options_({1000}),
+  : storage_options_({"uri", "storage_id", 0}), play_options_({1000}),
     reader_(std::make_shared<MockSequentialReader>()),
     writer_(std::make_shared<MockWriter>()),
     info_(std::make_shared<MockInfo>()) {}


### PR DESCRIPTION
Refactored changes in PR #171 
This is part of an effort to rework PR #158 into multiple, smaller PRs.

### Changes
* Add `max_bagfile_size` to `storage_options`. This is used to indicate when a bagfile should be split. A default value of 0 indicates no splitting.
* Add function `should_split_bagfile` to `Writer`. This will be used by `Writer` to determine when a bagfile should be split.

### Issues
* ros-security/aws-roadmap#11