### PR TITLE
Rosbag splitting in Writer

### DIFF
--- a/rosbag2/include/rosbag2/sequential_reader.hpp
+++ b/rosbag2/include/rosbag2/sequential_reader.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
 #include "rosbag2_storage/storage_factory_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
@@ -51,7 +52,9 @@ public:
     std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory =
     std::make_unique<rosbag2_storage::StorageFactory>(),
     std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory =
-    std::make_shared<SerializationFormatConverterFactory>());
+    std::make_shared<SerializationFormatConverterFactory>(),
+    std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io =
+    std::make_unique<rosbag2_storage::MetadataIo>());
 
   virtual ~SequentialReader();
 
@@ -104,6 +107,8 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_;
   std::unique_ptr<Converter> converter_;
+  std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
+  rosbag2_storage::BagMetadata metadata_;
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -107,17 +107,20 @@ private:
 
   // Used in bagfile splitting; specifies the best-effort maximum sub-section of a bagfile in bytes.
   uint64_t max_bagfile_size_;
+  uint64_t bagfile_counter_;
 
   // Used to track topic -> message count
   std::unordered_map<std::string, TopicInformation> topics_names_to_info_;
 
   rosbag2_storage::BagMetadata metadata_;
 
+  std::string next_bagfile_uri_();
+  void split_bagfile_();
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
   bool should_split_bagfile() const;
 
-  // Prepares the metadata by setting initial values.
   void init_metadata();
+  // Prepares the metadata by setting initial values.
 
   // Record TopicInformation into metadata
   void finalize_metadata();

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -98,7 +98,7 @@ public:
   virtual void write(std::shared_ptr<SerializedBagMessage> message);
 
 private:
-  std::string uri_;
+  std::string base_folder_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_;
@@ -108,16 +108,10 @@ private:
   // Used in bagfile splitting; specifies the best-effort maximum sub-section of a bagfile in bytes.
   uint64_t max_bagfile_size_;
 
-  // index used in bagfile splitting suffix. Starts at 0 and increments after each split.
-  uint64_t bagfile_counter_;
-
   // Used to track topic -> message count
   std::unordered_map<std::string, TopicInformation> topics_names_to_info_;
 
   rosbag2_storage::BagMetadata metadata_;
-
-  // Generates the next bagfile uri based on the bag_counter_ index.
-  std::string next_bagfile_uri();
 
   // Closes the current backed storage and opens the next bagfile.
   void split_bagfile();

--- a/rosbag2/include/rosbag2/writer.hpp
+++ b/rosbag2/include/rosbag2/writer.hpp
@@ -107,6 +107,8 @@ private:
 
   // Used in bagfile splitting; specifies the best-effort maximum sub-section of a bagfile in bytes.
   uint64_t max_bagfile_size_;
+
+  // index used in bagfile splitting suffix. Starts at 0 and increments after each split.
   uint64_t bagfile_counter_;
 
   // Used to track topic -> message count
@@ -114,13 +116,17 @@ private:
 
   rosbag2_storage::BagMetadata metadata_;
 
-  std::string next_bagfile_uri_();
-  void split_bagfile_();
+  // Generates the next bagfile uri based on the bag_counter_ index.
+  std::string next_bagfile_uri();
+
+  // Closes the current backed storage and opens the next bagfile.
+  void split_bagfile();
+
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
   bool should_split_bagfile() const;
 
-  void init_metadata();
   // Prepares the metadata by setting initial values.
