### PR TITLE
include hidden topics

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -64,6 +64,9 @@ class RecordVerb(VerbExtension):
             '--compression-format', type=str, default='', choices=['zstd'],
             help='Specify the compression format/algorithm. Default is none.'
         )
+        parser.add_argument(
+            '--include-hidden-topics', action='store_true',
+            help='record also hidden topics.')
         self._subparser = parser
 
     def create_bag_directory(self, uri):
@@ -105,7 +108,8 @@ class RecordVerb(VerbExtension):
                 all=True,
                 no_discovery=args.no_discovery,
                 polling_interval=args.polling_interval,
-                max_bagfile_size=args.max_bag_size)
+                max_bagfile_size=args.max_bag_size,
+                include_hidden_topics=args.include_hidden_topics)
         elif args.topics and len(args.topics) > 0:
             # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
             #               combined with constrained environments (as imposed by colcon test)
@@ -124,7 +128,8 @@ class RecordVerb(VerbExtension):
                 no_discovery=args.no_discovery,
                 polling_interval=args.polling_interval,
                 max_bagfile_size=args.max_bag_size,
-                topics=args.topics)
+                topics=args.topics,
+                include_hidden_topics=args.include_hidden_topics)
         else:
             self._subparser.print_help()
 

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -32,6 +32,7 @@ public:
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";
+  bool include_hidden_topics = false;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -50,13 +50,16 @@ public:
 private:
   void topics_discovery(
     std::chrono::milliseconds topic_polling_interval,
-    const std::vector<std::string> & requested_topics = {});
+    const std::vector<std::string> & requested_topics = {},
+    bool include_hidden_topics = false);
 
   std::unordered_map<std::string, std::string>
-  get_requested_or_available_topics(const std::vector<std::string> & requested_topics);
+  get_requested_or_available_topics(
+    const std::vector<std::string> & requested_topics,
+    bool include_hidden_topics = false);
 
   std::unordered_map<std::string, std::string>
-  get_missing_topics(const std::unordered_map<std::string, std::string> & topics);
+  get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics);
 
   void subscribe_topics(
     const std::unordered_map<std::string, std::string> & topics_and_types);

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -24,6 +24,8 @@
 
 #include "rcl/expand_topic_name.h"
 
+#include "rcpputils/split.hpp"
+
 #include "rosbag2_cpp/typesupport_helpers.hpp"
 
 #include "rosbag2_transport/logging.hpp"
@@ -149,13 +151,15 @@ std::unordered_map<std::string, std::string> Rosbag2Node::get_topics_with_types(
 }
 
 std::unordered_map<std::string, std::string>
-Rosbag2Node::get_all_topics_with_types()
+Rosbag2Node::get_all_topics_with_types(bool include_hidden_topics)
 {
-  return filter_topics_with_more_than_one_type(this->get_topic_names_and_types());
+  return filter_topics_with_more_than_one_type(
+    this->get_topic_names_and_types(), include_hidden_topics);
 }
 
 std::unordered_map<std::string, std::string> Rosbag2Node::filter_topics_with_more_than_one_type(
-  std::map<std::string, std::vector<std::string>> topics_and_types)
+  const std::map<std::string, std::vector<std::string>> & topics_and_types,
+  bool include_hidden_topics)
 {
   std::unordered_map<std::string, std::string> filtered_topics_and_types;
   for (const auto & topic_and_type : topics_and_types) {
@@ -163,10 +167,28 @@ std::unordered_map<std::string, std::string> Rosbag2Node::filter_topics_with_mor
       ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
         "Topic '" << topic_and_type.first <<
           "' has several types associated. Only topics with one type are supported");
-    } else {
-      filtered_topics_and_types.insert({topic_and_type.first, topic_and_type.second[0]});
+      continue;
     }
+
+    // According to rclpy's implementation, the indicator for a hidden topic is a leading '_'
+    // https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/topic_or_service_is_hidden.py#L15
+    if (!include_hidden_topics) {
+      auto tokens = rcpputils::split(topic_and_type.first, '/', true);  // skip empty
+      auto is_hidden = std::find_if(tokens.begin(), tokens.end(), [](const auto & token) -> bool {
+          return token[0] == '_';
+          });
+      if (is_hidden != tokens.end()) {
+        ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
+          "Hidden topics are not recorded. Topic '" <<
+            topic_and_type.first << "' will be skipped." <<
+            "You can enable them with --include-hidden-topics");
+        continue;
+      }
+    }
+
+    filtered_topics_and_types.insert({topic_and_type.first, topic_and_type.second[0]});
   }
