### PR TITLE
[Compression - 6] Add Zstd file decompression implementation

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -30,7 +30,8 @@ find_package(zstd_vendor REQUIRED)
 
 add_library(${PROJECT_NAME}_zstd
   SHARED
-  src/rosbag2_compression/zstd_compressor.cpp)
+  src/rosbag2_compression/zstd_compressor.cpp
+  src/rosbag2_compression/zstd_decompressor.cpp)
 target_include_directories(${PROJECT_NAME}_zstd
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/rosbag2_compression/include/rosbag2_compression/zstd_decompressor.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/zstd_decompressor.hpp
@@ -29,6 +29,11 @@
 namespace rosbag2_compression
 {
 
+/**
+ * A BaseDecompressorInterface that is used to decompress bagfiles stored using ZStandard compression.
+ *
+ * ZstdDecompressor should only be initialized by Reader.
+ */
 class ROSBAG2_COMPRESSION_PUBLIC ZstdDecompressor : public BaseDecompressorInterface
 {
 public:

--- a/rosbag2_compression/include/rosbag2_compression/zstd_decompressor.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/zstd_decompressor.hpp
@@ -1,0 +1,49 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__ZSTD_DECOMPRESSOR_HPP_
+#define ROSBAG2_COMPRESSION__ZSTD_DECOMPRESSOR_HPP_
+
+#include <zstd.h>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "rosbag2_compression/base_decompressor_interface.hpp"
+#include "rosbag2_compression/visibility_control.hpp"
+
+namespace rosbag2_compression
+{
+
+class ROSBAG2_COMPRESSION_PUBLIC ZstdDecompressor : public BaseDecompressorInterface
+{
+public:
+  ZstdDecompressor() = default;
+
+  ~ZstdDecompressor() = default;
+
+  std::string decompress_uri(const std::string & uri) override;
+
+  void decompress_serialized_bag_message(
+    rosbag2_storage::SerializedBagMessage * bag_message) override;
+
+  std::string get_decompression_identifier() const override;
+};
+
+}  // namespace rosbag2_compression
+
+#endif  // ROSBAG2_COMPRESSION__ZSTD_DECOMPRESSOR_HPP_

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -71,9 +71,10 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
     throw std::runtime_error{errmsg.str()};
   }
 
-  // Allocate and read in
-  std::vector<uint8_t> compressed_buffer;
-  compressed_buffer.resize(compressed_buffer_length);
+  // Initialize compress_buffer with size = compressed_buffer_length.
+  // Uniform initialization cannot be used here since it will choose
+  // the initializer list constructor instead.
+  std::vector<uint8_t> compressed_buffer(compressed_buffer_length);
 
   const auto nRead = fread(
     compressed_buffer.data(), sizeof(decltype(compressed_buffer)::value_type),
@@ -207,8 +208,10 @@ std::string ZstdDecompressor::decompress_uri(const std::string & uri)
     ZSTD_getFrameContentSize(compressed_buffer.data(), compressed_buffer_length);
   check_frame_content(decompressed_buffer_length);
 
-  std::vector<uint8_t> decompressed_buffer;
-  decompressed_buffer.resize(decompressed_buffer_length);
+  // Initializes decompressed_buffer with size = decompressed_buffer_length.
+  // Uniform initialization cannot be used here since it will choose
+  // the initializer list constructor instead.
+  std::vector<uint8_t> decompressed_buffer(decompressed_buffer_length);
 
   const auto decompression_result = ZSTD_decompress(
     decompressed_buffer.data(), decompressed_buffer_length,

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -169,6 +169,9 @@ void check_frame_content(const size_t frame_content)
  * Prints decompression statistics to the debug log stream.
  * The log statement is formatted as JSON.
  *
+ * Example:
+ *  "Decompression statistics" : {"Time" : 1.2, "Compression Ratio" : 0.5}
+ *
  * \param start is the time_point when compression started.
  * \param end is the time_point when compression ended.
  * \param decompressed_size is the file size after decompression
@@ -185,7 +188,7 @@ void print_decompression_statistics(
     static_cast<double>(decompressed_size) / static_cast<double>(compressed_size);
 
   ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
-    "\"Decompression statistics\" : {\n" <<
+    "\"Decompression statistics\" : {" <<
       "\"Time\" : " << (duration.count() / 1000.0) <<
       ", \"Compression Ratio\" : " << decompression_ratio <<
       "}");

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -76,7 +76,8 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
   compressed_buffer.resize(compressed_buffer_length);
 
   const auto nRead = fread(
-    compressed_buffer.data(), sizeof(uint8_t), compressed_buffer_length, file_pointer);
+    compressed_buffer.data(), sizeof(decltype(compressed_buffer)::value_type),
+    compressed_buffer_length, file_pointer);
 
   if (nRead != compressed_buffer_length) {
     ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Bytes read !(" <<

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -60,7 +60,16 @@ std::vector<uint8_t> get_input_buffer(
   // Allocate and read in
   std::vector<uint8_t> compressed_buffer;
   compressed_buffer.reserve(compressed_buffer_length);
-  fread(compressed_buffer.data(), sizeof(uint8_t), compressed_buffer_length, file_pointer);
+
+  const auto nRead = fread(
+    compressed_buffer.data(), sizeof(uint8_t), compressed_buffer_length, file_pointer);
+
+  if (nRead != compressed_buffer_length) {
+    ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Bytes read !(" <<
+      nRead << ") != compressed_buffer_length (" << compressed_buffer_length <<
+      ")!");
+    // An error indicator is set by fread, so the following check will throw.
+  }
 
   if (ferror(file_pointer)) {
     fclose(file_pointer);
@@ -88,7 +97,15 @@ void write_output_buffer(
     throw std::runtime_error(errmsg.str());
   }
 
-  fwrite(output_buffer, sizeof(uint8_t), output_buffer_length, file_pointer);
+  const auto nWrite = fwrite(
+    output_buffer, sizeof(uint8_t), output_buffer_length, file_pointer);
+
+  if (nWrite != output_buffer_length) {
+    ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Bytes written (" <<
+      nWrite << " != output_buffer_length (" << output_buffer_length <<
+      ")!");
+    // An error indicator is set by fwrite, so the following check will throw.
+  }
 
   if (ferror(file_pointer)) {
     fclose(file_pointer);

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -1,0 +1,124 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "rcpputils/filesystem_helper.hpp"
+
+#include "logging.hpp"
+#include "rosbag2_compression/zstd_decompressor.hpp"
+
+namespace
+{
+std::unique_ptr<char[]> get_input_buffer(const std::string & uri, size_t & buffer_length)
+{
+  try {
+    std::ifstream infile{uri};
+    infile.exceptions(std::ifstream::failbit);
+    // Get size and allocate
+    infile.seekg(0, std::ios::end);
+    buffer_length = infile.tellg();
+    auto decompressed_buffer = std::make_unique<char[]>(buffer_length);
+    // Go back and read in contents
+    infile.seekg(0 /* off */, std::ios::beg);
+    infile.read(decompressed_buffer.get(), buffer_length);
+    return decompressed_buffer;
+  } catch (std::ios_base::failure & fail) {
+    ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
+      "Caught IO stream exception while reading file: " << fail.what());
+    throw fail;
+  }
+}
+
+void check_frame_content(const size_t frame_content)
+{
+  if (frame_content == ZSTD_CONTENTSIZE_ERROR) {
+    throw std::runtime_error("File not compressed with Zstd.");
+  }
+  if (frame_content == ZSTD_CONTENTSIZE_UNKNOWN) {
+    ROSBAG2_COMPRESSION_LOG_WARN("Unable to determine file size, considering upper bound.");
+  }
+}
+
+void check_decompression_result(const size_t decompression_result)
+{
+  if (ZSTD_isError(decompression_result)) {
+    std::stringstream error;
+    error << "ZSTD compression error: " << ZSTD_getErrorName(decompression_result);
+    throw std::runtime_error(error.str());
+  }
+  ROSBAG2_COMPRESSION_LOG_DEBUG("ZSTD decompressed file.");
+}
+
+void print_statistics(
+  std::chrono::high_resolution_clock::time_point start,
+  std::chrono::high_resolution_clock::time_point end)
+{
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
+    "Decompression statistics:\n" <<
+      "Time: " << duration.count() << " microseconds");
+}
+}  // namespace
+
+namespace rosbag2_compression
+{
+
+std::string ZstdDecompressor::decompress_uri(const std::string & uri)
+{
+  auto start = std::chrono::high_resolution_clock::now();
+  try {
+    // Prepare the compression buffers
+    size_t compressed_buffer_length{0};
+    auto compressed_buffer = get_input_buffer(uri, compressed_buffer_length);
+    const size_t decompressed_buffer_length =
+      ZSTD_getFrameContentSize(compressed_buffer.get(), compressed_buffer_length);
+    check_frame_content(decompressed_buffer_length);
+    auto decompressed_buffer = std::make_unique<char[]>(decompressed_buffer_length);
+    // Perform decompression
+    const size_t decompression_result = ZSTD_decompress(
+      decompressed_buffer.get(), decompressed_buffer_length,
+      compressed_buffer.get(), compressed_buffer_length);
+    check_decompression_result(decompression_result);
+    // Remove extension and write decompressed file
+    auto uri_path = rcpputils::fs::path(uri);
+    auto decompressed_uri = rcpputils::fs::remove_extension(uri_path);
+    std::ofstream outfile(decompressed_uri.string());
+    outfile.exceptions(std::ofstream::failbit);
+    outfile.write(decompressed_buffer.get(), decompression_result);
+    outfile.close();
+    auto end = std::chrono::high_resolution_clock::now();
+    print_statistics(start, end);
+    return decompressed_uri.string();
+  } catch (std::ios_base::failure & fail) {
+    ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
+      "Caught IO stream exception while decompressing: " << fail.what());
+    throw fail;
+  }
+}
+
+void ZstdDecompressor::decompress_serialized_bag_message(
+  rosbag2_storage::SerializedBagMessage *)
+{
+  throw std::logic_error("Not implemented");
+}
+
+std::string ZstdDecompressor::get_decompression_identifier() const
+{
+  static std::string kCompressionIdentifier = "zstd";
+  return kCompressionIdentifier;
+}
+}  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -190,7 +190,7 @@ void print_decompression_statistics(
   ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
     "\"Decompression statistics\" : {" <<
       "\"Time\" : " << (duration.count() / 1000.0) <<
-      ", \"Compression Ratio\" : " << decompression_ratio <<
+      ", \"Decompression Ratio\" : " << decompression_ratio <<
       "}");
 }
 }  // namespace

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -103,12 +103,10 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
 /**
  * Writes the output buffer to the specified file path.
  * \param output_buffer is the data to write.
- * \param output_buffer_length is the number of bytes to write.
  * \param uri is the relative file path to the output storage.
  */
 void write_output_buffer(
-  const uint8_t * output_buffer,
-  const size_t output_buffer_length,
+  const std::vector<uint8_t> & output_buffer,
   const std::string & uri)
 {
   const auto file_pointer = open_file(uri.c_str(), "wb");
@@ -120,11 +118,12 @@ void write_output_buffer(
   }
 
   const auto nWrite = fwrite(
-    output_buffer, sizeof(uint8_t), output_buffer_length, file_pointer);
+    output_buffer.data(), sizeof(uint8_t),
+    output_buffer.size(), file_pointer);
 
-  if (nWrite != output_buffer_length) {
+  if (nWrite != output_buffer.size()) {
     ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Bytes written (" <<
-      nWrite << " != output_buffer_length (" << output_buffer_length <<
+      nWrite << " != output_buffer_length (" << output_buffer.size() <<
       ")!");
     // An error indicator is set by fwrite, so the following check will throw.
   }
@@ -219,7 +218,7 @@ std::string ZstdDecompressor::decompress_uri(const std::string & uri)
 
   throw_on_zstd_error(decompression_result);
 
-  write_output_buffer(decompressed_buffer.data(), decompressed_buffer_length, decompressed_uri);
+  write_output_buffer(decompressed_buffer, decompressed_uri);
 
   const auto end = std::chrono::high_resolution_clock::now();
   print_decompression_statistics(start, end, decompression_result, compressed_buffer_length);

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -155,3 +155,12 @@ TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_file)
   auto decompressor = rosbag2_compression::ZstdDecompressor{};
   EXPECT_THROW(decompressor.decompress_uri(uri), std::runtime_error);
 }
+
+TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_uri)
+{
+  const auto bad_uri =
+    rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "bad_uri.txt"});
+  auto decompressor = rosbag2_compression::ZstdDecompressor{};
+
+  EXPECT_THROW(decompressor.decompress_uri(bad_uri), std::runtime_error);
+}

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -144,8 +144,12 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
   const auto decompressed_file_size =
     rosbag2_storage::FilesystemHelper::get_file_size(decompressed_uri);
 
