### PR TITLE
Override Subscriber QoS - Record

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
@@ -78,7 +78,7 @@ public:
     const std::string & topic_name,
     std::shared_ptr<T> message,
     size_t expected_messages = 0,
-    const rclcpp::QoS & qos = rclcpp::QoS(10))
+    const rclcpp::QoS & qos = rclcpp::QoS{10})
   {
     auto node_name = std::string("publisher") + std::to_string(counter_++);
     auto publisher_node = std::make_shared<rclcpp::Node>(

--- a/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
@@ -75,13 +75,16 @@ public:
 
   template<class T>
   void add_publisher(
-    const std::string & topic_name, std::shared_ptr<T> message, size_t expected_messages = 0)
+    const std::string & topic_name,
+    std::shared_ptr<T> message,
+    size_t expected_messages = 0,
+    const rclcpp::QoS & qos = rclcpp::QoS(10))
   {
     auto node_name = std::string("publisher") + std::to_string(counter_++);
     auto publisher_node = std::make_shared<rclcpp::Node>(
       node_name,
       rclcpp::NodeOptions().start_parameter_event_publisher(false).enable_rosout(false));
-    auto publisher = publisher_node->create_publisher<T>(topic_name, 10);
+    auto publisher = publisher_node->create_publisher<T>(topic_name, qos);
 
     publisher_nodes_.push_back(publisher_node);
     publishers_.push_back(

--- a/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publisher_manager.hpp
@@ -78,7 +78,7 @@ public:
     const std::string & topic_name,
     std::shared_ptr<T> message,
     size_t expected_messages = 0,
-    const rclcpp::QoS & qos = rclcpp::QoS{10})
+    const rclcpp::QoS & qos = rclcpp::QoS{rclcpp::KeepAll()})
   {
     auto node_name = std::string("publisher") + std::to_string(counter_++);
     auto publisher_node = std::make_shared<rclcpp::Node>(

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -15,6 +15,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
+# TODO(piraka9011) Remove once testing is finished
+add_definitions(-DROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION)
+
 # Windows supplies macros for min and max by default. We should only use min and max from stl
 if(WIN32)
   add_definitions(-DNOMINMAX)

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -153,10 +153,10 @@ function(create_tests_for_rmw_implementation)
 
   rosbag2_transport_add_gmock(test_record
     test/rosbag2_transport/test_record.cpp
-    ${SKIP_TEST}
-    LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common
-    INCLUDE_DIRS src/rosbag2_transport)
+    INCLUDE_DIRS src
+    LINK_LIBS rosbag2_transport
+    ${SKIP_TEST})
 
   rosbag2_transport_add_gmock(test_play
     test/rosbag2_transport/test_play.cpp

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -155,7 +155,8 @@ function(create_tests_for_rmw_implementation)
     test/rosbag2_transport/test_record.cpp
     ${SKIP_TEST}
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS test_msgs rosbag2_test_common)
+    AMENT_DEPS test_msgs rosbag2_test_common
+    INCLUDE_DIRS src/rosbag2_transport)
 
   rosbag2_transport_add_gmock(test_play
     test/rosbag2_transport/test_play.cpp

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -151,7 +151,7 @@ function(create_tests_for_rmw_implementation)
   rosbag2_transport_add_gmock(test_record
     test/rosbag2_transport/test_record.cpp
     AMENT_DEPS test_msgs rosbag2_test_common
-    INCLUDE_DIRS src
+    INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
     LINK_LIBS rosbag2_transport
     ${SKIP_TEST})
 

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -15,9 +15,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
-# TODO(piraka9011) Remove once testing is finished
-add_definitions(-DROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION)
-
 # Windows supplies macros for min and max by default. We should only use min and max from stl
 if(WIN32)
   add_definitions(-DNOMINMAX)

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -17,7 +17,10 @@
 
 #include <chrono>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include "rclcpp/rclcpp.hpp"
 
 namespace rosbag2_transport
 {
@@ -32,7 +35,7 @@ public:
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";
-  std::string qos_profiles = "";
+  std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides{};
   bool include_hidden_topics = false;
 };
 

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -32,6 +32,7 @@ public:
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";
+  std::string qos_profiles = "";
   bool include_hidden_topics = false;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -203,7 +203,7 @@ std::string Recorder::serialized_offered_qos_profiles_for_topic(const std::strin
 
 rclcpp::QoS Recorder::subscription_qos_for_topic(const std::string & topic_name)
 {
-  rclcpp::QoS subscription_qos{10};
+  rclcpp::QoS subscription_qos{rclcpp::KeepAll()};
   if (topic_qos_profile_overrides_.count(topic_name)) {
     subscription_qos = topic_qos_profile_overrides_.at(topic_name);
     ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Overriding subscription profile for " << topic_name);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -150,9 +150,9 @@ void Recorder::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   // that callback called before we reached out the line: writer_->create_topic(topic)
   writer_->create_topic(topic);
 
-  // TODO(emersonknapp) re-enable common_qos_or_fallback once the cyclone situation is resolved
+  // TODO(emersonknapp) re-enable subscription_qos_for_topic once the cyclone situation is resolved
   #ifdef ROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION
-  Rosbag2QoS subscription_qos{common_qos_or_fallback(topic.name)};
+  Rosbag2QoS subscription_qos{subscription_qos_for_topic(topic.name)};
   #else
   Rosbag2QoS subscription_qos{};
   #endif  // ROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION
@@ -206,7 +206,7 @@ std::string Recorder::serialized_offered_qos_profiles_for_topic(const std::strin
   return YAML::Dump(offered_qos_profiles);
 }
 
-rclcpp::QoS Recorder::common_qos_or_fallback(const std::string & topic_name)
+rclcpp::QoS Recorder::subscription_qos_for_topic(const std::string & topic_name)
 {
   rclcpp::QoS subscription_qos{10};
   if (topic_qos_profile_overrides_.count(topic_name)) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<GenericSubscription>
 Recorder::create_subscription(
   const std::string & topic_name, const std::string & topic_type, const rclcpp::QoS & qos)
 {
-  auto subscription_qos = Rosbag2QoS();
+  Rosbag2QoS subscription_qos(qos);
   if (qos_profile_overrides_[topic_name]) {
     subscription_qos = qos_profile_overrides_[topic_name].as<Rosbag2QoS>();
     ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Overriding subscription profile for " << topic_name);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -98,11 +98,18 @@ private:
 
   void record_messages() const;
 
-  /** Find the QoS profile that should be used for subscribing.
-    * If all currently offered QoS Profiles for a topic are the same, return that profile.
-    * Otherwise, print a warning and return a fallback value.
-    */
-  rclcpp::QoS common_qos_or_fallback(const std::string & topic_name);
+  /**
+   * Find the QoS profile that should be used for subscribing.
+   *
+   * Profiles are prioritized by:
+   *   1. The override specified in the record_options, if one exists for the topic.
+   *   2. The common offered QoS profile.
+   *   2. A fallback QoS profile if the offered and requested profiles are different.
+   *
+   *   \param topic_name The full name of the topic, with namespace (ex. /arm/joint_status).
+   *   \return The QoS profile to be used for subscribing.
+   */
+  rclcpp::QoS subscription_qos_for_topic(const std::string & topic_name);
 
   // Serialize all currently offered QoS profiles for a topic into a YAML list.
   std::string serialized_offered_qos_profiles_for_topic(const std::string & topic_name);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -90,8 +90,8 @@ private:
    *
    * Profiles are prioritized by:
    *   1. The override specified in the record_options, if one exists for the topic.
-   *   2. The publisher's offered QoS profile.
-   *      If all current publishers are offering the exact same compatibility profile.
+   *   2. The publisher's offered QoS profile if all current publishers are offering the exact same
+   *      compatibility profile.
    *   3. The default Rosbag2QoS profile, if the above conditions are not met.
    *
    *   \param topic_name The full name of the topic, with namespace (ex. /arm/joint_status).

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -23,6 +23,19 @@
 #include <utility>
 #include <vector>
 
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
+
 #include "rclcpp/qos.hpp"
 
 #include "rosbag2_cpp/writer.hpp"
@@ -101,6 +114,7 @@ private:
   std::unordered_map<std::string, std::shared_ptr<GenericSubscription>> subscriptions_;
   std::unordered_set<std::string> topics_warned_about_incompatibility_;
   std::string serialization_format_;
+  YAML::Node qos_profile_overrides_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -114,7 +114,7 @@ private:
   std::unordered_map<std::string, std::shared_ptr<GenericSubscription>> subscriptions_;
   std::unordered_set<std::string> topics_warned_about_incompatibility_;
   std::string serialization_format_;
-  YAML::Node qos_profile_overrides_;
+  std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -23,19 +23,6 @@
 #include <utility>
 #include <vector>
 
-#ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
-// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-# pragma warning(push)
-# pragma warning(disable:4251)
-# pragma warning(disable:4275)
-#endif
-#include "yaml-cpp/yaml.h"
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
-
 #include "rclcpp/qos.hpp"
 
 #include "rosbag2_cpp/writer.hpp"
@@ -103,8 +90,9 @@ private:
    *
    * Profiles are prioritized by:
    *   1. The override specified in the record_options, if one exists for the topic.
-   *   2. The common offered QoS profile.
-   *   2. A fallback QoS profile if the offered and requested profiles are different.
+   *   2. The publisher's offered QoS profile.
+   *      If all current publishers are offering the exact same compatibility profile.
+   *   3. The default Rosbag2QoS profile, if the above conditions are not met.
    *
    *   \param topic_name The full name of the topic, with namespace (ex. /arm/joint_status).
    *   \return The QoS profile to be used for subscribing.

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -172,8 +172,8 @@ TEST_F(RecordIntegrationTestFixture, topic_qos_overrides)
 
   // Create two publishers on the same topic with different QoS profiles.
   // If no override is specified, then the recorder cannot see any published messages.
-  auto profile1 = rosbag2_transport::Rosbag2QoS().best_effort().durability_volatile();
-  auto profile2 = rosbag2_transport::Rosbag2QoS().best_effort().transient_local();
+  auto profile1 = rosbag2_transport::Rosbag2QoS{}.best_effort().durability_volatile();
+  auto profile2 = rosbag2_transport::Rosbag2QoS{}.best_effort().transient_local();
   pub_man_.add_publisher<test_msgs::msg::Strings>(strict_topic, strict_msg, 3, profile1);
   pub_man_.add_publisher<test_msgs::msg::Strings>(strict_topic, strict_msg, 3, profile2);
 
@@ -181,7 +181,7 @@ TEST_F(RecordIntegrationTestFixture, topic_qos_overrides)
   run_publishers();
   stop_recording();
 
-  MockSequentialWriter & writer =
+  auto & writer =
     static_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
   auto recorded_messages = writer.get_messages();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -144,7 +144,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data) {
 
 TEST_F(RecordIntegrationTestFixture, topic_qos_overrides)
 {
-  const auto num_expected_msgs = 3;
+  const auto num_msgs = 3;
   auto strict_msg = std::make_shared<test_msgs::msg::Strings>();
   strict_msg->string_value = "strict";
   const auto strict_topic = "/strict_topic";
@@ -158,14 +158,14 @@ TEST_F(RecordIntegrationTestFixture, topic_qos_overrides)
   };
   record_options.topic_qos_profile_overrides = topic_qos_profile_overrides;
 
-  // Create two publishers on the same topic with different QoS profiles.
+  // Create two BEST_EFFORT publishers on the same topic with different Durability policies.
   // If no override is specified, then the recorder cannot see any published messages.
   auto profile1 = rosbag2_transport::Rosbag2QoS{}.best_effort().durability_volatile();
   auto profile2 = rosbag2_transport::Rosbag2QoS{}.best_effort().transient_local();
   pub_man_.add_publisher<test_msgs::msg::Strings>(
-    strict_topic, strict_msg, num_expected_msgs, profile1);
+    strict_topic, strict_msg, num_msgs, profile1);
   pub_man_.add_publisher<test_msgs::msg::Strings>(
-    strict_topic, strict_msg, num_expected_msgs, profile2);
+    strict_topic, strict_msg, num_msgs, profile2);
 
   start_recording(record_options);
   run_publishers();

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -147,10 +147,9 @@ TEST_F(RecordIntegrationTestFixture, topic_qos_overrides)
   auto strict_msg = std::make_shared<test_msgs::msg::Strings>();
   strict_msg->string_value = "strict";
   std::string strict_topic = "/strict_topic";
-  std::string relaxed_topic = "/relaxed_topic";
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, {strict_topic, relaxed_topic}, "rmw_format", 100ms};
+  {false, false, {strict_topic}, "rmw_format", 100ms};
   // 0 means system default for all options
   record_options.qos_profiles =
     "/strict_topic:\n"

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -118,7 +118,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data) {
       publisher->publish(msg);
     }
   );
-  MockSequentialWriter &writer =
+  MockSequentialWriter & writer =
     static_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
 
   auto start = clock::now();

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -21,7 +21,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "rosbag2_transport/qos.hpp"
+#include "qos.hpp"
 #include "rosbag2_transport/rosbag2_transport.hpp"
 
 #include "test_msgs/msg/arrays.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -21,7 +21,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "../../src/rosbag2_transport/qos.hpp"
+#include "qos.hpp"
 #include "rosbag2_transport/rosbag2_transport.hpp"
 
 #include "test_msgs/msg/arrays.hpp"
@@ -140,6 +140,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data) {
   EXPECT_EQ(recorded_topics.size(), 1u);
   EXPECT_FALSE(recorded_messages.empty());
 }
+#endif  // ROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION
 
 TEST_F(RecordIntegrationTestFixture, topic_qos_overrides)
 {
@@ -174,4 +175,3 @@ TEST_F(RecordIntegrationTestFixture, topic_qos_overrides)
 
   ASSERT_GE(recorded_messages.size(), 0u);
 }
-#endif  // ROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION


### PR DESCRIPTION
* Add a `qos_profiles` string to the recording options
* Expose Publisher's QoS profile option in `PublisherManager`
* Override a topic's QoS profile if an override is specified.

Part of #125
Part of ros-tooling/aws-roadmap#218

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>