### PR TITLE
[compression] Enable compression through ros2bag cli

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -55,6 +55,15 @@ class RecordVerb(VerbExtension):
                   'Default it is zero, recording written in single bagfile and splitting '
                   'is disabled.'
         )
+        parser.add_argument(
+            '--compression-mode', type=str, default='none',
+            choices=['none', 'file', 'message'],
+            help='Determine whether to compress by file or message. Default is "none".'
+        )
+        parser.add_argument(
+            '--compression-format', type=str, default='', choices=['zstd'],
+            help='Specify the compression format/algorithm. Default is none.'
+        )
         self._subparser = parser
 
     def create_bag_directory(self, uri):
@@ -72,6 +81,10 @@ class RecordVerb(VerbExtension):
         if os.path.isdir(uri):
             return "[ERROR] [ros2bag]: Output folder '{}' already exists.".format(uri)
 
+        if args.compression_format and args.compression_mode == 'none':
+            return 'Invalid choice: Cannot specify compression format without a compression mode.'
+        args.compression_mode = args.compression_mode.upper()
+
         self.create_bag_directory(uri)
 
         if args.all:
@@ -87,6 +100,8 @@ class RecordVerb(VerbExtension):
                 storage_id=args.storage,
                 serialization_format=args.serialization_format,
                 node_prefix=NODE_NAME_PREFIX,
+                compression_mode=args.compression_mode,
+                compression_format=args.compression_format,
                 all=True,
                 no_discovery=args.no_discovery,
                 polling_interval=args.polling_interval,
@@ -104,6 +119,8 @@ class RecordVerb(VerbExtension):
                 storage_id=args.storage,
                 serialization_format=args.serialization_format,
                 node_prefix=NODE_NAME_PREFIX,
+                compression_mode=args.compression_mode,
+                compression_format=args.compression_format,
                 no_discovery=args.no_discovery,
                 polling_interval=args.polling_interval,
                 max_bagfile_size=args.max_bag_size,

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -89,6 +89,7 @@ install(
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}_zstd)
+ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rosbag2_storage rcutils zstd_vendor)
 
 if(BUILD_TESTING)

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -30,6 +30,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(rmw_fastrtps_cpp QUIET)
+  find_package(rosbag2_compression REQUIRED)
   find_package(rosbag2_cpp REQUIRED)
   find_package(rosbag2_storage REQUIRED)
   find_package(rosbag2_storage_default_plugins REQUIRED)
@@ -47,6 +48,7 @@ if(BUILD_TESTING)
     if(TARGET test_rosbag2_record_end_to_end)
       ament_target_dependencies(test_rosbag2_record_end_to_end
         rclcpp
+        rosbag2_compression
         rosbag2_storage
         rosbag2_storage_default_plugins
         rosbag2_test_common

--- a/rosbag2_tests/package.xml
+++ b/rosbag2_tests/package.xml
@@ -17,6 +17,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>ros2bag</test_depend>
+  <test_depend>rosbag2_compression</test_depend>
   <test_depend>rosbag2_cpp</test_depend>
   <test_depend>rosbag2_converter_default_plugins</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -82,6 +82,11 @@ public:
     return bag_file_name.str();
   }
 
+  rcpputils::fs::path get_compressed_bag_file_path(int split_index)
+  {
+    return root_bag_path_ / (get_bag_file_name(split_index) + ".db3.zstd");
+  }
+
   rcpputils::fs::path get_bag_file_path(int split_index)
   {
     return root_bag_path_ / (get_bag_file_name(split_index) + ".db3");

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -478,6 +478,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
   }
   #endif
 
