### PR TITLE
resolve relative file paths

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+#include "rcpputils/asserts.hpp"
 #include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/logging.hpp"
@@ -30,7 +31,7 @@ namespace readers
 namespace details
 {
 std::vector<std::string> resolve_relative_paths(
-  const std::string & base_folder, std::vector<std::string> relative_files, size_t version = 4)
+  const std::string & base_folder, std::vector<std::string> relative_files, const int version = 4)
 {
   auto base_path = rcpputils::fs::path(base_folder);
   if (version < 4) {
@@ -38,10 +39,10 @@ std::vector<std::string> resolve_relative_paths(
     base_path = rcpputils::fs::path(base_folder).parent_path();
   }
 
-  rcpputils::require_true(base_path.exists(), "base folder does not exist: " + base_folder);
-  if (!base_path.is_directory()) {
-    throw std::invalid_argument("base folder has to be a directory: " + base_folder);
-  }
+  rcpputils::require_true(
+    base_path.exists(), "base folder does not exist: " + base_folder);
+  rcpputils::require_true(
+    base_path.is_directory(), "base folder has to be a directory: " + base_folder);
 
   for (auto & file : relative_files) {
     auto path = rcpputils::fs::path(file);

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -38,9 +38,7 @@ std::vector<std::string> resolve_relative_paths(
     base_path = rcpputils::fs::path(base_folder).parent_path();
   }
 
-  if (!base_path.exists()) {
-    throw std::invalid_argument("base folder does not exist: " + base_folder);
-  }
+  rcpputils::require_true(base_path.exists(), "base folder does not exist: " + base_folder);
   if (!base_path.is_directory()) {
     throw std::invalid_argument("base folder has to be a directory: " + base_folder);
   }

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -43,6 +43,12 @@ std::string format_storage_uri(const std::string & base_folder, uint64_t storage
 
   return (rcpputils::fs::path(base_folder) / storage_file_name.str()).string();
 }
+
+std::string strip_parent_path(const std::string & relative_path)
+{
+  return rcpputils::fs::path(relative_path).filename().string();
+}
+
 }  // namespace
 
 SequentialWriter::SequentialWriter(
@@ -70,7 +76,7 @@ void SequentialWriter::init_metadata()
   metadata_.storage_identifier = storage_->get_storage_identifier();
   metadata_.starting_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
     std::chrono::nanoseconds::max());
-  metadata_.relative_file_paths = {storage_->get_relative_file_path()};
+  metadata_.relative_file_paths = {strip_parent_path(storage_->get_relative_file_path())};
 }
 
 void SequentialWriter::open(
@@ -178,7 +184,7 @@ void SequentialWriter::split_bagfile()
     throw std::runtime_error(errmsg.str());
   }
 
-  metadata_.relative_file_paths.push_back(storage_->get_relative_file_path());
+  metadata_.relative_file_paths.push_back(strip_parent_path(storage_->get_relative_file_path()));
 
   // Re-register all topics since we rolled-over to a new bagfile.
   for (const auto & topic : topics_names_to_info_) {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -41,10 +41,10 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
+    storage_uri_(rcpputils::fs::temp_directory_path().string()),
     relative_path_1_("some_relative_path_1"),
     relative_path_2_("some_relative_path_2"),
-    absolute_path_1_(rcpputils::fs::path("/some/absolute/path1").string()),  // convert to MS
-    storage_uri_(rcpputils::fs::temp_directory_path().string()),
+    absolute_path_1_((rcpputils::fs::path(storage_uri_) / "some/folder").string()),
     default_storage_options_({storage_uri_, ""})
   {}
 
@@ -91,10 +91,10 @@ public:
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<rosbag2_cpp::Reader> reader_;
   std::string storage_serialization_format_;
+  std::string storage_uri_;
   std::string relative_path_1_;
   std::string relative_path_2_;
   std::string absolute_path_1_;
-  std::string storage_uri_;
   rosbag2_cpp::StorageOptions default_storage_options_;
 };
 
@@ -106,7 +106,7 @@ public:
   {
     relative_path_1_ = "rosbag_name/some_relative_path_1";
     relative_path_2_ = "rosbag_name/some_relative_path_2";
-    absolute_path_1_ = rcpputils::fs::path("/some/absolute/path1").string();
+    absolute_path_1_ = (rcpputils::fs::path(storage_uri_) / "some/folder").string();
   }
 
   rosbag2_storage::BagMetadata get_metadata() const override

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -82,7 +82,7 @@ public:
     rosbag2_storage::BagMetadata metadata;
 
     metadata.relative_file_paths =
-      {relative_path_1_, relative_path_2_, absolute_path_1_};
+    {relative_path_1_, relative_path_2_, absolute_path_1_};
 
     return metadata;
   }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -43,7 +43,7 @@ public:
     storage_serialization_format_("rmw1_format"),
     relative_path_1_("some_relative_path_1"),
     relative_path_2_("some_relative_path_2"),
