### PR TITLE
Fix compression logging logic

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -211,7 +211,7 @@ void SequentialCompressionWriter::compress_last_file()
 
     metadata_.relative_file_paths.back() = compressed_uri;
 
-    if (rcpputils::fs::remove(to_compress)) {
+    if (!rcpputils::fs::remove(to_compress)) {
       ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
         "Failed to remove uncompressed bag: \"" << to_compress.string() << "\"");
     }


### PR DESCRIPTION
Fix an issue with `rosbag2_compression` logging an error statement when removing the uncompressed bagfiles.
See the docs of [`rcpputils::fs::remove()`](https://github.com/ros2/rcpputils/blob/6bc8fa85b6da5aa39a4fc8f5537ca227f1211fe1/include/rcpputils/filesystem_helper.hpp#L447).

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>