### PR TITLE
Query offered QoS profiles for a topic and store in metadata

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -30,7 +30,6 @@
 # pragma warning(pop)
 #endif
 
-
 namespace rosbag2_transport
 {
 /// Simple wrapper around rclcpp::QoS to provide a default constructor for YAML deserialization.
@@ -43,7 +42,6 @@ public:
   : rclcpp::QoS(value) {}
 };
 }  // namespace rosbag2_transport
-
 
 namespace YAML
 {
@@ -61,6 +59,5 @@ struct convert<rosbag2_transport::Rosbag2QoS>
   static bool decode(const Node & node, rosbag2_transport::Rosbag2QoS & qos);
 };
 }  // namespace YAML
-
 
 #endif  // ROSBAG2_TRANSPORT__QOS_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -143,7 +143,8 @@ void Recorder::subscribe_topics(
         topic_with_type.first,
         topic_with_type.second,
         serialization_format_,
-        serialized_offered_qos_profiles_for_topic(node_, topic_with_type.first)});
+        serialized_offered_qos_profiles_for_topic(node_, topic_with_type.first)
+      });
   }
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -119,7 +119,8 @@ Recorder::get_missing_topics(const std::unordered_map<std::string, std::string> 
   return missing_topics;
 }
 
-namespace {
+namespace
+{
 std::string serialized_offered_qos_profiles_for_topic(
   std::shared_ptr<rosbag2_transport::Rosbag2Node> node,
   const std::string & topic_name)
@@ -137,11 +138,12 @@ void Recorder::subscribe_topics(
   const std::unordered_map<std::string, std::string> & topics_and_types)
 {
   for (const auto & topic_with_type : topics_and_types) {
-    subscribe_topic({
-      topic_with_type.first,
-      topic_with_type.second,
-      serialization_format_,
-      serialized_offered_qos_profiles_for_topic(node_, topic_with_type.first)});
+    subscribe_topic(
+      {
+        topic_with_type.first,
+        topic_with_type.second,
+        serialization_format_,
+        serialized_offered_qos_profiles_for_topic(node_, topic_with_type.first)});
   }
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -28,7 +28,21 @@
 #include "rosbag2_transport/logging.hpp"
 
 #include "generic_subscription.hpp"
+#include "qos.hpp"
 #include "rosbag2_node.hpp"
+
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
 
 namespace rosbag2_transport
 {
@@ -105,11 +119,29 @@ Recorder::get_missing_topics(const std::unordered_map<std::string, std::string> 
   return missing_topics;
 }
 
+namespace {
+std::string serialized_offered_qos_profiles_for_topic(
+  std::shared_ptr<rosbag2_transport::Rosbag2Node> node,
+  const std::string & topic_name)
+{
+  YAML::Node offered_qos_profiles;
+  auto publishers_info = node->get_publishers_info_by_topic(topic_name);
+  for (auto info : publishers_info) {
+    offered_qos_profiles.push_back(rosbag2_transport::Rosbag2QoS(info.qos_profile()));
+  }
+  return YAML::Dump(offered_qos_profiles);
+}
+}  // unnamed namespace
+
 void Recorder::subscribe_topics(
   const std::unordered_map<std::string, std::string> & topics_and_types)
 {
   for (const auto & topic_with_type : topics_and_types) {
-    subscribe_topic({topic_with_type.first, topic_with_type.second, serialization_format_, ""});
+    subscribe_topic({
+      topic_with_type.first,
+      topic_with_type.second,
+      serialization_format_,
+      serialized_offered_qos_profiles_for_topic(node_, topic_with_type.first)});
   }
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -79,5 +79,22 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   auto recorded_topics = writer.get_topics();
   std::string serialized_profiles = recorded_topics.at(topic).offered_qos_profiles;
   // Basic smoke test that the profile was serialized into the metadata as a string.
-  EXPECT_THAT(serialized_profiles, ContainsRegex("reliability"));
+  EXPECT_THAT(
+    serialized_profiles, ContainsRegex(
+      "- history: 3\n"
+      "  depth: 0\n"
+      "  reliability: 1\n"
+      "  durability: 2\n"
+      "  deadline:\n"
+      "    sec: 2147483647\n"
+      "    nsec: 4294967295\n"
+      "  lifespan:\n"
+      "    sec: 2147483647\n"
+      "    nsec: 4294967295\n"
+      "  liveliness: 1\n"
+      "  liveliness_lease_duration:\n"
+      "    sec: 2147483647\n"
+      "    nsec: 4294967295\n"
+      "  avoid_ros_namespace_conventions: false"
+  ));
 }


### PR DESCRIPTION
Part of #125 
Moves https://github.com/ros-tooling/aws-roadmap/issues/215 to Done
This change queries the currently offered QoS profiles for a given topic at the time of subscription, and stores them in the TopicMetadata. This does not use the queried QoS profile in any way, just stores it. 

With this in, you will see the string-serialized profiles in both the metadata.yaml file and the sqlite topics table.

This does _not_ handle new publishers that join after subscribing to a topic. We do not currently have a mechanism to change TopicMetadata after initial creation, and do not plan to add this ability for Foxy.

Once we have used the queried QoS profile to subscribe (upcoming change), we will need to make sure to notice late-joining publishers that offer a different QoS profile than we used to subscribe, to warn the user that this has happened.