### PR TITLE
Add project() to sqlite3_cmakelists.txt

### DIFF
--- a/sqlite3_vendor/sqlite3_cmakelists.txt
+++ b/sqlite3_vendor/sqlite3_cmakelists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+project(sqlite3_cmake)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # for Linux, since the library will be used in a shared lib
 add_library(sqlite3 sqlite3.c)
 set_target_properties(sqlite3 PROPERTIES

--- a/sqlite3_vendor/sqlite3_cmakelists.txt
+++ b/sqlite3_vendor/sqlite3_cmakelists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(sqlite3_cmake)
+project(sqlite3)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # for Linux, since the library will be used in a shared lib
 add_library(sqlite3 sqlite3.c)
 set_target_properties(sqlite3 PROPERTIES


### PR DESCRIPTION
Attempting to address issue #323. I'm not sure if this is the correct way of going about this since it's being included from another cmakelists.txt. I'm also open to naming the project whatever you all think is appropriate. I just didn't want to name it sqlite3_vendor (already taken) nor sqlite3 (may conflict with another cmake project?). 

Signed-off-by: Stephen Brawner <brawner@gmail.com>