### PR TITLE
[Compression - 8] Enable reader to read from compressed files/messages

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -60,7 +60,7 @@ install(
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}_zstd)
-ament_export_dependencies(rosbag2_storage rcutils zstd_vendor zstd)
+ament_export_dependencies(rosbag2_storage rcutils zstd_vendor)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -112,6 +112,13 @@ if(BUILD_TESTING)
     RUNTIME DESTINATION bin)
   pluginlib_export_plugin_description_file(rosbag2_cpp test/rosbag2_cpp/converter_test_plugin.xml)
 
+  ament_add_gmock(test_compression_options
+    test/rosbag2_cpp/test_compression_options.cpp)
+  if(TARGET test_compression_options)
+    target_include_directories(test_compression_options PRIVATE include)
+    target_link_libraries(test_compression_options ${PROJECT_NAME})
+  endif()
+
   ament_add_gmock(test_converter_factory
     test/rosbag2_cpp/test_converter_factory.cpp)
   if(TARGET test_converter_factory)

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -34,12 +34,14 @@ find_package(poco_vendor)
 find_package(Poco COMPONENTS Foundation)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(rosbag2_compression REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
+  src/rosbag2_cpp/compression_options.cpp
   src/rosbag2_cpp/converter.cpp
   src/rosbag2_cpp/info.cpp
   src/rosbag2_cpp/reader.cpp
@@ -57,6 +59,7 @@ ament_target_dependencies(${PROJECT_NAME}
   Poco
   rcpputils
   rcutils
+  rosbag2_compression
   rosbag2_storage
   rosidl_generator_cpp
   rosidl_typesupport_introspection_cpp
@@ -88,7 +91,7 @@ install(
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(pluginlib rosbag2_storage rosidl_typesupport_introspection_cpp)
+ament_export_dependencies(pluginlib rosbag2_compression rosbag2_storage rosidl_typesupport_introspection_cpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
@@ -156,6 +159,7 @@ if(BUILD_TESTING)
       ament_index_cpp
       Poco
       rcutils
+      rosbag2_compression
       rosbag2_storage
       rosidl_generator_cpp
       rosidl_typesupport_introspection_cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
@@ -1,0 +1,41 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_CPP__COMPRESSION_OPTIONS_HPP_
+#define ROSBAG2_CPP__COMPRESSION_OPTIONS_HPP_
+
+#include <string>
+
+namespace rosbag2_cpp
+{
+
+enum class CompressionMode
+{
+  NONE,
+  FILE,
+  MESSAGE,
+};
+
+CompressionMode compression_mode_from_string(const std::string & compression_mode);
+
+std::string compression_mode_to_string(CompressionMode compression_mode);
+
+struct CompressionOptions
+{
+  std::string compression_format;
+  CompressionMode compression_mode;
+};
+
+}  // namespace rosbag2_cpp
+#endif  // ROSBAG2_CPP__COMPRESSION_OPTIONS_HPP_

--- a/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
@@ -20,6 +20,10 @@
 namespace rosbag2_cpp
 {
 
+/**
+ * Modes are used to specify whether to compress by individual serialized bag messages or by file.
+ * rosbag2_cpp defaults to NONE.
+ */
 enum class CompressionMode
 {
   NONE,
@@ -27,15 +31,21 @@ enum class CompressionMode
   MESSAGE,
 };
 
+/**
+ * Converts a string into a rosbag2_cpp::CompressionMode enum.
+ *
+ * \param compression_mode A case insensitive string that is either "FILE" or "MESSAGE".
+ * \return CompressionMode NONE if compression_mode is invalid. FILE or MESSAGE otherwise.
+ */
 CompressionMode compression_mode_from_string(const std::string & compression_mode);
 
+/**
+ * Converts a rosbag2_cpp::CompressionMode enum into a string.
+ *
+ * \param compression_mode A CompressionMode enum.
+ * \return The corresponding mode as a string.
+ */
 std::string compression_mode_to_string(CompressionMode compression_mode);
-
-struct CompressionOptions
-{
-  std::string compression_format;
-  CompressionMode compression_mode;
-};
 
 }  // namespace rosbag2_cpp
 #endif  // ROSBAG2_CPP__COMPRESSION_OPTIONS_HPP_

--- a/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
@@ -24,11 +24,12 @@ namespace rosbag2_cpp
  * Modes are used to specify whether to compress by individual serialized bag messages or by file.
  * rosbag2_cpp defaults to NONE.
  */
-enum class CompressionMode
+enum class CompressionMode : uint32_t
 {
-  NONE,
+  NONE = 0,
   FILE,
   MESSAGE,
+  LAST_MODE = MESSAGE
 };
 
 /**

--- a/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/compression_options.hpp
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include "visibility_control.hpp"
+
 namespace rosbag2_cpp
 {
 
@@ -24,7 +26,7 @@ namespace rosbag2_cpp
  * Modes are used to specify whether to compress by individual serialized bag messages or by file.
  * rosbag2_cpp defaults to NONE.
  */
-enum class CompressionMode : uint32_t
+enum class ROSBAG2_CPP_PUBLIC CompressionMode : uint32_t
 {
   NONE = 0,
   FILE,
@@ -38,7 +40,7 @@ enum class CompressionMode : uint32_t
  * \param compression_mode A case insensitive string that is either "FILE" or "MESSAGE".
  * \return CompressionMode NONE if compression_mode is invalid. FILE or MESSAGE otherwise.
  */
-CompressionMode compression_mode_from_string(const std::string & compression_mode);
+ROSBAG2_CPP_PUBLIC CompressionMode compression_mode_from_string(const std::string & compression_mode);
 
 /**
  * Converts a rosbag2_cpp::CompressionMode enum into a string.
@@ -46,7 +48,7 @@ CompressionMode compression_mode_from_string(const std::string & compression_mod
  * \param compression_mode A CompressionMode enum.
  * \return The corresponding mode as a string.
  */
-std::string compression_mode_to_string(CompressionMode compression_mode);
+ROSBAG2_CPP_PUBLIC std::string compression_mode_to_string(CompressionMode compression_mode);
 
 }  // namespace rosbag2_cpp
 #endif  // ROSBAG2_CPP__COMPRESSION_OPTIONS_HPP_

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -19,12 +19,14 @@
 #include <string>
 #include <vector>
 
+#include "rosbag2_cpp/compression_options.hpp"
 #include "rosbag2_cpp/converter.hpp"
 #include "rosbag2_cpp/reader_interfaces/base_reader_interface.hpp"
 #include "rosbag2_cpp/serialization_format_converter_factory.hpp"
 #include "rosbag2_cpp/serialization_format_converter_factory_interface.hpp"
 #include "rosbag2_cpp/visibility_control.hpp"
 
+#include "rosbag2_compression/base_decompressor_interface.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
 #include "rosbag2_storage/storage_factory_interface.hpp"
@@ -125,10 +127,27 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_{};
   std::unique_ptr<Converter> converter_{};
+  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_;
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
   rosbag2_storage::BagMetadata metadata_{};
   std::vector<std::string> file_paths_{};  // List of database files.
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
+  rosbag2_cpp::CompressionMode compression_mode_;
+
+protected:
+  /**
+   * Checks if the compression mode is of type MESSAGE and if so, decompresses the message.
+   *
+   * \param message A serialized bag message
+   */
+  virtual void decompress_message(rosbag2_storage::SerializedBagMessage * message);
+
+  /**
+   * Checks if the compression mode is of type FILE and if so, decompresses the file.
+   *
+   * \param uri Relative path as a string
+   */
+  virtual void decompress_file(const std::string & uri);
 };
 
 }  // namespace readers

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -123,16 +123,30 @@ private:
     const std::string & converter_serialization_format,
     const std::string & storage_serialization_format);
 
+  /**
+   * Opens a storage plugin for read only.
+   *
+   * \throws runtime_error If no storage could be initialized.
+   */
+  virtual void open_storage();
+
+  /**
+   * Initializes the decompressor if a compression mode is specified in the metadata.
+   *
+   * \throws runtime_error If compression format doesn't exist.
+   */
+  virtual void setup_compression();
+
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_{};
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_{};
   std::unique_ptr<Converter> converter_{};
-  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_;
+  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
   rosbag2_storage::BagMetadata metadata_{};
   std::vector<std::string> file_paths_{};  // List of database files.
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
-  rosbag2_cpp::CompressionMode compression_mode_;
+  rosbag2_cpp::CompressionMode compression_mode_{rosbag2_cpp::CompressionMode::NONE};
 
 protected:
   /**

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -126,14 +126,14 @@ private:
   /**
    * Opens a storage plugin for read only.
    *
-   * \throws runtime_error If no storage could be initialized.
+   * \throws std::runtime_error If no storage could be initialized.
    */
   virtual void open_storage();
 
   /**
    * Initializes the decompressor if a compression mode is specified in the metadata.
    *
-   * \throws runtime_error If compression format doesn't exist.
+   * \throws std::runtime_error If compression format doesn't exist.
    */
   virtual void setup_compression();
 

--- a/rosbag2_cpp/package.xml
+++ b/rosbag2_cpp/package.xml
@@ -13,6 +13,7 @@
   <depend>pluginlib</depend>
   <depend>poco_vendor</depend>
   <depend>rcutils</depend>
+  <depend>rosbag2_compression</depend>
   <depend>rosbag2_storage</depend>
   <depend>rosidl_generator_cpp</depend>
   <depend>rosidl_typesupport_cpp</depend>

--- a/rosbag2_cpp/src/rosbag2_cpp/compression_options.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/compression_options.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <string>
 
 #include "rosbag2_cpp/compression_options.hpp"
@@ -23,19 +24,26 @@ namespace rosbag2_cpp
 namespace
 {
 
-  constexpr const char kCompressionModeNoneStr[] = "NONE";
-  constexpr const char kCompressionModeFileStr[] = "FILE";
-  constexpr const char kCompressionModeMessageStr[] = "MESSAGE";
+constexpr const char kCompressionModeNoneStr[] = "NONE";
+constexpr const char kCompressionModeFileStr[] = "FILE";
+constexpr const char kCompressionModeMessageStr[] = "MESSAGE";
 
+std::string to_upper(const std::string & text)
+{
+  std::string uppercase_text = text;
+  transform(uppercase_text.begin(), uppercase_text.end(), uppercase_text.begin(), ::toupper);
+  return uppercase_text;
+}
 }  // namespace
 
 CompressionMode compression_mode_from_string(const std::string & compression_mode)
 {
-  if (compression_mode.empty() || compression_mode == kCompressionModeNoneStr) {
+  auto compression_mode_upper = to_upper(compression_mode);
+  if (compression_mode.empty() || compression_mode_upper == kCompressionModeNoneStr) {
     return CompressionMode::NONE;
-  } else if (compression_mode == kCompressionModeFileStr) {
+  } else if (compression_mode_upper == kCompressionModeFileStr) {
     return CompressionMode::FILE;
-  } else if (compression_mode == kCompressionModeMessageStr) {
+  } else if (compression_mode_upper == kCompressionModeMessageStr) {
     return CompressionMode::MESSAGE;
   } else {
     ROSBAG2_CPP_LOG_ERROR_STREAM(

--- a/rosbag2_cpp/src/rosbag2_cpp/compression_options.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/compression_options.cpp
@@ -1,0 +1,61 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "rosbag2_cpp/compression_options.hpp"
+#include "rosbag2_cpp/logging.hpp"
+
+namespace rosbag2_cpp
+{
+
+namespace
+{
+
+  constexpr const char kCompressionModeNoneStr[] = "NONE";
+  constexpr const char kCompressionModeFileStr[] = "FILE";
+  constexpr const char kCompressionModeMessageStr[] = "MESSAGE";
+
+}  // namespace
+
+CompressionMode compression_mode_from_string(const std::string & compression_mode)
+{
+  if (compression_mode.empty() || compression_mode == kCompressionModeNoneStr) {
+    return CompressionMode::NONE;
+  } else if (compression_mode == kCompressionModeFileStr) {
+    return CompressionMode::FILE;
+  } else if (compression_mode == kCompressionModeMessageStr) {
+    return CompressionMode::MESSAGE;
+  } else {
+    ROSBAG2_CPP_LOG_ERROR_STREAM(
+      "CompressionMode: \"" << compression_mode << "\" is not supported!");
+    return CompressionMode::NONE;
+  }
+}
+
+std::string compression_mode_to_string(const CompressionMode compression_mode)
+{
+  switch (compression_mode) {
+    case CompressionMode::NONE:
+      return kCompressionModeNoneStr;
+    case CompressionMode::FILE:
+      return kCompressionModeFileStr;
+    case CompressionMode::MESSAGE:
+      return kCompressionModeMessageStr;
+    default:
+      ROSBAG2_CPP_LOG_ERROR_STREAM("CompressionMode not supported!");
+      return kCompressionModeNoneStr;
+  }
+}
+}  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/compression_options.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/compression_options.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,14 +31,14 @@ constexpr const char kCompressionModeMessageStr[] = "MESSAGE";
 std::string to_upper(const std::string & text)
 {
   std::string uppercase_text = text;
-  transform(uppercase_text.begin(), uppercase_text.end(), uppercase_text.begin(), ::toupper);
+  std::transform(uppercase_text.begin(), uppercase_text.end(), uppercase_text.begin(), ::toupper);
   return uppercase_text;
 }
 }  // namespace
 
 CompressionMode compression_mode_from_string(const std::string & compression_mode)
 {
-  auto compression_mode_upper = to_upper(compression_mode);
+  const auto compression_mode_upper = to_upper(compression_mode);
   if (compression_mode.empty() || compression_mode_upper == kCompressionModeNoneStr) {
     return CompressionMode::NONE;
   } else if (compression_mode_upper == kCompressionModeFileStr) {

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -54,7 +54,7 @@ void SequentialReader::open_storage()
   storage_ = storage_factory_->open_read_only(
     *current_file_iterator_, metadata_.storage_identifier);
   if (!storage_) {
-    throw std::runtime_error("No storage could be initialized. Abort");
+    throw std::runtime_error{"No storage could be initialized. Abort"};
   }
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,14 @@
 
 TEST(CompressionOptionsFromStringTest, BadInputReturnsNoneMode)
 {
-  std::string compression_mode_string{"bad_mode"};
+  const std::string compression_mode_string{"bad_mode"};
+  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::NONE);
+}
+
+TEST(CompressionOptionsFromStringTest, EmptyInputReturnsNoneMode)
+{
+  const std::string compression_mode_string;
   auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::NONE);
 }
@@ -32,11 +39,25 @@ TEST(CompressionOptionsFromStringTest, FileStringReturnsFileMode)
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::FILE);
 }
 
+TEST(CompressionOptionsFromStringTest, MixedCaseMessageStringReturnsMessageMode)
+{
+  std::string compression_mode_string{"MeSsAgE"};
+  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::MESSAGE);
+}
+
 TEST(CompressionOptionsFromStringTest, MessageStringReturnsMessageMode)
 {
   std::string compression_mode_string{"MESSAGE"};
   auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::MESSAGE);
+}
+
+TEST(CompressionOptionsToStringTest, BadModeReturnsNoneString)
+{
+  const auto compression_mode = static_cast<rosbag2_cpp::CompressionMode>(100);
+  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  EXPECT_EQ(compression_mode_string, "NONE");
 }
 
 TEST(CompressionOptionsToStringTest, MessageModeReturnsMessageString)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
