### PR TITLE
Fix race condition in transport recorder

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -108,6 +108,9 @@ void Recorder::subscribe_topics(
 
 void Recorder::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 {
+  // Need to create topic in writer before we are trying to create subscription. Since in
+  // callback for subscription we are calling writer_->write(bag_message); and it could happened
+  // that callback called before we reached out the line: writer_->create_topic(topic)
   writer_->create_topic(topic);
   auto subscription = create_subscription(topic.name, topic.type);
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -108,10 +108,10 @@ void Recorder::subscribe_topics(
 
 void Recorder::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 {
+  writer_->create_topic(topic);
   auto subscription = create_subscription(topic.name, topic.type);
 
   if (subscription) {
-    writer_->create_topic(topic);
     subscribed_topics_.insert(topic.name);
     subscriptions_.push_back(subscription);
     ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Subscribed to topic '" << topic.name << "'");


### PR DESCRIPTION
This PR fixes a race condition when creating a topic in robasg2 transport recorder.

Sometimes  `test_rosbag2_record_end_to_end` fails by timeout with the following error messages:

```bash
1: [ERROR] [rosbag2_transport]: Failed to record: Topic '/test_topic' has not been created yet! Call 'create_topic' first
```

Signed-off-by: Carlos San Vicente <carlos.sanvicente@apex.ai>

