### PR TITLE
Refactor Compression Reader/Writers to use the CompressionFactory

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -44,7 +44,7 @@ class ROSBAG2_COMPRESSION_PUBLIC CompressionFactory
 {
 public:
   CompressionFactory();
-  ~CompressionFactory();
+  virtual ~CompressionFactory();
 
   /**
    * Create a compressor based on the specified compression format.
@@ -53,7 +53,7 @@ public:
    * \return A unique pointer to the newly created compressor.
    * \throw invalid_argument If the compression format does not exist.
    */
-  std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
+  virtual std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
   create_compressor(const std::string & compression_format);
 
   /**
@@ -63,7 +63,7 @@ public:
    * \return A unique pointer to the newly created decompressor.
    * \throw invalid_argument If the compression format does not exist.
    */
-  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
+  virtual std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
   create_decompressor(const std::string & compression_format);
 
 private:

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
@@ -32,8 +32,10 @@
 #include "rosbag2_storage/storage_factory_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
 
+#include "compression_factory.hpp"
 #include "visibility_control.hpp"
 #include "zstd_decompressor.hpp"
+
 
 #ifdef _WIN32
 # pragma warning(push)
@@ -48,6 +50,8 @@ class ROSBAG2_COMPRESSION_PUBLIC SequentialCompressionReader
 {
 public:
   explicit SequentialCompressionReader(
+    std::unique_ptr<rosbag2_compression::CompressionFactory> =
+    std::make_unique<rosbag2_compression::CompressionFactory>(),
     std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory =
     std::make_unique<rosbag2_storage::StorageFactory>(),
     std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory =
@@ -146,6 +150,7 @@ private:
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
   rosbag2_compression::CompressionMode compression_mode_{
     rosbag2_compression::CompressionMode::NONE};
+  std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
 };
 
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -34,6 +34,7 @@
 #include "rosbag2_compression/compression_options.hpp"
 
 #include "base_compressor_interface.hpp"
+#include "compression_factory.hpp"
 #include "compression_options.hpp"
 #include "visibility_control.hpp"
 
@@ -55,6 +56,7 @@ public:
 
   SequentialCompressionWriter(
     const rosbag2_compression::CompressionOptions & compression_options,
+    std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory,
     std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
     std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory,
     std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io);
@@ -132,6 +134,7 @@ private:
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
   std::unique_ptr<rosbag2_cpp::Converter> converter_{};
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};
+  std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
 
   // Used in bagfile splitting; specifies the best-effort maximum sub-section of a bagfile in bytes.
   uint64_t max_bagfile_size_{rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT};

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -31,12 +31,14 @@ namespace rosbag2_compression
 {
 
 SequentialCompressionReader::SequentialCompressionReader(
+  std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory,
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
   std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory,
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
 : storage_factory_{std::move(storage_factory)},
   converter_factory_{std::move(converter_factory)},
-  metadata_io_{std::move(metadata_io)}
+  metadata_io_{std::move(metadata_io)},
+  compression_factory_{std::move(compression_factory)}
 {}
 
 SequentialCompressionReader::~SequentialCompressionReader()
@@ -53,16 +55,10 @@ void SequentialCompressionReader::setup_decompression()
 {
   compression_mode_ = rosbag2_compression::compression_mode_from_string(metadata_.compression_mode);
   if (compression_mode_ != rosbag2_compression::CompressionMode::NONE) {
-    if (metadata_.compression_format == "zstd") {
-      decompressor_ = std::make_unique<rosbag2_compression::ZstdDecompressor>();
-      // Decompress the first file so that it is readable.
-      ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
-      set_current_file(decompressor_->decompress_uri(get_current_file()));
-    } else {
-      std::stringstream err;
-      err << "Unsupported compression format " << metadata_.compression_format;
-      throw std::invalid_argument{err.str()};
-    }
+    decompressor_ = compression_factory_->create_decompressor(metadata_.compression_format);
+    // Decompress the first file so that it is readable.
+    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
+    set_current_file(decompressor_->decompress_uri(get_current_file()));
   } else {
     throw std::invalid_argument{
             "SequentialCompressionReader requires a CompressionMode that is not NONE!"};

--- a/rosbag2_compression/test/rosbag2_compression/mock_compression.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_compression.hpp
@@ -1,0 +1,46 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__MOCK_COMPRESSION_HPP_
+#define ROSBAG2_COMPRESSION__MOCK_COMPRESSION_HPP_
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include "rosbag2_compression/base_compressor_interface.hpp"
+#include "rosbag2_compression/base_decompressor_interface.hpp"
+
+class MockCompressor : public rosbag2_compression::BaseCompressorInterface
+{
+public:
+  MOCK_METHOD1(compress_uri, std::string(const std::string & uri));
+  MOCK_METHOD1(
+    compress_serialized_bag_message,
+    void(rosbag2_storage::SerializedBagMessage * bag_message));
+  MOCK_CONST_METHOD0(get_compression_identifier, std::string());
+};
+
+class MockDecompressor : public rosbag2_compression::BaseDecompressorInterface
+{
+public:
+  MOCK_METHOD1(decompress_uri, std::string(const std::string & uri));
+  MOCK_METHOD1(
+    decompress_serialized_bag_message,
+    void(rosbag2_storage::SerializedBagMessage * bag_message));
+  MOCK_CONST_METHOD0(get_decompression_identifier, std::string());
+};
+
+#endif  // ROSBAG2_COMPRESSION__MOCK_COMPRESSION_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_compression_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_compression_factory.hpp
@@ -1,0 +1,39 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__MOCK_COMPRESSION_FACTORY_HPP_
+#define ROSBAG2_COMPRESSION__MOCK_COMPRESSION_FACTORY_HPP_
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include "rosbag2_compression/compression_factory.hpp"
+
+class MockCompressionFactory : public rosbag2_compression::CompressionFactory
+{
+public:
+  MOCK_METHOD1(
+    create_compressor,
+    std::unique_ptr<rosbag2_compression::BaseCompressorInterface>(
+      const std::string &));
+
+  MOCK_METHOD1(
+    create_decompressor,
+    std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>(
+      const std::string & compression_format));
+};
+
+#endif  // ROSBAG2_COMPRESSION__MOCK_COMPRESSION_FACTORY_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_compression_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_compression_factory.hpp
@@ -33,7 +33,7 @@ public:
   MOCK_METHOD1(
     create_decompressor,
     std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>(
-      const std::string & compression_format));
+      const std::string &));
 };
 
 #endif  // ROSBAG2_COMPRESSION__MOCK_COMPRESSION_FACTORY_HPP_


### PR DESCRIPTION
* Refactored the compression setup in the readers/writers to use the `CompressionFactory`.
* Added a MockCompression and MockCompressionFactory for future work.

Note: `CompressionFactory` methods were made `virtual` so that they could be mocked.

Closes #297 

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>