### PR TITLE
Replace poco dependency by rcutils

### DIFF
--- a/rosbag2_converter_default_plugins/CMakeLists.txt
+++ b/rosbag2_converter_default_plugins/CMakeLists.txt
@@ -22,10 +22,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-find_package(poco_vendor REQUIRED)
-find_package(Poco COMPONENTS Foundation)
 find_package(pluginlib REQUIRED)
-find_package(rcutils REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_fastrtps_cpp QUIET)
 find_package(rosbag2_cpp REQUIRED)
@@ -38,8 +36,7 @@ if(rmw_fastrtps_cpp_FOUND)
   ament_target_dependencies(${PROJECT_NAME}
     ament_index_cpp
     pluginlib
-    Poco
-    rcutils
+    rcpputils
     rmw
     rosbag2_cpp
     rosidl_generator_cpp)

--- a/rosbag2_converter_default_plugins/package.xml
+++ b/rosbag2_converter_default_plugins/package.xml
@@ -11,9 +11,8 @@
 
   <depend>ament_index_cpp</depend>
   <depend>pluginlib</depend>
-  <depend>poco_vendor</depend>
   <depend>rosidl_generator_cpp</depend>
-  <depend>rcutils</depend>
+  <depend>rcpputils</depend>
   <depend>rmw</depend>
   <depend>rmw_fastrtps_cpp</depend>
   <depend>rosbag2_cpp</depend>
@@ -21,7 +20,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>rcutils</test_depend>
+  <test_depend>rcpputils</test_depend>
   <test_depend>rmw_fastrtps_cpp</test_depend>
   <test_depend>rosbag2_cpp</test_depend>
   <test_depend>rosbag2_test_common</test_depend>

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
@@ -67,6 +67,8 @@ CdrConverter::CdrConverter()
   } catch (std::runtime_error &) {
     throw std::runtime_error(
             std::string("poco exception: library could not be found:") + library_path);
+  } catch (std::bad_alloc &) {
+    throw std::bad_alloc();
   }
 
   std::string serialize_symbol = "rmw_serialize";

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
@@ -67,8 +67,6 @@ CdrConverter::CdrConverter()
   } catch (std::runtime_error &) {
     throw std::runtime_error(
             std::string("poco exception: library could not be found:") + library_path);
-  } catch (std::bad_alloc &) {
-    throw std::bad_alloc();
   }
 
   std::string serialize_symbol = "rmw_serialize";

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
@@ -20,8 +20,7 @@
 #include "ament_index_cpp/get_resources.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
-#include "Poco/SharedLibrary.h"
-
+#include "rcpputils/shared_library.hpp"
 #include "rcutils/strdup.h"
 
 #include "rosbag2_cpp/types.hpp"
