### PR TITLE
Subscribe to topics using the common offered QoS

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -130,6 +130,7 @@ if(BUILD_TESTING)
     src/rosbag2_transport/generic_publisher.cpp
     src/rosbag2_transport/generic_subscription.cpp
     src/rosbag2_transport/qos.cpp
+    src/rosbag2_transport/recorder.cpp
     src/rosbag2_transport/rosbag2_node.cpp
     test/rosbag2_transport/test_rosbag2_node.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
@@ -48,7 +48,8 @@ GenericSubscription::GenericSubscription(
     rosbag2_get_subscription_options(qos),
     true),
   default_allocator_(rcutils_get_default_allocator()),
-  callback_(callback)
+  callback_(callback),
+  qos_(qos)
 {}
 
 std::shared_ptr<void> GenericSubscription::create_message()
@@ -86,6 +87,11 @@ void GenericSubscription::return_serialized_message(
   std::shared_ptr<rmw_serialized_message_t> & message)
 {
   message.reset();
+}
+
+const rclcpp::QoS & GenericSubscription::qos_profile() const
+{
+  return qos_;
 }
 
 std::shared_ptr<rmw_serialized_message_t>

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
@@ -68,12 +68,16 @@ public:
 
   void return_serialized_message(std::shared_ptr<rmw_serialized_message_t> & message) override;
 
+  // Provide a const reference to the QoS Profile used to create this subscription.
+  const rclcpp::QoS & qos_profile() const;
+
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
 
   std::shared_ptr<rmw_serialized_message_t> borrow_serialized_message(size_t capacity);
   rcutils_allocator_t default_allocator_;
   std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback_;
+  const rclcpp::QoS qos_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -40,6 +40,12 @@ public:
   : rclcpp::QoS(rmw_qos_profile_default.depth) {}
   explicit Rosbag2QoS(const rclcpp::QoS & value)
   : rclcpp::QoS(value) {}
+
+  Rosbag2QoS & default_history()
+  {
+    keep_last(rmw_qos_profile_default.depth);
+    return *this;
+  }
 };
 }  // namespace rosbag2_transport
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -160,7 +160,7 @@ void Recorder::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   // that callback called before we reached out the line: writer_->create_topic(topic)
   writer_->create_topic(topic);
 
-  Rosbag2QoS subscription_qos(common_qos_or_fallback(topic.name));
+  Rosbag2QoS subscription_qos{common_qos_or_fallback(topic.name)};
   auto subscription = create_subscription(topic.name, topic.type, subscription_qos);
   if (subscription) {
     subscriptions_.insert({topic.name, subscription});
@@ -219,7 +219,7 @@ rclcpp::QoS Recorder::common_qos_or_fallback(const std::string & topic_name)
   }
   ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
     "Topic " << topic_name << " has publishers offering different QoS settings. "
-      "Can't guess what QoS to request, falling back to default QoS profile."
+      "Cannot determine what QoS to request, falling back to default QoS profile."
   );
   topics_warned_about_incompatibility_.insert(topic_name);
   return Rosbag2QoS{};
@@ -236,14 +236,14 @@ void Recorder::warn_if_new_qos_for_subscribed_topic(const std::string & topic_na
     // Already warned about this topic
     return;
   }
-  const rclcpp::QoS & used_qos = existing_subscription->second->qos_profile();
+  const auto & used_qos = existing_subscription->second->qos_profile();
   auto publishers_info = node_->get_publishers_info_by_topic(topic_name);
   for (const auto & info : publishers_info) {
     if (info.qos_profile() != used_qos) {
       ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
         "A new publisher for subscribed topic " << topic_name << " was found that is offering "
-          "a (possibly) incompatible QoS profile. Not changing subscription QoS. It is possible "
-          "you will not record messages from this new publisher."
+          "a (possibly) incompatible QoS profile. Not changing subscription QoS. "
+          "Messages from this publisher may not be recorded."
       );
       topics_warned_about_incompatibility_.insert(topic_name);
       return;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -246,6 +246,7 @@ void Recorder::warn_if_new_qos_for_subscribed_topic(const std::string & topic_na
           "you will not record messages from this new publisher."
       );
       topics_warned_about_incompatibility_.insert(topic_name);
+      return;
     }
   }
 }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -219,7 +219,7 @@ rclcpp::QoS Recorder::common_qos_or_fallback(const std::string & topic_name)
   }
   ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
     "Topic " << topic_name << " has publishers offering different QoS settings. "
