### PR TITLE
Fix compress uri

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -127,7 +127,7 @@ std::string ZstdCompressor::compress_uri(const std::string & uri)
     compressed_buffer.data(), compressed_buffer_length,
     decompressed_buffer.data(), decompressed_buffer_length, DEFAULT_ZSTD_COMPRESSION_LEVEL);
   throw_on_zstd_error(compression_result);
-  write_output_buffer(compressed_buffer.data(), compression_result, uri);
+  write_output_buffer(compressed_buffer.data(), compression_result, compressed_uri);
   const auto end = std::chrono::high_resolution_clock::now();
   print_compression_statistics(start, end, decompressed_buffer_length, compression_result);
   return compressed_uri;

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -68,13 +68,14 @@ TEST_F(CompressionHelperFixture, zstd_compress_file_uri)
   const auto uri = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "file1.txt"});
   create_garbage_file(uri);
   auto zstd_compressor = rosbag2_compression::ZstdCompressor();
-  auto compressed_uri = zstd_compressor.compress_uri(uri);
+  const auto compressed_uri = zstd_compressor.compress_uri(uri);
 
   const auto expected_compressed_uri = uri + "." + zstd_compressor.get_compression_identifier();
   const auto uncompressed_file_size = rosbag2_storage::FilesystemHelper::get_file_size(uri);
   const auto compressed_file_size =
     rosbag2_storage::FilesystemHelper::get_file_size(compressed_uri);
 
+  EXPECT_NE(compressed_uri, uri);
   EXPECT_EQ(compressed_uri, expected_compressed_uri);
   EXPECT_LT(compressed_file_size, uncompressed_file_size);
   EXPECT_GT(compressed_file_size, 0u);

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -77,4 +77,6 @@ TEST_F(CompressionHelperFixture, zstd_compress_file_uri)
 
   EXPECT_EQ(compressed_uri, expected_compressed_uri);
   EXPECT_LT(compressed_file_size, uncompressed_file_size);
+  EXPECT_GT(compressed_file_size, 0u);
+  EXPECT_TRUE(rosbag2_storage::FilesystemHelper::file_exists(compressed_uri));
 }


### PR DESCRIPTION
### Issue
* `ZstdCompressor::compress_uri` was writing to `uri` instead of `compressed_uri`

### Changes
* `ZstdCompress::compress_uri` now correctly writes to `compressed_uri`
* Add check in unit test to verify the compressed file is not empty
* Add check in unit test to verify that the compressed file exists
* Add check in unit test to verify that the `compressed_uri` is not the `uri`

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>