-    absolute_path_1_("/some/absolute/path1"),
+    absolute_path_1_(rcpputils::fs::path("/some/absolute/path1").string()),  // convert to MS
     storage_uri_(rcpputils::fs::temp_directory_path().string()),
     default_storage_options_({storage_uri_, ""})
   {}
@@ -81,7 +81,8 @@ public:
   {
     rosbag2_storage::BagMetadata metadata;
 
-    metadata.relative_file_paths = {relative_path_1_, relative_path_2_, absolute_path_1_};
+    metadata.relative_file_paths =
+      {relative_path_1_, relative_path_2_, absolute_path_1_};
 
     return metadata;
   }
@@ -105,7 +106,7 @@ public:
   {
     relative_path_1_ = "rosbag_name/some_relative_path_1";
     relative_path_2_ = "rosbag_name/some_relative_path_2";
-    absolute_path_1_ = "/some/absolute/path1";
+    absolute_path_1_ = rcpputils::fs::path("/some/absolute/path1").string();
   }
 
   rosbag2_storage::BagMetadata get_metadata() const override
@@ -139,6 +140,8 @@ TEST_F(MultifileReaderTest, has_next_reads_next_file)
     (rcpputils::fs::path(storage_uri_) / relative_path_1_).string();
   auto resolved_relative_path_2 =
     (rcpputils::fs::path(storage_uri_) / relative_path_2_).string();
+  auto resolved_absolute_path_1 =
+    rcpputils::fs::path(absolute_path_1_).string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->has_next();
   reader_->read_next();
@@ -146,7 +149,7 @@ TEST_F(MultifileReaderTest, has_next_reads_next_file)
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);
   reader_->read_next();
   reader_->has_next();
-  EXPECT_EQ(sr.get_current_file(), absolute_path_1_);
+  EXPECT_EQ(sr.get_current_file(), resolved_absolute_path_1);
 }
 
 TEST_F(MultifileReaderTestVersion3, has_next_reads_next_file_version3)
@@ -172,6 +175,8 @@ TEST_F(MultifileReaderTestVersion3, has_next_reads_next_file_version3)
     (rcpputils::fs::path(storage_uri_).parent_path() / relative_path_1_).string();
   auto resolved_relative_path_2 =
     (rcpputils::fs::path(storage_uri_).parent_path() / relative_path_2_).string();
+  auto resolved_absolute_path_1 =
+    rcpputils::fs::path(absolute_path_1_).string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->has_next();
   reader_->read_next();
@@ -179,7 +184,7 @@ TEST_F(MultifileReaderTestVersion3, has_next_reads_next_file_version3)
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);
   reader_->read_next();
   reader_->has_next();
