### PR TITLE
Minimal multifile reader

### DIFF
--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -132,6 +132,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_sequential_reader rosbag2)
   endif()
 
+  ament_add_gmock(test_multifile_reader
+    test/rosbag2/test_multifile_reader.cpp)
+  if(TARGET test_multifile_reader)
+    target_link_libraries(test_multifile_reader rosbag2)
+  endif()
+
   # If compiling with gcc, run this test with sanitizers enabled
   ament_add_gmock(test_ros2_message
     test/rosbag2/types/test_ros2_message.cpp

--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(ament_index_cpp REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(poco_vendor)
 find_package(Poco COMPONENTS Foundation)
+find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
@@ -51,6 +52,7 @@ ament_target_dependencies(${PROJECT_NAME}
   ament_index_cpp
   pluginlib
   Poco
+  rcpputils
   rcutils
   rosbag2_storage
   rosidl_generator_cpp

--- a/rosbag2/include/rosbag2/sequential_reader.hpp
+++ b/rosbag2/include/rosbag2/sequential_reader.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
 #include "rosbag2_storage/storage_factory_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
@@ -51,7 +52,9 @@ public:
     std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory =
     std::make_unique<rosbag2_storage::StorageFactory>(),
     std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory =
-    std::make_shared<SerializationFormatConverterFactory>());
+    std::make_shared<SerializationFormatConverterFactory>(),
+    std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io =
+    std::make_unique<rosbag2_storage::MetadataIo>());
 
   virtual ~SequentialReader();
 
@@ -69,7 +72,8 @@ public:
    * \param converter_options Options for specifying the output data format
    */
   virtual void open(
-    const StorageOptions & storage_options, const ConverterOptions & converter_options);
+    const StorageOptions & storage_options,
+    const ConverterOptions & converter_options);
 
   /**
    * Ask whether the underlying bagfile contains at least one more message.
@@ -126,12 +130,12 @@ public:
    */
   virtual std::string get_current_uri() const;
 
-
 private:
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_;
-  std::unique_ptr<rosbag2_storage::BagMetadata> metadata_;
+  std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
+  rosbag2_storage::BagMetadata metadata_;
   std::unique_ptr<Converter> converter_;
   StorageOptions storage_options_{};
   std::vector<std::string> file_paths_{};  // List of database files.

--- a/rosbag2/include/rosbag2/sequential_reader.hpp
+++ b/rosbag2/include/rosbag2/sequential_reader.hpp
@@ -41,7 +41,7 @@ namespace rosbag2
 {
 /**
  * The SequentialReader allows opening and reading messages of a bag. Messages will be read
- * sequentially according to timestamp.
+ * sequentially according to timestamp. Functions are virtual so that they can be mocked in tests.
  */
 class ROSBAG2_PUBLIC SequentialReader
 {
@@ -99,7 +99,6 @@ public:
    */
   virtual std::vector<TopicMetadata> get_all_topics_and_types();
 
-private:
   /**
    * Ask whether there is another database file to read from the list of relative
    * file paths.
@@ -109,21 +108,34 @@ private:
   virtual bool has_next_file() const;
 
   /**
-   * Update the current database file to read from and remove the first (front)
-   * element in the list of files to read from.
+   * Increment the current file iterator to point to the next file in the list of relative file
+   * paths.
    *
    * Expected usage:
-   * if (has_next_file()) get_next_file();
+   * if (has_next_file()) load_next_file();
    */
-  std::string get_next_file();
+  virtual void load_next_file();
 
+  /**
+   * Return the relative file path pointed to by the current file iterator.
+   */
+  virtual std::string get_current_file() const;
+
+  /**
+   * Return the URI of the current file (i.e. no extensions).
+   */
+  virtual std::string get_current_uri() const;
+
+
+private:
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_;
+  std::unique_ptr<rosbag2_storage::BagMetadata> metadata_;
   std::unique_ptr<Converter> converter_;
   StorageOptions storage_options_{};
-  std::vector<std::string> file_paths_ {};  // List of database files.
-  std::vector<std::string>::iterator current_file_iterator_ {};  // Index of file to read from
+  std::vector<std::string> file_paths_{};  // List of database files.
+  std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
 };
 
 }  // namespace rosbag2

--- a/rosbag2/include/rosbag2/sequential_reader.hpp
+++ b/rosbag2/include/rosbag2/sequential_reader.hpp
@@ -100,10 +100,30 @@ public:
   virtual std::vector<TopicMetadata> get_all_topics_and_types();
 
 private:
+  /**
+   * Ask whether there is another database file to read from the list of relative
+   * file paths.
+   *
+   * \return true if there are still files to read in the list
+   */
+  virtual bool has_next_file() const;
+
+  /**
+   * Update the current database file to read from and remove the first (front)
+   * element in the list of files to read from.
+   *
+   * Expected usage:
+   * if (has_next_file()) get_next_file();
+   */
+  std::string get_next_file();
+
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_;
   std::unique_ptr<Converter> converter_;
