### PR TITLE
WIP: Set default QoS Profile - Record

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -72,6 +72,10 @@ class RecordVerb(VerbExtension):
         parser.add_argument(
             '--include-hidden-topics', action='store_true',
             help='record also hidden topics.')
+        parser.add_argument(
+            '--qos-profile', type=str, default='',
+            help='Path to a yaml file with a QoS policy to override the default profile.'
+        )
         self._subparser = parser
 
     def create_bag_directory(self, uri):
@@ -92,6 +96,14 @@ class RecordVerb(VerbExtension):
         if args.compression_format and args.compression_mode == 'none':
             return 'Invalid choice: Cannot specify compression format without a compression mode.'
         args.compression_mode = args.compression_mode.upper()
+
+        qos_profile = args.qos_profile
+        if qos_profile:
+            if os.path.isfile(qos_profile):
+                with open(qos_profile, 'r') as file:
+                    qos_profile = file.read()
+            else:
+                return "[ERROR] [ros2bag]: {} does not exist.".format(args.qos_profile)
 
         self.create_bag_directory(uri)
 
@@ -115,7 +127,7 @@ class RecordVerb(VerbExtension):
                 polling_interval=args.polling_interval,
                 max_bagfile_size=args.max_bag_size,
                 max_cache_size=args.max_cache_size,
-                include_hidden_topics=args.include_hidden_topics)
+                qos_profile=qos_profile)
         elif args.topics and len(args.topics) > 0:
             # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
             #               combined with constrained environments (as imposed by colcon test)
@@ -136,7 +148,8 @@ class RecordVerb(VerbExtension):
                 max_bagfile_size=args.max_bag_size,
                 max_cache_size=args.max_cache_size,
                 topics=args.topics,
-                include_hidden_topics=args.include_hidden_topics)
+                include_hidden_topics=args.include_hidden_topics,
+                qos_profile=qos_profile)
         else:
             self._subparser.print_help()
 

--- a/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
@@ -75,13 +75,16 @@ public:
 
   template<class T>
   void add_publisher(
-    const std::string & topic_name, std::shared_ptr<T> message, size_t expected_messages = 0)
+    const std::string & topic_name,
+    std::shared_ptr<T> message,
+    size_t expected_messages = 0,
+    rclcpp::QoS qos = rclcpp::SystemDefaultsQoS())
   {
     auto node_name = std::string("publisher") + std::to_string(counter_++);
     auto publisher_node = std::make_shared<rclcpp::Node>(
       node_name,
       rclcpp::NodeOptions().start_parameter_event_publisher(false).enable_rosout(false));
-    auto publisher = publisher_node->create_publisher<T>(topic_name, 10);
+    auto publisher = publisher_node->create_publisher<T>(topic_name, qos);
 
     publisher_nodes_.push_back(publisher_node);
     publishers_.push_back(

--- a/rosbag2_tests/resources/qos_test/qos_profile.yaml
+++ b/rosbag2_tests/resources/qos_test/qos_profile.yaml
@@ -1,0 +1,15 @@
+history: 3
+depth: 0
+reliability: 1
+durability: 2
+deadline:
+  sec: 2147483647
+  nsec: 4294967295
+lifespan:
+  sec: 2147483647
+  nsec: 4294967295
+liveliness: 2147483647
+liveliness_lease_duration:
+  sec: 2147483647
+  nsec: 4294967295
+avoid_ros_namespace_conventions: false

--- a/rosbag2_tests/resources/qos_test/qos_profile.yaml
+++ b/rosbag2_tests/resources/qos_test/qos_profile.yaml
@@ -1,15 +1,18 @@
-history: 3
-depth: 0
-reliability: 1
-durability: 2
-deadline:
-  sec: 2147483647
-  nsec: 4294967295
-lifespan:
-  sec: 2147483647
-  nsec: 4294967295
-liveliness: 2147483647
-liveliness_lease_duration:
-  sec: 2147483647
-  nsec: 4294967295
-avoid_ros_namespace_conventions: false
+fallback:
+  history: 0
+test_topic:
+  history: 3
+  depth: 0
+  reliability: 1
+  durability: 2
+  deadline:
+    sec: 2147483647
+    nsec: 4294967295
+  lifespan:
+    sec: 2147483647
+    nsec: 4294967295
+  liveliness: 2147483647
+  liveliness_lease_duration:
+    sec: 2147483647
+    nsec: 4294967295
+  avoid_ros_namespace_conventions: false

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -196,6 +196,15 @@ public:
     return std::get<0>(topic_format);
   }
 
+  std::string get_qos_profile_for_topic(
+    const std::string & topic_name, rosbag2_storage_plugins::SqliteWrapper & db)
+  {
+    std::string sql_query = "SELECT offered_qos_profiles FROM topics WHERE name = ?;";
+    auto qos_profile = db.prepare_statement(sql_query)
+      ->bind(topic_name)->execute_query<std::string>().get_single_line();
+    return std::get<0>(qos_profile);
+  }
+
   // relative path to the root of the bag file.
   rcpputils::fs::path root_bag_path_;
 

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -139,6 +139,7 @@ if(BUILD_TESTING)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
       $<INSTALL_INTERFACE:include>)