-  EXPECT_EQ(initial_data.size() * sizeof(char), initial_file_size);
-  EXPECT_EQ(decompressed_data.size() * sizeof(char), decompressed_file_size);
+  EXPECT_EQ(
+    initial_data.size() * sizeof(decltype(initial_data)::value_type),
+    initial_file_size);
+  EXPECT_EQ(
+    decompressed_data.size() * sizeof(decltype(initial_data)::value_type),
+    decompressed_file_size);
   EXPECT_EQ(initial_data, decompressed_data);
 }
 

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -93,7 +93,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
   auto zstd_compressor = rosbag2_compression::ZstdCompressor();
   const auto compressed_uri = zstd_compressor.compress_uri(uri);
 
-  ASSERT_EQ(0, std::remove(uri.c_str()));  // the test is invalid if the initial file is not deleted
+  ASSERT_EQ(0, std::remove(uri.c_str()));  // The test is invalid if the initial file is not deleted
 
   auto zstd_decompressor = rosbag2_compression::ZstdDecompressor();
   const auto decompressed_uri = zstd_decompressor.decompress_uri(compressed_uri);

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -17,6 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rosbag2_compression/zstd_compressor.hpp"
+#include "rosbag2_compression/zstd_decompressor.hpp"
 #include "rosbag2_storage/filesystem_helper.hpp"
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
@@ -80,4 +81,23 @@ TEST_F(CompressionHelperFixture, zstd_compress_file_uri)
   EXPECT_LT(compressed_file_size, uncompressed_file_size);
   EXPECT_GT(compressed_file_size, 0u);
   EXPECT_TRUE(rosbag2_storage::FilesystemHelper::file_exists(compressed_uri));
