### PR TITLE
Move get_storage_identifier and get_bagfile_size

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
@@ -39,6 +39,18 @@ public:
    * \returns the relative path.
    */
   virtual std::string get_relative_file_path() const = 0;
+  
+  /**
+   * Returns the size of the bagfile.
+   * \returns the size of the bagfile in bytes.
+   */
+  virtual uint64_t get_bagfile_size() const = 0;
+
+  /**
+   * Returns the identifier for the storage plugin.
+   * \returns the identifier.
+   */
+  virtual std::string get_storage_identifier() const = 0;
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
@@ -39,7 +39,7 @@ public:
    * \returns the relative path.
    */
   virtual std::string get_relative_file_path() const = 0;
-  
+
   /**
    * Returns the size of the bagfile.
    * \returns the size of the bagfile in bytes.

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_io_interface.hpp
@@ -50,18 +50,6 @@ public:
    * The storage plugin will append the uri in the case of creating a new bagfile backing.
    */
   virtual void open(const std::string & uri, IOFlag io_flag) = 0;
-
-  /**
-   * Returns the size of the bagfile.
-   * \returns the size of the bagfile in bytes.
-   */
-  virtual uint64_t get_bagfile_size() const = 0;
-
-  /**
-   * Returns the identifier for the storage plugin.
-   * \returns the identifier.
-   */
-  virtual std::string get_storage_identifier() const = 0;
 };
 
 }  // namespace storage_interfaces


### PR DESCRIPTION
Resolves Issue: ros2/rosbag2#197

### Changes
* Move `get_storage_identifier` to `BaseInfoInterface`
* Move `get_bagfile_size` to `BaseInfoInterface`

### Notes
* This change does not require changes to `rosbag2_bag_v2`

### Testing
* Ran colcon build and test on subprojects of `rosbag2`
* Ran colcon build and test on `rosbag2_bag_v2`