+    target_link_libraries(test_rosbag2_node rosbag2_transport)
     ament_target_dependencies(test_rosbag2_node
       ament_index_cpp
       rclcpp

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -32,7 +32,7 @@ public:
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";
-  std::string qos_profile = "";
+  std::string qos_profiles = "";
   bool include_hidden_topics = false;
 };
 

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -32,6 +32,7 @@ public:
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";
+  std::string qos_profile = "";
   bool include_hidden_topics = false;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -14,6 +14,24 @@
 
 #include "qos.hpp"
 
+namespace rosbag2_transport
+{
+  std::ostream & operator<< (std::ostream & stream, const Rosbag2QoS & qos) {
+    const auto profile = qos.get_rmw_qos_profile();
+    stream << "history: " << profile.history << std::endl <<
+    "depth: " << profile.depth << std::endl <<
+    "reliability: " << profile.reliability << std::endl <<
+    "durability: " << profile.durability << std::endl <<
+    "deadline: " << profile.deadline.sec << "." << profile.deadline.nsec << std::endl <<
+    "lifespan: " << profile.lifespan.sec << "." << profile.lifespan.nsec << std::endl <<
+    "liveliness: " << profile.liveliness << std::endl <<
+    "liveliness_lease_duration: " << profile.liveliness_lease_duration.sec << "." <<
+    profile.liveliness_lease_duration.nsec << std::endl <<
+    "avoid_ros_namespace_conventions: " << profile.avoid_ros_namespace_conventions << std::endl;
+    return stream;
+  }
+}
+
 namespace YAML
 {
 Node convert<rmw_time_t>::encode(const rmw_time_t & time)

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -16,9 +16,10 @@
 
 namespace rosbag2_transport
 {
-  std::ostream & operator<< (std::ostream & stream, const Rosbag2QoS & qos) {
-    const auto profile = qos.get_rmw_qos_profile();
-    stream << "history: " << profile.history << std::endl <<
+std::ostream & operator<<(std::ostream & stream, const Rosbag2QoS & qos)
+{
+  const auto profile = qos.get_rmw_qos_profile();
+  stream << "history: " << profile.history << std::endl <<
     "depth: " << profile.depth << std::endl <<
     "reliability: " << profile.reliability << std::endl <<
     "durability: " << profile.durability << std::endl <<
@@ -28,8 +29,8 @@ namespace rosbag2_transport
     "liveliness_lease_duration: " << profile.liveliness_lease_duration.sec << "." <<
     profile.liveliness_lease_duration.nsec << std::endl <<
     "avoid_ros_namespace_conventions: " << profile.avoid_ros_namespace_conventions << std::endl;
-    return stream;
-  }
+  return stream;
+}
 }
 
 namespace YAML

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -40,6 +40,8 @@ public:
   : rclcpp::QoS(rmw_qos_profile_default.depth) {}
   explicit Rosbag2QoS(const rclcpp::QoS & value)
   : rclcpp::QoS(value) {}
+
+  friend std::ostream & operator<< (std::ostream & stream, const Rosbag2QoS & qos);
 };
 }  // namespace rosbag2_transport
 

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -41,7 +41,7 @@ public:
   explicit Rosbag2QoS(const rclcpp::QoS & value)
   : rclcpp::QoS(value) {}
 
-  friend std::ostream & operator<< (std::ostream & stream, const Rosbag2QoS & qos);
+  friend std::ostream & operator<<(std::ostream & stream, const Rosbag2QoS & qos);
 };
 }  // namespace rosbag2_transport
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -62,7 +62,8 @@ private:
   get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics);
 
   void subscribe_topics(
-    const std::unordered_map<std::string, std::string> & topics_and_types);
+    const std::unordered_map<std::string, std::string> & topics_and_types,
+    std::string offered_qos_profile = "");
 
   void subscribe_topic(const rosbag2_storage::TopicMetadata & topic);
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -23,6 +23,19 @@
 #include <utility>
 #include <vector>
 
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
+
 #include "rosbag2_cpp/writer.hpp"
 
 #include "rosbag2_storage/topic_metadata.hpp"