+  void init_metadata();
 
   // Record TopicInformation into metadata
   void finalize_metadata();

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -21,15 +21,19 @@
 #include <vector>
 
 #include "rosbag2/info.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
 
 namespace rosbag2
 {
 
 SequentialReader::SequentialReader(
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
-  std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory)
-: storage_factory_(std::move(storage_factory)), converter_factory_(std::move(converter_factory)),
-  converter_(nullptr)
+  std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory,
+  std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
+: storage_factory_(std::move(storage_factory)),
+  converter_factory_(std::move(converter_factory)),
+  converter_(nullptr),
+  metadata_io_(std::move(metadata_io))
 {}
 
 SequentialReader::~SequentialReader()
@@ -41,11 +45,12 @@ void
 SequentialReader::open(
   const StorageOptions & storage_options, const ConverterOptions & converter_options)
 {
+  metadata_ = metadata_io_->read_metadata(storage_options.uri);
   storage_ = storage_factory_->open_read_only(storage_options.uri, storage_options.storage_id);
   if (!storage_) {
     throw std::runtime_error("No storage could be initialized. Abort");
   }
-  auto topics = storage_->get_metadata().topics_with_message_count;
+  auto topics = metadata_.topics_with_message_count;
   if (topics.empty()) {
     return;
   }

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "rosbag2/info.hpp"
+#include "rosbag2/logging.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 
 namespace rosbag2
@@ -46,13 +47,18 @@ SequentialReader::open(
   const StorageOptions & storage_options, const ConverterOptions & converter_options)
 {
   metadata_ = metadata_io_->read_metadata(storage_options.uri);
+  if (metadata_.relative_file_paths.empty()) {
+    ROSBAG2_LOG_WARN("No file paths were found in metadata.");
+    return;
+  }
   storage_ = storage_factory_->open_read_only(
-    metadata_.relative_file_paths[0], storage_options.storage_id);
+    metadata_.relative_file_paths.at(0), storage_options.storage_id);
   if (!storage_) {
     throw std::runtime_error("No storage could be initialized. Abort");
   }
   auto topics = metadata_.topics_with_message_count;
   if (topics.empty()) {
+    ROSBAG2_LOG_WARN("No topics were listed in metadata.");
     return;
   }
 

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -46,7 +46,8 @@ SequentialReader::open(
   const StorageOptions & storage_options, const ConverterOptions & converter_options)
 {
   metadata_ = metadata_io_->read_metadata(storage_options.uri);
-  storage_ = storage_factory_->open_read_only(storage_options.uri, storage_options.storage_id);
+  storage_ = storage_factory_->open_read_only(
+    metadata_.relative_file_paths[0], storage_options.storage_id);
   if (!storage_) {
     throw std::runtime_error("No storage could be initialized. Abort");
   }

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -162,7 +162,7 @@ void Writer::split_bagfile()
 
   metadata_.relative_file_paths.push_back(storage_->get_relative_file_path());
 
-  // Re-register all Topics since we rolled-over to a new bagfile.
+  // Re-register all topics since we rolled-over to a new bagfile.
   for (const auto & topic : topics_names_to_info_) {
     storage_->create_topic(topic.second.topic_metadata);
   }

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -35,13 +35,8 @@ std::string format_storage_uri(const std::string & base_folder, uint64_t storage
   // Right now `base_folder_` is always just the folder name for where to install the bagfile.
   // The name of the folder needs to be queried in case Writer is opened with a relative path.
   std::stringstream storage_file_name;
-  storage_file_name << rosbag2_storage::FilesystemHelper::get_folder_name(base_folder);
-
-  // Only append the counter after we have split.
-  // This is so bagfiles have the old naming convention if splitting is disabled.
-  if (storage_count > 0) {
-    storage_file_name << "_" << storage_count;
-  }
+  storage_file_name << rosbag2_storage::FilesystemHelper::get_folder_name(base_folder) <<
+    "_" << storage_count;
 
   return rosbag2_storage::FilesystemHelper::concat({base_folder, storage_file_name.str()});
 }
@@ -78,7 +73,7 @@ void Writer::init_metadata()
   metadata_.storage_identifier = storage_->get_storage_identifier();
   metadata_.starting_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
     std::chrono::nanoseconds::max());
-  metadata_.relative_file_paths = {storage_->get_relative_path()};
+  metadata_.relative_file_paths = {storage_->get_relative_file_path()};
 }
 
 void Writer::open(
@@ -165,7 +160,7 @@ void Writer::split_bagfile()
     throw std::runtime_error(errmsg.str());
   }
 
-  metadata_.relative_file_paths.push_back(storage_->get_relative_path());
+  metadata_.relative_file_paths.push_back(storage_->get_relative_file_path());
 
   // Re-register all Topics since we rolled-over to a new bagfile.
   for (const auto & topic : topics_names_to_info_) {

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -69,6 +69,7 @@ void Writer::open(
   const ConverterOptions & converter_options)
 {
   max_bagfile_size_ = storage_options.max_bagfile_size;
+  uri_ = storage_options.uri;
 
   if (converter_options.output_serialization_format !=
     converter_options.input_serialization_format)

--- a/rosbag2/src/rosbag2/writer.cpp
+++ b/rosbag2/src/rosbag2/writer.cpp
@@ -77,14 +77,12 @@ void Writer::open(
     converter_ = std::make_unique<Converter>(converter_options, converter_factory_);
   }
 
-  auto bagfile_uri = next_bagfile_uri_();
+  auto bagfile_uri = next_bagfile_uri();
 
   storage_ = storage_factory_->open_read_write(bagfile_uri, storage_options.storage_id);
   if (!storage_) {
     throw std::runtime_error("No storage could be initialized. Abort");
   }
-
-  uri_ = storage_options.uri;
 
   init_metadata();
 }
@@ -136,9 +134,9 @@ void Writer::remove_topic(const TopicMetadata & topic_with_type)
   }
 }
 
-void Writer::split_bagfile_()
+void Writer::split_bagfile()
 {
-  auto bagfile_uri = next_bagfile_uri_();
+  auto bagfile_uri = next_bagfile_uri();
 
   storage_ = storage_factory_->open_read_write(bagfile_uri, metadata_.storage_identifier);
 
@@ -164,7 +162,7 @@ void Writer::write(std::shared_ptr<SerializedBagMessage> message)
   ++topics_names_to_info_.at(message->topic_name).message_count;
 
   if (should_split_bagfile()) {
-    split_bagfile_();
+    split_bagfile();
   }
   const auto message_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
     std::chrono::nanoseconds(message->time_stamp));
@@ -203,7 +201,7 @@ void Writer::finalize_metadata()
   }
 }
 
-std::string Writer::next_bagfile_uri_()
+std::string Writer::next_bagfile_uri()
 {
   std::stringstream db_name;
   db_name << rosbag2_storage::FilesystemHelper::get_folder_name(uri_);

--- a/rosbag2/test/rosbag2/mock_storage.hpp
+++ b/rosbag2/test/rosbag2/mock_storage.hpp
@@ -38,7 +38,7 @@ public:
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
   MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
-  MOCK_CONST_METHOD0(get_relative_path, std::string());
+  MOCK_CONST_METHOD0(get_relative_file_path, std::string());
   MOCK_CONST_METHOD0(get_storage_identifier, std::string());
 };
 

--- a/rosbag2/test/rosbag2/test_sequential_reader.cpp
+++ b/rosbag2/test/rosbag2/test_sequential_reader.cpp
@@ -21,8 +21,8 @@
 
 #include "rosbag2/sequential_reader.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
-#include "rosbag2_storage/topic_metadata.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
 
 #include "mock_converter.hpp"
 #include "mock_converter_factory.hpp"
@@ -72,8 +72,7 @@ public:
   std::string storage_serialization_format_;
 };
 
-TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_format)
-{
+TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_format) {
   std::string output_format = "rmw2_format";
 
   auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
@@ -90,8 +89,7 @@ TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_
   reader_->read_next();
 }
 
-TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exist)
-{
+TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exist) {
   std::string output_format = "rmw2_format";
 
   auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
@@ -104,8 +102,7 @@ TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exis
 }
 
 TEST_F(SequentialReaderTest,
-  read_next_does_not_use_converters_if_input_and_output_format_are_equal)
-{
+  read_next_does_not_use_converters_if_input_and_output_format_are_equal) {
   std::string storage_serialization_format = "rmw1_format";
 
   EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format)).Times(0);

--- a/rosbag2/test/rosbag2/test_sequential_reader.cpp
+++ b/rosbag2/test/rosbag2/test_sequential_reader.cpp
@@ -22,9 +22,11 @@
 #include "rosbag2/sequential_reader.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
 
 #include "mock_converter.hpp"
 #include "mock_converter_factory.hpp"
+#include "mock_metadata_io.hpp"
 #include "mock_storage.hpp"
 #include "mock_storage_factory.hpp"
 
@@ -38,48 +40,48 @@ public:
     storage_factory_ = std::make_unique<StrictMock<MockStorageFactory>>();
     storage_ = std::make_shared<NiceMock<MockStorage>>();
     converter_factory_ = std::make_shared<StrictMock<MockConverterFactory>>();
