### PR TITLE
Add playback rate command line arg

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -32,6 +32,9 @@ class PlayVerb(VerbExtension):
             help='size of message queue rosbag tries to hold in memory to help deterministic '
                  'playback. Larger size will result in larger memory needs but might prevent '
                  'delay of message playback.')
+        parser.add_argument(
+            '-x', '--rate', type=float, default=1.0,
+            help='rate at which to play back messages')
 
     def main(self, *, args):  # noqa: D102
         bag_file = args.bag_file
@@ -47,4 +50,5 @@ class PlayVerb(VerbExtension):
             uri=bag_file,
             storage_id=args.storage,
             node_prefix=NODE_NAME_PREFIX,
-            read_ahead_queue_size=args.read_ahead_queue_size)
+            read_ahead_queue_size=args.read_ahead_queue_size,
+            rate=args.rate)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from argparse import ArgumentTypeError
+import os
 
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
@@ -41,10 +41,10 @@ class PlayVerb(VerbExtension):
         try:
             fvalue = float(value)
             if fvalue <= 0.0:
-                raise ArgumentTypeError("%s is not in the valid range (> 0.0)" % value)
+                raise ArgumentTypeError('%s is not in the valid range (> 0.0)' % value)
             return fvalue
         except ValueError:
-            raise ArgumentTypeError("%s is not of the valid type (float)" % value)
+            raise ArgumentTypeError('%s is not of the valid type (float)' % value)
 
     def main(self, *, args):  # noqa: D102
         bag_file = args.bag_file

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from argparse import ArgumentTypeError
 
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
@@ -28,13 +29,22 @@ class PlayVerb(VerbExtension):
             '-s', '--storage', default='sqlite3',
             help='storage identifier to be used, defaults to "sqlite3"')
         parser.add_argument(
-            '-r', '--read-ahead-queue-size', type=int, default=1000,
+            '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
                  'playback. Larger size will result in larger memory needs but might prevent '
                  'delay of message playback.')
         parser.add_argument(
-            '-x', '--rate', type=float, default=1.0,
-            help='rate at which to play back messages')
+            '-r', '--rate', type=self.check_positive_float, default=1.0,
+            help='rate at which to play back messages. Valid range > 0.0.')
+
+    def check_positive_float(self, value):
+        try:
+            fvalue = float(value)
+            if fvalue <= 0.0:
+                raise ArgumentTypeError("%s is not in the valid range (> 0.0)" % value)
+            return fvalue
+        except ValueError:
+            raise ArgumentTypeError("%s is not of the valid type (float)" % value)
 
     def main(self, *, args):  # noqa: D102
         bag_file = args.bag_file

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -26,6 +26,7 @@ struct PlayOptions
 public:
   size_t read_ahead_queue_size;
   std::string node_prefix = "";
+  float rate = 1.0;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -137,7 +137,7 @@ void Player::play_messages_until_queue_empty(const PlayOptions & options)
   ReplayableMessage message;
   while (message_queue_.try_dequeue(message) && rclcpp::ok()) {
     std::this_thread::sleep_until(start_time_ +
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
         1.0 / options.rate * message.time_since_start));
     if (rclcpp::ok()) {
       publishers_[message.message->topic_name]->publish(message.message->serialized_data);

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -135,10 +135,17 @@ void Player::play_messages_from_queue(const PlayOptions & options)
 void Player::play_messages_until_queue_empty(const PlayOptions & options)
 {
   ReplayableMessage message;
+
+  float rate = 1.0;
+  // Use rate if in valid range
+  if (options.rate > 0.0) {
+    rate = options.rate;
+  }
+
   while (message_queue_.try_dequeue(message) && rclcpp::ok()) {
     std::this_thread::sleep_until(start_time_ +
       std::chrono::duration_cast<std::chrono::nanoseconds>(
-        1.0 / options.rate * message.time_since_start));
+        1.0 / rate * message.time_since_start));
     if (rclcpp::ok()) {
       publishers_[message.message->topic_name]->publish(message.message->serialized_data);
     }

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -143,8 +143,8 @@ void Player::play_messages_until_queue_empty(const PlayOptions & options)
   }
 
   while (message_queue_.try_dequeue(message) && rclcpp::ok()) {
-    std::this_thread::sleep_until(start_time_ +
-      std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::this_thread::sleep_until(
+      start_time_ + std::chrono::duration_cast<std::chrono::nanoseconds>(
         1.0 / rate * message.time_since_start));
     if (rclcpp::ok()) {
       publishers_[message.message->topic_name]->publish(message.message->serialized_data);

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -55,8 +55,8 @@ private:
   bool is_storage_completely_loaded() const;
   void enqueue_up_to_boundary(const TimePoint & time_first_message, uint64_t boundary);
   void wait_for_filled_queue(const PlayOptions & options) const;
-  void play_messages_from_queue();
-  void play_messages_until_queue_empty();
+  void play_messages_from_queue(const PlayOptions & options);
+  void play_messages_until_queue_empty(const PlayOptions & options);
   void prepare_publishers();
 
   static constexpr double read_ahead_lower_bound_percentage_ = 0.9;

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -145,6 +145,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
     "storage_id",
     "node_prefix",
     "read_ahead_queue_size",
+    "rate",
     nullptr
   };
 
@@ -152,12 +153,14 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   char * storage_id;
   char * node_prefix;
   size_t read_ahead_queue_size;
+  float rate;
   if (!PyArg_ParseTupleAndKeywords(
-      args, kwargs, "sss|k", const_cast<char **>(kwlist),
+      args, kwargs, "sss|kf", const_cast<char **>(kwlist),
       &uri,
       &storage_id,
       &node_prefix,
-      &read_ahead_queue_size))
+      &read_ahead_queue_size,
+      &rate))
   {
     return nullptr;
   }
