### PR TITLE
Use a separate bag per test

### DIFF
--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -48,6 +48,21 @@ public:
     set_path("bag");
   }
 
+  /**
+   * Return the name of the currently executing unit test.
+   */
+  std::string get_test_name() const
+  {
+    const auto * test_info = UnitTest::GetInstance()->current_test_info();
+
+    return test_info->name();
+  }
+
+  /**
+   * Configures all bag related paths.
+   * A unique bagname should be used for each test to make it so each test cannot reuse resources.
+   * Resources may be left over from tests depending on the filesystem and if tests properly terminated.
+   */
   void set_path(const std::string & bagname)
   {
     auto root_path = rcpputils::fs::path{temporary_dir_path_} / bagname;

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -66,14 +66,13 @@ public:
   void set_path(const std::string & bagname)
   {
     auto root_path = rcpputils::fs::path{temporary_dir_path_} / bagname;
+    ASSERT_FALSE(root_path.exists()) << "Path: \"" << bagname <<
+      "\" already exists!";
 
-    if (root_path.exists()) {
-      remove_directory_recursively(root_path.string());
-    }
+    root_bag_path_ = root_path.string();
 
     const std::string first_bagfile = bagname + "_0";
 
-    root_bag_path_ = root_path.string();
     storage_path_ = (root_path / first_bagfile).string();
     database_path_ = storage_path_ + ".db3";
   }

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -45,18 +45,23 @@ class RecordFixture : public TemporaryDirectoryFixture
 public:
   RecordFixture()
   {
-    root_bag_path_ = (rcpputils::fs::path(temporary_dir_path_) / "bag").string();
-    storage_path_ = (rcpputils::fs::path(root_bag_path_) / "bag_0").string();
-    database_path_ = storage_path_ + ".db3";
-    std::cout << "Database " << database_path_ << " in " << temporary_dir_path_ << std::endl;
+    set_path("bag");
   }
 
-  void SetUp() override
+  void set_path(const std::string & bagname)
   {
-    const auto path = rcpputils::fs::path{root_bag_path_};
-    if (rcpputils::fs::exists(path)) {
-      remove_directory_recursively(path.string());
+    auto root_path = rcpputils::fs::path{temporary_dir_path_} / bagname;
+
+    if (root_path.exists()) {
+      remove_directory_recursively(root_path.string());
     }
+
+    const std::string first_bagfile = bagname + "_0";
+
+    root_bag_path_ = root_path.string();
+    storage_path_ = (root_path / first_bagfile).string();
+    database_path_ = storage_path_ + ".db3";
+    std::cout << "Database " << database_path_ << " in " << temporary_dir_path_ << std::endl;
   }
 
   static void SetUpTestCase()

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -61,7 +61,6 @@ public:
     root_bag_path_ = root_path.string();
     storage_path_ = (root_path / first_bagfile).string();
     database_path_ = storage_path_ + ".db3";
-    std::cout << "Database " << database_path_ << " in " << temporary_dir_path_ << std::endl;
   }
 
   static void SetUpTestCase()

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -55,7 +55,8 @@ std::shared_ptr<test_msgs::msg::Strings> create_string_message(
 }  // namespace
 
 TEST_F(RecordFixture, record_end_to_end_test) {
-  set_path("record");
+  constexpr const char bag_file_name[] = "simple_record";
+  set_path(bag_file_name);
   auto message = get_messages_strings()[0];
   message->string_value = "test";
   size_t expected_test_messages = 3;
@@ -85,7 +86,8 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::BagMetadata metadata{};
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
-  metadata.relative_file_paths = {"record_0.db3"};
+  std::string bag_file_path = std::string(bag_file_name) + "_0.db3";
+  metadata.relative_file_paths = {bag_file_name};
   metadata.duration = std::chrono::nanoseconds(0);
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));
@@ -205,12 +207,9 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 
     // Loop until expected_splits in case it split or the bagfile doesn't exist.
     for (int i = 0; i < expected_splits; ++i) {
-      std::stringstream file_name;
-      file_name << bag_file_name << i << ".db3";
-
-      const auto bag_file_path =
-        (rcpputils::fs::path(root_bag_path_) / file_name.str());
-
+      std::stringstream bag_name;
+      bag_name << bag_file_name << "_" << i << ".db3";
+      const auto bag_file_path = rcpputils::fs::path(root_bag_path_) / bag_name.str();
       if (bag_file_path.exists()) {
         metadata.relative_file_paths.push_back(bag_file_path.string());
       } else {
@@ -347,7 +346,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
 
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bag_name;
-      bag_name << bag_file_name << i << ".db3";
+      bag_name << bag_file_name << "_" << i << ".db3";
 
       const auto bag_path = rcpputils::fs::path(root_bag_path_) / bag_name.str();
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -85,7 +85,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::BagMetadata metadata{};
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
-  metadata.relative_file_paths = {"bag_0.db3"};
+  metadata.relative_file_paths = {"record_0.db3"};
   metadata.duration = std::chrono::nanoseconds(0);
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));
@@ -173,7 +173,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   command << "ros2 bag record " <<
     " --output " << root_bag_path_ <<
     " --max-bag-size " << bagfile_split_size <<
