### PR TITLE
Read serialized qos profiles out of the metadata

### DIFF
--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -39,6 +39,28 @@
 
 namespace YAML
 {
+/// Pass metadata version to the sub-structs of BagMetadata for deserializing.
+/**
+  * Encoding should always use the current metadata version, so it does not need this value.
+  * We cannot extend the YAML::Node class to include this, so we must call it
+  * as a function with the node as an argument.
+  */
+template<typename T>
+T decode_for_version(const Node & node, int version)
+{
+  static_assert(
+    std::is_default_constructible<T>::value,
+    "Type passed to decode_for_version that has is not default constructible.");
+  if (!node.IsDefined()) {
+    throw TypedBadConversion<T>(node.Mark());
+  }
+  T value{};
+  if (convert<T>::decode(node, value, version)) {
+    return value;
+  }
+  throw TypedBadConversion<T>(node.Mark());
+}
+
 template<>
 struct convert<rosbag2_storage::TopicMetadata>
 {
@@ -52,12 +74,16 @@ struct convert<rosbag2_storage::TopicMetadata>
     return node;
   }
 
-  static bool decode(const Node & node, rosbag2_storage::TopicMetadata & topic)
+  static bool decode(const Node & node, rosbag2_storage::TopicMetadata & topic, int version)
   {
     topic.name = node["name"].as<std::string>();
     topic.type = node["type"].as<std::string>();
     topic.serialization_format = node["serialization_format"].as<std::string>();
-
+    if (version >= 4) {
+      topic.offered_qos_profiles = node["offered_qos_profiles"].as<std::string>();
+    } else {
+      topic.offered_qos_profiles = "";
+    }
     return true;
   }
 };
@@ -73,10 +99,38 @@ struct convert<rosbag2_storage::TopicInformation>
     return node;
   }
 
-  static bool decode(const Node & node, rosbag2_storage::TopicInformation & metadata)
+  static bool decode(const Node & node, rosbag2_storage::TopicInformation & metadata, int version)
   {
-    metadata.topic_metadata = node["topic_metadata"].as<rosbag2_storage::TopicMetadata>();
+    metadata.topic_metadata = decode_for_version<rosbag2_storage::TopicMetadata>(
+      node["topic_metadata"], version);
     metadata.message_count = node["message_count"].as<uint64_t>();
+    return true;
+  }
+};
+
+template<>
+struct convert<std::vector<rosbag2_storage::TopicInformation>>
+{
+  static Node encode(const std::vector<rosbag2_storage::TopicInformation> & rhs)
+  {
+    Node node(NodeType::Sequence);
+    for (const auto & value : rhs) {
+      node.push_back(value);
+    }
+    return node;
+  }
+
+  static bool decode(
+    const Node & node, std::vector<rosbag2_storage::TopicInformation> & rhs, int version)
+  {
+    if (!node.IsSequence()) {
+      return false;
+    }
+
+    rhs.clear();
+    for (const auto & value : node) {
+      rhs.push_back(decode_for_version<rosbag2_storage::TopicInformation>(value, version));
+    }
     return true;
   }
 };
@@ -148,7 +202,8 @@ struct convert<rosbag2_storage::BagMetadata>
       .as<std::chrono::time_point<std::chrono::high_resolution_clock>>();
     metadata.message_count = node["message_count"].as<uint64_t>();
     metadata.topics_with_message_count =
-      node["topics_with_message_count"].as<std::vector<rosbag2_storage::TopicInformation>>();
+      decode_for_version<std::vector<rosbag2_storage::TopicInformation>>(
+      node["topics_with_message_count"], metadata.version);
 
     if (metadata.version >= 3) {  // fields introduced by rosbag2_compression
       metadata.compression_format = node["compression_format"].as<std::string>();

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -113,7 +113,7 @@ struct convert<std::vector<rosbag2_storage::TopicInformation>>
 {
   static Node encode(const std::vector<rosbag2_storage::TopicInformation> & rhs)
   {
-    Node node(NodeType::Sequence);
+    Node node{NodeType::Sequence};
     for (const auto & value : rhs) {
       node.push_back(value);
     }


### PR DESCRIPTION
Part of #125 

This PR introduces the ability to read the new field `offered_qos_profiles` out of a bag metadata. This required making a way to pass version information to sub-structs of BagMetadata so that backwards compatibility can be maintained.