+    metadata_io_ = std::make_unique<NiceMock<MockMetadataIo>>();
+    storage_serialization_format_ = "rmw1_format";
 
     rosbag2_storage::TopicMetadata topic_with_type;
     topic_with_type.name = "topic";
     topic_with_type.type = "test_msgs/BasicTypes";
+    topic_with_type.serialization_format = storage_serialization_format_;
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));
 
+    metadata_.topics_with_message_count.push_back({{topic_with_type}, 1});
+    EXPECT_CALL(*metadata_io_, read_metadata(_)).WillRepeatedly(Return(metadata_));
+
     auto message = std::make_shared<rosbag2::SerializedBagMessage>();
     message->topic_name = topic_with_type.name;
     EXPECT_CALL(*storage_, read_next()).WillRepeatedly(Return(message));
-
-    EXPECT_CALL(*storage_factory_, open_read_only(_, _)).WillOnce(Return(storage_));
+    EXPECT_CALL(*storage_factory_, open_read_only(_, _)).WillRepeatedly(Return(storage_));
 
     reader_ = std::make_unique<rosbag2::SequentialReader>(
-      std::move(storage_factory_), converter_factory_);
-  }
-
-  void set_storage_serialization_format(const std::string & format)
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.topics_with_message_count.push_back({{"", "", format}, 1});
-    EXPECT_CALL(*storage_, get_metadata()).WillOnce(Return(metadata));
+      std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
   std::shared_ptr<NiceMock<MockStorage>> storage_;
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<rosbag2::SequentialReader> reader_;
+  std::unique_ptr<MockMetadataIo> metadata_io_;
+  rosbag2_storage::BagMetadata metadata_;
+  std::string storage_serialization_format_;
 };
 
-TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_format) {
-  std::string storage_serialization_format = "rmw1_format";
+TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_format)
+{
   std::string output_format = "rmw2_format";
-  set_storage_serialization_format(storage_serialization_format);
 
   auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
   auto format2_converter = std::make_unique<StrictMock<MockConverter>>();
   EXPECT_CALL(*format1_converter, deserialize(_, _, _)).Times(1);
   EXPECT_CALL(*format2_converter, serialize(_, _, _)).Times(1);
 
-  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format))
+  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_))
   .WillOnce(Return(ByMove(std::move(format1_converter))));
   EXPECT_CALL(*converter_factory_, load_serializer(output_format))
   .WillOnce(Return(ByMove(std::move(format2_converter))));
@@ -88,13 +90,12 @@ TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_
   reader_->read_next();
 }
 
-TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exist) {
-  std::string storage_serialization_format = "rmw1_format";
+TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exist)
+{
   std::string output_format = "rmw2_format";
-  set_storage_serialization_format(storage_serialization_format);
 
   auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
-  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format))
+  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_))
   .WillOnce(Return(ByMove(std::move(format1_converter))));
   EXPECT_CALL(*converter_factory_, load_serializer(output_format))
   .WillOnce(Return(ByMove(nullptr)));
@@ -106,7 +107,6 @@ TEST_F(SequentialReaderTest,
   read_next_does_not_use_converters_if_input_and_output_format_are_equal)
 {
   std::string storage_serialization_format = "rmw1_format";
-  set_storage_serialization_format(storage_serialization_format);
 
   EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format)).Times(0);
   EXPECT_CALL(*converter_factory_, load_serializer(storage_serialization_format)).Times(0);

--- a/rosbag2/test/rosbag2/test_sequential_reader.cpp
+++ b/rosbag2/test/rosbag2/test_sequential_reader.cpp
@@ -51,6 +51,7 @@ public:
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));
 
+    metadata_.relative_file_paths = {"/path/to/storage"};
     metadata_.topics_with_message_count.push_back({{topic_with_type}, 1});
     EXPECT_CALL(*metadata_io_, read_metadata(_)).WillRepeatedly(Return(metadata_));
 

--- a/rosbag2/test/rosbag2/test_writer.cpp
+++ b/rosbag2/test/rosbag2/test_writer.cpp
@@ -44,8 +44,15 @@ public:
     storage_options_ = rosbag2::StorageOptions{};
     storage_options_.uri = "uri";
 
+    ON_CALL(*storage_factory_, open_read_write(_, _)).WillByDefault(
+      DoAll(
+        Invoke([this](const std::string & uri, const std::string &) {
+          fake_storage_size_ = 0;
+          fake_storage_uri_ = uri;
+        }),
+        Return(storage_)));
     EXPECT_CALL(
-      *storage_factory_, open_read_write(_, _)).Times(AtLeast(0)).WillRepeatedly(Return(storage_));
+      *storage_factory_, open_read_write(_, _)).Times(AtLeast(0));
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
@@ -54,6 +61,9 @@ public:
   std::unique_ptr<MockMetadataIo> metadata_io_;
   std::unique_ptr<rosbag2::Writer> writer_;
   rosbag2::StorageOptions storage_options_;
+  uint64_t fake_storage_size_;
+  rosbag2_storage::BagMetadata fake_metadata_;
+  std::string fake_storage_uri_;
 };
 
 TEST_F(WriterTest,
@@ -147,5 +157,73 @@ TEST_F(WriterTest, bagfile_size_is_checked_on_every_write) {
 
   for (auto i = 0; i < counter; ++i) {
     writer_->write(message);
+  }
+}
+
+TEST_F(WriterTest, writer_splits_when_storage_bagfile_size_gt_max_bagfile_size) {
+  const int message_count = 15;
+  const int max_bagfile_size = 5;
+  const auto expected_splits = message_count / max_bagfile_size;
+  fake_storage_size_ = 0;
+
+  ON_CALL(*storage_, write).WillByDefault(
+    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+      fake_storage_size_ += 1;
+    });
+
+  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
+    [this]() {
+      return fake_storage_size_;
+    });
+
+  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
+    [this]() {
+      return fake_storage_uri_;
+    });
+
+  EXPECT_CALL(*metadata_io_, write_metadata).Times(1);
+
+  // intercept the metadata write so we can analyze it.
+  ON_CALL(*metadata_io_, write_metadata).WillByDefault(
+    [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
+      fake_metadata_ = metadata;
+    });
+
+  writer_ = std::make_unique<rosbag2::Writer>(
+    std::move(storage_factory_),
+    converter_factory_,
+    std::move(metadata_io_));
+
+  std::string rmw_format = "rmw_format";
+
+  auto message = std::make_shared<rosbag2::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+
+  storage_options_.max_bagfile_size = max_bagfile_size;
+
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", ""});
+
+  for (auto i = 0; i < message_count; ++i) {
+    writer_->write(message);
+  }
+
+  writer_.reset();
+  // metadata should be written now that the Writer was released.
+
+  EXPECT_EQ(fake_metadata_.relative_file_paths.size(),
+    static_cast<unsigned int>(expected_splits)) <<
+    "Storage should have split bagfile " << (expected_splits - 1);
+
+  const auto base_path = rosbag2_storage::FilesystemHelper::concat({
+    storage_options_.uri, storage_options_.uri});
+  int counter = 0;
+  for (const auto & path : fake_metadata_.relative_file_paths) {
+    std::stringstream ss;
+    ss << base_path << "_" << counter;
+
+    const auto expected_path = ss.str();
+    counter++;
+    EXPECT_EQ(expected_path, path);
   }
 }

