### PR TITLE
Allocate storage for template_char in TemporaryDirectoryFixture

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -38,7 +38,7 @@ class TemporaryDirectoryFixture : public Test
 public:
   TemporaryDirectoryFixture()
   {
-    char template_char[] = "tmp_test_dir.XXXXXX";
+    char template_char[32] = "tmp_test_dir.XXXXXX";
 #ifdef _WIN32
     char temp_path[255];
     GetTempPathA(255, temp_path);


### PR DESCRIPTION
### Issues
* Resolves: https://github.com/ros2/rcpputils/pull/28#discussion_r359649639

### Testing
* compiled with `colcon build --packages-up-to rosbag2_tests --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo` and ran `valgrind ./build/rosbag2/test_info`

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>