+  wait_for_metadata();
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   for (const auto & path : metadata.relative_file_paths) {

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -453,7 +453,9 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
     metadata.compression_mode = "file";
     metadata.compression_format = "zstd";
 
-    for (int i = 0; i < expected_splits; ++i) {
+    // expected_splits - 1 since the last split is written by the dtor
+    // which might have been skipped due to SIGKILL
+    for (int i = 0; i < expected_splits - 1; ++i) {
       std::stringstream bag_name;
       bag_name << "bag_" << i << ".db3.zstd";
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -55,6 +55,7 @@ std::shared_ptr<test_msgs::msg::Strings> create_string_message(
 }
 }  // namespace
 
+#ifndef _WIN32
 TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
   auto message = get_messages_strings()[0];
   message->string_value = "test";
@@ -85,23 +86,6 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
 
   stop_execution(process_handle);
 
-  // TODO(zmichaels11): Find out how to correctly send a Ctrl-C signal on Windows
-  // This is necessary as the process is killed hard on Windows and doesn't write a metadata file
-#ifdef _WIN32
-  rosbag2_storage::BagMetadata metadata{};
-  metadata.version = 3;
-  metadata.storage_identifier = "sqlite3";
-  metadata.relative_file_paths = {"bag_0.db3.zstd"};
-  metadata.duration = std::chrono::nanoseconds{0};
-  metadata.starting_time =
-    std::chrono::time_point<std::chrono::high_resolution_clock>{std::chrono::nanoseconds{0}};
-  metadata.message_count = 0;
-  metadata.compression_mode = "file";
-  metadata.compression_format = "zstd";
-  rosbag2_storage::MetadataIo metadata_io;
-  metadata_io.write_metadata(root_bag_path_, metadata);
-#endif
-
   const auto compressed_database_path = database_path_ + ".zstd";
   ASSERT_TRUE(rcpputils::fs::path(compressed_database_path).exists());
 
@@ -120,6 +104,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
   auto wrong_topic_messages = get_messages_for_topic<test_msgs::msg::BasicTypes>("/wrong_topic");
   EXPECT_THAT(wrong_topic_messages, IsEmpty());
 }
+#endif
 
 TEST_F(RecordFixture, record_end_to_end_test) {
   auto message = get_messages_strings()[0];

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -470,12 +470,12 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
   const auto metadata = metadata_io.read_metadata(root_bag_path_);
 
   for (const auto & path : metadata.relative_file_paths) {
-    const auto file_path = rcpputils::fs::path(path);
+    const auto file_path = rcpputils::fs::path{path};
 
-    EXPECT_TRUE(file_path.exists());
-    EXPECT_EQ(file_path.extension().string(), ".zstd");
-
-    EXPECT_LT(static_cast<int>(rcutils_get_file_size(path.c_str())), bagfile_split_size);
+    EXPECT_TRUE(file_path.exists()) << "File: \"" <<
+      file_path.string() << "\" does not exist!";
+    EXPECT_EQ(file_path.extension().string(), ".zstd") << "File :\"" <<
+      file_path.string() << "\" does not have proper \".zstd\" extension!";
   }
 }
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -82,7 +82,8 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
     database_path,
     rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY};
 
-  pub_man_.run_publishers([this, &db](const std::string & topic_name) {
+  pub_man_.run_publishers(
+    [this, &db](const std::string & topic_name) {
       return count_stored_messages(db, topic_name);
     });
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -21,6 +21,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/filesystem.h"
+#include "rosbag2_compression/zstd_decompressor.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_test_common/process_execution_helpers.hpp"
 
@@ -53,6 +54,72 @@ std::shared_ptr<test_msgs::msg::Strings> create_string_message(
   return message;
 }
 }  // namespace
+
+TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
+  auto message = get_messages_strings()[0];
+  message->string_value = "test";
+  size_t expected_test_messages = 3;
+
+  auto wrong_message = get_messages_strings()[0];
+  wrong_message->string_value = "wrong_content";
+
+  std::stringstream cmd;
+  cmd << "ros2 bag record" <<
+    " --compression-mode file" <<
+    " --compression-format zstd" <<
+    " --output " << root_bag_path_ <<
+    " /test_topic";
+  auto process_handle = start_execution(cmd.str());
+  wait_for_db();
+
+  pub_man_.add_publisher("/test_topic", message, expected_test_messages);
+  pub_man_.add_publisher("/wrong_topic", wrong_message);
+
+  rosbag2_storage_plugins::SqliteWrapper db{
+    database_path_,
+    rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY};
+
+  pub_man_.run_publishers([this, &db](const std::string & topic_name) {
+      return count_stored_messages(db, topic_name);
+    });
+
+  stop_execution(process_handle);
+
+  // TODO(zmichaels11): Find out how to correctly send a Ctrl-C signal on Windows
+  // This is necessary as the process is killed hard on Windows and doesn't write a metadata file
+#ifdef _WIN32
+  rosbag2_storage::BagMetadata metadata{};
+  metadata.version = 3;
+  metadata.storage_identifier = "sqlite3";
+  metadata.relative_file_paths = {"bag_0.db3.zstd"};
+  metadata.duration = std::chrono::nanoseconds{0};
+  metadata.starting_time =
+    std::chrono::time_point<std::chrono::high_resolution_clock>{std::chrono::nanoseconds{0}};
+  metadata.message_count = 0;
+  metadata.compression_mode = "file";
+  metadata.compression_format = "zstd";
+  rosbag2_storage::MetadataIo metadata_io;
+  metadata_io.write_metadata(root_bag_path_, metadata);
+#endif
+
+  const auto compressed_database_path = database_path_ + ".zstd";
+  ASSERT_TRUE(rcpputils::fs::path(compressed_database_path).exists());
+
+  rosbag2_compression::ZstdDecompressor decompressor;
+
+  const auto decompressed_uri = decompressor.decompress_uri(compressed_database_path);
+
+  ASSERT_EQ(decompressed_uri, database_path_);
+
+  auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>("/test_topic");
+  EXPECT_THAT(test_topic_messages, SizeIs(Ge(expected_test_messages)));
+  EXPECT_THAT(test_topic_messages,
+    Each(Pointee(Field(&test_msgs::msg::Strings::string_value, "test"))));
+  EXPECT_THAT(get_rwm_format_for_topic("/test_topic", db), Eq(rmw_get_serialization_format()));
+
+  auto wrong_topic_messages = get_messages_for_topic<test_msgs::msg::BasicTypes>("/wrong_topic");
+  EXPECT_THAT(wrong_topic_messages, IsEmpty());
+}
 
 TEST_F(RecordFixture, record_end_to_end_test) {
   auto message = get_messages_strings()[0];
@@ -356,7 +423,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   }
 }
 
