### PR TITLE
Remove assumptions and checks around QoS policies that don't affect compatibility

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -82,21 +82,21 @@ bool operator==(const rmw_time_t & left, const rmw_time_t & right)
 
 namespace rosbag2_transport
 {
-  // TODO(emersonknapp) it is the long term goal to have similar logic exist within rmw/rcl/rclcpp,
-  //  but it's not yet determined where that logic will go. We should remove this function before
-  //  G-Turtle
-  bool Rosbag2QoS::compatibility_policies_exactly_equal(const rclcpp::QoS & other) const
-  {
-    // Note that these policies do not affect QoS compatibility
-    // * History + Depth (relevant only for local behavior)
-    // * Lifespan (only relevant locally on Publishers)
-    // * avoid ros namespace conventions (this affects choice of topic names, not quality of service)
-    const auto & pl = get_rmw_qos_profile();
-    const auto & pr = other.get_rmw_qos_profile();
-    return pl.reliability == pr.reliability &&
-           pl.durability == pr.durability &&
-           pl.deadline == pr.deadline &&
-           pl.liveliness == pr.liveliness &&
-           pl.liveliness_lease_duration == pr.liveliness_lease_duration;
-  }
+// TODO(emersonknapp) it is the long term goal to have similar logic exist within rmw/rcl/rclcpp,
+//  but it's not yet determined where that logic will go. We should remove this function before
+//  G-Turtle
+bool Rosbag2QoS::compatibility_policies_exactly_equal(const rclcpp::QoS & other) const
+{
+  // Note that these policies do not affect QoS compatibility
+  // * History + Depth (relevant only for local behavior)
+  // * Lifespan (only relevant locally on Publishers)
+  // * avoid ros namespace conventions (this affects choice of topic names, not quality of service)
+  const auto & pl = get_rmw_qos_profile();
+  const auto & pr = other.get_rmw_qos_profile();
+  return pl.reliability == pr.reliability &&
+         pl.durability == pr.durability &&
+         pl.deadline == pr.deadline &&
+         pl.liveliness == pr.liveliness &&
+         pl.liveliness_lease_duration == pr.liveliness_lease_duration;
+}
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -68,3 +68,35 @@ bool convert<rosbag2_transport::Rosbag2QoS>::decode(
   return true;
 }
 }  // namespace YAML
+
+
+namespace
+{
+/// Check if two rmw_time_t have the same values.
+bool operator==(const rmw_time_t & left, const rmw_time_t & right)
+{
+  return left.sec == right.sec && left.nsec == right.nsec;
+}
+}  // unnamed namespace
+
+
+namespace rosbag2_transport
+{
+  // TODO(emersonknapp) it is the long term goal to have similar logic exist within rmw/rcl/rclcpp,
+  //  but it's not yet determined where that logic will go. We should remove this function before
+  //  G-Turtle
+  bool Rosbag2QoS::compatibility_policies_exactly_equal(const rclcpp::QoS & other) const
+  {
+    // Note that these policies do not affect QoS compatibility
+    // * History + Depth (relevant only for local behavior)
+    // * Lifespan (only relevant locally on Publishers)
+    // * avoid ros namespace conventions (this affects choice of topic names, not quality of service)
+    const auto & pl = get_rmw_qos_profile();
+    const auto & pr = other.get_rmw_qos_profile();
+    return pl.reliability == pr.reliability &&
+           pl.durability == pr.durability &&
+           pl.deadline == pr.deadline &&
+           pl.liveliness == pr.liveliness &&
+           pl.liveliness_lease_duration == pr.liveliness_lease_duration;
+  }
+}  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -46,6 +46,13 @@ public:
     keep_last(rmw_qos_profile_default.depth);
     return *this;
   }
+
+  /// Determine if all policies that affect QoS compatibility are equal.
+  /*
+    Note that this method does not check if the QoS policies are compatible.
+    This is a simple check for exact equality in all policies that affect compatibility.
+  */
+  bool compatibility_policies_exactly_equal(const rclcpp::QoS & other) const;
 };
 }  // namespace rosbag2_transport
 

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -48,10 +48,10 @@ public:
   }
 
   /// Determine if all policies that affect QoS compatibility are equal.
-  /*
-    Note that this method does not check if the QoS policies are compatible.
-    This is a simple check for exact equality in all policies that affect compatibility.
-  */
+  /**
+    * Note that this method does not check if the QoS policies are compatible.
+    * This is a simple check for exact equality in all policies that affect compatibility.
+    */
   bool compatibility_policies_exactly_equal(const rclcpp::QoS & other) const;
 };
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
@@ -73,7 +73,7 @@ TEST(TestQoS, supports_version_4)
   .liveliness(RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT)
   .liveliness_lease_duration(zerotime);
   // Any values not present in the YAML should take the default value in both profiles
-  EXPECT_TRUE(actual_qos.compatibility_policies_equal(expected_qos));
+  EXPECT_TRUE(actual_qos.compatibility_policies_exactly_equal(expected_qos));
 }
 
 TEST(TestQoS, detect_new_qos_fields)