@@ -63,10 +62,9 @@ std::string get_package_library_path(const std::string & package_name)
 CdrConverter::CdrConverter()
 {
   auto library_path = get_package_library_path("rmw_fastrtps_cpp");
-  std::shared_ptr<Poco::SharedLibrary> library;
   try {
-    library = std::make_shared<Poco::SharedLibrary>(library_path);
-  } catch (Poco::LibraryLoadException &) {
+    library = std::make_shared<rcpputils::SharedLibrary>(library_path);
+  } catch (std::runtime_error &) {
     throw std::runtime_error(
             std::string("poco exception: library could not be found:") + library_path);
   }
@@ -74,26 +72,26 @@ CdrConverter::CdrConverter()
   std::string serialize_symbol = "rmw_serialize";
   std::string deserialize_symbol = "rmw_deserialize";
 
-  if (!library->hasSymbol(serialize_symbol)) {
-    throw std::runtime_error(
-            std::string("poco exception: symbol not found: ") + serialize_symbol);
+  if (!library->has_symbol(serialize_symbol.c_str())) {
+    throw std::runtime_error{std::string("rcutils exception: symbol not found: ") +
+            serialize_symbol};
   }
 
-  if (!library->hasSymbol(deserialize_symbol)) {
-    throw std::runtime_error(
-            std::string("poco exception: symbol not found: ") + deserialize_symbol);
+  if (!library->has_symbol(deserialize_symbol.c_str())) {
+    throw std::runtime_error{
+            std::string("rcutils exception: symbol not found: ") + deserialize_symbol};
   }
 
-  serialize_fcn_ = (decltype(serialize_fcn_))library->getSymbol(serialize_symbol);
+  serialize_fcn_ = (decltype(serialize_fcn_))library->get_symbol(serialize_symbol.c_str());
   if (!serialize_fcn_) {
-    throw std::runtime_error(
-            std::string("poco exception: symbol of wrong type: ") + serialize_symbol);
+    throw std::runtime_error{
+            std::string("rcutils exception: symbol of wrong type: ") + serialize_symbol};
   }
 
-  deserialize_fcn_ = (decltype(deserialize_fcn_))library->getSymbol(deserialize_symbol);
+  deserialize_fcn_ = (decltype(deserialize_fcn_))library->get_symbol(deserialize_symbol.c_str());
   if (!deserialize_fcn_) {
-    throw std::runtime_error(
-            std::string("poco exception: symbol of wrong type: ") + deserialize_symbol);
+    throw std::runtime_error{
+            std::string("rcutils exception: symbol of wrong type: ") + deserialize_symbol};
   }
 }
 

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.hpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.hpp
@@ -22,6 +22,8 @@
 
 #include "rosidl_generator_cpp/message_type_support_decl.hpp"
 
+#include "rcpputils/shared_library.hpp"
+
 #include "rosbag2_cpp/converter_interfaces/serialization_format_converter.hpp"
 #include "rosbag2_cpp/types.hpp"
 
@@ -42,6 +44,9 @@ public:
     std::shared_ptr<const rosbag2_cpp::rosbag2_introspection_message_t> introspection_message,
     const rosidl_message_type_support_t * type_support,
     std::shared_ptr<rosbag2_storage::SerializedBagMessage> serialized_message) override;
+
+private:
+  std::shared_ptr<rcpputils::SharedLibrary> library;
 
 protected:
   rmw_ret_t (* serialize_fcn_)(

--- a/rosbag2_converter_default_plugins/test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/test/rosbag2_converter_default_plugins/cdr/test_cdr_converter.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 
+#include "rcpputils/shared_library.hpp"
 #include "rcutils/strdup.h"
 
 #include "rosbag2_cpp/converter_interfaces/serialization_format_converter.hpp"
@@ -77,8 +78,9 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_pr
   auto ros_message = make_shared_ros_message();
   test_msgs::msg::BasicTypes primitive_test_msg;
   ros_message->message = &primitive_test_msg;
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/BasicTypes", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/BasicTypes", "rosidl_typesupport_cpp", library);
 
   converter_->deserialize(serialized_message, type_support, ros_message);
 
@@ -96,8 +98,9 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_prim
 
   auto serialized_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   serialized_message->serialized_data = memory_management_->make_initialized_message();
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/BasicTypes", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/BasicTypes", "rosidl_typesupport_cpp", library);
 
   converter_->serialize(ros_message, type_support, serialized_message);
 
@@ -119,8 +122,9 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_st
   auto ros_message = make_shared_ros_message();
   test_msgs::msg::Strings string_test_msg;
   ros_message->message = &string_test_msg;
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/Strings", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/Strings", "rosidl_typesupport_cpp", library);
 
   converter_->deserialize(serialized_message, type_support, ros_message);
 
@@ -138,8 +142,9 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_stri
 
   auto serialized_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   serialized_message->serialized_data = memory_management_->make_initialized_message();
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/Strings", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/Strings", "rosidl_typesupport_cpp", library);
 
   converter_->serialize(ros_message, type_support, serialized_message);
 
@@ -161,8 +166,9 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_ws
   auto ros_message = make_shared_ros_message();
   test_msgs::msg::WStrings wstring_test_msg;
   ros_message->message = &wstring_test_msg;
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/WStrings", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/WStrings", "rosidl_typesupport_cpp", library);
 
   converter_->deserialize(serialized_message, type_support, ros_message);
 
