### PR TITLE
add dependency on python_cmake_module

### DIFF
--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>python_cmake_module</depend>
   <depend>rclcpp</depend>
   <depend>rosbag2</depend>
   <depend>rmw</depend>


### PR DESCRIPTION
used at https://github.com/ros2/rosbag2/blob/6a5c50e45cefe78dd310b90ccc3231de2906b96c/rosbag2_transport/cmake/configure_python.cmake#L16

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>