-TEST_F(RecordFixture, record_end_to_end_with_zstd_file_compression) {
+TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compresses_files) {
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
 
@@ -396,12 +463,14 @@ TEST_F(RecordFixture, record_end_to_end_with_zstd_file_compression) {
   #ifdef _WIN32
   {
     rosbag2_storage::BagMetadata metadata;
-    metadata.version = 2;
+    metadata.version = 3;
     metadata.storage_identifier = "sqlite3";
+    metadata.compression_mode = "file";
+    metadata.compression_format = "zstd";
 
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bag_name;
-      bag_name << "bag_" << i << ".db3";
+      bag_name << "bag_" << i << ".db3.zstd";
 
       const auto bag_path = rcpputils::fs::path(root_bag_path_) / bag_name.str();
 

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
+find_package(rosbag2_compression REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(shared_queues_vendor REQUIRED)
 
@@ -46,6 +47,7 @@ ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rcutils
   rmw
+  rosbag2_compression
   rosbag2_cpp
   rosidl_generator_cpp
   shared_queues_vendor
@@ -58,7 +60,7 @@ add_library(rosbag2_transport_py
   src/rosbag2_transport/rosbag2_transport_python.cpp)
 configure_python_c_extension_library(rosbag2_transport_py)
 target_link_libraries(rosbag2_transport_py rosbag2_transport)
-
+ament_target_dependencies(rosbag2_transport_py rosbag2_compression)
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_TRANSPORT_BUILDING_LIBRARY")
@@ -78,7 +80,7 @@ install(
 ament_export_include_directories(include)
 ament_export_interfaces(export_${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
-ament_export_dependencies(rosbag2_cpp)
+ament_export_dependencies(rosbag2_cpp rosbag2_compression)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -30,6 +30,8 @@ public:
   std::string rmw_serialization_format;
   std::chrono::milliseconds topic_polling_interval;
   std::string node_prefix = "";
+  std::string compression_mode = "NONE";
+  std::string compression_format = "";
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -30,7 +30,7 @@ public:
   std::string rmw_serialization_format;
   std::chrono::milliseconds topic_polling_interval;
   std::string node_prefix = "";
-  std::string compression_mode = "NONE";
+  std::string compression_mode = "";
   std::string compression_format = "";
 };
 

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -12,6 +12,7 @@
 
   <depend>python_cmake_module</depend>
   <depend>rclcpp</depend>
+  <depend>rosbag2_compression</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rmw</depend>
   <depend>shared_queues_vendor</depend>

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -116,12 +116,14 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   auto info = std::make_shared<rosbag2_cpp::Info>();
   auto reader = std::make_shared<rosbag2_cpp::Reader>(
     std::make_unique<rosbag2_cpp::readers::SequentialReader>());
-  auto writer = std::make_shared<rosbag2_cpp::Writer>(
-    std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
+  std::shared_ptr<rosbag2_cpp::Writer> writer;
   // Change writer based on recording options
   if (record_options.compression_format == "zstd") {
     writer = std::make_shared<rosbag2_cpp::Writer>(
       std::make_unique<rosbag2_compression::SequentialCompressionWriter>(compression_options));
+  } else {
+    writer = std::make_shared<rosbag2_cpp::Writer>(
+      std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
   }
 
   rosbag2_transport::Rosbag2Transport transport(reader, writer, info);
@@ -170,8 +172,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   rosbag2_storage::BagMetadata metadata{};
   // Specify defaults
   auto info = std::make_shared<rosbag2_cpp::Info>();
-  auto reader = std::make_shared<rosbag2_cpp::Reader>(
-    std::make_unique<rosbag2_cpp::readers::SequentialReader>());
+  std::shared_ptr<rosbag2_cpp::Reader> reader;
   auto writer = std::make_shared<rosbag2_cpp::Writer>(
     std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
   // Change reader based on metadata options
@@ -180,8 +181,15 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
     if (metadata.compression_format == "zstd") {
       reader = std::make_shared<rosbag2_cpp::Reader>(
         std::make_unique<rosbag2_compression::SequentialCompressionReader>());
+    } else {
+      reader = std::make_shared<rosbag2_cpp::Reader>(
+        std::make_unique<rosbag2_cpp::readers::SequentialReader>());
     }
+  } else {
+    reader = std::make_shared<rosbag2_cpp::Reader>(
+      std::make_unique<rosbag2_cpp::readers::SequentialReader>());
   }
+
   rosbag2_transport::Rosbag2Transport transport(reader, writer, info);
   transport.init();
   transport.play(storage_options, play_options);


### PR DESCRIPTION
### Changes
* Add `--compression-mode` and `--compression-format` arguments for `ros2bag`
* `rosbag2_transport` instantiates `SequentialCompressionReader` or `SequentialCompressionWriter` if both `compression-mode` and `compression-format` are specified.

### Testing
* Add e2e test to verify bagfiles are compressed
* Add e2e test to verify compressed bagfiles can be read