### PR TITLE
Wait for metadata to be written to disk

### DIFF
--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -89,7 +89,7 @@ public:
 
   void wait_for_metadata(int timeout_in_sec = 5)
   {
-    const auto metadata_path = rcpputils::fs::path{root_bag_path_} / "metadata.yaml";
+    const auto metadata_path = root_bag_path_ / "metadata.yaml";
     const auto start_time = std::chrono::steady_clock::now();
 
     while (std::chrono::steady_clock::now() - start_time < std::chrono::seconds(timeout_in_sec) &&

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -101,7 +101,8 @@ public:
       std::this_thread::sleep_for(50ms);
     }
     // Final check for metadata if we timeout. Fail otherwise
-    ASSERT_EQ(metadata_path.exists(), true) << "Could not find metadata.yaml";
+    ASSERT_EQ(metadata_path.exists(), true) << "Could not find metadata file: \"" <<
+      metadata_path.string() << "\"";
   }
 
   void wait_for_db()

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -87,6 +87,19 @@ public:
     return root_bag_path_ / (get_bag_file_name(split_index) + ".db3");
   }
 
+  void wait_for_metadata()
+  {
+    // Waits until metadata is written to disk since some platforms have slower IO sync times
+    // If the metadata does not exist, the test will timeout and fail
+    const auto metadata_path = rcpputils::fs::path{root_bag_path_} / "metadata.yaml";
+    while (true) {
+      if (metadata_path.exists()) {
+        return;
+      }
+      std::this_thread::sleep_for(50ms);
+    }
+  }
+
   void wait_for_db()
   {
     const auto database_path = get_bag_file_path(0);

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -87,12 +87,12 @@ public:
     return root_bag_path_ / (get_bag_file_name(split_index) + ".db3");
   }
 
-  void wait_for_metadata(int timeout_in_sec = 5)
+  void wait_for_metadata()
   {
     const auto metadata_path = root_bag_path_ / "metadata.yaml";
     const auto start_time = std::chrono::steady_clock::now();
 
-    while (std::chrono::steady_clock::now() - start_time < std::chrono::seconds(timeout_in_sec) &&
+    while (std::chrono::steady_clock::now() - start_time < std::chrono::seconds(5) &&
       rclcpp::ok())
     {
       if (metadata_path.exists()) {

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -91,7 +91,10 @@ public:
   {
     const auto metadata_path = rcpputils::fs::path{root_bag_path_} / "metadata.yaml";
     const auto start_time = std::chrono::steady_clock::now();
-    while (std::chrono::steady_clock::now() - start_time < std::chrono::seconds(timeout_in_sec)) {
+
+    while (std::chrono::steady_clock::now() - start_time < std::chrono::seconds(timeout_in_sec) &&
+      rclcpp::ok())
+    {
       if (metadata_path.exists()) {
         return;
       }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -94,6 +94,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::MetadataIo metadata_io;
   metadata_io.write_metadata(root_bag_path_.string(), metadata);
 #endif
+
   wait_for_metadata();
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>("/test_topic");
   EXPECT_THAT(test_topic_messages, SizeIs(Ge(expected_test_messages)));
@@ -217,7 +218,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 #endif
 
   wait_for_metadata();
-  const auto metadata = metadata_io.read_metadata(root_bag_path_);
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
   const auto actual_splits = static_cast<int>(metadata.relative_file_paths.size());
 
   // TODO(zmichaels11): Support reliable sync-to-disk for more accurate splits.
@@ -279,7 +280,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 #endif
 
   wait_for_metadata();
-  const auto metadata = metadata_io.read_metadata(root_bag_path_);
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   // Check that there's only 1 bagfile and that it exists.
   EXPECT_EQ(1u, metadata.relative_file_paths.size());
@@ -348,7 +349,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
 #endif
 
   wait_for_metadata();
-  const auto metadata = metadata_io.read_metadata(root_bag_path_);
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   for (const auto & path : metadata.relative_file_paths) {
     EXPECT_TRUE(rcpputils::fs::exists(path));

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -94,7 +94,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   rosbag2_storage::MetadataIo metadata_io;
   metadata_io.write_metadata(root_bag_path_.string(), metadata);
 #endif
-
+  wait_for_metadata();
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>("/test_topic");
   EXPECT_THAT(test_topic_messages, SizeIs(Ge(expected_test_messages)));
 
@@ -147,6 +147,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 
   stop_execution(process_handle);
 
+  wait_for_metadata();
   rosbag2_storage::MetadataIo metadataIo;
   const auto metadata = metadataIo.read_metadata(root_bag_path_.string());
   // Verify at least 2 topics are in the metadata.
@@ -215,7 +216,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   }
 #endif
 
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  wait_for_metadata();
+  const auto metadata = metadata_io.read_metadata(root_bag_path_);
   const auto actual_splits = static_cast<int>(metadata.relative_file_paths.size());
 
   // TODO(zmichaels11): Support reliable sync-to-disk for more accurate splits.
@@ -276,7 +278,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
   }
 #endif
 
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  wait_for_metadata();
+  const auto metadata = metadata_io.read_metadata(root_bag_path_);
 
   // Check that there's only 1 bagfile and that it exists.
   EXPECT_EQ(1u, metadata.relative_file_paths.size());
@@ -344,7 +347,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   }
 #endif
 
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  wait_for_metadata();
+  const auto metadata = metadata_io.read_metadata(root_bag_path_);
 
   for (const auto & path : metadata.relative_file_paths) {
     EXPECT_TRUE(rcpputils::fs::exists(path));


### PR DESCRIPTION
Adds a method to the rosbag2 record E2E test fixture to wait until the metadata has been written to disk.
This resolves test flakiness on systems that are slow to flush all file system data to disk.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>