@@ -55,7 +55,9 @@ TEST(CompressionOptionsFromStringTest, MessageStringReturnsMessageMode)
 
 TEST(CompressionOptionsToStringTest, BadModeReturnsNoneString)
 {
-  const auto compression_mode = static_cast<rosbag2_cpp::CompressionMode>(100);
+  // Get an out of bounds enum from CompressionMode
+  const auto compression_mode = static_cast<rosbag2_cpp::CompressionMode>(
+    static_cast<uint32_t>(rosbag2_cpp::CompressionMode::LAST_MODE) + 1);
   const auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
   EXPECT_EQ(compression_mode_string, "NONE");
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
@@ -21,62 +21,62 @@
 TEST(CompressionOptionsFromStringTest, BadInputReturnsNoneMode)
 {
   const std::string compression_mode_string{"bad_mode"};
-  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  const auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::NONE);
 }
 
 TEST(CompressionOptionsFromStringTest, EmptyInputReturnsNoneMode)
 {
   const std::string compression_mode_string;
-  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  const auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::NONE);
 }
 
 TEST(CompressionOptionsFromStringTest, FileStringReturnsFileMode)
 {
-  std::string compression_mode_string{"file"};
-  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  const std::string compression_mode_string{"file"};
+  const auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::FILE);
 }
 
 TEST(CompressionOptionsFromStringTest, MixedCaseMessageStringReturnsMessageMode)
 {
-  std::string compression_mode_string{"MeSsAgE"};
-  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  const std::string compression_mode_string{"MeSsAgE"};
+  const auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::MESSAGE);
 }
 
 TEST(CompressionOptionsFromStringTest, MessageStringReturnsMessageMode)
 {
-  std::string compression_mode_string{"MESSAGE"};
-  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  const std::string compression_mode_string{"MESSAGE"};
+  const auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
   EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::MESSAGE);
 }
 
 TEST(CompressionOptionsToStringTest, BadModeReturnsNoneString)
 {
   const auto compression_mode = static_cast<rosbag2_cpp::CompressionMode>(100);
-  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  const auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
   EXPECT_EQ(compression_mode_string, "NONE");
 }
 
 TEST(CompressionOptionsToStringTest, MessageModeReturnsMessageString)
 {
-  auto compression_mode = rosbag2_cpp::CompressionMode::MESSAGE;
-  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  const auto compression_mode = rosbag2_cpp::CompressionMode::MESSAGE;
+  const auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
   EXPECT_EQ(compression_mode_string, "MESSAGE");
 }
 
 TEST(CompressionOptionsToStringTest, FileModeReturnsFileString)
 {
-  auto compression_mode = rosbag2_cpp::CompressionMode::FILE;
-  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  const auto compression_mode = rosbag2_cpp::CompressionMode::FILE;
+  const auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
   EXPECT_EQ(compression_mode_string, "FILE");
 }
 
 TEST(CompressionOptionsToStringTest, NoneModeReturnsNoneString)
 {
-  auto compression_mode = rosbag2_cpp::CompressionMode::NONE;
-  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  const auto compression_mode = rosbag2_cpp::CompressionMode::NONE;
+  const auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
   EXPECT_EQ(compression_mode_string, "NONE");
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_compression_options.cpp
@@ -1,0 +1,61 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <string>
+
+#include "rosbag2_cpp/compression_options.hpp"
+
+TEST(CompressionOptionsFromStringTest, BadInputReturnsNoneMode)
+{
+  std::string compression_mode_string{"bad_mode"};
+  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::NONE);
+}
+
+TEST(CompressionOptionsFromStringTest, FileStringReturnsFileMode)
+{
+  std::string compression_mode_string{"file"};
+  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::FILE);
+}
+
+TEST(CompressionOptionsFromStringTest, MessageStringReturnsMessageMode)
+{
+  std::string compression_mode_string{"MESSAGE"};
+  auto compression_mode = rosbag2_cpp::compression_mode_from_string(compression_mode_string);
+  EXPECT_EQ(compression_mode, rosbag2_cpp::CompressionMode::MESSAGE);
+}
+
+TEST(CompressionOptionsToStringTest, MessageModeReturnsMessageString)
+{
+  auto compression_mode = rosbag2_cpp::CompressionMode::MESSAGE;
+  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  EXPECT_EQ(compression_mode_string, "MESSAGE");
+}
+
+TEST(CompressionOptionsToStringTest, FileModeReturnsFileString)
+{
+  auto compression_mode = rosbag2_cpp::CompressionMode::FILE;
+  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  EXPECT_EQ(compression_mode_string, "FILE");
+}
+
+TEST(CompressionOptionsToStringTest, NoneModeReturnsNoneString)
+{
+  auto compression_mode = rosbag2_cpp::CompressionMode::NONE;
+  auto compression_mode_string = rosbag2_cpp::compression_mode_to_string(compression_mode);
+  EXPECT_EQ(compression_mode_string, "NONE");
+}

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -30,6 +30,21 @@
 #include "mock_storage.hpp"
 #include "mock_storage_factory.hpp"
 
