### PR TITLE
Change validation functions to accept output type of ZSTD_getFrameContentSize

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -34,6 +34,7 @@ constexpr const int kDefaultZstdCompressionLevel = 1;
 
 // String constant used to identify ZstdCompressor.
 constexpr const char kCompressionIdentifier[] = "zstd";
+// Used as a parameter type in a function that accepts the output of ZSTD_compress.
 using ZstdCompressReturnType = decltype(ZSTD_compress(nullptr, 0, nullptr, 0, 0));
 
 /**

--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -137,7 +137,7 @@ void write_output_buffer(
 /**
  * Checks compression_result and throws a runtime_error if there was a ZSTD error.
  */
-void throw_on_zstd_error(const size_t compression_result)
+void throw_on_zstd_error(const unsigned long long compression_result)  // NOLINT(runtime/int)
 {
   if (ZSTD_isError(compression_result)) {
     std::stringstream error;
@@ -186,7 +186,7 @@ std::string ZstdCompressor::compress_uri(const std::string & uri)
 
   // Perform compression and check.
   // compression_result is either the actual compressed size or an error code.
-  const size_t compression_result = ZSTD_compress(
+  const auto compression_result = ZSTD_compress(
     compressed_buffer.data(), compressed_buffer.size(),
     decompressed_buffer.data(), decompressed_buffer.size(), kDefaultZstdCompressionLevel);
   throw_on_zstd_error(compression_result);

--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -34,6 +34,7 @@ constexpr const int kDefaultZstdCompressionLevel = 1;
 
 // String constant used to identify ZstdCompressor.
 constexpr const char kCompressionIdentifier[] = "zstd";
+using ZstdCompressReturnType = decltype(ZSTD_compress(nullptr, 0, nullptr, 0, 0));
 
 /**
  * Open a file using the OS-specific C API.
@@ -136,8 +137,9 @@ void write_output_buffer(
 
 /**
  * Checks compression_result and throws a runtime_error if there was a ZSTD error.
+ * \param compression_result is the return value of ZSTD_compress.
  */
-void throw_on_zstd_error(const unsigned long long compression_result)  // NOLINT(runtime/int)
+void throw_on_zstd_error(const ZstdCompressReturnType compression_result)
 {
   if (ZSTD_isError(compression_result)) {
     std::stringstream error;

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -31,7 +31,9 @@ namespace
 
 // String constant used to identify ZstdDecompressor.
 constexpr const char kDecompressionIdentifier[] = "zstd";
+// Used as a parameter type in a function that accepts the output of ZSTD_decompress.
 using ZstdDecompressReturnType = decltype(ZSTD_decompress(nullptr, 0, nullptr, 0));
+// Used as a parameter type in a function that accepts the output of ZSTD_getFrameContentSize.
 using ZstdGetFrameContentSizeReturnType = decltype(ZSTD_getFrameContentSize(nullptr, 0));
 
 /**

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -31,6 +31,8 @@ namespace
 
 // String constant used to identify ZstdDecompressor.
 constexpr const char kDecompressionIdentifier[] = "zstd";
+using ZstdDecompressReturnType = decltype(ZSTD_decompress(nullptr, 0, nullptr, 0));
+using ZstdGetFrameContentSizeReturnType = decltype(ZSTD_getFrameContentSize(nullptr, 0));
 
 /**
  * Open a file using the C API.
@@ -158,8 +160,9 @@ void write_output_buffer(
 
 /**
  * Checks compression_result and throws a runtime_error if there was a ZSTD error.
+ * \param compression_result is the return value of ZSTD_decompress.
  */
-void throw_on_zstd_error(const unsigned long long compression_result)  // NOLINT(runtime/int)
+void throw_on_zstd_error(const ZstdDecompressReturnType compression_result)
 {
   if (ZSTD_isError(compression_result)) {
     std::stringstream error;
@@ -172,8 +175,9 @@ void throw_on_zstd_error(const unsigned long long compression_result)  // NOLINT
 /**
  * Checks frame_content and throws a runtime_error if there was a ZSTD error
  * or frame_content is invalid.
+ * \param frame_content is the return value of ZSTD_getFrameContentSize.
  */
-void throw_on_invalid_frame_content(const unsigned long long frame_content)  // NOLINT(runtime/int)
+void throw_on_invalid_frame_content(const ZstdGetFrameContentSizeReturnType frame_content)
 {
   if (frame_content == ZSTD_CONTENTSIZE_ERROR) {
     throw std::runtime_error{"Unable to determine file size due to error."};

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -159,7 +159,7 @@ void write_output_buffer(
 /**
  * Checks compression_result and throws a runtime_error if there was a ZSTD error.
  */
-void throw_on_zstd_error(const size_t compression_result)
+void throw_on_zstd_error(const unsigned long long compression_result)  // NOLINT(runtime/int)
 {
   if (ZSTD_isError(compression_result)) {
     std::stringstream error;
@@ -173,7 +173,7 @@ void throw_on_zstd_error(const size_t compression_result)
  * Checks frame_content and throws a runtime_error if there was a ZSTD error
  * or frame_content is invalid.
  */
-void throw_on_invalid_frame_content(const size_t frame_content)
+void throw_on_invalid_frame_content(const unsigned long long frame_content)  // NOLINT(runtime/int)
 {
   if (frame_content == ZSTD_CONTENTSIZE_ERROR) {
     throw std::runtime_error{"Unable to determine file size due to error."};


### PR DESCRIPTION
Addresses the same issue to #282.
The root cause of the problem was an implicit conversion from `unsigned long long` to `size_t` (same on x86_64 platforms)

### Changes
* Accept `unsigned long long` directly. This is the return type of ZSTD_getFrameContentSize

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>