-    "Can't guess what QoS to request, falling back to default QoS profile."
+      "Can't guess what QoS to request, falling back to default QoS profile."
   );
   topics_warned_about_incompatibility_.insert(topic_name);
   return Rosbag2QoS{};
@@ -242,8 +242,8 @@ void Recorder::warn_if_new_qos_for_subscribed_topic(const std::string & topic_na
     if (info.qos_profile() != used_qos) {
       ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
         "A new publisher for subscribed topic " << topic_name << " was found that is offering "
-        "a (possibly) incompatible QoS profile. Not changing subscription QoS. It is possible "
-        "you will not record messages from this new publisher."
+          "a (possibly) incompatible QoS profile. Not changing subscription QoS. It is possible "
+          "you will not record messages from this new publisher."
       );
       topics_warned_about_incompatibility_.insert(topic_name);
     }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -215,7 +215,7 @@ rclcpp::QoS Recorder::common_qos_or_fallback(const std::string & topic_name)
 {
   auto endpoints = node_->get_publishers_info_by_topic(topic_name);
   if (!endpoints.empty() && all_qos_same(endpoints)) {
-    return endpoints[0].qos_profile();
+    return Rosbag2QoS(endpoints[0].qos_profile()).default_history();
   }
   ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
     "Topic " << topic_name << " has publishers offering different QoS settings. "

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -44,6 +44,22 @@
 # pragma warning(pop)
 #endif
 
+namespace
+{
+bool all_qos_same(const std::vector<rclcpp::TopicEndpointInfo> & values)
+{
+  auto adjacent_different_elements_it = std::adjacent_find(
+    values.begin(),
+    values.end(),
+    [](const rclcpp::TopicEndpointInfo & left, const rclcpp::TopicEndpointInfo & right) -> bool {
+      return left.qos_profile() != right.qos_profile();
+    }
+  );
+  // No adjacent elements were different, so all are the same.
+  return adjacent_different_elements_it == values.end();
+}
+}  // unnamed namespace
+
 namespace rosbag2_transport
 {
 Recorder::Recorder(std::shared_ptr<rosbag2_cpp::Writer> writer, std::shared_ptr<Rosbag2Node> node)
@@ -86,10 +102,13 @@ void Recorder::topics_discovery(
   while (rclcpp::ok()) {
     auto topics_to_subscribe =
       get_requested_or_available_topics(requested_topics, include_hidden_topics);
+    for (const auto & topic_and_type : topics_to_subscribe) {
+      warn_if_new_qos_for_subscribed_topic(topic_and_type.first);
+    }
     auto missing_topics = get_missing_topics(topics_to_subscribe);
     subscribe_topics(missing_topics);
 
-    if (!requested_topics.empty() && subscribed_topics_.size() == requested_topics.size()) {
+    if (!requested_topics.empty() && subscriptions_.size() == requested_topics.size()) {
       ROSBAG2_TRANSPORT_LOG_INFO("All requested topics are subscribed. Stopping discovery...");
       return;
     }
@@ -112,27 +131,13 @@ Recorder::get_missing_topics(const std::unordered_map<std::string, std::string> 
 {
   std::unordered_map<std::string, std::string> missing_topics;
   for (const auto & i : all_topics) {
-    if (subscribed_topics_.find(i.first) == subscribed_topics_.end()) {
+    if (subscriptions_.find(i.first) == subscriptions_.end()) {
       missing_topics.emplace(i.first, i.second);
     }
   }
   return missing_topics;
 }
 
-namespace
-{
-std::string serialized_offered_qos_profiles_for_topic(
-  std::shared_ptr<rosbag2_transport::Rosbag2Node> node,
-  const std::string & topic_name)
-{
-  YAML::Node offered_qos_profiles;
-  auto publishers_info = node->get_publishers_info_by_topic(topic_name);
-  for (auto info : publishers_info) {
-    offered_qos_profiles.push_back(rosbag2_transport::Rosbag2QoS(info.qos_profile()));
-  }
-  return YAML::Dump(offered_qos_profiles);
-}
-}  // unnamed namespace
 
 void Recorder::subscribe_topics(
   const std::unordered_map<std::string, std::string> & topics_and_types)
@@ -143,7 +148,7 @@ void Recorder::subscribe_topics(
         topic_with_type.first,
         topic_with_type.second,
         serialization_format_,
-        serialized_offered_qos_profiles_for_topic(node_, topic_with_type.first)
+        serialized_offered_qos_profiles_for_topic(topic_with_type.first)
       });
   }
 }
@@ -154,26 +159,26 @@ void Recorder::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   // callback for subscription we are calling writer_->write(bag_message); and it could happened
   // that callback called before we reached out the line: writer_->create_topic(topic)
   writer_->create_topic(topic);
-  auto subscription = create_subscription(topic.name, topic.type);
 
+  Rosbag2QoS subscription_qos(common_qos_or_fallback(topic.name));
+  auto subscription = create_subscription(topic.name, topic.type, subscription_qos);
   if (subscription) {
-    subscribed_topics_.insert(topic.name);
-    subscriptions_.push_back(subscription);
+    subscriptions_.insert({topic.name, subscription});
     ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Subscribed to topic '" << topic.name << "'");
   } else {
     writer_->remove_topic(topic);
-    subscribed_topics_.erase(topic.name);
+    subscriptions_.erase(topic.name);
   }
 }
 
 std::shared_ptr<GenericSubscription>
 Recorder::create_subscription(
-  const std::string & topic_name, const std::string & topic_type)
+  const std::string & topic_name, const std::string & topic_type, const rclcpp::QoS & qos)
 {
   auto subscription = node_->create_generic_subscription(
     topic_name,
     topic_type,
-    Rosbag2QoS{},
+    qos,
     [this, topic_name](std::shared_ptr<rmw_serialized_message_t> message) {
       auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
       bag_message->serialized_data = message;
@@ -194,6 +199,55 @@ Recorder::create_subscription(
 void Recorder::record_messages() const
 {
   spin(node_);
+}
+
+std::string Recorder::serialized_offered_qos_profiles_for_topic(const std::string & topic_name)
+{
+  YAML::Node offered_qos_profiles;
+  auto endpoints = node_->get_publishers_info_by_topic(topic_name);
+  for (const auto & info : endpoints) {
+    offered_qos_profiles.push_back(Rosbag2QoS(info.qos_profile()));
+  }
+  return YAML::Dump(offered_qos_profiles);
+}
+
+rclcpp::QoS Recorder::common_qos_or_fallback(const std::string & topic_name)
+{
+  auto endpoints = node_->get_publishers_info_by_topic(topic_name);
+  if (!endpoints.empty() && all_qos_same(endpoints)) {
+    return endpoints[0].qos_profile();
+  }
+  ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+    "Topic " << topic_name << " has publishers offering different QoS settings. "
+    "Can't guess what QoS to request, falling back to default QoS profile."
+  );
+  topics_warned_about_incompatibility_.insert(topic_name);
+  return Rosbag2QoS{};
+}
+
+void Recorder::warn_if_new_qos_for_subscribed_topic(const std::string & topic_name)
+{
+  auto existing_subscription = subscriptions_.find(topic_name);
+  if (existing_subscription == subscriptions_.end()) {
+    // Not subscribed yet
+    return;
+  }
+  if (topics_warned_about_incompatibility_.count(topic_name) > 0) {
+    // Already warned about this topic
+    return;
+  }
+  const rclcpp::QoS & used_qos = existing_subscription->second->qos_profile();
+  auto publishers_info = node_->get_publishers_info_by_topic(topic_name);
+  for (const auto & info : publishers_info) {
+    if (info.qos_profile() != used_qos) {
+      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+        "A new publisher for subscribed topic " << topic_name << " was found that is offering "
+        "a (possibly) incompatible QoS profile. Not changing subscription QoS. It is possible "
+        "you will not record messages from this new publisher."
+      );
+      topics_warned_about_incompatibility_.insert(topic_name);
+    }
+  }
 }
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -48,11 +48,15 @@ public:
   explicit Recorder(std::shared_ptr<rosbag2_cpp::Writer> writer, std::shared_ptr<Rosbag2Node> node);
 
   void record(const RecordOptions & record_options);
-  const std::unordered_set<std::string> & topics_using_fallback_qos() const
+
+  const std::unordered_set<std::string> &
+  topics_using_fallback_qos() const
   {
     return topics_warned_about_incompatibility_;
   }
-  const std::unordered_map<std::string, std::shared_ptr<GenericSubscription>> & subscriptions()
+
+  const std::unordered_map<std::string, std::shared_ptr<GenericSubscription>> &
+  subscriptions() const
   {
     return subscriptions_;
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -23,6 +23,8 @@
 #include <utility>
 #include <vector>
 
+#include "rclcpp/qos.hpp"
+
 #include "rosbag2_cpp/writer.hpp"
 
 #include "rosbag2_storage/topic_metadata.hpp"
@@ -67,14 +69,25 @@ private:
   void subscribe_topic(const rosbag2_storage::TopicMetadata & topic);
 
   std::shared_ptr<GenericSubscription> create_subscription(
-    const std::string & topic_name, const std::string & topic_type);
+    const std::string & topic_name, const std::string & topic_type, const rclcpp::QoS & qos);
 
   void record_messages() const;
 
+  /** Find the QoS profile that should be used for subscribing.
+    * If all currently offered QoS Profiles for a topic are the same, return that profile.
+    * Otherwise, print a warning and return a fallback value.
+    */
+  rclcpp::QoS common_qos_or_fallback(const std::string & topic_name);
+
+  // Serialize all currently offered QoS profiles for a topic into a YAML list.
+  std::string serialized_offered_qos_profiles_for_topic(const std::string & topic_name);
+
+  void warn_if_new_qos_for_subscribed_topic(const std::string & topic_name);
+
   std::shared_ptr<rosbag2_cpp::Writer> writer_;
   std::shared_ptr<Rosbag2Node> node_;
-  std::vector<std::shared_ptr<GenericSubscription>> subscriptions_;
-  std::unordered_set<std::string> subscribed_topics_;
+  std::unordered_map<std::string, std::shared_ptr<GenericSubscription>> subscriptions_;
+  std::unordered_set<std::string> topics_warned_about_incompatibility_;
   std::string serialization_format_;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -48,6 +48,14 @@ public:
   explicit Recorder(std::shared_ptr<rosbag2_cpp::Writer> writer, std::shared_ptr<Rosbag2Node> node);
 
   void record(const RecordOptions & record_options);
+  const std::unordered_set<std::string> & topics_using_fallback_qos() const
+  {
+    return topics_warned_about_incompatibility_;
+  }
+  const std::unordered_map<std::string, std::shared_ptr<GenericSubscription>> & subscriptions()
+  {
+    return subscriptions_;
+  }
 
 private:
   void topics_discovery(

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -133,7 +133,6 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
     }
     rclcpp::spin_some(publisher_node);
   }
-
   stop_recording();
 
   ASSERT_FALSE(timed_out);

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -100,3 +100,45 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   ));
 }
 #endif  // ENABLE_TEST_QOS_IS_STORED_IN_METADATA