+namespace
+{
+rosbag2_storage::TopicMetadata create_topic_metadata(
+  const std::string & name = "topic",
+  const std::string & type = "test_msgs/BasicTypes",
+  const std::string & serialization_format = "rmw1_format")
+{
+  rosbag2_storage::TopicMetadata topic_with_type;
+  topic_with_type.name = name;
+  topic_with_type.type = type;
+  topic_with_type.serialization_format = serialization_format;
+  return topic_with_type;
+}
+}  // namespace
+
 using namespace testing;  // NOLINT
 
 class MultifileReaderTest : public Test
@@ -39,19 +54,16 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
-    relative_path_1_("some_relativ_path_1"),
+    relative_path_1_("some_relative_path_1"),
     relative_path_2_("some_relative_path_2")
   {
-    rosbag2_storage::TopicMetadata topic_with_type;
-    topic_with_type.name = "topic";
-    topic_with_type.type = "test_msgs/BasicTypes";
-    topic_with_type.serialization_format = storage_serialization_format_;
+    auto topic_with_type =
+      create_topic_metadata("topic", "test_msgs/BasicTypes", storage_serialization_format_);
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
 
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type.name;
 
-    auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
     rosbag2_storage::BagMetadata metadata;
     metadata.relative_file_paths.push_back(relative_path_1_);
@@ -60,6 +72,7 @@ public:
     ON_CALL(*metadata_io, read_metadata(_)).WillByDefault(Return(metadata));
     EXPECT_CALL(*metadata_io, metadata_file_exists(_)).WillRepeatedly(Return(true));
 
+    auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));
     ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
