### PR TITLE
Add unit test for SequentialReader when metadata file does not exist

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -137,6 +137,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_sequential_reader ${PROJECT_NAME})
   endif()
 
+  ament_add_gmock(test_storage_without_metadata_file
+    test/rosbag2_cpp/test_storage_without_metadata_file.cpp)
+  if(TARGET test_storage_without_metadata_file)
+    target_link_libraries(test_storage_without_metadata_file ${PROJECT_NAME})
+  endif()
+
   # If compiling with gcc, run this test with sanitizers enabled
   ament_add_gmock(test_ros2_message
     test/rosbag2_cpp/types/test_ros2_message.cpp

--- a/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
@@ -1,0 +1,88 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <utility>
+
+#include "rosbag2_cpp/readers/sequential_reader.hpp"
+#include "rosbag2_cpp/reader.hpp"
+
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
+
+#include "mock_converter.hpp"
+#include "mock_converter_factory.hpp"
+#include "mock_metadata_io.hpp"
+#include "mock_storage.hpp"
+#include "mock_storage_factory.hpp"
+using namespace testing;  // NOLINT
+
+namespace
+{
+constexpr const char kTopicName[] = "topic";
+constexpr const char kStorageId[] = "StoragePlugin";
+constexpr const char kRmwFormat[] = "rmw1_format";
+}  // namespace
+
+class StorageWithoutMetadataFileTest : public Test
+{
+public:
+  StorageWithoutMetadataFileTest()
+  : storage_{std::make_shared<NiceMock<MockStorage>>()},
+    converter_factory_{std::make_shared<NiceMock<MockConverterFactory>>()}
+  {}
+
+  std::shared_ptr<NiceMock<MockStorage>> storage_;
+  std::shared_ptr<NiceMock<MockConverterFactory>> converter_factory_;
+};
+
+TEST_F(StorageWithoutMetadataFileTest, open_uses_storage_id_from_storage_options) {
+  {
+    auto topic_with_type = rosbag2_storage::TopicMetadata{
+      "topic",
+      "test_msgs/BasicTypes",
+      kRmwFormat
+    };
+
+    auto topic_information = rosbag2_storage::TopicInformation{
+      topic_with_type,
+      1
+    };
+
+    rosbag2_storage::BagMetadata metadata;
+    metadata.relative_file_paths = {"TestPath"};
+    metadata.topics_with_message_count = {topic_information};
+
+    EXPECT_CALL(*storage_, get_metadata).Times(1).WillOnce(Return(metadata));
+  }
+
+  auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
+  EXPECT_CALL(*storage_factory, open_read_only(_, kStorageId)).Times(1).WillOnce(Return(storage_));
+
+  auto metadata_io = std::make_unique<StrictMock<MockMetadataIo>>();
+  EXPECT_CALL(*metadata_io, metadata_file_exists).Times(1).WillOnce(Return(false));
+
+  rosbag2_cpp::StorageOptions storage_options;
+  storage_options.storage_id = kStorageId;
+
+  auto sequential_reader = std::make_unique<rosbag2_cpp::readers::SequentialReader>(
+    std::move(storage_factory),
+    converter_factory_,
+    std::move(metadata_io));
+
+  sequential_reader->open(storage_options, {"", kRmwFormat});
+}

--- a/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
@@ -34,7 +34,6 @@ using namespace testing;  // NOLINT
 
 namespace
 {
-constexpr const char kTopicName[] = "topic";
 constexpr const char kStorageId[] = "StoragePlugin";
 constexpr const char kRmwFormat[] = "rmw1_format";
 }  // namespace

--- a/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
@@ -29,6 +29,7 @@
 #include "mock_metadata_io.hpp"
 #include "mock_storage.hpp"
 #include "mock_storage_factory.hpp"
+
 using namespace testing;  // NOLINT
 
 namespace


### PR DESCRIPTION
### Changes
* ~~Pass `storage_options.storage_id` to `open_storage` when metadata file doesn't exist~~ Resolved in https://github.com/ros2/rosbag2/pull/257
* ~~Add line break in `compression_options` since linters were complaining about line length.~~ Resolved in https://github.com/ros2/rosbag2/pull/256
* Add unit test to `rosbag_cpp` checking if `storage_id` is resolved when `metadata_file` does not exist.

### Issues
* #253 

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>