@@ -180,8 +186,9 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_wstr
 
   auto serialized_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   serialized_message->serialized_data = memory_management_->make_initialized_message();
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/WStrings", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/WStrings", "rosidl_typesupport_cpp", library);
 
   converter_->serialize(ros_message, type_support, serialized_message);
 
@@ -203,8 +210,9 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_st
   auto ros_message = make_shared_ros_message();
   test_msgs::msg::Arrays primitive_test_msg;
   ros_message->message = &primitive_test_msg;
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/Arrays", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/Arrays", "rosidl_typesupport_cpp", library);
 
   converter_->deserialize(serialized_message, type_support, ros_message);
 
@@ -222,8 +230,9 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_stat
 
   auto serialized_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   serialized_message->serialized_data = memory_management_->make_initialized_message();
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/Arrays", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/Arrays", "rosidl_typesupport_cpp", library);
 
   converter_->serialize(ros_message, type_support, serialized_message);
 
@@ -245,8 +254,9 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_un
   auto ros_message = make_shared_ros_message();
   test_msgs::msg::UnboundedSequences dynamic_nested_message;
   ros_message->message = &dynamic_nested_message;
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/UnboundedSequences", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/UnboundedSequences", "rosidl_typesupport_cpp", library);
 
   converter_->deserialize(serialized_message, type_support, ros_message);
 
@@ -265,8 +275,9 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_unbo
 
   auto serialized_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   serialized_message->serialized_data = memory_management_->make_initialized_message();
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/UnboundedSequences", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/UnboundedSequences", "rosidl_typesupport_cpp", library);
 
   converter_->serialize(ros_message, type_support, serialized_message);
 
@@ -288,8 +299,9 @@ TEST_F(CdrConverterTestFixture, deserialize_converts_cdr_into_ros_message_for_mu
   auto ros_message = make_shared_ros_message();
   test_msgs::msg::MultiNested multi_nested_message;
   ros_message->message = &multi_nested_message;
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/MultiNested", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/MultiNested", "rosidl_typesupport_cpp", library);
 
   converter_->deserialize(serialized_message, type_support, ros_message);
 