-  EXPECT_EQ(sr.get_current_file(), absolute_path_1_);
+  EXPECT_EQ(sr.get_current_file(), resolved_absolute_path_1);
 }
 
 TEST_F(MultifileReaderTest, has_next_throws_if_no_storage)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -81,9 +81,7 @@ public:
   {
     rosbag2_storage::BagMetadata metadata;
 
-    metadata.relative_file_paths.push_back(relative_path_1_);
-    metadata.relative_file_paths.push_back(relative_path_2_);
-    metadata.relative_file_paths.push_back(absolute_path_1_);
+    metadata.relative_file_paths = {relative_path_1_, relative_path_2_, absolute_path_1_};
 
     return metadata;
   }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -46,21 +46,22 @@ public:
     absolute_path_1_("/some/absolute/path1"),
     storage_uri_(rcpputils::fs::temp_directory_path().string()),
     default_storage_options_({storage_uri_, ""})
+  {}
+
+  virtual void init()
   {
+    auto metadata = get_metadata();
+
     auto topic_with_type = rosbag2_storage::TopicMetadata{
       "topic", "test_msgs/BasicTypes", storage_serialization_format_, ""};
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
+    metadata.topics_with_message_count.push_back({topic_with_type, 10});
 
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type.name;
 
     auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
-    rosbag2_storage::BagMetadata metadata;
-    metadata.relative_file_paths.push_back(relative_path_1_);
-    metadata.relative_file_paths.push_back(relative_path_2_);
-    metadata.relative_file_paths.push_back(absolute_path_1_);
-    metadata.topics_with_message_count.push_back({topic_with_type, 10});
     ON_CALL(*metadata_io, read_metadata(_)).WillByDefault(Return(metadata));
     EXPECT_CALL(*metadata_io, metadata_file_exists(_)).WillRepeatedly(Return(true));
 
@@ -74,6 +75,19 @@ public:
     reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(sequential_reader));
   }
 
+  virtual ~MultifileReaderTest() = default;
+
+  virtual rosbag2_storage::BagMetadata get_metadata() const
+  {
+    rosbag2_storage::BagMetadata metadata;
+
+    metadata.relative_file_paths.push_back(relative_path_1_);
+    metadata.relative_file_paths.push_back(relative_path_2_);
+    metadata.relative_file_paths.push_back(absolute_path_1_);
+
+    return metadata;
+  }
+
   std::shared_ptr<NiceMock<MockStorage>> storage_;
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<rosbag2_cpp::Reader> reader_;
@@ -85,11 +99,35 @@ public:
   rosbag2_cpp::StorageOptions default_storage_options_;
 };
 
+class MultifileReaderTestVersion3 : public MultifileReaderTest
+{
+public:
+  MultifileReaderTestVersion3()
+  : MultifileReaderTest()
+  {
+    relative_path_1_ = "rosbag_name/some_relative_path_1";
+    relative_path_2_ = "rosbag_name/some_relative_path_2";
+    absolute_path_1_ = "/some/absolute/path1";
+  }
+
+  rosbag2_storage::BagMetadata get_metadata() const override
+  {
+    auto metadata = MultifileReaderTest::get_metadata();
+    metadata.version = 3;
+
+    return metadata;
+  }
+};
+
 TEST_F(MultifileReaderTest, has_next_reads_next_file)
 {
+  init();
+
   // storage::has_next() is called twice when reader::has_next() is called
   EXPECT_CALL(*storage_, has_next()).Times(6)
   .WillOnce(Return(true)).WillOnce(Return(true))  // We have a message
+  .WillOnce(Return(false))  // No message, load next file
+  .WillOnce(Return(true))  // True since we now have a message
   .WillOnce(Return(false))  // No message, load next file
   .WillOnce(Return(true));  // True since we now have a message
   EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_)).Times(0);
@@ -99,6 +137,39 @@ TEST_F(MultifileReaderTest, has_next_reads_next_file)
   auto & sr = static_cast<rosbag2_cpp::readers::SequentialReader &>(
     reader_->get_implementation_handle());
 
