### PR TITLE
Test all RMW implementations for rosbag2_transport

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,18 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.13
     - uses: ros-tooling/action-ros-ci@0.0.13
       with:
-        package-name: ros2bag rosbag2_compression rosbag2_cpp rosbag2_storage rosbag2_storage_default_plugins rosbag2_test_common rosbag2_tests shared_queues_vendor sqlite3_vendor
+        package-name: |
+          ros2bag
+          rosbag2_compression
+          rosbag2_converter_default_plugins
+          rosbag2_cpp
+          rosbag2_storage
+          rosbag2_storage_default_plugins
+          rosbag2_transport
+          shared_queues_vendor
+          sqlite3_vendor
+          rosbag2_test_common
+          rosbag2_tests
     - uses: actions/upload-artifact@master
       with:
         name: colcon-logs

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosbag2_compression REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
+find_package(rmw_implementation_cmake REQUIRED)
 find_package(shared_queues_vendor REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
@@ -84,6 +85,112 @@ ament_export_interfaces(export_${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rosbag2_cpp rosbag2_compression yaml_cpp_vendor)
 
+function(rosbag2_transport_add_gmock target_base)
+  cmake_parse_arguments(ARG
+    "SKIP_TEST"
+    ""
+    "LINK_LIBS;AMENT_DEPS;INCLUDE_DIRS"
+    ${ARGN})
+  if(NOT ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "rosbag2_transport_add_gmock() must be invoked with "
+      "at least one source file")
+  endif()
+  if(${ARG_SKIP_TEST})
+    set(SKIP_TEST "SKIP_TEST")
+  else()
+    set(SKIP_TEST "")
+  endif()
+
+  set(target_name ${target_base}${target_suffix})
+  set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+  ament_add_gmock(${target_name}
+    ${ARG_UNPARSED_ARGUMENTS}
+    ENV ${rmw_implementation_env_var}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    ${SKIP_TEST})
+  if(TARGET ${target_name})
+    target_link_libraries(${target_name} ${ARG_LINK_LIBS})
+    target_include_directories(${target_name} PUBLIC ${ARG_INCLUDE_DIRS})
+    ament_target_dependencies(${target_name} ${ARG_AMENT_DEPS})
+  endif()
+endfunction()
+
+function(create_tests_for_rmw_implementation)
+  rosbag2_transport_add_gmock(test_info
+    test/rosbag2_transport/test_info.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS rosbag2_test_common)
+
+  rosbag2_transport_add_gmock(test_record_all
+    test/rosbag2_transport/test_record_all.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
+  rosbag2_transport_add_gmock(test_record_all_no_discovery
+    test/rosbag2_transport/test_record_all_no_discovery.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
+  rosbag2_transport_add_gmock(test_play_timing
+    test/rosbag2_transport/test_play_timing.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
+  rosbag2_transport_add_gmock(test_rosbag2_node
+    src/rosbag2_transport/generic_publisher.cpp
+    src/rosbag2_transport/generic_subscription.cpp
+    src/rosbag2_transport/qos.cpp
+    src/rosbag2_transport/recorder.cpp
+    src/rosbag2_transport/rosbag2_node.cpp
+    test/rosbag2_transport/test_rosbag2_node.cpp
+    INCLUDE_DIRS
+      PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
+      $<INSTALL_INTERFACE:include>
+    AMENT_DEPS
+      ament_index_cpp
+      rclcpp
+      rosbag2_cpp
+      rosbag2_test_common
+      test_msgs
+      yaml_cpp_vendor)
+
+  rosbag2_transport_add_gmock(test_formatter
+    test/rosbag2_transport/test_formatter.cpp
+    src/rosbag2_transport/formatter.cpp
+    LINK_LIBS rosbag2_transport)
+
+  rosbag2_transport_add_gmock(test_qos
+    src/rosbag2_transport/qos.cpp
+    test/rosbag2_transport/test_qos.cpp
+    INCLUDE_DIRS
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
+    AMENT_DEPS
+      rosbag2_test_common
+      yaml_cpp_vendor)
+
+  # disable the following tests for connext
+  # due to slower discovery of nodes
+  set(SKIP_TEST "")
+  if(${rmw_implementation} MATCHES "(.*)connext(.*)")
+    set(SKIP_TEST "SKIP_TEST")
+  endif()
+
+  rosbag2_transport_add_gmock(test_record
+    test/rosbag2_transport/test_record.cpp
+    ${SKIP_TEST}
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
+  rosbag2_transport_add_gmock(test_play
+    test/rosbag2_transport/test_play.cpp
+    ${SKIP_TEST}
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+endfunction()
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_index_cpp REQUIRED)
@@ -93,111 +200,7 @@ if(BUILD_TESTING)
   # explicitly disable cppcheck
   set(ament_cmake_cppcheck_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
-
-  ament_add_gmock(test_info
-    test/rosbag2_transport/test_info.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_info)
-    target_link_libraries(test_info rosbag2_transport)
-    ament_target_dependencies(test_info rosbag2_test_common)
-  endif()
-
-  ament_add_gmock(test_record_all
-    test/rosbag2_transport/test_record_all.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_record_all)
-    target_link_libraries(test_record_all rosbag2_transport)
-    ament_target_dependencies(test_record_all test_msgs rosbag2_test_common)
-  endif()
-
-  ament_add_gmock(test_record_all_no_discovery
-    test/rosbag2_transport/test_record_all_no_discovery.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_record_all_no_discovery)
-    target_link_libraries(test_record_all_no_discovery rosbag2_transport)
-    ament_target_dependencies(test_record_all_no_discovery test_msgs rosbag2_test_common)
-  endif()
-
-  ament_add_gmock(test_play_timing
-    test/rosbag2_transport/test_play_timing.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_play_timing)
-    target_link_libraries(test_play_timing rosbag2_transport)
-    ament_target_dependencies(test_play_timing test_msgs rosbag2_test_common)
-  endif()
-
-  ament_add_gmock(test_rosbag2_node
-    src/rosbag2_transport/generic_publisher.cpp
-    src/rosbag2_transport/generic_subscription.cpp
-    src/rosbag2_transport/qos.cpp
-    src/rosbag2_transport/recorder.cpp
-    src/rosbag2_transport/rosbag2_node.cpp
-    test/rosbag2_transport/test_rosbag2_node.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_rosbag2_node)
-    target_include_directories(test_rosbag2_node
-      PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
-      $<INSTALL_INTERFACE:include>)
-    ament_target_dependencies(test_rosbag2_node
-      ament_index_cpp
-      rclcpp
-      rosbag2_cpp
-      rosbag2_test_common
-      test_msgs
-      yaml_cpp_vendor)
-  endif()
-
-  ament_add_gmock(test_formatter
-    test/rosbag2_transport/test_formatter.cpp
-    src/rosbag2_transport/formatter.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  if(TARGET test_formatter)
-    target_link_libraries(test_formatter rosbag2_transport)
-  endif()
-
-  # disable the following tests for connext
-  # due to slower discovery of nodes
-  get_default_rmw_implementation(rmw_default)
-  set(SKIP_TEST "")
-  if(${rmw_default} MATCHES "(.*)connext(.*)")
-    set(SKIP_TEST "SKIP_TEST")
-  endif()
-
-  ament_add_gmock(test_record
-    test/rosbag2_transport/test_record.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    ${SKIP_TEST})
-  if(TARGET test_record)
-    target_link_libraries(test_record rosbag2_transport)
-    ament_target_dependencies(test_record test_msgs rosbag2_test_common)
-  endif()
-
-  ament_add_gmock(test_play
-    test/rosbag2_transport/test_play.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    ${SKIP_TEST})
-  if(TARGET test_play)
-    target_link_libraries(test_play rosbag2_transport)
-    ament_target_dependencies(test_play test_msgs rosbag2_test_common)
-  endif()
-
-  ament_add_gmock(test_qos
-    src/rosbag2_transport/qos.cpp
-    test/rosbag2_transport/test_qos.cpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    ${SKIP_TEST})
-  if(TARGET test_qos)
-    target_include_directories(test_qos
-      PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>)
-    ament_target_dependencies(test_qos
-      rosbag2_test_common
-      yaml_cpp_vendor)
-  endif()
-
+  call_for_each_rmw_implementation(create_tests_for_rmw_implementation)
 endif()
 
 ament_package()

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -85,36 +85,6 @@ ament_export_interfaces(export_${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rosbag2_cpp rosbag2_compression yaml_cpp_vendor)
 
-function(rosbag2_transport_add_gmock target_base)
-  cmake_parse_arguments(ARG
-    "SKIP_TEST"
-    ""
-    "LINK_LIBS;AMENT_DEPS;INCLUDE_DIRS"
-    ${ARGN})
-  if(NOT ARG_UNPARSED_ARGUMENTS)
-    message(FATAL_ERROR "rosbag2_transport_add_gmock() must be invoked with "
-      "at least one source file")
-  endif()
-  if(${ARG_SKIP_TEST})
-    set(SKIP_TEST "SKIP_TEST")
-  else()
-    set(SKIP_TEST "")
-  endif()
-
-  set(target_name ${target_base}${target_suffix})
-  set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-  ament_add_gmock(${target_name}
-    ${ARG_UNPARSED_ARGUMENTS}
-    ENV ${rmw_implementation_env_var}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    ${SKIP_TEST})
-  if(TARGET ${target_name})
-    target_link_libraries(${target_name} ${ARG_LINK_LIBS})
-    target_include_directories(${target_name} PUBLIC ${ARG_INCLUDE_DIRS})
-    ament_target_dependencies(${target_name} ${ARG_AMENT_DEPS})
-  endif()
-endfunction()
-
 function(create_tests_for_rmw_implementation)
   rosbag2_transport_add_gmock(test_info
     test/rosbag2_transport/test_info.cpp
@@ -197,6 +167,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(test_msgs REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
+  include(cmake/rosbag2_transport_add_gmock.cmake)
   # explicitly disable cppcheck
   set(ament_cmake_cppcheck_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()

--- a/rosbag2_transport/cmake/rosbag2_transport_add_gmock.cmake
+++ b/rosbag2_transport/cmake/rosbag2_transport_add_gmock.cmake
@@ -1,0 +1,64 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Create a rosbag2_transport specific gmock test for a given rmw implementation
+#
+# The following variables must be set before calling this function. Note that
+# these are set by `call_for_each_rmw_implementation`, so if you call this
+# within that context, the constraint is already met:
+# * rmw_implementation: The package name of the RMW implementation
+# * target_suffix: Either a string derived from the RMW implementation or empty
+#   if there is only one RMW implementation
+#
+# :param target_base: the base name of the test to create, it will be suffixed
+# :type target_base: string
+# :param SKIP_TEST: if set, do not actually run the test at test time
+# :type GENERATE_DEFAULT: option
+# :param LINK_LIBS: libraries to link to the test executable
+# :type LINK_LIBS: list of strings
+# :param AMENT_DEPS: ament dependencies to declare for the test executable
+# :type AMENT_DEPS: list of strings
+# :param INCLUDE_DIRS: extra include directories to use for building the test
+# :type INCLUDE_DIRS: list of strings
+#
+function(rosbag2_transport_add_gmock target_base)
+  cmake_parse_arguments(ARG
+    "SKIP_TEST"
+    ""
+    "LINK_LIBS;AMENT_DEPS;INCLUDE_DIRS"
+    ${ARGN})
+  if(NOT ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "rosbag2_transport_add_gmock() must be invoked with "
+      "at least one source file")
+  endif()
+  if(${ARG_SKIP_TEST})
+    set(SKIP_TEST "SKIP_TEST")
+  else()
+    set(SKIP_TEST "")
+  endif()
+
+  set(target_name ${target_base}${target_suffix})
+  set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+  ament_add_gmock(${target_name}
+    ${ARG_UNPARSED_ARGUMENTS}
+    ENV ${rmw_implementation_env_var}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    ${SKIP_TEST})
+  if(TARGET ${target_name})
+    target_link_libraries(${target_name} ${ARG_LINK_LIBS})
+    target_include_directories(${target_name} PUBLIC ${ARG_INCLUDE_DIRS})
+    ament_target_dependencies(${target_name} ${ARG_AMENT_DEPS})
+  endif()
+endfunction()

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -22,8 +22,9 @@
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>test_msgs</test_depend>
+  <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
+  <test_depend>test_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Depends on https://github.com/ament/ament_cmake/pull/236 - there is a bug in `ament_add_gmock` that shows up when I start using `ENV`

Iterate over all RMW implementations for the rosbag2_transport tests, because it's been the case recently that some tests will pass on fastrtps but fail on cyclonedds.