@@ -113,4 +126,76 @@ TEST_F(MultifileReaderTest, read_next_throws_if_no_storage)
 TEST_F(MultifileReaderTest, get_all_topics_and_types_throws_if_no_storage)
 {
   EXPECT_ANY_THROW(reader_->get_all_topics_and_types());
+}
+
+class FakeSequentialReader : public rosbag2_cpp::readers::SequentialReader
+{
+public:
+  FakeSequentialReader(
+    std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
+    std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory,
+    std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
+    : SequentialReader(std::move(storage_factory),
+      std::move(converter_factory),
+      std::move(metadata_io)) {}
+
+  void decompress_message(rosbag2_storage::SerializedBagMessage *) override
+  {
+    decompress_message_called = true;
+  }
+
+  void decompress_file(const std::string &) override
+  {
+    decompress_file_called = true;
+  }
+
+  bool decompress_message_called = false;
+  bool decompress_file_called = false;
+};
+
+class ReaderCompressionTest : public Test
+{
+public:
+  ReaderCompressionTest()
+  : storage_(std::make_shared<NiceMock<MockStorage>>())
+  {
+    auto topic_with_type = create_topic_metadata();
+
+    auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+    message->topic_name = topic_with_type.name;
+
+    auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
+    rosbag2_storage::BagMetadata metadata;
+    metadata.relative_file_paths = {"some_relative_path_1", "some_relative_path_2"};
+    metadata.topics_with_message_count.push_back({{topic_with_type}, 1});
+    metadata.compression_mode = rosbag2_cpp::compression_mode_to_string(
+      rosbag2_cpp::CompressionMode::FILE);
+    metadata.compression_format = "test-compression";
+    EXPECT_CALL(*metadata_io, read_metadata(_)).WillRepeatedly(Return(metadata));
+    EXPECT_CALL(*metadata_io, metadata_file_exists(_)).WillRepeatedly(Return(true));
+
+    auto storage_factory = std::make_unique<NiceMock<MockStorageFactory>>();
+    ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
+    EXPECT_CALL(*storage_factory, open_read_only(_, _)).WillRepeatedly(Return(storage_));
+
+    fake_sequential_reader_ = std::make_unique<FakeSequentialReader>(
+      std::move(storage_factory), converter_factory_, std::move(metadata_io));
+  }
+
+  std::shared_ptr<NiceMock<MockStorage>> storage_;
+  std::shared_ptr<NiceMock<MockConverterFactory>> converter_factory_;
+  std::unique_ptr<FakeSequentialReader> fake_sequential_reader_;
+};
+
+TEST_F(ReaderCompressionTest, decompress_if_metadata_has_file_compression) {
+  // storage::has_next() is called twice when reader::has_next() is called
+  EXPECT_CALL(*storage_, has_next()).Times(4)
+    .WillOnce(Return(true)).WillOnce(Return(true))    // We have a message
+    .WillOnce(Return(false))   // No message, load next file
+    .WillOnce(Return(true));
+  fake_sequential_reader_->open(rosbag2_cpp::StorageOptions(), {"", "rmw1_format"});
+  fake_sequential_reader_->has_next();
+  fake_sequential_reader_->read_next();
+  fake_sequential_reader_->has_next();
+  EXPECT_EQ(fake_sequential_reader_->decompress_file_called, true);
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "rosbag2_cpp/compression_options.hpp"
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -141,16 +141,16 @@ public:
 
   void decompress_message(rosbag2_storage::SerializedBagMessage *) override
   {
-    decompress_message_called = true;
+    decompress_message_call_counter++;
   }
 
   void decompress_file(const std::string &) override
   {
-    decompress_file_called = true;
+    decompress_file_call_counter++;
   }
 
-  bool decompress_message_called = false;
-  bool decompress_file_called = false;
+  int decompress_message_call_counter = 0;
+  int decompress_file_call_counter = 0;
 };
 
 class ReaderCompressionTest : public Test
@@ -160,9 +160,9 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<NiceMock<MockConverterFactory>>())
   {
-    auto topic_with_type = create_topic_metadata();
+    auto topic_metadata_ = create_topic_metadata();
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-    message->topic_name = topic_with_type.name;
+    message->topic_name = topic_metadata_.name;
     ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
   }
 
@@ -217,5 +217,5 @@ TEST_F(ReaderCompressionTest, decompress_if_metadata_has_file_compression) {
   fake_sequential_reader->has_next();
   fake_sequential_reader->read_next();
   fake_sequential_reader->has_next();
-  EXPECT_EQ(fake_sequential_reader->decompress_file_called, true);
+  EXPECT_GT(fake_sequential_reader->decompress_file_call_counter, 0);
 }


### PR DESCRIPTION
This PR allows a Reader to decompress a file or serialized bag message by checking the bag file metadata.
It currently supports the Zstd decompressor only.
Creating a decompressor factory will be part of a later change.

## Changes

* Reader can now read from a compressed file or message.
* Validate metadata keys for compression, supporting older metadata versions.
* Unit test to check that compression occurs when specified in metadata.
* Unit test to check that compression options can be converted b/w string/enum.

Part of [aws-roadmap/#68](https://github.com/ros-security/aws-roadmap/issues/68).