@@ -307,8 +319,9 @@ TEST_F(CdrConverterTestFixture, serialize_converts_ros_message_into_cdr_for_mult
 
   auto serialized_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   serialized_message->serialized_data = memory_management_->make_initialized_message();
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto type_support =
-    rosbag2_cpp::get_typesupport("test_msgs/MultiNested", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/MultiNested", "rosidl_typesupport_cpp", library);
 
   converter_->serialize(ros_message, type_support, serialized_message);
 

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -30,8 +30,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(poco_vendor)
-find_package(Poco COMPONENTS Foundation)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
@@ -54,7 +52,6 @@ add_library(${PROJECT_NAME} SHARED
 ament_target_dependencies(${PROJECT_NAME}
   ament_index_cpp
   pluginlib
-  Poco
   rcpputils
   rcutils
   rosbag2_storage
@@ -160,8 +157,7 @@ if(BUILD_TESTING)
       $<INSTALL_INTERFACE:include>)
     ament_target_dependencies(test_ros2_message
       ament_index_cpp
-      Poco
-      rcutils
+      rcpputils
       rosbag2_storage
       rosidl_generator_cpp
       rosidl_typesupport_introspection_cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/converter.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/converter.hpp
@@ -28,6 +28,8 @@
 
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
+#include "rcpputils/shared_library.hpp"
+
 // This is necessary because of using stl types here. It is completely safe, because
 // a) the member is not accessible from the outside
 // b) there are no inline functions.
@@ -82,6 +84,8 @@ private:
   std::unique_ptr<converter_interfaces::SerializationFormatDeserializer> input_converter_;
   std::unique_ptr<converter_interfaces::SerializationFormatSerializer> output_converter_;
   std::unordered_map<std::string, ConverterTypeSupport> topics_and_types_;
+  std::shared_ptr<rcpputils::SharedLibrary> library_rosidl_typesupport_cpp_;
+  std::shared_ptr<rcpputils::SharedLibrary> library_rosidl_typesupport_introspection_cpp_;
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/typesupport_helpers.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/typesupport_helpers.hpp
@@ -18,8 +18,11 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <memory>
 
 #include "rosbag2_cpp/visibility_control.hpp"
+
+#include "rcpputils/shared_library.hpp"
 
 #include "rosidl_generator_cpp/message_type_support_decl.hpp"
 
@@ -28,7 +31,9 @@ namespace rosbag2_cpp
 
 ROSBAG2_CPP_PUBLIC
 const rosidl_message_type_support_t *
-get_typesupport(const std::string & type, const std::string & typesupport_identifier);
+get_typesupport(
+  const std::string & type, const std::string & typesupport_identifier,
+  std::shared_ptr<rcpputils::SharedLibrary> & library);
 
 ROSBAG2_CPP_PUBLIC
 const std::tuple<std::string, std::string, std::string>

--- a/rosbag2_cpp/package.xml
+++ b/rosbag2_cpp/package.xml
@@ -11,7 +11,6 @@
 
   <depend>ament_index_cpp</depend>
   <depend>pluginlib</depend>
-  <depend>poco_vendor</depend>
   <depend>rcutils</depend>
   <depend>rosbag2_storage</depend>
   <depend>rosidl_generator_cpp</depend>

--- a/rosbag2_cpp/src/rosbag2_cpp/converter.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/converter.cpp
@@ -82,9 +82,13 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> Converter::convert(
 void Converter::add_topic(const std::string & topic, const std::string & type)
 {
   ConverterTypeSupport type_support;
-  type_support.rmw_type_support = get_typesupport(type, "rosidl_typesupport_cpp");
+  type_support.rmw_type_support = get_typesupport(
+    type, "rosidl_typesupport_cpp",
+    library_rosidl_typesupport_cpp_);
   type_support.introspection_type_support =
-    get_typesupport(type, "rosidl_typesupport_introspection_cpp");
+    get_typesupport(
+    type, "rosidl_typesupport_introspection_cpp",
+    library_rosidl_typesupport_introspection_cpp_);
 
   topics_and_types_.insert({topic, type_support});
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
@@ -139,6 +139,8 @@ get_typesupport(
     return type_support;
   } catch (std::runtime_error &) {
     throw std::runtime_error(rcutils_dynamic_loading_error.str() + " Library could not be found.");
+  } catch (std::bad_alloc &) {
+    throw std::bad_alloc();
   }
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
@@ -139,8 +139,6 @@ get_typesupport(
     return type_support;
   } catch (std::runtime_error &) {
     throw std::runtime_error(rcutils_dynamic_loading_error.str() + " Library could not be found.");
-  } catch (std::bad_alloc &) {
-    throw std::bad_alloc();
   }
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
@@ -15,6 +15,7 @@
 #include "rosbag2_cpp/typesupport_helpers.hpp"
 
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -23,7 +24,7 @@
 #include "ament_index_cpp/get_resources.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"
 
-#include "Poco/SharedLibrary.h"
+#include "rcpputils/shared_library.hpp"
 
 #include "rosidl_generator_cpp/message_type_support_decl.hpp"
 
@@ -98,39 +99,46 @@ extract_type_identifier(const std::string & full_type)
 }
 
 const rosidl_message_type_support_t *
-get_typesupport(const std::string & type, const std::string & typesupport_identifier)
+get_typesupport(
+  const std::string & type, const std::string & typesupport_identifier,
+  std::shared_ptr<rcpputils::SharedLibrary> & library)
 {
   std::string package_name;
   std::string middle_module;
   std::string type_name;
   std::tie(package_name, middle_module, type_name) = extract_type_identifier(type);
 
-  std::string poco_dynamic_loading_error = "Something went wrong loading the typesupport library "
-    "for message type " + package_name + "/" + type_name + ".";
+  std::stringstream rcutils_dynamic_loading_error;
+  rcutils_dynamic_loading_error <<
+    "Something went wrong loading the typesupport library for message type " << package_name <<
+    "/" << type_name << ".";
 
   auto library_path = get_typesupport_library_path(package_name, typesupport_identifier);
 
   try {
-    auto typesupport_library = std::make_shared<Poco::SharedLibrary>(library_path);
+    library = std::make_shared<rcpputils::SharedLibrary>(library_path);
 
     auto symbol_name = typesupport_identifier + "__get_message_type_support_handle__" +
       package_name + "__" + (middle_module.empty() ? "msg" : middle_module) + "__" + type_name;
 
-    if (!typesupport_library->hasSymbol(symbol_name)) {
-      throw std::runtime_error(poco_dynamic_loading_error + " Symbol not found.");
+    if (!library->get_symbol(symbol_name)) {
+      throw std::runtime_error{
+              rcutils_dynamic_loading_error.str() +
+              std::string(" Symbol not found.")};
     }
 
     const rosidl_message_type_support_t * (* get_ts)() = nullptr;
-    get_ts = (decltype(get_ts))typesupport_library->getSymbol(symbol_name);
-    auto type_support = get_ts();
+    get_ts = (decltype(get_ts))library->get_symbol(symbol_name);
 
-    if (!type_support) {
-      throw std::runtime_error(poco_dynamic_loading_error + " Symbol of wrong type.");
+    if (!get_ts) {
+      throw std::runtime_error{
+              rcutils_dynamic_loading_error.str() +
+              std::string(" Symbol of wrong type.")};
     }
-
+    auto type_support = get_ts();
     return type_support;
-  } catch (Poco::LibraryLoadException &) {
-    throw std::runtime_error(poco_dynamic_loading_error + " Library could not be found.");
+  } catch (std::runtime_error &) {
+    throw std::runtime_error(rcutils_dynamic_loading_error.str() + " Library could not be found.");
   }
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_typesupport_helpers.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_typesupport_helpers.cpp
@@ -20,6 +20,8 @@
 
 #include "ament_index_cpp/get_package_prefix.hpp"
 
+#include "rcpputils/shared_library.hpp"
+
 #include "rosbag2_cpp/typesupport_helpers.hpp"
 
 using namespace ::testing;  // NOLINT
@@ -60,13 +62,17 @@ TEST(TypesupportHelpersTest, separates_into_package_and_name_for_multiple_slashe
 }
 
 TEST(TypesupportHelpersTest, throws_exception_if_library_cannot_be_found) {
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   EXPECT_THROW(
-    rosbag2_cpp::get_typesupport("invalid/message", "rosidl_typesupport_cpp"), std::runtime_error);
+    rosbag2_cpp::get_typesupport(
+      "invalid/message", "rosidl_typesupport_cpp",
+      library), std::runtime_error);
 }
 
 TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_legacy_library) {
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto string_typesupport =
-    rosbag2_cpp::get_typesupport("test_msgs/BasicTypes", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/BasicTypes", "rosidl_typesupport_cpp", library);
 
   EXPECT_THAT(
     std::string(string_typesupport->typesupport_identifier),
@@ -74,8 +80,9 @@ TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_legacy_library) {
 }
 
 TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_library) {
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   auto string_typesupport =
-    rosbag2_cpp::get_typesupport("test_msgs/msg/BasicTypes", "rosidl_typesupport_cpp");
+    rosbag2_cpp::get_typesupport("test_msgs/msg/BasicTypes", "rosidl_typesupport_cpp", library);
 
   EXPECT_THAT(
     std::string(string_typesupport->typesupport_identifier),

--- a/rosbag2_cpp/test/rosbag2_cpp/types/test_ros2_message.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/types/test_ros2_message.cpp
@@ -47,11 +47,11 @@ public:
   auto get_allocated_message(const std::string & message_type)
   {
     auto introspection_ts =
-      rosbag2_cpp::get_typesupport(message_type, "rosidl_typesupport_introspection_cpp");
+      rosbag2_cpp::get_typesupport(message_type, "rosidl_typesupport_introspection_cpp", library);
 
     return rosbag2_cpp::allocate_introspection_message(introspection_ts, &allocator_);
   }
-
+  std::shared_ptr<rcpputils::SharedLibrary> library;
   rcutils_allocator_t allocator_;
 };
 

--- a/rosbag2_tests/test/rosbag2_tests/test_converter.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_converter.cpp
@@ -43,14 +43,17 @@ public:
     cdr_serializer_ = factory_->load_serializer("cdr");
     cdr_deserializer_ = factory_->load_deserializer("cdr");
     type_support_ =
-      rosbag2_cpp::get_typesupport("test_msgs/MultiNested", "rosidl_typesupport_cpp");
+      rosbag2_cpp::get_typesupport(
+      "test_msgs/MultiNested", "rosidl_typesupport_cpp",
+      library_rosidl_typesupport_cpp_);
   }
 
   std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t>
   allocate_empty_dynamic_array_message()
   {
     auto introspection_type_support = rosbag2_cpp::get_typesupport(
-      "test_msgs/MultiNested", "rosidl_typesupport_introspection_cpp");
+      "test_msgs/MultiNested", "rosidl_typesupport_introspection_cpp",
+      library_rosidl_typesupport_introspection_cpp_);
     auto introspection_message =
       rosbag2_cpp::allocate_introspection_message(introspection_type_support, &allocator_);
     introspection_message->time_stamp = 1;
@@ -76,6 +79,8 @@ public:
   std::unique_ptr<MemoryManagement> memory_management_;
   std::string topic_name_;
   rcutils_allocator_t allocator_;
+  std::shared_ptr<rcpputils::SharedLibrary> library_rosidl_typesupport_introspection_cpp_;
+  std::shared_ptr<rcpputils::SharedLibrary> library_rosidl_typesupport_cpp_;
   const rosidl_message_type_support_t * type_support_;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -38,7 +38,9 @@ Rosbag2Node::Rosbag2Node(const std::string & node_name)
 std::shared_ptr<GenericPublisher> Rosbag2Node::create_generic_publisher(
   const std::string & topic, const std::string & type)
 {
-  auto type_support = rosbag2_cpp::get_typesupport(type, "rosidl_typesupport_cpp");
+  auto type_support = rosbag2_cpp::get_typesupport(
+    type, "rosidl_typesupport_cpp",
+    library_generic_publisher_);
   return std::make_shared<GenericPublisher>(get_node_base_interface().get(), topic, *type_support);
 }
 
@@ -47,7 +49,9 @@ std::shared_ptr<GenericSubscription> Rosbag2Node::create_generic_subscription(
   const std::string & type,
   std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback)
 {
-  auto type_support = rosbag2_cpp::get_typesupport(type, "rosidl_typesupport_cpp");
+  auto type_support = rosbag2_cpp::get_typesupport(
+    type, "rosidl_typesupport_cpp",
+    library_generic_subscriptor_);
 
   auto subscription = std::shared_ptr<GenericSubscription>();
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -56,7 +56,6 @@ std::shared_ptr<GenericSubscription> Rosbag2Node::create_generic_subscription(
   auto type_support = rosbag2_cpp::get_typesupport(
     type, "rosidl_typesupport_cpp",
     library_generic_subscriptor_);
-  auto type_support = rosbag2_cpp::get_typesupport(type, "rosidl_typesupport_cpp");
   auto subscription = std::shared_ptr<GenericSubscription>();
 
   try {

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "rclcpp/node.hpp"
+#include "rcpputils/shared_library.hpp"
 #include "rcutils/types.h"
 
 #include "generic_publisher.hpp"
@@ -58,6 +59,10 @@ public:
   std::unordered_map<std::string, std::string>
   filter_topics_with_more_than_one_type(
     std::map<std::string, std::vector<std::string>> topics_and_types);
+
+private:
+  std::shared_ptr<rcpputils::SharedLibrary> library_generic_subscriptor_;
+  std::shared_ptr<rcpputils::SharedLibrary> library_generic_publisher_;
 };
 
 }  // namespace rosbag2_transport


### PR DESCRIPTION
As part of the effort to remove Poco dependency described in this issue https://github.com/ros2/ros2/issues/867 this PR makes use of the recent changes in rcutils https://github.com/ros2/rcutils/pull/215 to load, unload and get symbols from shared libraries instead of using Poco.

Signed-off-by: ahcorde <ahcorde@gmail.com>