### PR TITLE
Import rosbag2_transport Python module on demand

### DIFF
--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -32,5 +32,10 @@ class InfoVerb(VerbExtension):
         bag_file = args.bag_file
         if not os.path.exists(bag_file):
             return "[ERROR] [ros2bag]: bag file '{}' does not exist!".format(bag_file)
+        # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
+        #               combined with constrained environments (as imposed by colcon test)
+        #               may result in DLL loading failures when attempting to import a C
+        #               extension. Therefore, do not import rosbag2_transport at the module
+        #               level but on demand, right before first use.
         from rosbag2_transport import rosbag2_transport_py
         rosbag2_transport_py.info(uri=bag_file, storage_id=args.storage)

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -16,8 +16,6 @@ import os
 
 from ros2bag.verb import VerbExtension
 
-from rosbag2_transport import rosbag2_transport_py
-
 
 class InfoVerb(VerbExtension):
     """ros2 bag info."""
@@ -34,5 +32,5 @@ class InfoVerb(VerbExtension):
         bag_file = args.bag_file
         if not os.path.exists(bag_file):
             return "[ERROR] [ros2bag]: bag file '{}' does not exist!".format(bag_file)
-
+        from rosbag2_transport import rosbag2_transport_py
         rosbag2_transport_py.info(uri=bag_file, storage_id=args.storage)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -37,6 +37,11 @@ class PlayVerb(VerbExtension):
         bag_file = args.bag_file
         if not os.path.exists(bag_file):
             return "[ERROR] [ros2bag] bag file '{}' does not exist!".format(bag_file)
+        # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
+        #               combined with constrained environments (as imposed by colcon test)
+        #               may result in DLL loading failures when attempting to import a C
+        #               extension. Therefore, do not import rosbag2_transport at the module
+        #               level but on demand, right before first use.
         from rosbag2_transport import rosbag2_transport_py
         rosbag2_transport_py.play(
             uri=bag_file,

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -16,7 +16,6 @@ import os
 
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_transport import rosbag2_transport_py
 
 
 class PlayVerb(VerbExtension):
@@ -38,7 +37,7 @@ class PlayVerb(VerbExtension):
         bag_file = args.bag_file
         if not os.path.exists(bag_file):
             return "[ERROR] [ros2bag] bag file '{}' does not exist!".format(bag_file)
-
+        from rosbag2_transport import rosbag2_transport_py
         rosbag2_transport_py.play(
             uri=bag_file,
             storage_id=args.storage,

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -72,6 +72,11 @@ class RecordVerb(VerbExtension):
         self.create_bag_directory(uri)
 
         if args.all:
+            # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
+            #               combined with constrained environments (as imposed by colcon test)
+            #               may result in DLL loading failures when attempting to import a C
+            #               extension. Therefore, do not import rosbag2_transport at the module
+            #               level but on demand, right before first use.
             from rosbag2_transport import rosbag2_transport_py
 
             rosbag2_transport_py.record(
@@ -83,6 +88,11 @@ class RecordVerb(VerbExtension):
                 no_discovery=args.no_discovery,
                 polling_interval=args.polling_interval)
         elif args.topics and len(args.topics) > 0:
+            # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
+            #               combined with constrained environments (as imposed by colcon test)
+            #               may result in DLL loading failures when attempting to import a C
+            #               extension. Therefore, do not import rosbag2_transport at the module
+            #               level but on demand, right before first use.
             from rosbag2_transport import rosbag2_transport_py
 
             rosbag2_transport_py.record(

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -20,7 +20,6 @@ from ros2bag.verb import VerbExtension
 from ros2cli.node.strategy import NodeStrategy
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_transport import rosbag2_transport_py
 
 
 class RecordVerb(VerbExtension):
@@ -73,6 +72,8 @@ class RecordVerb(VerbExtension):
         self.create_bag_directory(uri)
 
         if args.all:
+            from rosbag2_transport import rosbag2_transport_py
+
             rosbag2_transport_py.record(
                 uri=uri,
                 storage_id=args.storage,
@@ -82,6 +83,8 @@ class RecordVerb(VerbExtension):
                 no_discovery=args.no_discovery,
                 polling_interval=args.polling_interval)
         elif args.topics and len(args.topics) > 0:
+            from rosbag2_transport import rosbag2_transport_py
+
             rosbag2_transport_py.record(
                 uri=uri,
                 storage_id=args.storage,


### PR DESCRIPTION
Closes #179. This pull request ensure `ros2bag` imports `rosbag2_transport` on demand, as opposed to doing so at the module level. 

I purposefully didn't rehash the `rosbag2_transport` module to enforce delayed imports as there's been some discussion and work around removing this limitation, and hopefully we might at some point in the future (see https://github.com/ros2/rclpy/pull/417, https://github.com/ros2/rclpy/pull/420 and https://github.com/ros2/rclpy/pull/422).