--- a/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
@@ -64,18 +64,16 @@ TEST(TestQoS, supports_version_4)
 
   rmw_time_t zerotime{0, 0};
   // Explicitly set up the same QoS profile in case defaults change
-  rclcpp::QoS expected_qos(10);
-  expected_qos
-  .keep_last(10)
+  auto expected_qos = rosbag2_transport::Rosbag2QoS{}
+  .default_history()
   .reliable()
   .durability_volatile()
   .deadline(zerotime)
   .lifespan(zerotime)
   .liveliness(RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT)
-  .liveliness_lease_duration(zerotime)
-  .avoid_ros_namespace_conventions(false);
+  .liveliness_lease_duration(zerotime);
   // Any values not present in the YAML should take the default value in both profiles
-  EXPECT_EQ(actual_qos, expected_qos);
+  EXPECT_TRUE(actual_qos.compatibility_policies_equal(expected_qos));
 }
 
 TEST(TestQoS, detect_new_qos_fields)

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -81,21 +81,24 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   // Basic smoke test that the profile was serialized into the metadata as a string.
   EXPECT_THAT(serialized_profiles, ContainsRegex("reliability: 1\n"));
   EXPECT_THAT(serialized_profiles, ContainsRegex("durability: 2\n"));
-  EXPECT_THAT(serialized_profiles, ContainsRegex(
-    "deadline:\n"
-    "    sec: .+\n"
-    "    nsec: .+\n"
+  EXPECT_THAT(
+    serialized_profiles, ContainsRegex(
+      "deadline:\n"
+      "    sec: .+\n"
+      "    nsec: .+\n"
   ));
-  EXPECT_THAT(serialized_profiles, ContainsRegex(
-    "lifespan:\n"
-    "    sec: .+\n"
-    "    nsec: .+\n"
+  EXPECT_THAT(
+    serialized_profiles, ContainsRegex(
+      "lifespan:\n"
+      "    sec: .+\n"
+      "    nsec: .+\n"
   ));
   EXPECT_THAT(serialized_profiles, ContainsRegex("liveliness: 1\n"));
-  EXPECT_THAT(serialized_profiles, ContainsRegex(
-    "liveliness_lease_duration:\n"
-    "    sec: .+\n"
-    "    nsec: .+\n"
+  EXPECT_THAT(
+    serialized_profiles, ContainsRegex(
+      "liveliness_lease_duration:\n"
+      "    sec: .+\n"
+      "    nsec: .+\n"
   ));
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -65,7 +65,6 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   EXPECT_THAT(array_messages[0]->float32_values, Eq(array_message->float32_values));
 }
 
-#ifdef ROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION
 TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
 {
   auto string_message = get_messages_strings()[1];
@@ -80,26 +79,27 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   auto recorded_topics = writer.get_topics();
   std::string serialized_profiles = recorded_topics.at(topic).offered_qos_profiles;
   // Basic smoke test that the profile was serialized into the metadata as a string.
-  EXPECT_THAT(
-    serialized_profiles, ContainsRegex(
-      "- history: 3\n"
-      "  depth: 0\n"
-      "  reliability: 1\n"
-      "  durability: 2\n"
-      "  deadline:\n"
-      "    sec: 2147483647\n"
-      "    nsec: 4294967295\n"
-      "  lifespan:\n"
-      "    sec: 2147483647\n"
-      "    nsec: 4294967295\n"
-      "  liveliness: 1\n"
-      "  liveliness_lease_duration:\n"
-      "    sec: 2147483647\n"
-      "    nsec: 4294967295\n"
-      "  avoid_ros_namespace_conventions: false"
+  EXPECT_THAT(serialized_profiles, ContainsRegex("reliability: 1\n"));
+  EXPECT_THAT(serialized_profiles, ContainsRegex("durability: 2\n"));
+  EXPECT_THAT(serialized_profiles, ContainsRegex(
+    "deadline:\n"
+    "    sec: .+\n"
+    "    nsec: .+\n"
+  ));
+  EXPECT_THAT(serialized_profiles, ContainsRegex(
+    "lifespan:\n"
+    "    sec: .+\n"
+    "    nsec: .+\n"
+  ));
+  EXPECT_THAT(serialized_profiles, ContainsRegex("liveliness: 1\n"));
+  EXPECT_THAT(serialized_profiles, ContainsRegex(
+    "liveliness_lease_duration:\n"
+    "    sec: .+\n"
+    "    nsec: .+\n"
   ));
 }
 
+#ifdef ROSBAG2_ENABLE_ADAPTIVE_QOS_SUBSCRIPTION
 TEST_F(RecordIntegrationTestFixture, records_sensor_data)
 {
   using clock = std::chrono::system_clock;


### PR DESCRIPTION
Part of #125 
Depends on https://github.com/ros2/rclcpp/pull/1049

Some of the policies in QoS profiles don't affect compatibility, only local behavior, so it's not worth comparing those values. The different RMW implementations report these values inconsistently currently, so though it is useful to record everything, it is not meaningful to test for specific values.