+
   return filtered_topics_and_types;
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -174,9 +174,10 @@ std::unordered_map<std::string, std::string> Rosbag2Node::filter_topics_with_mor
     // https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/topic_or_service_is_hidden.py#L15
     if (!include_hidden_topics) {
       auto tokens = rcpputils::split(topic_and_type.first, '/', true);  // skip empty
-      auto is_hidden = std::find_if(tokens.begin(), tokens.end(), [](const auto & token) -> bool {
+      auto is_hidden = std::find_if(
+        tokens.begin(), tokens.end(), [](const auto & token) -> bool {
           return token[0] == '_';
-          });
+        });
       if (is_hidden != tokens.end()) {
         ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
           "Hidden topics are not recorded. Topic '" <<

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -188,7 +188,6 @@ std::unordered_map<std::string, std::string> Rosbag2Node::filter_topics_with_mor
 
     filtered_topics_and_types.insert({topic_and_type.first, topic_and_type.second[0]});
   }
-
   return filtered_topics_and_types;
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -179,7 +179,7 @@ std::unordered_map<std::string, std::string> Rosbag2Node::filter_topics_with_mor
           return token[0] == '_';
         });
       if (is_hidden != tokens.end()) {
-        ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
+        ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
           "Hidden topics are not recorded. Topic '" <<
             topic_and_type.first << "' will be skipped." <<
             "You can enable them with --include-hidden-topics");

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -179,10 +179,9 @@ std::unordered_map<std::string, std::string> Rosbag2Node::filter_topics_with_mor
           return token[0] == '_';
         });
       if (is_hidden != tokens.end()) {
-        ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
-          "Hidden topics are not recorded. Topic '" <<
-            topic_and_type.first << "' will be skipped." <<
-            "You can enable them with --include-hidden-topics");
+        RCLCPP_WARN_ONCE(
+          rclcpp::get_logger("rosbag2_transport"),
+          "Hidden topics are not recorded. Enable them with --include-hidden-topics");
         continue;
       }
     }

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
@@ -53,11 +53,12 @@ public:
   expand_topic_name(const std::string & topic_name);
 
   std::unordered_map<std::string, std::string>
-  get_all_topics_with_types();
+  get_all_topics_with_types(bool include_hidden_topics = false);
 
   std::unordered_map<std::string, std::string>
   filter_topics_with_more_than_one_type(
-    std::map<std::string, std::vector<std::string>> topics_and_types);
+    const std::map<std::string, std::vector<std::string>> & topics_and_types,
+    bool include_hidden_topics = false);
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -50,6 +50,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
     "polling_interval",
     "max_bagfile_size",
     "topics",
+    "include_hidden_topics",
     nullptr};
 
   char * uri = nullptr;
@@ -63,9 +64,10 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   uint64_t polling_interval_ms = 100;
   unsigned long long max_bagfile_size = 0;  // NOLINT
   PyObject * topics = nullptr;
+  bool include_hidden_topics = false;
   if (
     !PyArg_ParseTupleAndKeywords(
-      args, kwargs, "ssssss|bbKKO", const_cast<char **>(kwlist),
+      args, kwargs, "ssssss|bbKKOb", const_cast<char **>(kwlist),
       &uri,
       &storage_id,
       &serilization_format,
@@ -76,7 +78,8 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
       &no_discovery,
       &polling_interval_ms,
       &max_bagfile_size,
-      &topics))
+      &topics,
+      &include_hidden_topics))
   {
     return nullptr;
   }
@@ -90,6 +93,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   record_options.node_prefix = std::string(node_prefix);
   record_options.compression_mode = std::string(compression_mode);
   record_options.compression_format = compression_format;
+  record_options.include_hidden_topics = include_hidden_topics;
 
   rosbag2_compression::CompressionOptions compression_options{
     record_options.compression_format,


### PR DESCRIPTION
closes #331 

This change introduces a new command line option `--include-hidden-topics` which explicitly enables the recording of hidden topics. If this option is not set, hidden topics won't be recored by default.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>