+
+TEST_F(RecordIntegrationTestFixture, records_sensor_data)
+{
+  using clock = std::chrono::system_clock;
+  using namespace std::chrono_literals;
+
+  std::string topic = "/string_topic";
+  start_recording({false, false, {topic}, "rmw_format", 100ms});
+
+  auto publisher_node = std::make_shared<rclcpp::Node>("publisher_for_qos_test");
+  auto publisher = publisher_node->create_publisher<test_msgs::msg::Strings>(
+    topic, rclcpp::SensorDataQoS());
+  auto publish_timer = publisher_node->create_wall_timer(
+    50ms, [publisher]() -> void {
+      test_msgs::msg::Strings msg;
+      msg.string_value = "Hello";
+      publisher->publish(msg);
+    }
+  );
+  MockSequentialWriter & writer =
+    static_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
+
+  auto start = clock::now();
+  // Takes ~200ms normally, 5s chosen as "a very long time"
+  auto timeout = 5s;
+  bool timed_out = false;
+  while (writer.get_messages().empty()) {
+    if ((clock::now() - start) > timeout) {
+      timed_out = true;
+      break;
+    }
+    rclcpp::spin_some(publisher_node);
+  }
+
+  stop_recording();
+
+  ASSERT_FALSE(timed_out);
+  auto recorded_messages = writer.get_messages();
+  auto recorded_topics = writer.get_topics();
+  EXPECT_EQ(recorded_topics.size(), 1u);
+  EXPECT_FALSE(recorded_messages.empty());
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -299,7 +299,7 @@ TEST_F(RosBag2NodeFixture, mixed_qos_falls_back_to_default)
       break;
     }
     // rate limit the busy-wait and let other threads work
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(10ms);
   }
   ASSERT_FALSE(timed_out);
   // We must shut down rclcpp before returning from this test case or recording will block forever

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -21,13 +21,21 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include "rosbag2_cpp/writer.hpp"
+
 #include "rosbag2_test_common/memory_management.hpp"
