### PR TITLE
Fix compression log logic

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -211,7 +211,7 @@ void SequentialCompressionWriter::compress_last_file()
 
     metadata_.relative_file_paths.back() = compressed_uri;
 
-    if (rcpputils::fs::remove(to_compress)) {
+    if (!rcpputils::fs::remove(to_compress)) {
       ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
         "Failed to remove uncompressed bag: \"" << to_compress.string() << "\"");
     }


### PR DESCRIPTION
Duplicate of #318.

Fix an issue with `rosbag2_compression` logging an error statement when removing the uncompressed bagfiles.
See the docs of [`rcpputils::fs::remove()`](https://github.com/ros2/rcpputils/blob/6bc8fa85b6da5aa39a4fc8f5537ca227f1211fe1/include/rcpputils/filesystem_helper.hpp#L447).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9623)](http://ci.ros2.org/job/ci_linux/9623/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5317)](http://ci.ros2.org/job/ci_linux-aarch64/5317/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7844)](http://ci.ros2.org/job/ci_osx/7844/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9527)](http://ci.ros2.org/job/ci_windows/9527/)

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>