@@ -167,6 +170,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
 
   play_options.node_prefix = std::string(node_prefix);
   play_options.read_ahead_queue_size = read_ahead_queue_size;
+  play_options.rate = rate;
 
   rosbag2_storage::MetadataIo metadata_io{};
   rosbag2_storage::BagMetadata metadata{};

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -146,7 +146,7 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_rate)
   prepared_mock_reader->prepare(messages, topics_and_types);
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
 
-  play_options_.rate = -1.23;
+  play_options_.rate = -1.23f;
   start = std::chrono::steady_clock::now();
   rosbag2_transport = Rosbag2Transport(reader_, writer_, info_);
   rosbag2_transport.play(storage_options_, play_options_);

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -67,3 +67,92 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_relative_timing_of_stored_m
   ASSERT_THAT(replay_time, Gt(message_time_difference));
   rclcpp::shutdown();
 }
+
+TEST_F(Rosbag2TransportTestFixture, playing_respects_rate)
+{
+  rclcpp::init(0, nullptr);
+  auto primitive_message1 = get_messages_strings()[0];
+  primitive_message1->string_value = "Hello World 1";
+
+  auto primitive_message2 = get_messages_strings()[0];
+  primitive_message2->string_value = "Hello World 2";
+
+  auto message_time_difference = std::chrono::seconds(1);
+  auto topics_and_types =
+    std::vector<rosbag2_storage::TopicMetadata>{{"topic1", "test_msgs/Strings", ""}};
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {serialize_test_message("topic1", 0, primitive_message1),
+    serialize_test_message("topic1", 0, primitive_message2)};
+
+  messages[0]->time_stamp = 100;
+  messages[1]->time_stamp =
+    messages[0]->time_stamp + std::chrono::nanoseconds(message_time_difference).count();
+
+  // Play at 2x speed
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topics_and_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  play_options_.rate = 2.0;
+  auto start = std::chrono::steady_clock::now();
+  Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
+  rosbag2_transport.play(storage_options_, play_options_);
+  auto replay_time = std::chrono::steady_clock::now() - start;
+
+  ASSERT_THAT(replay_time, Gt(0.5 * message_time_difference));
+  ASSERT_THAT(replay_time, Lt(message_time_difference));
+
+  // Play at 1x speed
+  prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topics_and_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  play_options_.rate = 1.0;
+  start = std::chrono::steady_clock::now();
+  rosbag2_transport = Rosbag2Transport(reader_, writer_, info_);
+  rosbag2_transport.play(storage_options_, play_options_);
+  replay_time = std::chrono::steady_clock::now() - start;
+
+  ASSERT_THAT(replay_time, Gt(message_time_difference));
+
+  // Play at half speed
+  prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topics_and_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  play_options_.rate = 0.5;
+  start = std::chrono::steady_clock::now();
+  rosbag2_transport = Rosbag2Transport(reader_, writer_, info_);
+  rosbag2_transport.play(storage_options_, play_options_);
+  replay_time = std::chrono::steady_clock::now() - start;
+
+  ASSERT_THAT(replay_time, Gt(2 * message_time_difference));
+
+  // Invalid value should result in playing at default rate 1.0
+  prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topics_and_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  play_options_.rate = 0.0;
+  start = std::chrono::steady_clock::now();
+  rosbag2_transport = Rosbag2Transport(reader_, writer_, info_);
+  rosbag2_transport.play(storage_options_, play_options_);
+  replay_time = std::chrono::steady_clock::now() - start;
+
+  ASSERT_THAT(replay_time, Gt(message_time_difference));
+
+  // Invalid value should result in playing at default rate 1.0
+  prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topics_and_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  play_options_.rate = -1.23;
+  start = std::chrono::steady_clock::now();
+  rosbag2_transport = Rosbag2Transport(reader_, writer_, info_);
+  rosbag2_transport.play(storage_options_, play_options_);
+  replay_time = std::chrono::steady_clock::now() - start;
+
+  ASSERT_THAT(replay_time, Gt(message_time_difference));
+
+  rclcpp::shutdown();
+}


### PR DESCRIPTION
Addresses #290

Both `-r` and `-s` were taken, so I wasn't sure what is the next best letter to use for rate / speed. I just put in `-x` for this first implementation.

Examples of usage:
```
$ ros2 bag play -x 2.5 rosbag2_2020_01_15-21_25_18
$ ros2 bag play -x 0.5 rosbag2_2020_01_15-21_25_18
$ ros2 bag play -x 1 rosbag2_2020_01_15-21_25_18
```

with updated usage message:
```
$ ros2 bag play -h
usage: ros2 bag play [-h] [-s STORAGE] [-r READ_AHEAD_QUEUE_SIZE] [-x RATE]
                     bag_file

ros2 bag play

positional arguments:
  bag_file              bag file to replay

optional arguments:
  -h, --help            show this help message and exit
  -s STORAGE, --storage STORAGE
                        storage identifier to be used, defaults to "sqlite3"
  -r READ_AHEAD_QUEUE_SIZE, --read-ahead-queue-size READ_AHEAD_QUEUE_SIZE
                        size of message queue rosbag tries to hold in memory
                        to help deterministic playback. Larger size will
                        result in larger memory needs but might prevent delay
                        of message playback.
  -x RATE, --rate RATE  rate at which to play back messages
```

Signed-off-by: Mabel Zhang <mabel@openrobotics.org>