+
+#include "rosbag2_transport/logging.hpp"
+#include "rosbag2_transport/storage_options.hpp"
 
 #include "test_msgs/message_fixtures.hpp"
 #include "test_msgs/msg/basic_types.hpp"
 
 #include "qos.hpp"
+#include "recorder.hpp"
 #include "rosbag2_node.hpp"
+
+#include "mock_sequential_writer.hpp"
 
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
@@ -250,4 +258,69 @@ TEST_F(RosBag2NodeFixture, get_all_topics_with_types_returns_all_topics)
   EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/msg/Strings"));
   EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/msg/Strings"));
   EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/msg/Strings"));
+}
+
+TEST(RosBag2Recorder, mixed_qos_falls_back_to_default)
+{
+  using clock = std::chrono::system_clock;
+  using namespace std::chrono_literals;
+  rclcpp::init(0, nullptr);
+  auto node_ = std::make_shared<rosbag2_transport::Rosbag2Node>("rosbag2");
+
+  std::string topic = "/string_topic";
+
+  rosbag2_transport::StorageOptions storage_options {"uri", "storage_id", 0};
+  auto writer = std::make_shared<rosbag2_cpp::Writer>(std::make_unique<MockSequentialWriter>());
+  writer->open(storage_options, {rmw_get_serialization_format(), "rmw_format"});
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(writer, node_);
+  auto recording_future = std::async(
+    std::launch::async, [recorder, topic]() {
+      recorder->record({false, false, {topic}, "rmw_format", 100ms});
+    }
+  );
+
+  // two QoS profiles that are not compatible with the default request, but are not equal
+  auto profile1 = rosbag2_transport::Rosbag2QoS().best_effort().durability_volatile();
+  auto profile2 = rosbag2_transport::Rosbag2QoS().best_effort().transient_local();
+  test_msgs::msg::Strings msg;
+  msg.string_value = "Hello";
+
+  auto publisher1 = node_->create_publisher<test_msgs::msg::Strings>(topic, profile1);
+  auto publisher2 = node_->create_publisher<test_msgs::msg::Strings>(topic, profile2);
+  auto publish1_timer = node_->create_wall_timer(
+    100ms, [publisher1, msg]() -> void {
+      publisher1->publish(msg);
+    }
+  );
+  auto publish2_timer = node_->create_wall_timer(
+    100ms, [publisher2, msg]() -> void {
+      publisher2->publish(msg);
+    }
+  );
+
+  auto start = clock::now();
+  // Takes < 20ms normally, timeout chosen as "a very long time"
+  auto timeout = 5s;
+  bool timed_out = false;
+  auto success_condition = [recorder, topic]() -> bool {
+    // We really care about the warning, but if we shutdown rclcpp before the subscription
+    // is created it will throw an exception when the recorder tries to subscribe
+    bool warned = recorder->topics_using_fallback_qos().count(topic) != 0;
+    bool subscribed = recorder->subscriptions().count(topic) != 0;
+    return warned && subscribed;
+  };
+  while (!success_condition()) {
+    if ((clock::now() - start) > timeout) {
+      timed_out = true;
+      break;
+    }
+    // the Recorder spins the node for us, so we don't need to, but we do need to
+    // relinquish control to let the Recorder thread do some work
+    std::this_thread::sleep_for(5ms);
+  }
+
+  rclcpp::shutdown();
+  recording_future.get();
+
+  ASSERT_FALSE(timed_out);
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -281,18 +281,18 @@ TEST_F(RosBag2NodeFixture, mixed_qos_falls_back_to_default)
   writer->open(storage_options, {rmw_get_serialization_format(), "rmw_format"});
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(writer, node_);
   auto recording_future = std::async(
-    std::launch::async, [recorder, topic]() {
+    std::launch::async,
+    [recorder, topic]() {
       recorder->record({false, false, {topic}, "rmw_format", 100ms});
-    }
-  );
+    });
 
   auto start = clock::now();
   // Takes < 20ms normally, timeout chosen as "a very long time"
   auto timeout = 5s;
   bool timed_out = false;
   auto success_condition = [recorder, topic]() -> bool {
-    return recorder->topics_using_fallback_qos().count(topic) != 0;
-  };
+      return recorder->topics_using_fallback_qos().count(topic) != 0;
+    };
   while (!success_condition()) {
     if ((clock::now() - start) > timeout) {
       timed_out = true;


### PR DESCRIPTION
Part of #125 
Moves https://github.com/ros-tooling/aws-roadmap/issues/216 to Done

Subscribe to topics using the common offered QoS if there is one, with sufficient warning in the cases where we can't.

As we discussed in the original design, we will not try to resolve compatibility at all. So, if all publishers at the time of subscription offer the same QoS profile (likely vast majority of cases), then that profile will be used to subscribe.

However, if there are different profiles being offered for a topic, fallback to the preexisting default. This means rosbag2 acts the same for these cases as it does before this PR. But, now we print a warning about it.

If new publishers join after our subscription was created, and they offer a different QoS profile than we used to subscribe, also print a warning about that case because it may result in loss of data.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>