### PR TITLE
Improve testing robustness on Windows

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -17,6 +17,7 @@
 
 #include <gmock/gmock.h>
 
+#include <iostream>
 #include <string>
 
 #ifdef _WIN32
@@ -76,7 +77,16 @@ public:
     file_options.lpszProgressTitle = nullptr;
     file_options.hNameMappings = nullptr;
 
-    SHFileOperation(&file_options);
+    const auto rc = SHFileOperation(&file_options);
+    if (0 != rc) {
+      std::cerr << "Failed to recursively delete '" << directory_path <<
+        "' Error code: " << rc << std::endl;
+    }
+
+    if (file_options.fAnyOperationsAborted) {
+      std::cerr << "Recursive delete of '" << directory_path <<
+        "' was aborted." << std::endl;
+    }
     delete[] temp_dir;
 #else
     DIR * dir = opendir(directory_path.c_str());

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -51,6 +51,11 @@ public:
     std::cout << "Database " << database_path_ << " in " << temporary_dir_path_ << std::endl;
   }
 
+  void TearDown() override
+  {
+    remove_directory_recursively(root_bag_path_);
+  }
+
   static void SetUpTestCase()
   {
     rclcpp::init(0, nullptr);

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -55,8 +55,9 @@ std::shared_ptr<test_msgs::msg::Strings> create_string_message(
 }  // namespace
 
 TEST_F(RecordFixture, record_end_to_end_test) {
+  constexpr const char message_contents[] = "test";
   auto message = get_messages_strings()[0];
-  message->string_value = "test";
+  message->string_value = message_contents;
   size_t expected_test_messages = 3;
 
   auto wrong_message = get_messages_strings()[0];
@@ -94,8 +95,11 @@ TEST_F(RecordFixture, record_end_to_end_test) {
 
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>("/test_topic");
   EXPECT_THAT(test_topic_messages, SizeIs(Ge(expected_test_messages)));
-  EXPECT_THAT(test_topic_messages,
-    Each(Pointee(Field(&test_msgs::msg::Strings::string_value, "test"))));
+
+  for (const auto & message : test_topic_messages) {
+    EXPECT_EQ(message->string_value, message_contents);
+  }
+
   EXPECT_THAT(get_rwm_format_for_topic("/test_topic", db), Eq(rmw_get_serialization_format()));
 
   auto wrong_topic_messages = get_messages_for_topic<test_msgs::msg::BasicTypes>("/wrong_topic");


### PR DESCRIPTION
### Changes
* Deletes the bag file generated during an e2e test on TearDown.
* Use for-each loop instead since `Each(Pointee(Field(` was reporting memory errors in valgrind.
* Check return code on SHFileOperation and status of `fAnyOperationsAborted`

### Issues
* [unstable Windows build](https://ci.ros2.org/job/ci_windows/9083/consoleFull#console-section-247) was caused by e2e test finding old bag files. This is only a problem on Windows since the Windows workaround generates a metadata file.