### PR TITLE
Fixed #266 with updated documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Clone this repository into the source folder:
 ```
 $ git clone https://github.com/ros2/rosbag2.git
 ```
+**[Note]**: if you are only building rosbag2 on top of a Debian Installation of ROS2, please git clone the branch following your current ROS2 distribution. 
 
 Then build all the packages with this command:
 


### PR DESCRIPTION
# Description of Pull Request
This is a quick edit to the `README.md` documentation file to help existing and future **rosbag2** users avoid the issue highlighted in #266. 

# Summary of Issue #266 
The issue was a build error encountered when building **rosbag2** from source  using the **master** branch. It is resolved by building **rosbag2** using distribution specific branches provided. 