+  auto resolved_relative_path_1 =
+    (rcpputils::fs::path(storage_uri_) / relative_path_1_).string();
+  auto resolved_relative_path_2 =
+    (rcpputils::fs::path(storage_uri_) / relative_path_2_).string();
+  EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
+  reader_->has_next();
+  reader_->read_next();
+  reader_->has_next();
+  EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);
+  reader_->read_next();
+  reader_->has_next();
+  EXPECT_EQ(sr.get_current_file(), absolute_path_1_);
+}
+
+TEST_F(MultifileReaderTestVersion3, has_next_reads_next_file_version3)
+{
+  init();
+
+  // storage::has_next() is called twice when reader::has_next() is called
+  EXPECT_CALL(*storage_, has_next()).Times(6)
+  .WillOnce(Return(true)).WillOnce(Return(true))  // We have a message
+  .WillOnce(Return(false))  // No message, load next file
+  .WillOnce(Return(true))  // True since we now have a message
+  .WillOnce(Return(false))  // No message, load next file
+  .WillOnce(Return(true));  // True since we now have a message
+  EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_)).Times(0);
+  EXPECT_CALL(*converter_factory_, load_serializer(storage_serialization_format_)).Times(0);
+  reader_->open(default_storage_options_, {"", storage_serialization_format_});
+
+  auto & sr = static_cast<rosbag2_cpp::readers::SequentialReader &>(
+    reader_->get_implementation_handle());
+
+  // Legacy version <=3 have a parent_path() prefixed in the relative files
   auto resolved_relative_path_1 =
     (rcpputils::fs::path(storage_uri_).parent_path() / relative_path_1_).string();
   auto resolved_relative_path_2 =