--- a/rosbag2/test/rosbag2/test_writer.cpp
+++ b/rosbag2/test/rosbag2/test_writer.cpp
@@ -14,6 +14,8 @@
 
 #include <gmock/gmock.h>
 
+#include <rosbag2_storage/filesystem_helper.hpp>
+
 #include <memory>
 #include <string>
 #include <utility>
@@ -121,4 +123,30 @@ TEST_F(WriterTest, open_throws_error_if_converter_plugin_does_not_exist) {
   .WillOnce(Return(ByMove(nullptr)));
 
   EXPECT_ANY_THROW(writer_->open(storage_options_, {input_format, output_format}));
+}
+
+TEST_F(WriterTest, bagfile_size_is_checked_on_every_write) {
+  const int counter = 10;
+  const uint64_t max_bagfile_size = 100;
+
+  EXPECT_CALL(*storage_, get_bagfile_size()).Times(counter);
+
+  writer_ = std::make_unique<rosbag2::Writer>(
+    std::move(storage_factory_),
+    converter_factory_,
+    std::move(metadata_io_));
+
+  std::string rmw_format = "rmw_format";
+
+  auto message = std::make_shared<rosbag2::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+
+  storage_options_.max_bagfile_size = max_bagfile_size;
+
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", ""});
+
+  for (auto i = 0; i < counter; ++i) {
+    writer_->write(message);
+  }
 }

--- a/rosbag2/test/rosbag2/test_writer.cpp
+++ b/rosbag2/test/rosbag2/test_writer.cpp
@@ -14,8 +14,6 @@
 
 #include <gmock/gmock.h>
 
-#include <rosbag2_storage/filesystem_helper.hpp>
-
 #include <memory>
 #include <string>
 #include <utility>
@@ -23,6 +21,7 @@
 
 #include "rosbag2/writer.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/filesystem_helper.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 
 #include "mock_converter.hpp"

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
@@ -38,7 +38,7 @@ public:
    *
    * \returns the relative path.
    */
-  virtual std::string get_relative_path() const = 0;
+  virtual std::string get_relative_file_path() const = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -40,6 +40,15 @@ class ROSBAG2_STORAGE_PUBLIC BaseIOInterface
 public:
   virtual ~BaseIOInterface() = default;
 