+}
+
+TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
+{
+  const auto uri = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "file1.txt"});
+  create_garbage_file(uri);
+  const auto initial_file_size = rosbag2_storage::FilesystemHelper::get_file_size(uri);
+
+  auto zstd_compressor = rosbag2_compression::ZstdCompressor();
+  auto compressed_uri = zstd_compressor.compress_uri(uri);
+  auto zstd_decompressor = rosbag2_compression::ZstdDecompressor();
+  auto decompressed_uri = zstd_decompressor.decompress_uri(compressed_uri);
+
+  const auto expected_decompressed_uri = uri;
+  const auto decompressed_file_size =
+    rosbag2_storage::FilesystemHelper::get_file_size(decompressed_uri);
+
+  EXPECT_EQ(uri, expected_decompressed_uri);
+  EXPECT_EQ(initial_file_size, decompressed_file_size);
 }

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
 #include <fstream>
 #include <string>
 
@@ -90,14 +91,20 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
   const auto initial_file_size = rosbag2_storage::FilesystemHelper::get_file_size(uri);
 
   auto zstd_compressor = rosbag2_compression::ZstdCompressor();
-  auto compressed_uri = zstd_compressor.compress_uri(uri);
+  const auto compressed_uri = zstd_compressor.compress_uri(uri);
+
+  ASSERT_EQ(0, std::remove(uri.c_str()));  // the test is invalid if the initial file is not deleted
+
   auto zstd_decompressor = rosbag2_compression::ZstdDecompressor();