+  StorageOptions storage_options_{};
+  std::vector<std::string> file_paths_ {};  // List of database files.
+  std::vector<std::string>::iterator current_file_iterator_ {};  // Index of file to read from
 };
 
 }  // namespace rosbag2

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -53,6 +53,8 @@ SequentialReader::open(
     return;
   }
   file_paths_ = bag_metadata.relative_file_paths;
+  assert(!file_paths_.empty());
+  current_file_iterator_ = file_paths_.begin();
 
   // Currently a bag file can only be played if all topics have the same serialization format.
   auto storage_serialization_format = topics[0].topic_metadata.serialization_format;
@@ -77,19 +79,14 @@ SequentialReader::open(
 
 std::string SequentialReader::get_next_file()
 {
-  {
     assert(current_file_iterator_ != file_paths_.end());
     current_file_iterator_++;
     return *current_file_iterator_;
-  }
 }
 
 bool SequentialReader::has_next_file() const
 {
-  {
-    assert(!file_paths_.empty());
     return current_file_iterator_ + 1 != file_paths_.end();
-  }
 }
 
 bool SequentialReader::has_next()

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -79,14 +79,14 @@ SequentialReader::open(
 
 std::string SequentialReader::get_next_file()
 {
-    assert(current_file_iterator_ != file_paths_.end());
-    current_file_iterator_++;
-    return *current_file_iterator_;
+  assert(current_file_iterator_ != file_paths_.end());
+  current_file_iterator_++;
+  return *current_file_iterator_;
 }
 
 bool SequentialReader::has_next_file() const
 {
-    return current_file_iterator_ + 1 != file_paths_.end();
+  return current_file_iterator_ + 1 != file_paths_.end();
 }
 
 bool SequentialReader::has_next()

--- a/rosbag2/src/rosbag2/sequential_reader.cpp
+++ b/rosbag2/src/rosbag2/sequential_reader.cpp
@@ -53,7 +53,6 @@ SequentialReader::open(
     return;
   }
   file_paths_ = bag_metadata.relative_file_paths;
-  assert(!file_paths_.empty());
   current_file_iterator_ = file_paths_.begin();
 
   // Currently a bag file can only be played if all topics have the same serialization format.

--- a/rosbag2/test/rosbag2/test_multifile_reader.cpp
+++ b/rosbag2/test/rosbag2/test_multifile_reader.cpp
@@ -1,0 +1,99 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rosbag2/sequential_reader.hpp"
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
+
+#include "mock_converter_factory.hpp"
+#include "mock_storage.hpp"
+#include "mock_storage_factory.hpp"
+
+using namespace testing;  // NOLINT
+
+class MultifileReaderTest : public Test
+{
+public:
+  MultifileReaderTest()
+  {
+    storage_factory_ = std::make_unique<NiceMock<MockStorageFactory>>();
+    storage_ = std::make_shared<NiceMock<MockStorage>>();
+    converter_factory_ = std::make_shared<StrictMock<MockConverterFactory>>();
+
+    rosbag2_storage::TopicMetadata topic_with_type;
+    topic_with_type.name = "topic";
+    topic_with_type.type = "test_msgs/BasicTypes";
+    auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
+    EXPECT_CALL(*storage_, get_all_topics_and_types())
+    .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));
+
+    auto message = std::make_shared<rosbag2::SerializedBagMessage>();
+    message->topic_name = topic_with_type.name;
+    ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
+    ON_CALL(*storage_factory_, open_read_only(_, _)).WillByDefault(Return(storage_));
+
+    // Version 2 of the metadata file includes the split bag features.
+    metadata_.version = 2;
+    metadata_.storage_identifier = "sqlite3";
+    metadata_.relative_file_paths.emplace_back("some_relative_path");
+    metadata_.relative_file_paths.emplace_back("some_other_relative_path");
+    metadata_.duration = std::chrono::nanoseconds(100);
+    metadata_.starting_time =
+      std::chrono::time_point<std::chrono::high_resolution_clock>(
+      std::chrono::nanoseconds(1000000));
+    metadata_.message_count = 50;
+    metadata_.topics_with_message_count.push_back({{"topic1", "type1", serialization_format}, 100});
+    ON_CALL(*storage_, get_metadata()).WillByDefault(Return(metadata_));
+
+    reader_ = std::make_unique<rosbag2::SequentialReader>(
+      std::move(storage_factory_), converter_factory_);
+  }
+
+  std::unique_ptr<NiceMock<MockStorageFactory>> storage_factory_;
+  std::shared_ptr<NiceMock<MockStorage>> storage_;
+  std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
+  rosbag2_storage::BagMetadata metadata_;
+  std::unique_ptr<rosbag2::SequentialReader> reader_;
+  std::string serialization_format {"rmw1_format"};
+};
+
+TEST_F(MultifileReaderTest, has_next_reads_next_file)
+{
+  EXPECT_CALL(*storage_, has_next()).Times(AtLeast(2)).WillRepeatedly(Return(false));
+  reader_->open(rosbag2::StorageOptions(), {serialization_format, serialization_format});
+  reader_->has_next();
+  reader_->read_next();
+}
+
+TEST_F(MultifileReaderTest, has_next_throws_if_no_storage)
+{
+  EXPECT_ANY_THROW(reader_->has_next());
+}
+
+TEST_F(MultifileReaderTest, read_next_throws_if_no_storage)
+{
+  EXPECT_ANY_THROW(reader_->read_next());
+}
+
+TEST_F(MultifileReaderTest, get_all_topics_and_types_throws_if_no_storage)
+{
+  EXPECT_ANY_THROW(reader_->get_all_topics_and_types());
+}