-    " " << topic_name;
+    " " << topic_name <<
+    " __log_level:=debug";
   auto process_handle = start_execution(command.str());
   wait_for_db();
 
@@ -204,7 +205,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
     // Loop until expected_splits in case it split or the bagfile doesn't exist.
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bagfile_name;
-      bagfile_name << "bag_" << i << ".db3";
+      bagfile_name << "splitting_size_" << i << ".db3";
 
       const auto bagfile_path =
         (rcpputils::fs::path(root_bag_path_) / bagfile_name.str());
@@ -278,7 +279,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
     metadata.version = 2;
     metadata.storage_identifier = "sqlite3";
 
-    const auto bag_path = rcpputils::fs::path(root_bag_path_) / "bag_0.db3";
+    const auto bag_path = rcpputils::fs::path(root_bag_path_) / "not_split_0.db3";
 
     metadata.relative_file_paths = {bag_path.string()};
     metadata_io.write_metadata(root_bag_path_, metadata);
@@ -338,7 +339,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
 
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bag_name;
-      bag_name << "bag_" << i << ".db3";
+      bag_name << "splits_" << i << ".db3";
 
       const auto bag_path = rcpputils::fs::path(root_bag_path_) / bag_name.str();
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -112,7 +112,8 @@ TEST_F(RecordFixture, record_end_to_end_test) {
 // Stopping the process on Windows does a hard kill and the metadata file is not written.
 #ifndef _WIN32
 TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_topics) {
-  set_path("splitting_metadata");
+  constexpr const char bagfile_name[] = "splitting_metadata";
+  set_path(bagfile_name);
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
   command << "ros2 bag record" <<
@@ -166,7 +167,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 #endif
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size) {
-  set_path("splitting_size");
+  constexpr const char bagfile_name[] = "splitting_size";
+  set_path(bagfile_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
@@ -204,7 +206,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
     // Loop until expected_splits in case it split or the bagfile doesn't exist.
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bagfile_name;
-      bagfile_name << "splitting_size_" << i << ".db3";
+      bagfile_name << bagfile_name << i << ".db3";
 
       const auto bagfile_path =
         (rcpputils::fs::path(root_bag_path_) / bagfile_name.str());
@@ -240,7 +242,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
-  set_path("not_split");
+  constexpr const char bagfile_name[] = "not_split";
+  set_path(bagfile_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
@@ -278,7 +281,9 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
     metadata.version = 2;
     metadata.storage_identifier = "sqlite3";
 
-    const auto bag_path = rcpputils::fs::path(root_bag_path_) / "not_split_0.db3";
+    std::stringstream filename;
+    filename << bagfile_name << "_0.db3";
+    const auto bag_path = rcpputils::fs::path(root_bag_path_) / bagfile_name.str();
 
     metadata.relative_file_paths = {bag_path.string()};
     metadata_io.write_metadata(root_bag_path_, metadata);
@@ -296,7 +301,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
-  set_path("splits");
+  constexpr const char bagfile_name[] = "splits";
+  set_path(bagfile_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
 
@@ -338,7 +344,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
 
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bag_name;
-      bag_name << "splits_" << i << ".db3";
+      bag_name << bagfile_name << i << ".db3";
 
       const auto bag_path = rcpputils::fs::path(root_bag_path_) / bag_name.str();
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -55,6 +55,7 @@ std::shared_ptr<test_msgs::msg::Strings> create_string_message(
 }  // namespace
 
 TEST_F(RecordFixture, record_end_to_end_test) {
+  set_path("record");
   auto message = get_messages_strings()[0];
   message->string_value = "test";
   size_t expected_test_messages = 3;
@@ -111,6 +112,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
 // Stopping the process on Windows does a hard kill and the metadata file is not written.
 #ifndef _WIN32
 TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_topics) {
+  set_path("splitting_metadata");
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
   command << "ros2 bag record" <<
@@ -164,6 +166,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 #endif
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size) {
+  set_path("splitting_size");
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
@@ -237,6 +240,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
+  set_path("not_split");
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
@@ -292,6 +296,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
+  set_path("splits");
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -173,8 +173,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   command << "ros2 bag record " <<
     " --output " << root_bag_path_ <<
     " --max-bag-size " << bagfile_split_size <<
-    " " << topic_name <<
-    " __log_level:=debug";
+    " " << topic_name;
   auto process_handle = start_execution(command.str());
   wait_for_db();
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -86,8 +86,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::BagMetadata metadata{};
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
-  std::string bag_file_path = std::string(bag_file_name) + "_0.db3";
-  metadata.relative_file_paths = {bag_file_path};
+  metadata.relative_file_paths = {database_path_};
   metadata.duration = std::chrono::nanoseconds(0);
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -112,8 +112,8 @@ TEST_F(RecordFixture, record_end_to_end_test) {
 // Stopping the process on Windows does a hard kill and the metadata file is not written.
 #ifndef _WIN32
 TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_topics) {
-  constexpr const char bagfile_name[] = "splitting_metadata";
-  set_path(bagfile_name);
+  constexpr const char bag_file_name[] = "splitting_metadata";
+  set_path(bag_file_name);
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
   command << "ros2 bag record" <<
@@ -167,8 +167,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 #endif
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size) {
-  constexpr const char bagfile_name[] = "splitting_size";
-  set_path(bagfile_name);
+  constexpr const char bag_file_name[] = "splitting_size";
+  set_path(bag_file_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
@@ -205,14 +205,14 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 
     // Loop until expected_splits in case it split or the bagfile doesn't exist.
     for (int i = 0; i < expected_splits; ++i) {
-      std::stringstream bagfile_name;
-      bagfile_name << bagfile_name << i << ".db3";
+      std::stringstream file_name;
+      file_name << bag_file_name << i << ".db3";
 
-      const auto bagfile_path =
-        (rcpputils::fs::path(root_bag_path_) / bagfile_name.str());
+      const auto bag_file_path =
+        (rcpputils::fs::path(root_bag_path_) / file_name.str());
 
-      if (bagfile_path.exists()) {
-        metadata.relative_file_paths.push_back(bagfile_path.string());
+      if (bag_file_path.exists()) {
+        metadata.relative_file_paths.push_back(bag_file_path.string());
       } else {
         break;
       }
@@ -233,6 +233,9 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   // Don't include the last bagfile since it won't be full
   for (int i = 0; i < actual_splits - 1; ++i) {
     const auto bagfile_path = metadata.relative_file_paths[i];
+
+    std::cout << "Checking: " << bagfile_path << std::endl;
+
     EXPECT_TRUE(rcpputils::fs::exists(bagfile_path));
 
     const auto actual_split_size = static_cast<int>(rcutils_get_file_size(bagfile_path.c_str()));
@@ -242,8 +245,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
-  constexpr const char bagfile_name[] = "not_split";
-  set_path(bagfile_name);
+  constexpr const char bag_file_name[] = "not_split";
+  set_path(bag_file_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
@@ -281,9 +284,9 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
     metadata.version = 2;
     metadata.storage_identifier = "sqlite3";
 
-    std::stringstream filename;
-    filename << bagfile_name << "_0.db3";
-    const auto bag_path = rcpputils::fs::path(root_bag_path_) / bagfile_name.str();
+    std::stringstream file_name;
+    file_name << bag_file_name << "_0.db3";
+    const auto bag_path = rcpputils::fs::path(root_bag_path_) / file_name.str();
 
     metadata.relative_file_paths = {bag_path.string()};
     metadata_io.write_metadata(root_bag_path_, metadata);
@@ -301,8 +304,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
-  constexpr const char bagfile_name[] = "splits";
-  set_path(bagfile_name);
+  constexpr const char bag_file_name[] = "splits";
+  set_path(bag_file_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
 
@@ -344,7 +347,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
 
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bag_name;
-      bag_name << bagfile_name << i << ".db3";
+      bag_name << bag_file_name << i << ".db3";
 
       const auto bag_path = rcpputils::fs::path(root_bag_path_) / bag_name.str();
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -87,7 +87,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   metadata.version = 1;
   metadata.storage_identifier = "sqlite3";
   std::string bag_file_path = std::string(bag_file_name) + "_0.db3";
-  metadata.relative_file_paths = {bag_file_name};
+  metadata.relative_file_paths = {bag_file_path};
   metadata.duration = std::chrono::nanoseconds(0);
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));
@@ -209,7 +209,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
     for (int i = 0; i < expected_splits; ++i) {
       std::stringstream bag_name;
       bag_name << bag_file_name << "_" << i << ".db3";
-      const auto bag_file_path = rcpputils::fs::path(root_bag_path_) / bag_name.str();
+      const auto bag_file_path = rcpputils::fs::path{root_bag_path_} / bag_name.str();
       if (bag_file_path.exists()) {
         metadata.relative_file_paths.push_back(bag_file_path.string());
       } else {
@@ -232,8 +232,6 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   // Don't include the last bagfile since it won't be full
   for (int i = 0; i < actual_splits - 1; ++i) {
     const auto bagfile_path = metadata.relative_file_paths[i];
-
-    std::cout << "Checking: " << bagfile_path << std::endl;
 
     EXPECT_TRUE(rcpputils::fs::exists(bagfile_path));
 
@@ -285,7 +283,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 
     std::stringstream file_name;
     file_name << bag_file_name << "_0.db3";
-    const auto bag_path = rcpputils::fs::path(root_bag_path_) / file_name.str();
+    const auto bag_path = rcpputils::fs::path{root_bag_path_} / file_name.str();
 
     metadata.relative_file_paths = {bag_path.string()};
     metadata_io.write_metadata(root_bag_path_, metadata);

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<test_msgs::msg::Strings> create_string_message(
 }  // namespace
 
 TEST_F(RecordFixture, record_end_to_end_test) {
-  constexpr const char bag_file_name[] = "simple_record";
+  const auto bag_file_name = get_test_name();
   set_path(bag_file_name);
   auto message = get_messages_strings()[0];
   message->string_value = "test";
@@ -113,7 +113,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
 // Stopping the process on Windows does a hard kill and the metadata file is not written.
 #ifndef _WIN32
 TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_topics) {
-  constexpr const char bag_file_name[] = "splitting_metadata";
+  const auto bag_file_name = get_test_name();
   set_path(bag_file_name);
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   std::stringstream command;
@@ -168,7 +168,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 #endif
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size) {
-  constexpr const char bag_file_name[] = "splitting_size";
+  const auto bag_file_name = get_test_name();
   set_path(bag_file_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
@@ -241,7 +241,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
-  constexpr const char bag_file_name[] = "not_split";
+  const auto bag_file_name = get_test_name();
   set_path(bag_file_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
@@ -300,7 +300,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 }
 
 TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
-  constexpr const char bag_file_name[] = "splits";
+  const auto bag_file_name = get_test_name();
   set_path(bag_file_name);
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.


### PR DESCRIPTION
There's a bug where E2E tests will begin with a bagfile already existing.
This changes the recording E2E tests to use a separate path per test which reduces test flakiness.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>