-  auto decompressed_uri = zstd_decompressor.decompress_uri(compressed_uri);
+  const auto decompressed_uri = zstd_decompressor.decompress_uri(compressed_uri);
 
   const auto expected_decompressed_uri = uri;
   const auto decompressed_file_size =
     rosbag2_storage::FilesystemHelper::get_file_size(decompressed_uri);
 
+  EXPECT_NE(compressed_uri, uri);
+  EXPECT_NE(decompressed_uri, compressed_uri);
   EXPECT_EQ(uri, expected_decompressed_uri);
   EXPECT_EQ(initial_file_size, decompressed_file_size);
+  EXPECT_TRUE(rosbag2_storage::FilesystemHelper::file_exists(decompressed_uri));
 }

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -54,9 +54,11 @@ std::vector<char> read_file(const std::string & uri)
   std::ifstream infile{uri, std::ios_base::binary | std::ios::ate};
   infile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
-  std::vector<char> contents;
   const auto file_size = infile.tellg();
-  contents.resize(file_size);
+  // Initialize contents with size = file_size
+  // Uniform initialization cannot be used here since it will choose
+  // the initializer list constructor instead.
+  std::vector<char> contents(file_size);
 
   infile.seekg(0, std::ios_base::beg);
   infile.read(contents.data(), file_size);


### PR DESCRIPTION
## Changes

* Add `zstd_decompressor` header and source
* Add a new unit test for decompression
  * Compress a file then decompresses it using the same format. Make sure original size is the same.

## Dependencies
- [x] PR #220. 
- [x] Rebased after #220 is merged.