+  /**
+   * Opens the storage plugin.
+   * \param uri is the path to the bagfile. Exact behavior depends on the io_flag passed.
+   * \param io_flag is a hint for the type of storage plugin to open depending on the io operations requested.
+   * If IOFlag::READ_ONLY is passed, then only read operations are guaranteed.
+   * The uri passed should be the exact relative path to the bagfile.
+   * If IOFlag::READ_WRITE is passed, then a new bagfile is created with guaranteed read and write operations.
+   * The storage plugin will append the uri in the case of creating a new bagfile backing.
+   */
   virtual void open(const std::string & uri, IOFlag io_flag) = 0;
 
   /**

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -80,7 +80,7 @@ rosbag2_storage::BagMetadata TestPlugin::get_metadata()
   return rosbag2_storage::BagMetadata();
 }
 
-std::string TestPlugin::get_relative_path() const
+std::string TestPlugin::get_relative_file_path() const
 {
   std::cout << "\nreturning relative path\n";
   return test_constants::DUMMY_FILEPATH;

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -45,7 +45,7 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
-  std::string get_relative_path() const override;
+  std::string get_relative_file_path() const override;
 
   uint64_t get_bagfile_size() const override;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -55,7 +55,7 @@ std::vector<rosbag2_storage::TopicMetadata> TestReadOnlyPlugin::get_all_topics_a
   return std::vector<rosbag2_storage::TopicMetadata>();
 }
 
-std::string TestReadOnlyPlugin::get_relative_path() const
+std::string TestReadOnlyPlugin::get_relative_file_path() const
 {
   std::cout << "\nreturning relative path\n";
   return test_constants::DUMMY_FILEPATH;

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -36,7 +36,7 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
-  std::string get_relative_path() const override;
+  std::string get_relative_file_path() const override;
 
   uint64_t get_bagfile_size() const override;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
@@ -47,7 +47,7 @@ TEST_F(StorageFactoryTest, load_test_plugin) {
 
   EXPECT_EQ(
     test_constants::DUMMY_FILEPATH,
-    read_write_storage->get_relative_path());
+    read_write_storage->get_relative_file_path());
 
   EXPECT_EQ(
     test_constants::READ_WRITE_PLUGIN_IDENTIFIER,
@@ -74,7 +74,7 @@ TEST_F(StorageFactoryTest, loads_readonly_plugin_only_for_read_only_storage) {
 
   EXPECT_EQ(
     test_constants::DUMMY_FILEPATH,
-    storage_for_reading->get_relative_path());
+    storage_for_reading->get_relative_file_path());
 
   EXPECT_EQ(
     test_constants::READ_ONLY_PLUGIN_IDENTIFIER,

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -76,9 +76,6 @@ private:
   void prepare_for_reading();
   void fill_topics_and_types();
 
-  std::unique_ptr<rosbag2_storage::BagMetadata> load_metadata(const std::string & uri);
-  bool is_read_only(const rosbag2_storage::storage_interfaces::IOFlag & io_flag) const;
-
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string>;
 

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -64,7 +64,7 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
-  std::string get_relative_path() const override;
+  std::string get_relative_file_path() const override;
 
   uint64_t get_bagfile_size() const override;
 

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -83,7 +83,6 @@ private:
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string>;
 
   std::shared_ptr<SqliteWrapper> database_;
-  std::string database_name_;
   SqliteStatement write_statement_ {};
   SqliteStatement read_statement_ {};
   ReadQueryResult message_result_ {nullptr};
@@ -91,7 +90,7 @@ private:
     nullptr, SqliteStatementWrapper::QueryResult<>::Iterator::POSITION_END};
   std::unordered_map<std::string, int> topics_;
   std::vector<rosbag2_storage::TopicMetadata> all_topics_and_types_;
-  std::string uri_;
+  std::string relative_path_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -66,7 +66,7 @@ void SqliteStorage::open(
   }
 
   // Reset the read and write statements in case the database changed.
-  //  These will be reinitialized lazily on the first read or write.
+  // These will be reinitialized lazily on the first read or write.
   read_statement_ = nullptr;
   write_statement_ = nullptr;
 
@@ -124,7 +124,7 @@ std::vector<rosbag2_storage::TopicMetadata> SqliteStorage::get_all_topics_and_ty
 uint64_t SqliteStorage::get_bagfile_size() const
 {
   return rosbag2_storage::FilesystemHelper::get_file_size(
-    get_relative_path());
+    get_relative_file_path());
 }
 
 void SqliteStorage::initialize()
@@ -219,7 +219,7 @@ std::string SqliteStorage::get_storage_identifier() const
   return "sqlite3";
 }
 
-std::string SqliteStorage::get_relative_path() const
+std::string SqliteStorage::get_relative_file_path() const
 {
   return relative_path_;
 }
@@ -228,7 +228,7 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
 {
   rosbag2_storage::BagMetadata metadata;
   metadata.storage_identifier = get_storage_identifier();
-  metadata.relative_file_paths = {get_relative_path()};
+  metadata.relative_file_paths = {get_relative_file_path()};
 
   metadata.message_count = 0;
   metadata.topics_with_message_count = {};
@@ -264,11 +264,7 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(min_time));
   metadata.duration = std::chrono::nanoseconds(max_time) - std::chrono::nanoseconds(min_time);
-  metadata.bag_size = 0;
-
-  for (const auto & relative_path : metadata.relative_file_paths) {
-    metadata.bag_size += rosbag2_storage::FilesystemHelper::get_file_size(relative_path);
-  }
+  metadata.bag_size = rosbag2_storage::FilesystemHelper::get_file_size(get_relative_file_path());
 
   return metadata;
 }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -71,15 +71,20 @@ void SqliteStorage::open(
 {
   if (is_read_write(io_flag)) {
     relative_path_ = uri + FILE_EXTENSION;
+
+    // READ_WRITE requires the DB to not exist.
+    if (database_exists(relative_path_)) {
+      throw std::runtime_error(
+              "Failed to create bag: File '" + relative_path_ + "' file already exists!");
+    }
   } else {  // APPEND and READ_ONLY
     relative_path_ = uri;
-  }
 
-  // DB is created only if storage is opened for READ_WRITE.
-  // So READ_ONLY and APPEND require the DB to exist.
-  if (!is_read_write(io_flag) && !database_exists(relative_path_)) {
-    throw std::runtime_error(
-            "Failed to read from bag: File '" + relative_path_ + "' does not exist!");
+    // APPEND and READ_ONLY require the DB to exist
+    if (!database_exists(relative_path_)) {
+      throw std::runtime_error(
+              "Failed to read from bag: File '" + relative_path_ + "' does not exist!");
+    }
   }
 
   try {

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -35,12 +35,6 @@
 
 namespace
 {
-bool database_exists(const std::string & uri)
-{
-  std::ifstream database(uri);
-  return database.good();
-}
-
 std::string to_string(rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
   switch (io_flag) {
@@ -73,7 +67,7 @@ void SqliteStorage::open(
     relative_path_ = uri + FILE_EXTENSION;
 
     // READ_WRITE requires the DB to not exist.
-    if (database_exists(relative_path_)) {
+    if (rosbag2_storage::FilesystemHelper::file_exists(relative_path_)) {
       throw std::runtime_error(
               "Failed to create bag: File '" + relative_path_ + "' already exists!");
     }
@@ -81,7 +75,7 @@ void SqliteStorage::open(
     relative_path_ = uri;
 
     // APPEND and READ_ONLY require the DB to exist
-    if (!database_exists(relative_path_)) {
+    if (!rosbag2_storage::FilesystemHelper::file_exists(relative_path_)) {
       throw std::runtime_error(
               "Failed to read from bag: File '" + relative_path_ + "' does not exist!");
     }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -124,7 +124,8 @@ std::vector<rosbag2_storage::TopicMetadata> SqliteStorage::get_all_topics_and_ty
 
 uint64_t SqliteStorage::get_bagfile_size() const
 {
-  return rosbag2_storage::FilesystemHelper::get_file_size(relative_path_);
+  return rosbag2_storage::FilesystemHelper::get_file_size(
+    get_relative_path());
 }
 
 void SqliteStorage::initialize()

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 #include <fstream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -49,12 +48,7 @@ namespace rosbag2_storage_plugins
 void SqliteStorage::open(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
-  ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opening DB: " << uri << ".");
-
-  std::stringstream relative_path_builder;
-  relative_path_builder << uri << "." << get_storage_identifier();
-
-  relative_path_ = relative_path_builder.str();
+  relative_path_ = uri + ".db3";
 
   if (is_read_only(io_flag) && !database_exists(relative_path_)) {
     throw std::runtime_error("Failed to read from bag: File '" + relative_path_ + "' does not exist!");
@@ -75,7 +69,7 @@ void SqliteStorage::open(
   read_statement_ = nullptr;
   write_statement_ = nullptr;
 
-  ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opened database '" << uri << "'.");
+  ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opened database '" << relative_path_ << "'.");
 }
 
 void SqliteStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -56,7 +56,6 @@ void SqliteStorage::open(
   }
 
   try {
-    database_ = std::make_unique<SqliteWrapper>(uri, io_flag);
     database_ = std::make_unique<SqliteWrapper>(relative_path_, io_flag);
   } catch (const SqliteException & e) {
     throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -75,7 +75,7 @@ void SqliteStorage::open(
     // READ_WRITE requires the DB to not exist.
     if (database_exists(relative_path_)) {
       throw std::runtime_error(
-              "Failed to create bag: File '" + relative_path_ + "' file already exists!");
+              "Failed to create bag: File '" + relative_path_ + "' already exists!");
     }
   } else {  // APPEND and READ_ONLY
     relative_path_ = uri;
@@ -104,9 +104,7 @@ void SqliteStorage::open(
   write_statement_ = nullptr;
 
   ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opened database '" <<
-    relative_path_ <<
-    "' for " <<
-    to_string(io_flag) << ".");
+    relative_path_ << "' for " << to_string(io_flag) << ".");
 }
 
 void SqliteStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <fstream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -48,42 +49,32 @@ namespace rosbag2_storage_plugins
 void SqliteStorage::open(
   const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
-  auto metadata = is_read_only(io_flag) ?
-    load_metadata(uri) :
-    std::unique_ptr<rosbag2_storage::BagMetadata>();
+  ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opening DB: " << uri << ".");
 
-  if (metadata) {
-    if (metadata->relative_file_paths.empty()) {
-      throw std::runtime_error(
-              "Failed to read from bag '" + uri + "': Missing database file path in metadata");
-    }
+  std::stringstream relative_path_builder;
+  relative_path_builder << uri << "." << get_storage_identifier();
 
-    database_name_ = metadata->relative_file_paths[0];
-  } else {
-    if (is_read_only(io_flag)) {
-      throw std::runtime_error("Failed to read from bag '" + uri + "': No metadata found.");
-    }
+  relative_path_ = relative_path_builder.str();
 
-    database_name_ = rosbag2_storage::FilesystemHelper::get_folder_name(uri) + ".db3";
-  }
-
-  std::string database_path = rosbag2_storage::FilesystemHelper::concat({uri, database_name_});
-  if (is_read_only(io_flag) && !database_exists(database_path)) {
-    throw std::runtime_error(
-            "Failed to read from bag '" + uri + "': File '" + database_name_ + "' does not exist.");
+  if (is_read_only(io_flag) && !database_exists(relative_path_)) {
+    throw std::runtime_error("Failed to read from bag: File '" + relative_path_ + "' does not exist!");
   }
 
   try {
-    database_ = std::make_unique<SqliteWrapper>(database_path, io_flag);
+    database_ = std::make_unique<SqliteWrapper>(uri, io_flag);
   } catch (const SqliteException & e) {
     throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));
   }
 
-  if (!metadata) {
+  if (!is_read_only(io_flag)) {
     initialize();
   }
 
-  uri_ = uri;
+  // Reset the read and write statements in case the database changed.
+  //  These will be reinitialized lazily on the first read or write.
+  read_statement_ = nullptr;
+  write_statement_ = nullptr;
+
   ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM("Opened database '" << uri << "'.");
 }
 
@@ -137,8 +128,7 @@ std::vector<rosbag2_storage::TopicMetadata> SqliteStorage::get_all_topics_and_ty
 
 uint64_t SqliteStorage::get_bagfile_size() const
 {
-  return rosbag2_storage::FilesystemHelper::get_file_size(
-    rosbag2_storage::FilesystemHelper::concat({uri_, database_name_}));
+  return rosbag2_storage::FilesystemHelper::get_file_size(relative_path_);
 }
 
 void SqliteStorage::initialize()
@@ -235,14 +225,14 @@ std::string SqliteStorage::get_storage_identifier() const
 
 std::string SqliteStorage::get_relative_path() const
 {
-  return database_name_;
+  return relative_path_;
 }
 
 rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
 {
   rosbag2_storage::BagMetadata metadata;
   metadata.storage_identifier = get_storage_identifier();
-  metadata.relative_file_paths = {database_name_};
+  metadata.relative_file_paths = {get_relative_path()};
 
   metadata.message_count = 0;
   metadata.topics_with_message_count = {};
@@ -278,7 +268,11 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(min_time));
   metadata.duration = std::chrono::nanoseconds(max_time) - std::chrono::nanoseconds(min_time);
-  metadata.bag_size = rosbag2_storage::FilesystemHelper::calculate_directory_size(database_name_);
+  metadata.bag_size = 0;
+
+  for (const auto & relative_path : metadata.relative_file_paths) {
+    metadata.bag_size += rosbag2_storage::FilesystemHelper::get_file_size(relative_path);
+  }
 
   return metadata;
 }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -51,11 +51,13 @@ void SqliteStorage::open(
   relative_path_ = uri + ".db3";
 
   if (is_read_only(io_flag) && !database_exists(relative_path_)) {
-    throw std::runtime_error("Failed to read from bag: File '" + relative_path_ + "' does not exist!");
+    throw std::runtime_error(
+            "Failed to read from bag: File '" + relative_path_ + "' does not exist!");
   }
 
   try {
     database_ = std::make_unique<SqliteWrapper>(uri, io_flag);
+    database_ = std::make_unique<SqliteWrapper>(relative_path_, io_flag);
   } catch (const SqliteException & e) {
     throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));
   }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -39,6 +39,8 @@ SqliteWrapper::SqliteWrapper(
     if (rc != SQLITE_OK) {
       throw SqliteException("Could not read-only open database. Error code: " + std::to_string(rc));
     }
+    // throws an exception if the database is not valid.
+    prepare_statement("PRAGMA schema_version;")->execute_and_reset();
   } else {
     int rc = sqlite3_open_v2(uri.c_str(), &db_ptr,
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX, nullptr);

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -107,7 +107,7 @@ public:
       writable_storage->write(bag_message);
     }
 
-    metadata_io_.write_metadata(temporary_dir_path_ + "", writable_storage->get_metadata());
+    metadata_io_.write_metadata(temporary_dir_path_, writable_storage->get_metadata());
   }
 
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -91,7 +91,7 @@ public:
     std::unique_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> writable_storage =
       std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
 
     writable_storage->open(db_file);
 
@@ -116,7 +116,7 @@ public:
     std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
       std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
 
     readable_storage->open(
       db_file, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -91,7 +91,9 @@ public:
     std::unique_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> writable_storage =
       std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-    writable_storage->open(temporary_dir_path_);
+    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+
+    writable_storage->open(db_file);
 
     for (auto msg : messages) {
       std::string topic_name = std::get<2>(msg);
@@ -105,7 +107,7 @@ public:
       writable_storage->write(bag_message);
     }
 
-    metadata_io_.write_metadata(temporary_dir_path_, writable_storage->get_metadata());
+    metadata_io_.write_metadata(temporary_dir_path_ + "", writable_storage->get_metadata());
   }
 
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
@@ -113,8 +115,11 @@ public:
   {
     std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
       std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+
+    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+
     readable_storage->open(
-      temporary_dir_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+      db_file, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
     std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> read_messages;
 
     while (readable_storage->has_next()) {

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -116,7 +116,7 @@ public:
     std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
       std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
+    auto db_file = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db3"});
 
     readable_storage->open(
       db_file, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -77,7 +77,9 @@ TEST_F(StorageTestFixture, has_next_return_false_if_there_are_no_more_messages) 
   write_messages_to_sqlite(string_messages);
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  readable_storage->open(temporary_dir_path_);
+
+  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+  readable_storage->open(db_filename);
 
   EXPECT_TRUE(readable_storage->has_next());
   readable_storage->read_next();
@@ -95,7 +97,9 @@ TEST_F(StorageTestFixture, get_next_returns_messages_in_timestamp_order) {
   write_messages_to_sqlite(string_messages);
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  readable_storage->open(temporary_dir_path_);
+
+  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+  readable_storage->open(db_filename);
 
   EXPECT_TRUE(readable_storage->has_next());
   auto first_message = readable_storage->read_next();
@@ -109,7 +113,10 @@ TEST_F(StorageTestFixture, get_next_returns_messages_in_timestamp_order) {
 TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) {
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> writable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  writable_storage->open(temporary_dir_path_);
+
+  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+
+  writable_storage->open(db_filename);
   writable_storage->create_topic({"topic1", "type1", "rmw1"});
   writable_storage->create_topic({"topic2", "type2", "rmw2"});
   metadata_io_.write_metadata(temporary_dir_path_, writable_storage->get_metadata());
@@ -117,7 +124,7 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
 
   auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
   readable_storage->open(
-    temporary_dir_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+    db_filename, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
   auto topics_and_types = readable_storage->get_all_topics_and_types();
 
   EXPECT_THAT(topics_and_types, ElementsAreArray({
@@ -140,13 +147,14 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
   write_messages_to_sqlite(messages);
 
   auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  readable_storage->open(
-    temporary_dir_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+
+  readable_storage->open(db_filename, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
   auto metadata = readable_storage->get_metadata();
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
   EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
-    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
+    db_filename
   }));
   EXPECT_THAT(metadata.topics_with_message_count, ElementsAreArray({
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
@@ -165,13 +173,14 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_if_no_messages) {
   write_messages_to_sqlite({});
 
   auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  readable_storage->open(
-    temporary_dir_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+
+  readable_storage->open(db_filename, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
   auto metadata = readable_storage->get_metadata();
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
   EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
-    rosbag2_storage::FilesystemHelper::get_folder_name(temporary_dir_path_) + ".db3"
+    db_filename
   }));
   EXPECT_THAT(metadata.topics_with_message_count, IsEmpty());
   EXPECT_THAT(metadata.message_count, Eq(0u));
@@ -184,7 +193,10 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_if_no_messages) {
 TEST_F(StorageTestFixture, remove_topics_and_types_returns_the_empty_vector) {
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> writable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  writable_storage->open(temporary_dir_path_);
+
+  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db"});
+
+  writable_storage->open(db_filename);
   writable_storage->create_topic({"topic1", "type1", "rmw1"});
   metadata_io_.write_metadata(temporary_dir_path_, writable_storage->get_metadata());
   writable_storage->remove_topic({"topic1", "type1", "rmw1"});
@@ -193,8 +205,7 @@ TEST_F(StorageTestFixture, remove_topics_and_types_returns_the_empty_vector) {
   // Remove topics
 
   auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  readable_storage->open(
-    temporary_dir_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+  readable_storage->open(db_filename, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
   auto topics_and_types = readable_storage->get_all_topics_and_types();
 
   EXPECT_THAT(topics_and_types, IsEmpty());

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -163,5 +163,7 @@ TEST_F(StorageTestFixture, get_relative_path_returns_db_name_with_ext) {
   auto storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
   auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
 
+  storage->open(db_filename);
+
   EXPECT_EQ(storage->get_relative_path(), db_filename + ".db3");
 }

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -115,8 +115,8 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
   // extension is omitted since storage is being created; io_flag = READ_WRITE
-  const auto read_write_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_,
-        "rosbag"});
+  const auto read_write_filename =
+    rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
 
   writable_storage->open(read_write_filename);
   writable_storage->create_topic({"topic1", "type1", "rmw1"});
@@ -158,9 +158,7 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
   const auto metadata = readable_storage->get_metadata();
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
-  EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
-    db_filename
-  }));
+  EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({db_filename}));
   EXPECT_THAT(metadata.topics_with_message_count, ElementsAreArray({
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
         "topic1", "type1", "rmw_format"}, 2u},
@@ -185,9 +183,7 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_if_no_messages) {
   const auto metadata = readable_storage->get_metadata();
 
   EXPECT_THAT(metadata.storage_identifier, Eq("sqlite3"));
-  EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({
-    db_filename
-  }));
+  EXPECT_THAT(metadata.relative_file_paths, ElementsAreArray({db_filename}));
   EXPECT_THAT(metadata.topics_with_message_count, IsEmpty());
   EXPECT_THAT(metadata.message_count, Eq(0u));
   EXPECT_THAT(metadata.starting_time, Eq(
@@ -201,8 +197,8 @@ TEST_F(StorageTestFixture, remove_topics_and_types_returns_the_empty_vector) {
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
   // extension is omitted since storage is created; io_flag = READ_WRITE
-  const auto read_write_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_,
-        "rosbag"});
+  const auto read_write_filename =
+    rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
 
   writable_storage->open(read_write_filename);
   writable_storage->create_topic({"topic1", "type1", "rmw1"});
@@ -233,8 +229,8 @@ TEST_F(StorageTestFixture, get_relative_file_path_returns_db_name_with_ext) {
   // check that storage::get_relative_file_path returns the relative path to the sqlite3 db
   // and that uri is handled properly when storage::open is called with different io_flags
   // READ_WRITE expects uri to not end in extension
-  const auto read_write_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_,
-        "rosbag"});
+  const auto read_write_filename =
+    rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
   const auto storage_filename = read_write_filename + ".db3";
   const auto read_write_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
   read_write_storage->open(read_write_filename,

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -78,7 +78,8 @@ TEST_F(StorageTestFixture, has_next_return_false_if_there_are_no_more_messages) 
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db3"});
+  auto db_filename =
+    rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db3"});
   readable_storage->open(db_filename);
 
   EXPECT_TRUE(readable_storage->has_next());
@@ -98,7 +99,8 @@ TEST_F(StorageTestFixture, get_next_returns_messages_in_timestamp_order) {
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db3"});
+  auto db_filename =
+    rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag.db3"});
   readable_storage->open(db_filename);
 
   EXPECT_TRUE(readable_storage->has_next());

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -220,11 +220,11 @@ TEST_F(StorageTestFixture, get_storage_identifier_returns_sqlite3) {
   EXPECT_EQ(storage->get_storage_identifier(), "sqlite3");
 }
 
-TEST_F(StorageTestFixture, get_relative_path_returns_db_name_with_ext) {
+TEST_F(StorageTestFixture, get_relative_file_path_returns_db_name_with_ext) {
   auto storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
   auto db_filename = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "rosbag"});
 
   storage->open(db_filename);
 
-  EXPECT_EQ(storage->get_relative_path(), db_filename + ".db3");
+  EXPECT_EQ(storage->get_relative_file_path(), db_filename + ".db3");
 }

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -42,8 +42,8 @@ class RecordFixture : public TemporaryDirectoryFixture
 public:
   RecordFixture()
   {
-    bag_path_ = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "bag"});
-    storage_path_ = rosbag2_storage::FilesystemHelper::concat({bag_path_, "bag_0"});
+    root_bag_path_ = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "bag"});
+    storage_path_ = rosbag2_storage::FilesystemHelper::concat({root_bag_path_, "bag_0"});
     database_path_ = storage_path_ + ".db3";
     std::cout << "Database " << database_path_ << " in " << temporary_dir_path_ << std::endl;
   }
@@ -120,7 +120,7 @@ public:
   {
     std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> table_msgs;
     auto storage = std::make_shared<rosbag2_storage_plugins::SqliteStorage>();
-    storage->open(storage_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+    storage->open(database_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
 
     while (storage->has_next()) {
       table_msgs.push_back(storage->read_next());
@@ -139,8 +139,12 @@ public:
     return std::get<0>(topic_format);
   }
 
-  std::string bag_path_;
+  // relative path to the root of the bag file.
+  std::string root_bag_path_;
+  // relative path including file name (excludes extension
+  // used to open a storage plugin only for read-write)
   std::string database_path_;
+  // path to the SQLite3 db.
   std::string storage_path_;
   PublisherManager pub_man_;
   MemoryManagement memory_management_;

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -43,7 +43,7 @@ public:
   RecordFixture()
   {
     bag_path_ = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "bag"});
-    storage_path_ = rosbag2_storage::FilesystemHelper::concat({bag_path_, "bag"});
+    storage_path_ = rosbag2_storage::FilesystemHelper::concat({bag_path_, "bag_0"});
     database_path_ = storage_path_ + ".db3";
     std::cout << "Database " << database_path_ << " in " << temporary_dir_path_ << std::endl;
   }

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -43,7 +43,8 @@ public:
   RecordFixture()
   {
     bag_path_ = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "bag"});
-    database_path_ = rosbag2_storage::FilesystemHelper::concat({bag_path_, "bag.db3"});
+    storage_path_ = rosbag2_storage::FilesystemHelper::concat({bag_path_, "bag"});
+    database_path_ = storage_path_ + ".db3";
     std::cout << "Database " << database_path_ << " in " << temporary_dir_path_ << std::endl;
   }
 
@@ -119,7 +120,7 @@ public:
   {
     std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> table_msgs;
     auto storage = std::make_shared<rosbag2_storage_plugins::SqliteStorage>();
-    storage->open(bag_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
+    storage->open(storage_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
 
     while (storage->has_next()) {
       table_msgs.push_back(storage->read_next());
@@ -140,6 +141,7 @@ public:
 
   std::string bag_path_;
   std::string database_path_;
+  std::string storage_path_;
   PublisherManager pub_man_;
   MemoryManagement memory_management_;
 };

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -29,7 +29,8 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   auto wrong_message = get_messages_strings()[0];
   wrong_message->string_value = "wrong_content";
 
-  auto process_handle = start_execution("ros2 bag record --output " + bag_path_ + " /test_topic");
+  auto process_handle = start_execution(
+    "ros2 bag record --output " + root_bag_path_ + " /test_topic");
   wait_for_db();
 
   pub_man_.add_publisher("/test_topic", message, expected_test_messages);
@@ -49,13 +50,13 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::BagMetadata metadata{};
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
-  metadata.relative_file_paths.emplace_back("bag_0.db3");
+  metadata.relative_file_paths = {"bag_0.db3"};
   metadata.duration = std::chrono::nanoseconds(0);
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));
   metadata.message_count = 0;
   rosbag2_storage::MetadataIo metadata_io;
-  metadata_io.write_metadata(bag_path_, metadata);
+  metadata_io.write_metadata(root_bag_path_, metadata);
 #endif
 
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>("/test_topic");

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -49,7 +49,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::BagMetadata metadata{};
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
-  metadata.relative_file_paths.emplace_back("bag.db3");
+  metadata.relative_file_paths.emplace_back("bag_0.db3");
   metadata.duration = std::chrono::nanoseconds(0);
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));


### PR DESCRIPTION
This is part of an effort to rework PR #158 into multiple, smaller PRs.

### Changes
* `open` in `BaseIOInterface` now must point to the storage file
* `Writer` is responsible for writing and generating `BagMetadata`
* `Writer` rolls over to a new storage when the bagfile exceeds `max_bagfile_size` by opening a new storage.

### Dependent PRs
- [x] PR #182 
- [x] PR #183 
- [x] PR #184 

### Issues
* ros-security/aws-roadmap#11
