### PR TITLE
[compression] Follow ROS2 style conventions better and throw eagerly

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/zstd_compressor.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/zstd_compressor.hpp
@@ -29,6 +29,11 @@
 namespace rosbag2_compression
 {
 
+/**
+ * A BaseCompressorInterface that is used to compress bagfiles stored using ZStandard compression.
+ *
+ * ZstdCompressor should only be initialized by Writer.
+ */
 class ROSBAG2_COMPRESSION_PUBLIC ZstdCompressor : public BaseCompressorInterface
 {
 public:

--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -30,10 +30,10 @@ namespace
 //   - Increase the time taken to compress
 //   - Decrease the size of the compressed data
 // Setting to zero uses Zstd's default value of 3.
-constexpr const int DEFAULT_ZSTD_COMPRESSION_LEVEL = 1;
+constexpr const int kDefaultZstdCompressionLevel = 1;
 
 // String constant used to identify ZstdCompressor.
-constexpr const char COMPRESSION_IDENTIFIER[] = "zstd";
+constexpr const char kCompressionIdentifier[] = "zstd";
 
 /**
  * Open a file using the OS-specific C API.
@@ -187,7 +187,7 @@ std::string ZstdCompressor::compress_uri(const std::string & uri)
   // compression_result is either the actual compressed size or an error code.
   const size_t compression_result = ZSTD_compress(
     compressed_buffer.data(), compressed_buffer.size(),
-    decompressed_buffer.data(), decompressed_buffer.size(), DEFAULT_ZSTD_COMPRESSION_LEVEL);
+    decompressed_buffer.data(), decompressed_buffer.size(), kDefaultZstdCompressionLevel);
   throw_on_zstd_error(compression_result);
 
   // Compression_buffer_length might be larger than the actual compression size
@@ -208,7 +208,7 @@ void ZstdCompressor::compress_serialized_bag_message(
 
 std::string ZstdCompressor::get_compression_identifier() const
 {
-  return COMPRESSION_IDENTIFIER;
+  return kCompressionIdentifier;
 }
 
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -123,7 +123,6 @@ void write_output_buffer(
     throw std::runtime_error{errmsg.str()};
   }
 
-
   const auto file_pointer = open_file(uri.c_str(), "wb");
   if (file_pointer == nullptr) {
     std::stringstream errmsg;

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -59,9 +59,6 @@ FILE * open_file(const std::string & uri, const std::string & read_mode)
  */
 std::vector<uint8_t> get_input_buffer(const std::string & uri)
 {
-  // Get the file size
-  const auto compressed_buffer_length = rosbag2_storage::FilesystemHelper::get_file_size(uri);
-
   // Read in buffer, handling accordingly
   const auto file_pointer = open_file(uri.c_str(), "rb");
   if (file_pointer == nullptr) {
@@ -71,18 +68,28 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
     throw std::runtime_error{errmsg.str()};
   }
 
+  const auto compressed_buffer_length = rosbag2_storage::FilesystemHelper::get_file_size(uri);
+  if (compressed_buffer_length == 0) {
+    fclose(file_pointer);
+
+    std::stringstream errmsg;
+    errmsg << "Unable to get size of file: " << uri;
+
+    throw std::runtime_error{errmsg.str()};
+  }
+
   // Initialize compress_buffer with size = compressed_buffer_length.
   // Uniform initialization cannot be used here since it will choose
   // the initializer list constructor instead.
   std::vector<uint8_t> compressed_buffer(compressed_buffer_length);
 
-  const auto nRead = fread(
+  const auto read_count = fread(
     compressed_buffer.data(), sizeof(decltype(compressed_buffer)::value_type),
     compressed_buffer_length, file_pointer);
 
-  if (nRead != compressed_buffer_length) {
+  if (read_count != compressed_buffer_length) {
     ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Bytes read !(" <<
-      nRead << ") != compressed_buffer_length (" << compressed_buffer_length <<
+      read_count << ") != compressed_buffer size (" << compressed_buffer.size() <<
       ")!");
     // An error indicator is set by fread, so the following check will throw.
   }
@@ -109,6 +116,14 @@ void write_output_buffer(
   const std::vector<uint8_t> & output_buffer,
   const std::string & uri)
 {
+  if (output_buffer.empty()) {
+    std::stringstream errmsg;
+    errmsg << "Cannot write empty buffer to file: " << uri;
+
+    throw std::runtime_error{errmsg.str()};
+  }
+
+
   const auto file_pointer = open_file(uri.c_str(), "wb");
   if (file_pointer == nullptr) {
     std::stringstream errmsg;
@@ -117,13 +132,13 @@ void write_output_buffer(
     throw std::runtime_error{errmsg.str()};
   }
 
-  const auto nWrite = fwrite(
+  const auto write_count = fwrite(
     output_buffer.data(), sizeof(uint8_t),
     output_buffer.size(), file_pointer);
 
-  if (nWrite != output_buffer.size()) {
+  if (write_count != output_buffer.size()) {
     ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Bytes written (" <<
-      nWrite << " != output_buffer_length (" << output_buffer.size() <<
+      write_count << " != output_buffer size (" << output_buffer.size() <<
       ")!");
     // An error indicator is set by fwrite, so the following check will throw.
   }
@@ -154,9 +169,10 @@ void throw_on_zstd_error(const size_t compression_result)
 }
 
 /**
- * Checks if the frame content is valid.
+ * Checks frame_content and throws a runtime_error if there was a ZSTD error
+ * or frame_content is invalid.
  */
-void check_frame_content(const size_t frame_content)
+void throw_on_invalid_frame_content(const size_t frame_content)
 {
   if (frame_content == ZSTD_CONTENTSIZE_ERROR) {
     throw std::runtime_error{"Unable to determine file size due to error."};
@@ -168,6 +184,7 @@ void check_frame_content(const size_t frame_content)
 /**
  * Prints decompression statistics to the debug log stream.
  * The log statement is formatted as JSON.
+ * Time is formatted as a decimal of seconds.
  *
  * Example:
  *  "Decompression statistics" : {"Time" : 1.2, "Compression Ratio" : 0.5}
@@ -208,7 +225,8 @@ std::string ZstdDecompressor::decompress_uri(const std::string & uri)
 
   const auto decompressed_buffer_length =
     ZSTD_getFrameContentSize(compressed_buffer.data(), compressed_buffer_length);
-  check_frame_content(decompressed_buffer_length);
+
+  throw_on_invalid_frame_content(decompressed_buffer_length);
 
   // Initializes decompressed_buffer with size = decompressed_buffer_length.
   // Uniform initialization cannot be used here since it will choose
@@ -220,6 +238,7 @@ std::string ZstdDecompressor::decompress_uri(const std::string & uri)
     compressed_buffer.data(), compressed_buffer_length);
 
   throw_on_zstd_error(decompression_result);
+  decompressed_buffer.resize(decompression_result);
 
   write_output_buffer(decompressed_buffer, decompressed_uri);
 

--- a/rosbag2_compression/test/rosbag2_compression/fake_decompressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/fake_decompressor.cpp
@@ -20,7 +20,7 @@
 
 std::string FakeDecompressor::decompress_uri(const std::string & uri)
 {
-  auto uri_path = rcpputils::fs::path(uri);
+  auto uri_path = rcpputils::fs::path{uri};
   const auto decompressed_path = rcpputils::fs::remove_extension(uri_path);
   return decompressed_path.string();
 }

--- a/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_compressor.cpp
@@ -29,7 +29,7 @@ public:
 
 TEST_F(FakeCompressorTest, test_compress_file_method)
 {
-  const rcpputils::fs::path test_path("/path/file.txt");
+  const rcpputils::fs::path test_path{"/path/file.txt"};
   const auto expected_compressed_uri = test_path.string() + "." +
     compressor.get_compression_identifier();
   const auto compressed_uri = compressor.compress_uri(test_path.string());

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -27,38 +27,37 @@
 
 namespace
 {
-constexpr const char * GARBAGE_STATEMENT = "garbage";
-constexpr const int DEFAULT_GARBAGE_FILE_SIZE = 10;  // MiB
+constexpr const char kGarbageStatement[] = "garbage";
+constexpr const int kDefaultGarbageFileSize = 10;  // MiB
 
 /**
  * Creates a text file of a certain size.
  * \param uri File path to write file.
  * \param size Size of file in MiB.
  */
-void create_garbage_file(const std::string & uri, int size = DEFAULT_GARBAGE_FILE_SIZE)
+void create_garbage_file(const std::string & uri, int size = kDefaultGarbageFileSize)
 {
-  std::ofstream out{uri};
-  if (!out) {
-    throw std::runtime_error("Unable to write garbage file.");
-  }
+  auto out = std::ofstream{uri};
+  out.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
   const auto file_size = size * 1024 * 1024;
-  const auto num_iterations = file_size / static_cast<int>(strlen(GARBAGE_STATEMENT));
+  const auto num_iterations = file_size / static_cast<int>(strlen(kGarbageStatement));
 
   for (int i = 0; i < num_iterations; i++) {
-    out << GARBAGE_STATEMENT;
+    out << kGarbageStatement;
   }
 }
 
 std::vector<char> read_file(const std::string & uri)
 {
-  std::ifstream infile{uri, std::ios_base::binary | std::ios::ate};
+  auto infile = std::ifstream{uri, std::ios_base::binary | std::ios::ate};
   infile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
   const auto file_size = infile.tellg();
   // Initialize contents with size = file_size
   // Uniform initialization cannot be used here since it will choose
   // the initializer list constructor instead.
-  std::vector<char> contents(file_size);
+  auto contents = std::vector<char>(file_size);
 
   infile.seekg(0, std::ios_base::beg);
   infile.read(contents.data(), file_size);
@@ -87,7 +86,7 @@ TEST_F(CompressionHelperFixture, zstd_compress_file_uri)
 {
   const auto uri = rosbag2_storage::FilesystemHelper::concat({temporary_dir_path_, "file1.txt"});
   create_garbage_file(uri);
-  auto zstd_compressor = rosbag2_compression::ZstdCompressor();
+  auto zstd_compressor = rosbag2_compression::ZstdCompressor{};
   const auto compressed_uri = zstd_compressor.compress_uri(uri);
 
   const auto expected_compressed_uri = uri + "." + zstd_compressor.get_compression_identifier();
@@ -108,12 +107,12 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
   create_garbage_file(uri);
   const auto initial_file_size = rosbag2_storage::FilesystemHelper::get_file_size(uri);
 
-  auto zstd_compressor = rosbag2_compression::ZstdCompressor();
+  auto zstd_compressor = rosbag2_compression::ZstdCompressor{};
   const auto compressed_uri = zstd_compressor.compress_uri(uri);
 
   ASSERT_EQ(0, std::remove(uri.c_str()));  // The test is invalid if the initial file is not deleted
 
-  auto zstd_decompressor = rosbag2_compression::ZstdDecompressor();
+  auto zstd_decompressor = rosbag2_compression::ZstdDecompressor{};
   const auto decompressed_uri = zstd_decompressor.decompress_uri(compressed_uri);
 
   const auto expected_decompressed_uri = uri;


### PR DESCRIPTION
### Changes
* Renamed `check_frame_content` to `throw_on_invalid_frame_content` to match what its actually doing.
* [ZstdCompressor] Throw an exception if file size is 0 when opening a file for compression.
* [ZstdDecompressor] Throw an exception if file size is 0 when opening a file for decompression.
* [ZstdCompressor] Document private methods.
* Align to [ROS2 style guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#id1) better:
  * Variables use [lower snake case](https://google.github.io/styleguide/cppguide.html#Variable_Names).
  * Constants use [`k` prefix followed by CamelCase](https://google.github.io/styleguide/cppguide.html#Constant_Names).
* Use brace-initialization when possible.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>