--- a/rosbag2/test/rosbag2/test_sequential_reader.cpp
+++ b/rosbag2/test/rosbag2/test_sequential_reader.cpp
@@ -22,9 +22,11 @@
 #include "rosbag2/sequential_reader.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
 
 #include "mock_converter.hpp"
 #include "mock_converter_factory.hpp"
+#include "mock_metadata_io.hpp"
 #include "mock_storage.hpp"
 #include "mock_storage_factory.hpp"
 
@@ -38,48 +40,48 @@ public:
     storage_factory_ = std::make_unique<StrictMock<MockStorageFactory>>();
     storage_ = std::make_shared<NiceMock<MockStorage>>();
     converter_factory_ = std::make_shared<StrictMock<MockConverterFactory>>();
+    metadata_io_ = std::make_unique<NiceMock<MockMetadataIo>>();
+    storage_serialization_format_ = "rmw1_format";
 
     rosbag2_storage::TopicMetadata topic_with_type;
     topic_with_type.name = "topic";
     topic_with_type.type = "test_msgs/BasicTypes";
+    topic_with_type.serialization_format = storage_serialization_format_;
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));
 
+    metadata_.topics_with_message_count.push_back({{topic_with_type}, 1});
+    EXPECT_CALL(*metadata_io_, read_metadata(_)).WillRepeatedly(Return(metadata_));
+
     auto message = std::make_shared<rosbag2::SerializedBagMessage>();
     message->topic_name = topic_with_type.name;
     EXPECT_CALL(*storage_, read_next()).WillRepeatedly(Return(message));
-
-    EXPECT_CALL(*storage_factory_, open_read_only(_, _)).WillOnce(Return(storage_));
+    EXPECT_CALL(*storage_factory_, open_read_only(_, _)).WillRepeatedly(Return(storage_));
 
     reader_ = std::make_unique<rosbag2::SequentialReader>(
-      std::move(storage_factory_), converter_factory_);
-  }
-
-  void set_storage_serialization_format(const std::string & format)
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.topics_with_message_count.push_back({{"", "", format}, 1});
-    EXPECT_CALL(*storage_, get_metadata()).WillOnce(Return(metadata));
+      std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
   std::shared_ptr<NiceMock<MockStorage>> storage_;
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<rosbag2::SequentialReader> reader_;
+  std::unique_ptr<MockMetadataIo> metadata_io_;
+  rosbag2_storage::BagMetadata metadata_;
+  std::string storage_serialization_format_;
 };
 
-TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_format) {
-  std::string storage_serialization_format = "rmw1_format";
+TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_format)
+{
   std::string output_format = "rmw2_format";
-  set_storage_serialization_format(storage_serialization_format);
 
   auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
   auto format2_converter = std::make_unique<StrictMock<MockConverter>>();
   EXPECT_CALL(*format1_converter, deserialize(_, _, _)).Times(1);
   EXPECT_CALL(*format2_converter, serialize(_, _, _)).Times(1);
 
-  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format))
+  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_))
   .WillOnce(Return(ByMove(std::move(format1_converter))));
   EXPECT_CALL(*converter_factory_, load_serializer(output_format))
   .WillOnce(Return(ByMove(std::move(format2_converter))));
@@ -88,13 +90,12 @@ TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_
   reader_->read_next();
 }
 
-TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exist) {
-  std::string storage_serialization_format = "rmw1_format";
+TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exist)
+{
   std::string output_format = "rmw2_format";
-  set_storage_serialization_format(storage_serialization_format);
 
   auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
-  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format))
+  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_))
   .WillOnce(Return(ByMove(std::move(format1_converter))));
   EXPECT_CALL(*converter_factory_, load_serializer(output_format))
   .WillOnce(Return(ByMove(nullptr)));
@@ -106,7 +107,6 @@ TEST_F(SequentialReaderTest,
   read_next_does_not_use_converters_if_input_and_output_format_are_equal)
 {
   std::string storage_serialization_format = "rmw1_format";
-  set_storage_serialization_format(storage_serialization_format);
 
   EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format)).Times(0);
   EXPECT_CALL(*converter_factory_, load_serializer(storage_serialization_format)).Times(0);


### PR DESCRIPTION
Introduce the minimal changes needed to read multiple storage files.
Part of an effort to rework PR #158 into smaller PRs.

@Karsten1987 this will be the first step for the reader/writer interface changes. Adding this will enable us to at least test the splitting feature end-to-end.

### Changes 

* Add `has_next_file()` and `get_next_file()` private methods to `SequentialReader`.
* Add private variables for storing a list of files to read from and current file being read.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>