### PR TITLE
load metadata from storage if no yaml file is found

### DIFF
--- a/rosbag2/test/rosbag2/test_multifile_reader.cpp
+++ b/rosbag2/test/rosbag2/test_multifile_reader.cpp
@@ -58,6 +58,7 @@ public:
     metadata.relative_file_paths.push_back(relative_path_2_);
     metadata.topics_with_message_count.push_back({topic_with_type, 10});
     ON_CALL(*metadata_io, read_metadata(_)).WillByDefault(Return(metadata));
+    EXPECT_CALL(*metadata_io, metadata_file_exists(_)).WillRepeatedly(Return(true));
 
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));

--- a/rosbag2/test/rosbag2/test_sequential_reader.cpp
+++ b/rosbag2/test/rosbag2/test_sequential_reader.cpp
@@ -57,6 +57,7 @@ public:
     metadata.relative_file_paths = {"/path/to/storage"};
     metadata.topics_with_message_count.push_back({{topic_with_type}, 1});
     EXPECT_CALL(*metadata_io, read_metadata(_)).WillRepeatedly(Return(metadata));
+    EXPECT_CALL(*metadata_io, metadata_file_exists(_)).WillRepeatedly(Return(true));
 
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));


### PR DESCRIPTION
This is necessary when loading legacy ros1 bag files, where no metadata.yaml file is present.
connected to https://github.com/ros2/rosbag2_bag_v2/pull/8
Signed-off-by: Knese Karsten <karsten@openrobotics.org>