### PR TITLE
QoS Profile Overrides - Player

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -43,7 +43,7 @@ public:
   void add_subscription(
     const std::string & topic_name,
     size_t expected_number_of_messages,
-    const rclcpp::QoS & qos = rclcpp::QoS{rclcpp::KeepAll()})
+    const rclcpp::QoS & qos = rclcpp::QoS{rmw_qos_profile_default.depth})
   {
     expected_topics_with_size_[topic_name] = expected_number_of_messages;
 

--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -40,13 +40,11 @@ public:
   }
 
   template<typename MessageT>
-  void add_subscription(const std::string & topic_name, size_t expected_number_of_messages)
+  void add_subscription(
+    const std::string & topic_name,
+    size_t expected_number_of_messages,
+    const rclcpp::QoS & qos = rclcpp::QoS{rclcpp::KeepAll()})
   {
-    auto qos = rclcpp::QoS(rclcpp::KeepAll());
-    qos.get_rmw_qos_profile().depth = 4;
-    qos.reliability(RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT);
-    qos.durability(RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT);
-    qos.avoid_ros_namespace_conventions(false);
     expected_topics_with_size_[topic_name] = expected_number_of_messages;
 
     auto options = rclcpp::SubscriptionOptions();

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -17,6 +17,9 @@
 
 #include <cstddef>
 #include <string>
+#include <unordered_map>
+
+#include "rclcpp/qos.hpp"
 
 namespace rosbag2_transport
 {
@@ -27,6 +30,7 @@ public:
   size_t read_ahead_queue_size;
   std::string node_prefix = "";
   float rate = 1.0;
+  std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides = {};
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -59,6 +59,7 @@ bool Player::is_storage_completely_loaded() const
 
 void Player::play(const PlayOptions & options)
 {
+  topic_qos_profile_overrides_ = options.topic_qos_profile_overrides;
   prepare_publishers();
 
   storage_loading_future_ = std::async(
@@ -157,10 +158,14 @@ void Player::prepare_publishers()
 {
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
+    rclcpp::QoS topic_qos{10};
+    if (topic_qos_profile_overrides_.count(topic.name)) {
+      topic_qos = topic_qos_profile_overrides_.at(topic.name);
+    }
     publishers_.insert(
       std::make_pair(
         topic.name, rosbag2_transport_->create_generic_publisher(
-          topic.name, topic.type, Rosbag2QoS{})));
+          topic.name, topic.type, topic_qos)));
   }
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -158,9 +158,9 @@ void Player::prepare_publishers()
 {
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
-    rclcpp::QoS topic_qos{rclcpp::KeepAll()};
+    Rosbag2QoS topic_qos{};
     if (topic_qos_profile_overrides_.count(topic.name)) {
-      topic_qos = topic_qos_profile_overrides_.at(topic.name);
+      topic_qos = Rosbag2QoS{topic_qos_profile_overrides_.at(topic.name)};
       ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Overriding QoS profile for topic " << topic.name);
     }
     publishers_.insert(

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -158,9 +158,10 @@ void Player::prepare_publishers()
 {
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
-    rclcpp::QoS topic_qos{10};
+    rclcpp::QoS topic_qos{rclcpp::KeepAll()};
     if (topic_qos_profile_overrides_.count(topic.name)) {
       topic_qos = topic_qos_profile_overrides_.at(topic.name);
+      ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Overriding QoS profile for topic " << topic.name);
     }
     publishers_.insert(
       std::make_pair(

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -169,7 +169,7 @@ void Player::prepare_publishers()
 {
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
-    rclcpp::QoS topic_qos = publisher_qos_for_topic(topic.name);
+    auto topic_qos = publisher_qos_for_topic(topic.name);
     publishers_.insert(
       std::make_pair(
         topic.name, rosbag2_transport_->create_generic_publisher(

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -159,7 +159,7 @@ rclcpp::QoS Player::publisher_qos_for_topic(const std::string & topic_name)
   auto qos_it = topic_qos_profile_overrides_.find(topic_name);
   if (qos_it != topic_qos_profile_overrides_.end()) {
     ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Overriding QoS profile for topic " << topic_name);
-    return Rosbag2QoS{topic_qos_profile_overrides_.at(topic_name)};
+    return Rosbag2QoS{qos_it->second};
   } else {
     return Rosbag2QoS{};
   }

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -24,6 +24,8 @@
 
 #include "moodycamel/readerwriterqueue.h"
 
+#include "rclcpp/qos.hpp"
+
 #include "rosbag2_transport/play_options.hpp"
 
 #include "replayable_message.hpp"
@@ -68,6 +70,7 @@ private:
   mutable std::future<void> storage_loading_future_;
   std::shared_ptr<Rosbag2Node> rosbag2_transport_;
   std::unordered_map<std::string, std::shared_ptr<GenericPublisher>> publishers_;
+  std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -60,18 +60,6 @@ private:
   void play_messages_from_queue(const PlayOptions & options);
   void play_messages_until_queue_empty(const PlayOptions & options);
   void prepare_publishers();
-
-  /**
-   * Determine which QoS to offer for a topic.
-   * The priority of the profile selected is:
-   *   1. The override specified in play_options (if one exists for the topic).
-   *   2. The default RMW QoS profile.
-   *
-   * \param topic_name The full name of the topic, with namespace (ex. /arm/joint_status).
-   * @return The QoS profile to be used for subscribing.
-   */
-  rclcpp::QoS publisher_qos_for_topic(const std::string & topic_name);
-
   static constexpr double read_ahead_lower_bound_percentage_ = 0.9;
   static const std::chrono::milliseconds queue_read_wait_period_;
 

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -61,6 +61,15 @@ private:
   void play_messages_until_queue_empty(const PlayOptions & options);
   void prepare_publishers();
 
+  /**
+   * Determine which QoS to offer for a topic.
+   * Overrides the QoS for a topic if one is specified in the play_options.
+   *
+   * \param topic_name The full name of the topic, with namespace (ex. /arm/joint_status).
+   * @return The QoS profile to be used for subscribing.
+   */
+  rclcpp::QoS publisher_qos_for_topic(const std::string & topic_name);
+
   static constexpr double read_ahead_lower_bound_percentage_ = 0.9;
   static const std::chrono::milliseconds queue_read_wait_period_;
 

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -63,7 +63,9 @@ private:
 
   /**
    * Determine which QoS to offer for a topic.
-   * Overrides the QoS for a topic if one is specified in the play_options.
+   * The priority of the profile selected is:
+   *   1. The override specified in play_options (if one exists for the topic).
+   *   2. The default RMW QoS profile.
    *
    * \param topic_name The full name of the topic, with namespace (ex. /arm/joint_status).
    * @return The QoS profile to be used for subscribing.

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -167,10 +167,14 @@ TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden)
   Rosbag2Transport rosbag2_transport{reader_, writer_, info_};
   rosbag2_transport.play(storage_options_, play_options_);
 
-  await_received_messages.get();
+  using namespace std::chrono_literals;
+  // Avoid timeouts by only waiting for 3 seconds if no messages are received.
+  const auto future_result = await_received_messages.wait_for(3s);
+  EXPECT_EQ(future_result, std::future_status::ready);
+
+  rosbag2_transport.shutdown();
   const auto received_messages =
     sub_->get_received_messages<test_msgs::msg::BasicTypes>(topic_name_);
-
   EXPECT_GT(received_messages.size(), 0u);
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -164,7 +164,7 @@ TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden)
   };
   play_options_.topic_qos_profile_overrides = topic_qos_profile_overrides;
 
-  Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
+  Rosbag2Transport rosbag2_transport{reader_, writer_, info_};
   rosbag2_transport.play(storage_options_, play_options_);
 
   await_received_messages.get();
@@ -189,7 +189,7 @@ TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden_incompati
   };
   play_options_.topic_qos_profile_overrides = topic_qos_profile_overrides;
 
-  Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
+  Rosbag2Transport rosbag2_transport{reader_, writer_, info_};
   rosbag2_transport.play(storage_options_, play_options_);
 
   using namespace std::chrono_literals;

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -166,3 +166,49 @@ TEST_F(RosBag2PlayTestFixture, topic_qos_profiles_overriden)
 
   EXPECT_GT(received_messages_1.size(), 0u);
 }
+
+TEST_F(RosBag2PlayTestFixture, topic_qos_profiles_overriden_incompatible)
+{
+  const auto topic_name = "/test_topic";
+  const auto msg_type = "test_msgs/BasicTypes";
+  const auto num_msgs = 3;
+  auto basic_msg = get_messages_basic_types()[0];
+  basic_msg->int32_value = 42;
+  const auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {topic_name, msg_type, "" /*serialization_format*/, "" /*offered_qos_profiles*/}
+  };
+
+  const std::vector<int64_t> topic_timestamps_ms = {500, 700, 900};
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages;
+  messages.reserve(topic_timestamps_ms.size());
+  for (const auto topic_timestamp : topic_timestamps_ms) {
+    messages.push_back(serialize_test_message(topic_name, topic_timestamp, basic_msg));
+  }
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.durability_volatile();
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(topic_name, num_msgs, qos_request);
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  // The previous subscriber requested durability VOLATILE which is the default in rosbag2.
+  // We override the requested durability to TRANSIENT_LOCAL so that we can receive messages.
+  // If the previous subscription requested TRANSIENT_LOCAL and we overrode with VOLATILE, then we
+  // would not receive any messages.
+  const auto qos_override = rclcpp::QoS{rclcpp::KeepAll()}.transient_local();
+  const auto topic_qos_profile_overrides = std::unordered_map<std::string, rclcpp::QoS>{
+    std::pair<std::string, rclcpp::QoS>{topic_name, qos_override},
+  };
+  play_options_.topic_qos_profile_overrides = topic_qos_profile_overrides;
+
+  Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
+  rosbag2_transport.play(storage_options_, play_options_);
+
+  await_received_messages.get();
+  const auto received_messages_1 =
+    sub_->get_received_messages<test_msgs::msg::BasicTypes>(topic_name);
+
+  EXPECT_GT(received_messages_1.size(), 0u);
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -136,7 +136,7 @@ TEST_F(RosBag2PlayTestFixture, topic_qos_profiles_overriden)
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages;
   messages.reserve(topic_timestamps_ms.size());
   for (const auto topic_timestamp : topic_timestamps_ms) {
-     messages.push_back(serialize_test_message(topic_name, topic_timestamp, basic_msg));
+    messages.push_back(serialize_test_message(topic_name, topic_timestamp, basic_msg));
   }
 
   auto prepared_mock_reader = std::make_unique<MockSequentialReader>();

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -150,15 +150,15 @@ public:
 
 TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden)
 {
-  const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.durability_volatile();
+  const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.best_effort();
   sub_->add_subscription<test_msgs::msg::BasicTypes>(topic_name_, num_msgs_, qos_request);
   auto await_received_messages = sub_->spin_subscriptions();
 
-  // The previous subscriber requested durability VOLATILE which is the default in rosbag2.
-  // We override the requested durability to TRANSIENT_LOCAL so that we can receive messages.
-  // If the previous subscription requested TRANSIENT_LOCAL and we overrode with VOLATILE, then we
+  // The previous subscriber requested reliability BEST_EFFORT.
+  // We override the requested reliability to RELIABLE so that we can receive messages.
+  // If the previous subscription requested BEST_EFFORT and we overrode with RELIABLE, then we
   // would not receive any messages.
-  const auto qos_override = rclcpp::QoS{rclcpp::KeepAll()}.transient_local();
+  const auto qos_override = rclcpp::QoS{rclcpp::KeepAll()}.reliable();
   const auto topic_qos_profile_overrides = std::unordered_map<std::string, rclcpp::QoS>{
     std::pair<std::string, rclcpp::QoS>{topic_name_, qos_override},
   };
@@ -180,14 +180,14 @@ TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden)
 
 TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden_incompatible)
 {
-  const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.transient_local();
+  const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.reliable();
   sub_->add_subscription<test_msgs::msg::BasicTypes>(topic_name_, num_msgs_, qos_request);
   auto await_received_messages = sub_->spin_subscriptions();
 
-  // The previous subscriber requested durability TRANSIENT_LOCAL.
-  // We override the requested durability to VOLATILE.
+  // The previous subscriber requested reliability RELIABLE.
+  // We override the requested reliability to BEST_EFFORT.
   // Since they are incompatible policies, we will not receive any messages.
-  const auto qos_override = rclcpp::QoS{rclcpp::KeepAll()}.durability_volatile();
+  const auto qos_override = rclcpp::QoS{rclcpp::KeepAll()}.best_effort();
   const auto topic_qos_profile_overrides = std::unordered_map<std::string, rclcpp::QoS>{
     std::pair<std::string, rclcpp::QoS>{topic_name_, qos_override},
   };

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -166,13 +166,9 @@ TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden)
 
   Rosbag2Transport rosbag2_transport{reader_, writer_, info_};
   rosbag2_transport.play(storage_options_, play_options_);
-
-  using namespace std::chrono_literals;
-  // Avoid timeouts by only waiting for 3 seconds if no messages are received.
-  const auto future_result = await_received_messages.wait_for(3s);
-  EXPECT_EQ(future_result, std::future_status::ready);
-
+  await_received_messages.get();
   rosbag2_transport.shutdown();
+
   const auto received_messages =
     sub_->get_received_messages<test_msgs::msg::BasicTypes>(topic_name_);
   EXPECT_GT(received_messages.size(), 0u);

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -125,6 +125,7 @@ TEST_F(RosBag2PlayTestFixture, topic_qos_profiles_overriden)
 {
   const auto topic_name = "/test_topic";
   const auto msg_type = "test_msgs/BasicTypes";
+  const auto num_msgs = 3;
   auto basic_msg = get_messages_basic_types()[0];
   basic_msg->int32_value = 42;
   const auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
@@ -143,7 +144,7 @@ TEST_F(RosBag2PlayTestFixture, topic_qos_profiles_overriden)
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
 
   const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.durability_volatile();
-  sub_->add_subscription<test_msgs::msg::BasicTypes>(topic_name, 3, qos_request);
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(topic_name, num_msgs, qos_request);
   auto await_received_messages = sub_->spin_subscriptions();
 
   // The previous subscriber requested durability VOLATILE which is the default in rosbag2.

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
@@ -118,4 +119,59 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
         Field(
           &test_msgs::msg::Arrays::float32_values,
           ElementsAre(40.0f, 2.0f, 0.0f)))));
+}
+
+TEST_F(RosBag2PlayTestFixture, topic_qos_profiles_overriden)
+{
+  const auto topic1 = "topic1";
+  const auto topic2 = "topic2";
+  const auto msg_type = "test_msgs/BasicTypes";
+  auto basic_msg = get_messages_basic_types()[0];
+  basic_msg->int32_value = 42;
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {topic1, msg_type, "", ""},
+    {topic2, msg_type, "", ""},
+  };
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {serialize_test_message(topic1, 500, basic_msg),
+    serialize_test_message(topic1, 700, basic_msg),
+    serialize_test_message(topic1, 900, basic_msg),
+    serialize_test_message(topic2, 550, basic_msg),
+    serialize_test_message(topic2, 750, basic_msg),
+    serialize_test_message(topic2, 950, basic_msg)};
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  // Due to a problem related to the subscriber, we play many (3) messages but make the subscriber
+  // node spin only until 2 have arrived. Hence the 2 as `launch_subscriber()` argument.
+  sub_->add_subscription<test_msgs::msg::BasicTypes>("/topic1", 2);
+  sub_->add_subscription<test_msgs::msg::BasicTypes>("/topic2", 2);
+
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  const auto profile1 = rclcpp::QoS{0}.keep_all().durability_volatile();
+  const auto profile2 = rclcpp::QoS{0}.keep_last(10).reliable();
+  const auto topic_qos_profile_overrides = std::unordered_map<std::string, rclcpp::QoS>{
+    std::pair<std::string, rclcpp::QoS>{"/topic1", profile1},
+    std::pair<std::string, rclcpp::QoS>{"/topic2", profile2}
+  };
+  play_options_.topic_qos_profile_overrides = topic_qos_profile_overrides;
+
+  Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
+  rosbag2_transport.play(storage_options_, play_options_);
+
+  await_received_messages.get();
+
+  auto received_messages_1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
+    "/topic1");
+
+  auto received_messages_2 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
+    "/topic2");
+
+  EXPECT_GT(received_messages_1.size(), 0u);
+  EXPECT_GT(received_messages_2.size(), 0u);
 }


### PR DESCRIPTION
* Add playback option to override QoS profiles for topics.
* Enable `SusbcriptionManager` to accept a QoS profile.

Part of #125
Part of ros-tooling/aws-roadmap#218

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>