@@ -115,15 +186,21 @@ TEST_F(MultifileReaderTest, has_next_reads_next_file)
 
 TEST_F(MultifileReaderTest, has_next_throws_if_no_storage)
 {
+  init();
+
   EXPECT_ANY_THROW(reader_->has_next());
 }
 
 TEST_F(MultifileReaderTest, read_next_throws_if_no_storage)
 {
+  init();
+
   EXPECT_ANY_THROW(reader_->read_next());
 }
 
 TEST_F(MultifileReaderTest, get_all_topics_and_types_throws_if_no_storage)
 {
+  init();
+
   EXPECT_ANY_THROW(reader_->get_all_topics_and_types());
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -139,7 +139,7 @@ TEST_F(SequentialReaderTest, set_filter_calls_storage) {
   EXPECT_ANY_THROW(reader_->get_implementation_handle().reset_filter());
 
   EXPECT_CALL(*storage_, set_filter(_)).Times(2);
-  reader_->open(rosbag2_cpp::StorageOptions(), {"", storage_serialization_format_});
+  reader_->open(default_storage_options_, {"", storage_serialization_format_});
   reader_->get_implementation_handle().set_filter(storage_filter);
   reader_->read_next();
   storage_filter.topics.clear();

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -55,10 +55,11 @@ public:
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type.name;
 
+    auto relative_file_path = rcpputils::fs::path("/absolute/path/to/storage").string();
     auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
     rosbag2_storage::BagMetadata metadata;
-    metadata.relative_file_paths = {"/path/to/storage"};
+    metadata.relative_file_paths = {relative_file_path};
     metadata.topics_with_message_count.push_back({{topic_with_type}, 1});
 
     EXPECT_CALL(*metadata_io, read_metadata(_)).WillRepeatedly(Return(metadata));
@@ -71,7 +72,7 @@ public:
     EXPECT_CALL(*storage_factory, open_read_only(_, _));
     ON_CALL(*storage_factory, open_read_only).WillByDefault(
       [this](const std::string & path, const std::string & /* storage_id */) {
-        EXPECT_STREQ("/path/to/storage", path.c_str());
+        EXPECT_STREQ(relative_file_path.c_str(), path.c_str());
         return storage_;
       });
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -71,7 +71,7 @@ public:
 
     EXPECT_CALL(*storage_factory, open_read_only(_, _));
     ON_CALL(*storage_factory, open_read_only).WillByDefault(
-      [this](const std::string & path, const std::string & /* storage_id */) {
+      [this, relative_file_path](const std::string & path, const std::string & /* storage_id */) {
         EXPECT_STREQ(relative_file_path.c_str(), path.c_str());
         return storage_;
       });

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -55,7 +55,8 @@ public:
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type.name;
 
-    auto relative_file_path = rcpputils::fs::path("/absolute/path/to/storage").string();
+    auto relative_file_path =
+      (rcpputils::fs::path(storage_uri_) / rcpputils::fs::path("some/folder")).string();
     auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
     rosbag2_storage::BagMetadata metadata;

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -56,7 +56,7 @@ public:
     message->topic_name = topic_with_type.name;
 
     auto relative_file_path =
-      (rcpputils::fs::path(storage_uri_) / rcpputils::fs::path("some/folder")).string();
+      (rcpputils::fs::path(storage_uri_) / "some/folder").string();
     auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
     rosbag2_storage::BagMetadata metadata;

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -243,8 +243,7 @@ TEST_F(SequentialWriterTest, writer_splits_when_storage_bagfile_size_gt_max_bagf
     static_cast<unsigned int>(expected_splits)) <<
     "Storage should have split bagfile " << (expected_splits - 1);
 
-  const auto base_path =
-    (rcpputils::fs::path(storage_options_.uri) / storage_options_.uri).string();
+  const auto base_path = storage_options_.uri;
   int counter = 0;
   for (const auto & path : fake_metadata_.relative_file_paths) {
     std::stringstream ss;

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -258,7 +258,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 
     // Loop until expected_splits in case it split or the bagfile doesn't exist.
     for (int i = 0; i < expected_splits; ++i) {
-      const auto bag_file_path = get_bag_file_path(i);
+      const auto bag_file_path = get_bag_file_name(i);
 
       if (bag_file_path.exists()) {
         metadata.relative_file_paths.push_back(bag_file_path.string());
@@ -329,7 +329,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
     rosbag2_storage::BagMetadata metadata;
     metadata.version = 4;
     metadata.storage_identifier = "sqlite3";
-    metadata.relative_file_paths = {get_bag_file_path(0).string()};
+    metadata.relative_file_paths = {get_bag_file_name(0).string()};
     metadata_io.write_metadata(root_bag_path_.string(), metadata);
   }
 #endif
@@ -388,7 +388,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
     metadata.storage_identifier = "sqlite3";
 
     for (int i = 0; i < expected_splits; ++i) {
-      const auto bag_file_path = get_bag_file_path(i);
+      const auto bag_file_path = get_bag_file_name(i);
 
       // There is no guarantee that the bagfile split expected_split times
       // due to possible io sync delays. Instead, assert that the bagfile split

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -338,8 +338,10 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   // Check that there's only 1 bagfile and that it exists.
-  EXPECT_EQ(1u, metadata.relative_file_paths.size());
-  EXPECT_TRUE((root_bag_path_ / metadata.relative_file_paths[0]).exists());
+  ASSERT_EQ(1u, metadata.relative_file_paths.size());
+  const auto bagfile_path = root_bag_path_ / rcpputils::fs::path{metadata.relative_file_paths[0]};
+  ASSERT_TRUE(bagfile_path.exists()) <<
+    "Expected bag file: \"" << bagfile_path.string() << "\" to exist.";
 
   // Check that the next bagfile does not exist.
   const auto next_bag_file = get_bag_file_path(1);

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -329,7 +329,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
     rosbag2_storage::BagMetadata metadata;
     metadata.version = 4;
     metadata.storage_identifier = "sqlite3";
-    metadata.relative_file_paths = {get_bag_file_name(0)};
+    metadata.relative_file_paths = {get_bag_file_name(0) + ".db3"};
     metadata_io.write_metadata(root_bag_path_.string(), metadata);
   }
 #endif

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -260,8 +260,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
     for (int i = 0; i < expected_splits; ++i) {
       const auto bag_file_path = get_bag_file_name(i);
 
-      if (bag_file_path.exists()) {
-        metadata.relative_file_paths.push_back(bag_file_path.string());
+      if (rcpputils::fs::path(bag_file_path).exists()) {
+        metadata.relative_file_paths.push_back(bag_file_path);
       } else {
         break;
       }
@@ -329,7 +329,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
     rosbag2_storage::BagMetadata metadata;
     metadata.version = 4;
     metadata.storage_identifier = "sqlite3";
-    metadata.relative_file_paths = {get_bag_file_name(0).string()};
+    metadata.relative_file_paths = {get_bag_file_name(0)};
     metadata_io.write_metadata(root_bag_path_.string(), metadata);
   }
 #endif
@@ -393,8 +393,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
       // There is no guarantee that the bagfile split expected_split times
       // due to possible io sync delays. Instead, assert that the bagfile split
       // at least once
-      if (bag_file_path.exists()) {
-        metadata.relative_file_paths.push_back(bag_file_path.string());
+      if (rcpputils::fs::path(bag_file_path).exists()) {
+        metadata.relative_file_paths.push_back(bag_file_path);
       }
     }
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -253,7 +253,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 #ifdef _WIN32
   {
     rosbag2_storage::BagMetadata metadata;
-    metadata.version = 2;
+    metadata.version = 4;
     metadata.storage_identifier = "sqlite3";
 
     // Loop until expected_splits in case it split or the bagfile doesn't exist.
@@ -282,7 +282,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 
   // Don't include the last bagfile since it won't be full
   for (int i = 0; i < actual_splits - 1; ++i) {
-    const auto bagfile_path = rcpputils::fs::path{metadata.relative_file_paths[i]};
+    const auto bagfile_path = root_bag_path_ / rcpputils::fs::path{metadata.relative_file_paths[i]};
     ASSERT_TRUE(bagfile_path.exists()) <<
       "Expected bag file: \"" << bagfile_path.string() << "\" to exist.";
 
@@ -327,7 +327,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 #ifdef _WIN32
   {
     rosbag2_storage::BagMetadata metadata;
-    metadata.version = 2;
+    metadata.version = 4;
     metadata.storage_identifier = "sqlite3";
     metadata.relative_file_paths = {get_bag_file_path(0).string()};
     metadata_io.write_metadata(root_bag_path_.string(), metadata);
@@ -339,7 +339,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 
   // Check that there's only 1 bagfile and that it exists.
   EXPECT_EQ(1u, metadata.relative_file_paths.size());
-  EXPECT_TRUE(rcpputils::fs::exists(metadata.relative_file_paths[0]));
+  EXPECT_TRUE((root_bag_path_ / metadata.relative_file_paths[0]).exists());
 
   // Check that the next bagfile does not exist.
   const auto next_bag_file = get_bag_file_path(1);
@@ -384,7 +384,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
 #ifdef _WIN32
   {
     rosbag2_storage::BagMetadata metadata;
-    metadata.version = 2;
+    metadata.version = 4;
     metadata.storage_identifier = "sqlite3";
 
     for (int i = 0; i < expected_splits; ++i) {
@@ -406,7 +406,8 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   wait_for_metadata();
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
-  for (const auto & path : metadata.relative_file_paths) {
+  for (const auto & rel_path : metadata.relative_file_paths) {
+    auto path = root_bag_path_ / rcpputils::fs::path(rel_path);
     EXPECT_TRUE(rcpputils::fs::exists(path));
   }
 }


### PR DESCRIPTION
fixes #229 

It basically takes the relative file paths and resolves them relativ to the base folder name, essentially the name of the rosbag to be replayed.
If one of these relativ files is actually in an absolute form, it will ignore it.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>