### PR TITLE
Add GitHub action workflow to run linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,82 @@
+# Run linters automatically on pull requests.
+name: Lint rosbag2
+on:
+  pull_request:
+
+jobs:
+  ament_copyright:
+    name: ament_copyright
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros2@0.0.7
+    - uses: ros-tooling/action-ros2-lint@0.0.5
+      with:
+        linter: copyright
+        package-name: |
+            ros2bag
+            rosbag2
+            rosbag2_compression
+            rosbag2_converter_default_plugins
+            rosbag2_test_common
+            rosbag2_tests
+            rosbag2_transport
+            shared_queues_vendor
+
+  ament_xmllint:
+    name: ament_xmllint
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros2@0.0.7
+    - uses: ros-tooling/action-ros2-lint@0.0.5
+      with:
+        linter: xmllint
+        package-name: |
+            ros2bag
+            rosbag2
+            rosbag2_compression
+            rosbag2_converter_default_plugins
+            rosbag2_test_common
+            rosbag2_tests
+            rosbag2_transport
+            shared_queues_vendor
+            sqlite3_vendor
+
+  ament_lint_cpp: # Linters applicable to C++ packages
+    name: ament_${{ matrix.linter }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+          linter: [cppcheck, cpplint, uncrustify]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros2@0.0.7
+    - uses: ros-tooling/action-ros2-lint@0.0.5
+      with:
+        linter: ${{ matrix.linter }}
+        package-name: |
+            rosbag2
+            rosbag2_compression
+            rosbag2_converter_default_plugins
+            rosbag2_test_common
+            rosbag2_tests
+            rosbag2_transport
+            shared_queues_vendor
+
+  ament_lint_python: # Linters applicable to Python packages
+    name: ament_${{ matrix.linter }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+          linter: [flake8, pep257]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros2@0.0.7
+    - uses: ros-tooling/action-ros2-lint@0.0.5
+      with:
+        linter: ${{ matrix.linter }}
+        package-name: |
+            ros2bag


### PR DESCRIPTION
This commit enables linters to run quickly without
requiring to download and compile the code.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>