### PR TITLE
[compression] Improve logging in rosbag2_compression

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -64,7 +64,11 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
   // Read in buffer, handling accordingly
   const auto file_pointer = open_file(uri.c_str(), "rb");
   if (file_pointer == nullptr) {
-    throw std::runtime_error{"Error opening file"};
+    std::stringstream errmsg;
+    errmsg << "Error opening file: \"" << uri <<
+      "\" for binary reading! errno(" << errno << ")";
+
+    throw std::runtime_error{errmsg.str()};
   }
 
   const auto decompressed_buffer_length = rcutils_get_file_size(uri.c_str());
@@ -73,7 +77,7 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
     fclose(file_pointer);
 
     std::stringstream errmsg;
-    errmsg << "Unable to get size of file: " << uri;
+    errmsg << "Unable to get size of file: \"" << uri << "\"";
 
     throw std::runtime_error{errmsg.str()};
   }
@@ -93,7 +97,11 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
 
   if (ferror(file_pointer)) {
     fclose(file_pointer);
-    throw std::runtime_error{"Unable to read file"};
+
+    std::stringstream errmsg;
+    errmsg << "Unable to read binary data from file: \"" << uri << "\"!";
+
+    throw std::runtime_error{errmsg.str()};
   }
   fclose(file_pointer);
   return decompressed_buffer;
@@ -110,7 +118,7 @@ void write_output_buffer(
 {
   if (output_buffer.empty()) {
     std::stringstream errmsg;
-    errmsg << "Cannot write empty buffer to file: " << uri;
+    errmsg << "Cannot write empty buffer to file: \"" << uri << "\"";
 
     throw std::runtime_error{errmsg.str()};
   }
@@ -131,7 +139,11 @@ void write_output_buffer(
 
   if (ferror(file_pointer)) {
     fclose(file_pointer);
-    throw std::runtime_error{"Unable to write compressed file"};
+
+    std::stringstream errmsg;
+    errmsg << "Unable to write compressed data to file: \"" << uri << "\"!";
+
+    throw std::runtime_error{errmsg.str()};
   }
   fclose(file_pointer);
 }

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -67,7 +67,8 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
   const auto file_pointer = open_file(uri.c_str(), "rb");
   if (file_pointer == nullptr) {
     std::stringstream errmsg;
-    errmsg << "Failed to open file: \"" << uri << "\" for binary reading!";
+    errmsg << "Failed to open file: \"" << uri <<
+      "\" for binary reading! errno(" << errno << ")";
 
     throw std::runtime_error{errmsg.str()};
   }
@@ -77,7 +78,7 @@ std::vector<uint8_t> get_input_buffer(const std::string & uri)
     fclose(file_pointer);
 
     std::stringstream errmsg;
-    errmsg << "Unable to get size of file: " << uri;
+    errmsg << "Unable to get size of file: \"" << uri << "\"";
 
     throw std::runtime_error{errmsg.str()};
   }
@@ -123,7 +124,7 @@ void write_output_buffer(
 {
   if (output_buffer.empty()) {
     std::stringstream errmsg;
-    errmsg << "Cannot write empty buffer to file: " << uri;
+    errmsg << "Cannot write empty buffer to file: \"" << uri << "\"";
 
     throw std::runtime_error{errmsg.str()};
   }
@@ -131,7 +132,8 @@ void write_output_buffer(
   const auto file_pointer = open_file(uri.c_str(), "wb");
   if (file_pointer == nullptr) {
     std::stringstream errmsg;
-    errmsg << "Failed to open file: \"" << uri << "\" for binary writing!";
+    errmsg << "Failed to open file: \"" << uri <<
+      "\" for binary writing! errno(" << errno << ")";
 
     throw std::runtime_error{errmsg.str()};
   }


### PR DESCRIPTION
### Changes
* Include uri and errno in thrown exceptions
* Include message in EXPECT operations when EXPECT is applied to a function that consumes a URI.

### Notes:
* This is work refactored out of #263 

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>