### PR TITLE
[Compression - 3] Add compressor interface

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -31,18 +31,25 @@ install(
   DESTINATION include)
 
 ament_export_include_directories(include)
-ament_export_dependencies(rcutils rosbag2_storage)
+#ament_export_dependencies(rcutils rosbag2_storage)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  add_compile_options(-fvisibility=hidden)
+
+  add_library(fake_compressor SHARED
+    test/rosbag2_compression/fake_compressor.cpp)
+  target_include_directories(fake_compressor PUBLIC include)
+  ament_target_dependencies(fake_compressor rosbag2_storage)
+  target_compile_definitions(fake_compressor PRIVATE ROSBAG2_COMPRESSION_BUILDING_DLL)
 
   ament_add_gmock(test_compressor
-    test/rosbag2_compression/test_compressor.cpp
-    test/rosbag2_compression/fake_compressor.cpp)
-  target_include_directories(test_compressor PUBLIC include)
-  ament_target_dependencies(test_compressor rosbag2_storage)
+    test/rosbag2_compression/test_compressor.cpp)
+  if(TARGET test_compressor)
+    target_link_libraries(test_compressor fake_compressor)
+  endif()
 endif()
 
 ament_package()

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(rosbag2_storage REQUIRED)
 
 install(
   DIRECTORY include/

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -31,13 +31,15 @@ install(
   DESTINATION include)
 
 ament_export_include_directories(include)
-#ament_export_dependencies(rcutils rosbag2_storage)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  add_compile_options(-fvisibility=hidden)
+  set_target_properties(fake_compressor 
+  PROPERTIES 
+  CXX_VISIBILITY_PRESET hidden 
+  VISIBILITY_INLINES_HIDDEN 1)
 
   add_library(fake_compressor SHARED
     test/rosbag2_compression/fake_compressor.cpp)
@@ -47,9 +49,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_compressor
     test/rosbag2_compression/test_compressor.cpp)
-  if(TARGET test_compressor)
-    target_link_libraries(test_compressor fake_compressor)
-  endif()
+  target_link_libraries(test_compressor fake_compressor)
 endif()
 
 ament_package()

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -23,7 +23,6 @@ if(NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_index_cpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 
@@ -31,21 +30,19 @@ install(
   DIRECTORY include/
   DESTINATION include)
 
+ament_export_include_directories(include)
+ament_export_dependencies(rcutils rosbag2_storage)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  add_library(fake_compressor SHARED
-    test/rosbag2_compression/fake_compressor.cpp)
-  target_include_directories(fake_compressor PUBLIC include)
-  ament_target_dependencies(fake_compressor rosbag2_storage)
-
   ament_add_gmock(test_compressor
-    test/rosbag2_compression/test_compressor.cpp)
-  if(TARGET test_compressor)
-    target_link_libraries(test_compressor fake_compressor)
-  endif()
+    test/rosbag2_compression/test_compressor.cpp
+    test/rosbag2_compression/fake_compressor.cpp)
+  target_include_directories(test_compressor PUBLIC include)
+  ament_target_dependencies(test_compressor rosbag2_storage)
 endif()
 
 ament_package()

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 
@@ -36,20 +37,21 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  set_target_properties(fake_compressor 
-  PROPERTIES 
-  CXX_VISIBILITY_PRESET hidden 
-  VISIBILITY_INLINES_HIDDEN 1)
 
   add_library(fake_compressor SHARED
     test/rosbag2_compression/fake_compressor.cpp)
   target_include_directories(fake_compressor PUBLIC include)
   ament_target_dependencies(fake_compressor rosbag2_storage)
+  set_target_properties(fake_compressor
+    PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN 1)
   target_compile_definitions(fake_compressor PRIVATE ROSBAG2_COMPRESSION_BUILDING_DLL)
 
   ament_add_gmock(test_compressor
     test/rosbag2_compression/test_compressor.cpp)
   target_link_libraries(test_compressor fake_compressor)
