### PR TITLE
Add compression factory stubs

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -56,6 +56,7 @@ target_compile_definitions(${PROJECT_NAME}_zstd
 
 add_library(${PROJECT_NAME}
   SHARED
+  src/rosbag2_compression/compression_factory.cpp
   src/rosbag2_compression/compression_options.cpp
   src/rosbag2_compression/sequential_compression_reader.cpp
   src/rosbag2_compression/sequential_compression_writer.cpp)

--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_HPP_
 
 #include <memory>
+#include <string>
 
 #include "base_compressor_interface.hpp"
 #include "base_decompressor_interface.hpp"
@@ -40,7 +41,7 @@ public:
    * \return A unique pointer to the newly created compressor.
    */
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
-  create_compressor(rosbag2_compression::CompressionFormat compression_format);
+  create_compressor(const std::string & compression_format);
 
   /**
    * Create a decompressor based on the specified compression format.
@@ -49,7 +50,7 @@ public:
    * \return A unique pointer to the newly created decompressor.
    */
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
-  create_decompressor(rosbag2_compression::CompressionFormat compression_format);
+  create_decompressor(const std::string & compression_format);
 
 private:
   std::unique_ptr<CompressionFactoryImpl> impl_;

--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -26,6 +26,12 @@
 namespace rosbag2_compression
 {
 
+/**
+ * Implementation of CompressionFactory.
+ * This class implements methods for creating instances of a BaseCompressionInterface and
+ * BaseDecompressionInterface.
+ * This class should only be used by CompressionFactory.
+ */
 class CompressionFactoryImpl;
 
 class ROSBAG2_COMPRESSION_PUBLIC CompressionFactory

--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -43,7 +43,7 @@ public:
   /**
    * Create a compressor based on the specified compression format.
    *
-   * \param compression_format The compression format enum
+   * \param compression_format The compression format as a string.
    * \return A unique pointer to the newly created compressor.
    */
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
@@ -52,7 +52,7 @@ public:
   /**
    * Create a decompressor based on the specified compression format.
    *
-   * \param compression_format The compression format enum
+   * \param compression_format The compression format as a string.
    * \return A unique pointer to the newly created decompressor.
    */
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>

--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -1,0 +1,60 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_HPP_
+#define ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_HPP_
+
+#include <memory>
+
+#include "base_compressor_interface.hpp"
+#include "base_decompressor_interface.hpp"
+#include "compression_options.hpp"
+#include "visibility_control.hpp"
+
+namespace rosbag2_compression
+{
+
+class CompressionFactoryImpl;
+
+class ROSBAG2_COMPRESSION_PUBLIC CompressionFactory
+{
+public:
+  CompressionFactory();
+  ~CompressionFactory();
+
+  /**
+   * Create a compressor based on the specified compression format.
+   *
+   * \param compression_format The compression format enum
+   * \return A unique pointer to the newly created compressor.
+   */
+  std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
+  create_compressor(rosbag2_compression::CompressionFormat compression_format);
+
+  /**
+   * Create a decompressor based on the specified compression format.
+   *
+   * \param compression_format The compression format enum
+   * \return A unique pointer to the newly created decompressor.
+   */
+  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
+  create_decompressor(rosbag2_compression::CompressionFormat compression_format);
+
+private:
+  std::unique_ptr<CompressionFactoryImpl> impl_;
+};
+
+}  // namespace rosbag2_compression
+
+#endif  // ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_HPP_

--- a/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
@@ -51,6 +51,32 @@ ROSBAG2_COMPRESSION_PUBLIC CompressionMode compression_mode_from_string(
  */
 ROSBAG2_COMPRESSION_PUBLIC std::string compression_mode_to_string(CompressionMode compression_mode);
 
+enum class ROSBAG2_COMPRESSION_PUBLIC CompressionFormat: uint32_t
+{
+  NONE = 0,
+  ZSTD,
+  LAST_FORMAT = ZSTD
+};
+
+/**
+ * Converts a string into a rosbag2_compression::CompressionFormat enum.
+ *
+ * \param compression_format A case insensitive string of the compression format.
+ * \return The corresponding CompressionFormat enum.
+ *         Returns NONE if compression_format is invalid.
+ */
+ROSBAG2_COMPRESSION_PUBLIC std::string compression_format_from_string(
+  const std::string & compression_format);
+
+/**
+ * Converts a rosbag2_compression::CompressionFormat enum into a string.
+ *
+ * \param compression_format A CompressionFormat enum.
+ * \return The corresponding format as a string.
+ */
+ROSBAG2_COMPRESSION_PUBLIC std::string compression_format_to_string(
+  CompressionFormat compression_format);
+
 /**
  * Compression options used in the writer which are passed down from the CLI in rosbag2_transport.
  */

--- a/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
@@ -51,32 +51,6 @@ ROSBAG2_COMPRESSION_PUBLIC CompressionMode compression_mode_from_string(
  */
 ROSBAG2_COMPRESSION_PUBLIC std::string compression_mode_to_string(CompressionMode compression_mode);
 
-enum class ROSBAG2_COMPRESSION_PUBLIC CompressionFormat: uint32_t
-{
-  NONE = 0,
-  ZSTD,
-  LAST_FORMAT = ZSTD
-};
-
-/**
- * Converts a string into a rosbag2_compression::CompressionFormat enum.
- *
- * \param compression_format A case insensitive string of the compression format.
- * \return The corresponding CompressionFormat enum.
- *         Returns NONE if compression_format is invalid.
- */
-ROSBAG2_COMPRESSION_PUBLIC std::string compression_format_from_string(
-  const std::string & compression_format);
-
-/**
- * Converts a rosbag2_compression::CompressionFormat enum into a string.
- *
- * \param compression_format A CompressionFormat enum.
- * \return The corresponding format as a string.
- */
-ROSBAG2_COMPRESSION_PUBLIC std::string compression_format_to_string(
-  CompressionFormat compression_format);
-
 /**
  * Compression options used in the writer which are passed down from the CLI in rosbag2_transport.
  */

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
@@ -1,0 +1,44 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "rosbag2_compression/compression_factory.hpp"
+#include "rosbag2_compression/compression_options.hpp"
+
+#include "compression_factory_impl.hpp"
+
+namespace rosbag2_compression
+{
+
+CompressionFactory::CompressionFactory()
+: impl_(new CompressionFactoryImpl()) {}
+
+CompressionFactory::~CompressionFactory() {}
+
+std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
+CompressionFactory::create_compressor(
+  const rosbag2_compression::CompressionFormat compression_format)
+{
+  return impl_->create_compressor(compression_format);
+}
+
+std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
+CompressionFactory::create_decompressor(
+  const rosbag2_compression::CompressionFormat compression_format)
+{
+  return impl_->create_decompressor(compression_format);
+}
+
+}  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <memory>
+#include <string>
 
 #include "rosbag2_compression/compression_factory.hpp"
-#include "rosbag2_compression/compression_options.hpp"
 
 #include "compression_factory_impl.hpp"
 
@@ -25,18 +25,16 @@ namespace rosbag2_compression
 CompressionFactory::CompressionFactory()
 : impl_(new CompressionFactoryImpl()) {}
 
-CompressionFactory::~CompressionFactory() {}
+CompressionFactory::~CompressionFactory() = default;
 
 std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
-CompressionFactory::create_compressor(
-  const rosbag2_compression::CompressionFormat compression_format)
+CompressionFactory::create_compressor(const std::string & compression_format)
 {
   return impl_->create_compressor(compression_format);
 }
 
 std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
-CompressionFactory::create_decompressor(
-  const rosbag2_compression::CompressionFormat compression_format)
+CompressionFactory::create_decompressor(const std::string & compression_format)
 {
   return impl_->create_decompressor(compression_format);
 }

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -1,0 +1,45 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_IMPL_HPP_
+#define ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_IMPL_HPP_
+
+#include <memory>
+
+#include "rosbag2_compression/compression_factory.hpp"
+
+namespace rosbag2_compression
+{
+
+class CompressionFactoryImpl
+{
+public:
+  CompressionFactoryImpl() = default;
+  ~CompressionFactoryImpl() = default;
+
+  std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
+  create_compressor(const rosbag2_compression::CompressionFormat)
+  {
+    return std::unique_ptr<rosbag2_compression::BaseCompressorInterface>();
+  }
+
+  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
+  create_decompressor(const rosbag2_compression::CompressionFormat)
+  {
+    return std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>();
+  }
+};
+}  // namespace rosbag2_compression
+
+#endif  // ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_IMPL_HPP_

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -23,18 +23,21 @@
 namespace rosbag2_compression
 {
 
+/// Implementation of the CompressionFactory. See CompressionFactory for documentation.
 class CompressionFactoryImpl
 {
 public:
   CompressionFactoryImpl() = default;
   ~CompressionFactoryImpl() = default;
 
+  /// See CompressionFactory::create_compressor for documentation.
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
   create_compressor(const std::string &)
   {
     throw std::logic_error{"Not implemented"};
   }
 
+  /// See CompressionFactory::create_decompressor for documentation.
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
   create_decompressor(const std::string &)
   {

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -32,13 +32,13 @@ public:
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
   create_compressor(const std::string &)
   {
-    return std::unique_ptr<rosbag2_compression::BaseCompressorInterface>();
+    throw std::logic_error{"Not implemented"};
   }
 
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
   create_decompressor(const std::string &)
   {
-    return std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>();
+    throw std::logic_error{"Not implemented"};
   }
 };
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_COMPRESSION__COMPRESSION_FACTORY_IMPL_HPP_
 
 #include <memory>
+#include <string>
 
 #include "rosbag2_compression/compression_factory.hpp"
 
@@ -29,13 +30,13 @@ public:
   ~CompressionFactoryImpl() = default;
 
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
-  create_compressor(const rosbag2_compression::CompressionFormat)
+  create_compressor(const std::string &)
   {
     return std::unique_ptr<rosbag2_compression::BaseCompressorInterface>();
   }
 
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
-  create_decompressor(const rosbag2_compression::CompressionFormat)
+  create_decompressor(const std::string &)
   {
     return std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>();
   }


### PR DESCRIPTION
Add the initial stubs of the `compression_factory` used to create de/compressors.
Part of #297.

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>