@@ -62,8 +75,7 @@ private:
   get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics);
 
   void subscribe_topics(
-    const std::unordered_map<std::string, std::string> & topics_and_types,
-    std::string offered_qos_profile = "");
+    const std::unordered_map<std::string, std::string> & topics_and_types);
 
   void subscribe_topic(const rosbag2_storage::TopicMetadata & topic);
 
@@ -77,6 +89,7 @@ private:
   std::vector<std::shared_ptr<GenericSubscription>> subscriptions_;
   std::unordered_set<std::string> subscribed_topics_;
   std::string serialization_format_;
+  YAML::Node qos_profile_overrides_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -52,6 +52,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
     "max_cache_size",
     "topics",
     "include_hidden_topics",
+    "qos_profile",
     nullptr};
 
   char * uri = nullptr;
@@ -60,6 +61,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   char * node_prefix = nullptr;
   char * compression_mode = nullptr;
   char * compression_format = nullptr;
+  char * qos_profile = nullptr;
   bool all = false;
   bool no_discovery = false;
   uint64_t polling_interval_ms = 100;
@@ -69,7 +71,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   bool include_hidden_topics = false;
   if (
     !PyArg_ParseTupleAndKeywords(
-      args, kwargs, "ssssss|bbKKKOb", const_cast<char **>(kwlist),
+      args, kwargs, "ssssss|bbKKKObs", const_cast<char **>(kwlist),
       &uri,
       &storage_id,
       &serilization_format,
@@ -82,8 +84,8 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
       &max_bagfile_size,
       &max_cache_size,
       &topics,
-      &include_hidden_topics
-  ))
+      &include_hidden_topics,
+      &qos_profile))
   {
     return nullptr;
   }
@@ -99,6 +101,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   record_options.compression_mode = std::string(compression_mode);
   record_options.compression_format = compression_format;
   record_options.include_hidden_topics = include_hidden_topics;
+  record_options.qos_profile = qos_profile;
 
   rosbag2_compression::CompressionOptions compression_options{
     record_options.compression_format,

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -52,7 +52,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
     "max_cache_size",
     "topics",
     "include_hidden_topics",
-    "qos_profile",
+    "qos_profiles",
     nullptr};
 
   char * uri = nullptr;
@@ -61,7 +61,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   char * node_prefix = nullptr;
   char * compression_mode = nullptr;
   char * compression_format = nullptr;
-  char * qos_profile = nullptr;
+  char * qos_profiles = nullptr;
   bool all = false;
   bool no_discovery = false;
   uint64_t polling_interval_ms = 100;
@@ -85,7 +85,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
       &max_cache_size,
       &topics,
       &include_hidden_topics,
-      &qos_profile))
+      &qos_profiles))
   {
     return nullptr;
   }
@@ -101,7 +101,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   record_options.compression_mode = std::string(compression_mode);
   record_options.compression_format = compression_format;
   record_options.include_hidden_topics = include_hidden_topics;
-  record_options.qos_profile = qos_profile;
+  record_options.qos_profiles = qos_profiles;
 
   rosbag2_compression::CompressionOptions compression_options{
     record_options.compression_format,

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -19,15 +19,35 @@
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
+
 #include "rclcpp/rclcpp.hpp"
 
+#include "rosbag2_cpp/writer.hpp"
+
 #include "rosbag2_test_common/memory_management.hpp"
+#include "rosbag2_transport/record_options.hpp"
+#include "rosbag2_transport/storage_options.hpp"
 
 #include "test_msgs/message_fixtures.hpp"
 #include "test_msgs/msg/basic_types.hpp"
 
 #include "qos.hpp"
+#include "recorder.hpp"
 #include "rosbag2_node.hpp"
+
+#include "mock_sequential_writer.hpp"
 
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
@@ -251,3 +271,5 @@ TEST_F(RosBag2NodeFixture, get_all_topics_with_types_returns_all_topics)
   EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/msg/Strings"));
   EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/msg/Strings"));
 }
+
+


### PR DESCRIPTION
Part of #125
Part of ros-tooling/aws-roadmap#216
Depends on #340

Add a new CLI parameter `--qos-profile` to the `ros2bag` `record` verb that accepts a YAML file and overrides the default QoS configuration.

TODO:
[ ] Accept multiple QoS profiles for each topic
[ ] Sanitize input

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>