### PR TITLE
test rosbag2_cpp package

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@ jobs:
         linter: copyright
         package-name: |
             ros2bag
-            rosbag2
             rosbag2_compression
             rosbag2_converter_default_plugins
             rosbag2_cpp
@@ -59,7 +58,6 @@ jobs:
       with:
         linter: ${{ matrix.linter }}
         package-name: |
-            rosbag2
             rosbag2_compression
             rosbag2_converter_default_plugins
             rosbag2_cpp

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
             rosbag2
             rosbag2_compression
             rosbag2_converter_default_plugins
+            rosbag2_cpp
             rosbag2_test_common
             rosbag2_tests
             rosbag2_transport
@@ -37,6 +38,7 @@ jobs:
             rosbag2
             rosbag2_compression
             rosbag2_converter_default_plugins
+            rosbag2_cpp
             rosbag2_test_common
             rosbag2_tests
             rosbag2_transport
@@ -60,6 +62,7 @@ jobs:
             rosbag2
             rosbag2_compression
             rosbag2_converter_default_plugins
+            rosbag2_cpp
             rosbag2_test_common
             rosbag2_tests
             rosbag2_transport

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: ros-tooling/setup-ros2@0.0.11
     - uses: ros-tooling/action-ros2-ci@0.0.11
       with:
-        package-name: ros2bag rosbag2 rosbag2_compression rosbag2_cpp rosbag2_storage rosbag2_storage_default_plugins rosbag2_test_common rosbag2_tests shared_queues_vendor sqlite3_vendor
+        package-name: ros2bag rosbag2_compression rosbag2_cpp rosbag2_storage rosbag2_storage_default_plugins rosbag2_test_common rosbag2_tests shared_queues_vendor sqlite3_vendor
     - uses: actions/upload-artifact@master
       with:
         name: colcon-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: ros-tooling/setup-ros2@0.0.11
     - uses: ros-tooling/action-ros2-ci@0.0.11
       with:
-        package-name: ros2bag rosbag2 rosbag2_compression rosbag2_storage rosbag2_storage_default_plugins rosbag2_test_common rosbag2_tests shared_queues_vendor sqlite3_vendor
+        package-name: ros2bag rosbag2 rosbag2_compression rosbag2_cpp rosbag2_storage rosbag2_storage_default_plugins rosbag2_test_common rosbag2_tests shared_queues_vendor sqlite3_vendor
     - uses: actions/upload-artifact@master
       with:
         name: colcon-logs


### PR DESCRIPTION
adds `rosbag2_cpp` to the list of packages to test

More future-proof alternative: Modifying the actions to determine the package list based on repository content rather than requiring maintainers to provide an explicit list (if an explicit list is passed this could override the default of "all packages in the repo")