+  ament_target_dependencies(test_compressor rcpputils)
 endif()
 
 ament_package()

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -15,6 +15,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+option(DISABLE_SANITIZERS "Disable the use of gcc sanitizers")
+# Only enable sanitizers on x64 architectures
+# https://github.com/google/sanitizers/issues/794
+if(NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+  set(DISABLE_SANITIZERS ON)
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
@@ -24,8 +31,20 @@ install(
   DESTINATION include)
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  add_library(fake_compressor SHARED
+    test/rosbag2_compression/fake_compressor.cpp)
+  target_include_directories(fake_compressor PUBLIC include)
+  ament_target_dependencies(fake_compressor rosbag2_storage)
+
+  ament_add_gmock(test_compressor
+    test/rosbag2_compression/test_compressor.cpp)
+  if(TARGET test_compressor)
+    target_link_libraries(test_compressor fake_compressor)
+  endif()
 endif()
 
 ament_package()

--- a/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
@@ -1,0 +1,76 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__BASE_COMPRESSOR_INTERFACE_HPP_
+#define ROSBAG2_COMPRESSION__BASE_COMPRESSOR_INTERFACE_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_compression/visibility_control.hpp"
+
+/**
+ * An interface for developers adding a new compression algorithm to rosbag2.
+ * These functions must be implemented to that a writer can properly compress a file or bag message.
+ * A corresponding decompressor must also be implemented.
+ *
+ * Example file compression usage:
+ *
+ * MyCompressor my_compressor();
+ * std::string current_uri = storage.get_relative_path();
+ * std::string compressed_path_uri = my_compressor.compress_uri(current_uri);
+ * relative_file_paths.push_back(compressed_path_uri);
+ *
+ * Example message compression usage:
+ *
+ * MyCompressor my_compressor();
+ * std::shared_ptr<SerializedBagMessage> bag_message = std::make_shared<SerializedBagMessage>();
+ * ...fill message
+ * std::shared_ptr<SerializedBagMessage> compressed_message =
+ *   my_compressor.compress_serialized_bag_message(bag_message);
+ */
+namespace rosbag2_compression
+{
+
+class ROSBAG2_COMPRESSION_PUBLIC BaseCompressorInterface
+{
+public:
+  virtual ~BaseCompressorInterface() = default;
+
+  /**
+   * Compress a file on disk.
+   *
+   * \param uri Input file to compress with file extension.
+   * \return The relative path to the compressed file with the compressed extension.
+   */
+  virtual std::string compress_uri(const std::string & uri) = 0;
+
+  /**
+   * Compress the serialized_data of a serialized bag message in place.
+   *
+   * \param bag_message A serialized bag message.
+   */
+  virtual void compress_serialized_bag_message(
+    std::shared_ptr<rosbag2_storage::SerializedBagMessage> & bag_message) = 0;
+
+  /**
+   * Get the identifier of the compression algorithm.
+   * This is appended to the extension of the compressed file.
+   */
+  virtual std::string get_compression_identifier() const = 0;
+};
+}  // namespace rosbag2_compression
+
+#endif  // ROSBAG2_COMPRESSION__BASE_COMPRESSOR_INTERFACE_HPP_

--- a/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
@@ -20,6 +20,9 @@
 #include "rosbag2_storage/serialized_bag_message.hpp"
 #include "visibility_control.hpp"
 
+namespace rosbag2_compression
+{
+
 /**
  * An interface for developers adding a new compression algorithm to rosbag2.
  * These functions must be implemented so that a writer can properly compress a file or bag message.
@@ -39,9 +42,6 @@
  * ...fill message
  * my_compressor.compress_serialized_bag_message(bag_message.get());
  */
-namespace rosbag2_compression
-{
-
 class ROSBAG2_COMPRESSION_PUBLIC BaseCompressorInterface
 {
 public:

--- a/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "rosbag2_storage/serialized_bag_message.hpp"
-#include "rosbag2_compression/visibility_control.hpp"
+#include "visibility_control.hpp"
 
 /**
  * An interface for developers adding a new compression algorithm to rosbag2.

--- a/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/base_compressor_interface.hpp
@@ -15,7 +15,6 @@
 #ifndef ROSBAG2_COMPRESSION__BASE_COMPRESSOR_INTERFACE_HPP_
 #define ROSBAG2_COMPRESSION__BASE_COMPRESSOR_INTERFACE_HPP_
 
-#include <memory>
 #include <string>
 
 #include "rosbag2_storage/serialized_bag_message.hpp"
@@ -23,8 +22,8 @@
 
 /**
  * An interface for developers adding a new compression algorithm to rosbag2.
- * These functions must be implemented to that a writer can properly compress a file or bag message.
- * A corresponding decompressor must also be implemented.
+ * These functions must be implemented so that a writer can properly compress a file or bag message.
+ * A corresponding decompressor with an identical decompression format must also be implemented.
  *
  * Example file compression usage:
  *
@@ -38,8 +37,7 @@
  * MyCompressor my_compressor();
  * std::shared_ptr<SerializedBagMessage> bag_message = std::make_shared<SerializedBagMessage>();
  * ...fill message
- * std::shared_ptr<SerializedBagMessage> compressed_message =
- *   my_compressor.compress_serialized_bag_message(bag_message);
+ * my_compressor.compress_serialized_bag_message(bag_message.get());
  */
 namespace rosbag2_compression
 {
@@ -63,7 +61,7 @@ public:
    * \param bag_message A serialized bag message.
    */
   virtual void compress_serialized_bag_message(
-    std::shared_ptr<rosbag2_storage::SerializedBagMessage> & bag_message) = 0;
+    rosbag2_storage::SerializedBagMessage * bag_message) = 0;
 
   /**
    * Get the identifier of the compression algorithm.
@@ -71,6 +69,7 @@ public:
    */
   virtual std::string get_compression_identifier() const = 0;
 };
+
 }  // namespace rosbag2_compression
 
 #endif  // ROSBAG2_COMPRESSION__BASE_COMPRESSOR_INTERFACE_HPP_

--- a/rosbag2_compression/package.xml
+++ b/rosbag2_compression/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <depend>rosbag2_storage</depend>
 

--- a/rosbag2_compression/package.xml
+++ b/rosbag2_compression/package.xml
@@ -12,6 +12,7 @@
   <depend>rcutils</depend>
   <depend>rosbag2_storage</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rosbag2_compression/package.xml
+++ b/rosbag2_compression/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rcutils</depend>
+  <depend>rosbag2_storage</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_compression/test/rosbag2_compression/fake_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/fake_compressor.cpp
@@ -22,10 +22,7 @@ std::string FakeCompressor::compress_uri(const std::string & uri)
 }
 
 void FakeCompressor::compress_serialized_bag_message(
-  rosbag2_storage::SerializedBagMessage * bag_message)
-{
-  (void) bag_message;
-}
+  rosbag2_storage::SerializedBagMessage *) {}
 
 std::string FakeCompressor::get_compression_identifier() const
 {

--- a/rosbag2_compression/test/rosbag2_compression/fake_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/fake_compressor.cpp
@@ -1,0 +1,33 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "fake_compressor.hpp"
+
+std::string FakeCompressor::compress_uri(const std::string & uri)
+{
+  return uri + "." + get_compression_identifier();
+}
+
+void FakeCompressor::compress_serialized_bag_message(
+  rosbag2_storage::SerializedBagMessage * bag_message)
+{
+  (void) bag_message;
+}
+
+std::string FakeCompressor::get_compression_identifier() const
+{
+  return "fake_comp";
+}

--- a/rosbag2_compression/test/rosbag2_compression/fake_compressor.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/fake_compressor.hpp
@@ -17,18 +17,23 @@
 
 #include <string>
 
-#include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_compression/base_compressor_interface.hpp"
+#include "rosbag2_compression/visibility_control.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
 
-class FakeCompressor : public rosbag2_compression::BaseCompressorInterface
+class ROSBAG2_COMPRESSION_PUBLIC FakeCompressor : public rosbag2_compression::BaseCompressorInterface
 {
 public:
+  FakeCompressor() = default;
+
   std::string compress_uri(const std::string & uri) override;
 
   void compress_serialized_bag_message(
     rosbag2_storage::SerializedBagMessage * bag_message) override;
 
   std::string get_compression_identifier() const override;
+
+  ~FakeCompressor() override = default;
 };
 
 #endif  // ROSBAG2_COMPRESSION__FAKE_COMPRESSOR_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/fake_compressor.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/fake_compressor.hpp
@@ -1,0 +1,34 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__FAKE_COMPRESSOR_HPP_
+#define ROSBAG2_COMPRESSION__FAKE_COMPRESSOR_HPP_
+
+#include <string>
+
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_compression/base_compressor_interface.hpp"
+
+class FakeCompressor : public rosbag2_compression::BaseCompressorInterface
+{
+public:
+  std::string compress_uri(const std::string & uri) override;
+
+  void compress_serialized_bag_message(
+    rosbag2_storage::SerializedBagMessage * bag_message) override;
+
+  std::string get_compression_identifier() const override;
+};
+
+#endif  // ROSBAG2_COMPRESSION__FAKE_COMPRESSOR_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/fake_compressor.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/fake_compressor.hpp
@@ -21,7 +21,8 @@
 #include "rosbag2_compression/visibility_control.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
-class ROSBAG2_COMPRESSION_PUBLIC FakeCompressor : public rosbag2_compression::BaseCompressorInterface
+class ROSBAG2_COMPRESSION_PUBLIC FakeCompressor : public rosbag2_compression::
+  BaseCompressorInterface
 {
 public:
   FakeCompressor() = default;

--- a/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#include "rcpputils/filesystem_helper.hpp"
+
 #include "fake_compressor.hpp"
 
 class FakeCompressorTest : public ::testing::Test
@@ -27,9 +29,10 @@ public:
 
 TEST_F(FakeCompressorTest, test_compress_file_method)
 {
-  std::string test_path = "/path/file.txt";
-  auto expected_compressed_uri = test_path + "." + compressor.get_compression_identifier();
-  auto compressed_uri = compressor.compress_uri(test_path);
+  rcpputils::fs::path test_path("/path/file.txt");
+  auto expected_compressed_uri = test_path.string() + "." +
+    compressor.get_compression_identifier();
+  auto compressed_uri = compressor.compress_uri(test_path.string());
   EXPECT_EQ(compressed_uri, expected_compressed_uri);
 }
 
@@ -37,5 +40,5 @@ TEST_F(FakeCompressorTest, test_compress_bag_method)
 {
   auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   compressor.compress_serialized_bag_message(bag_message.get());
-  EXPECT_THAT(bag_message, NotNull());
+  EXPECT_THAT(bag_message, ::testing::NotNull());
 }

--- a/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
@@ -19,9 +19,7 @@
 
 #include "fake_compressor.hpp"
 
-using namespace ::testing;  // NOLINT
-
-class FakeCompressorTest : public Test
+class FakeCompressorTest : public ::testing::Test
 {
 public:
   FakeCompressor compressor;

--- a/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
@@ -1,0 +1,43 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include "fake_compressor.hpp"
+
+using namespace ::testing;  // NOLINT
+
+class FakeCompressorTest : public Test
+{
+public:
+  FakeCompressor compressor;
+};
+
+TEST_F(FakeCompressorTest, test_compress_file_method)
+{
+  std::string test_path = "/path/file.txt";
+  auto expected_compressed_uri = test_path + "." + compressor.get_compression_identifier();
+  auto compressed_uri = compressor.compress_uri(test_path);
+  EXPECT_EQ(compressed_uri, expected_compressed_uri);
+}
+
+TEST_F(FakeCompressorTest, test_compress_bag_method)
+{
+  auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  compressor.compress_serialized_bag_message(bag_message.get());
+  EXPECT_THAT(bag_message, NotNull());
+}


### PR DESCRIPTION
Add the `BaseCompressorInterface` that will be used to implement compressors.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>

