### PR TITLE
Add loop option to rosbag play

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -48,6 +48,10 @@ class PlayVerb(VerbExtension):
         parser.add_argument(
             '--qos-profile-overrides-path', type=FileType('r'),
             help='Path to a yaml file defining overrides of the QoS profile for specific topics.')
+        parser.add_argument(
+            '-l', '--loop', action='store_true',
+            help='enables loop playback when playing a bagfile: it starts back at the beginning '
+                 'on reaching the end and plays indefinitely.')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -72,4 +76,5 @@ class PlayVerb(VerbExtension):
             read_ahead_queue_size=args.read_ahead_queue_size,
             rate=args.rate,
             topics=args.topics,
-            qos_profile_overrides=qos_profile_overrides)
+            qos_profile_overrides=qos_profile_overrides,
+            loop=args.loop)

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -160,6 +160,13 @@ function(create_tests_for_rmw_implementation)
     ${SKIP_TEST}
     LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common)
+
+  rosbag2_transport_add_gmock(test_play_loop
+    test/rosbag2_transport/test_play_loop.cpp
+    ${SKIP_TEST}
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
 endfunction()
 
 if(BUILD_TESTING)

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -38,6 +38,7 @@ public:
   std::vector<std::string> topics_to_filter = {};
 
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides = {};
+  bool loop = false;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -1,4 +1,5 @@
 // Copyright 2018, Bosch Software Innovations GmbH.
+// Copyright 2020, TNG Technology Consulting GmbH.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,12 +94,13 @@ void Rosbag2Transport::play(
   const StorageOptions & storage_options, const PlayOptions & play_options)
 {
   try {
-    reader_->open(storage_options, {"", rmw_get_serialization_format()});
-
     auto transport_node = setup_node(play_options.node_prefix);
-
     Player player(reader_, transport_node);
-    player.play(play_options);
+
+    do {
+      reader_->open(storage_options, {"", rmw_get_serialization_format()});
+      player.play(play_options);
+    } while (rclcpp::ok() && play_options.loop);
   } catch (std::runtime_error & e) {
     ROSBAG2_TRANSPORT_LOG_ERROR("Failed to play: %s", e.what());
   }

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -1,4 +1,5 @@
 // Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2020, TNG Technology Consulting GmbH.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -210,6 +211,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
     "rate",
     "topics",
     "qos_profile_overrides",
+    "loop",
     nullptr
   };
 
@@ -220,15 +222,18 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   float rate;
   PyObject * topics = nullptr;
   PyObject * qos_profile_overrides{nullptr};
+  bool loop = false;
+
   if (!PyArg_ParseTupleAndKeywords(
-      args, kwargs, "sss|kfOO", const_cast<char **>(kwlist),
+      args, kwargs, "sss|kfOOb", const_cast<char **>(kwlist),
       &uri,
       &storage_id,
       &node_prefix,
       &read_ahead_queue_size,
       &rate,
       &topics,
-      &qos_profile_overrides))
+      &qos_profile_overrides,
+      &loop))
   {
     return nullptr;
   }
@@ -239,6 +244,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   play_options.node_prefix = std::string(node_prefix);
   play_options.read_ahead_queue_size = read_ahead_queue_size;
   play_options.rate = rate;
+  play_options.loop = loop;
 
   if (topics) {
     PyObject * topic_iterator = PyObject_GetIter(topics);

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -31,6 +31,7 @@ public:
   {
     (void) storage_options;
     (void) converter_options;
+    num_read_ = 0;
   }
 
   void reset() override {}

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_play_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_play_test_fixture.hpp
@@ -1,0 +1,40 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_TRANSPORT__ROSBAG2_PLAY_TEST_FIXTURE_HPP_
+#define ROSBAG2_TRANSPORT__ROSBAG2_PLAY_TEST_FIXTURE_HPP_
+
+#include <memory>
+
+#include "rosbag2_transport_test_fixture.hpp"
+
+class RosBag2PlayTestFixture : public Rosbag2TransportTestFixture
+{
+public:
+  RosBag2PlayTestFixture()
+  : Rosbag2TransportTestFixture()
+  {
+    rclcpp::init(0, nullptr);
+    sub_ = std::make_shared<SubscriptionManager>();
+  }
+
+  ~RosBag2PlayTestFixture() override
+  {
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<SubscriptionManager> sub_;
+};
+
+#endif  //  ROSBAG2_TRANSPORT__ROSBAG2_PLAY_TEST_FIXTURE_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -32,30 +32,12 @@
 #include "test_msgs/msg/basic_types.hpp"
 #include "test_msgs/message_fixtures.hpp"
 
-#include "rosbag2_transport_test_fixture.hpp"
+#include "rosbag2_play_test_fixture.hpp"
 
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_transport;  // NOLINT
 using namespace std::chrono_literals;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
-
-class RosBag2PlayTestFixture : public Rosbag2TransportTestFixture
-{
-public:
-  RosBag2PlayTestFixture()
-  : Rosbag2TransportTestFixture()
-  {
-    rclcpp::init(0, nullptr);
-    sub_ = std::make_shared<SubscriptionManager>();
-  }
-
-  ~RosBag2PlayTestFixture() override
-  {
-    rclcpp::shutdown();
-  }
-
-  std::shared_ptr<SubscriptionManager> sub_;
-};
 
 TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
 {

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -65,7 +65,7 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   bool loop_playback = true;
   std::thread loop_thread(&rosbag2_transport::Rosbag2Transport::play, rosbag2_transport_ptr,
     storage_options_,
-    rosbag2_transport::PlayOptions{1000, "", 1.0, {}, loop_playback});
+    rosbag2_transport::PlayOptions{1000, "", 1.0, {}, {}, loop_playback});
   std::this_thread::sleep_for(std::chrono_literals::operator""s(1));
   rclcpp::shutdown();
   loop_thread.join();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -1,0 +1,83 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+// Copyright 2020, TNG Technology Consulting GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "rosbag2_test_common/subscription_manager.hpp"
+
+#include "rosbag2_transport/rosbag2_transport.hpp"
+
+#include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+#include "rosbag2_play_test_fixture.hpp"
+
+using namespace ::testing;  // NOLINT
+using namespace rosbag2_transport;  // NOLINT
+using namespace std::chrono_literals;  // NOLINT
+using namespace rosbag2_test_common;  // NOLINT
+
+TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
+  auto primitive_message1 = get_messages_basic_types()[0];
+  primitive_message1->int32_value = 42;
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {"loop_test_topic", "test_msgs/BasicTypes", "", ""}
+  };
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {serialize_test_message("loop_test_topic", 700, primitive_message1)};
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  //  any number greater than 2 would be logic to test the loop_playback functionality,
+  //  for example 4.
+  size_t expected_number_of_messages = 4;
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(
+    "/loop_test_topic",
+    expected_number_of_messages);
+
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  auto rosbag2_transport_ptr = std::make_shared<Rosbag2Transport>(reader_, writer_, info_);
+  bool loop_playback = true;
+  std::thread loop_thread(&Rosbag2Transport::play, rosbag2_transport_ptr, storage_options_,
+    rosbag2_transport::PlayOptions{1000, "", 1.0, loop_playback});
+  std::this_thread::sleep_for(1s);
+  rclcpp::shutdown();
+  loop_thread.join();
+
+  await_received_messages.get();
+  auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
+    "/loop_test_topic");
+
+  EXPECT_THAT(replayed_test_primitives.size(), Ge(4u));
+  EXPECT_THAT(
+    replayed_test_primitives,
+    Each(Pointee(Field(&test_msgs::msg::BasicTypes::int32_value, 42))));
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -65,7 +65,7 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   bool loop_playback = true;
   std::thread loop_thread(&rosbag2_transport::Rosbag2Transport::play, rosbag2_transport_ptr,
     storage_options_,
-    rosbag2_transport::PlayOptions{1000, "", 1.0, loop_playback});
+    rosbag2_transport::PlayOptions{1000, "", 1.0, {}, loop_playback});
   std::this_thread::sleep_for(std::chrono_literals::operator""s(1));
   rclcpp::shutdown();
   loop_thread.join();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -71,11 +71,11 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   std::thread loop_thread(&rosbag2_transport::Rosbag2Transport::play, rosbag2_transport_ptr,
     storage_options_,
     rosbag2_transport::PlayOptions{read_ahead_queue_size, "", rate, {}, {}, loop_playback});
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  await_received_messages.get();
   rclcpp::shutdown();
   loop_thread.join();
 
-  await_received_messages.get();
   auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
     "/loop_test_topic");
 


### PR DESCRIPTION
With the option -l or --loop it's now possible to play a bagfile in loop.
The current implementation is as simple as possible, but that means that the database has to be reopened every time the bagfile starts from the beginning. But also with this implementation we don't rewrite timestamps, so the loop will jump back in time on every new opening.
If the database should not be reopened every time, I can think of two ways to fix it:
we can add a function start_reading_from_beginning() to the SequentialReader.
Or we can add a flag to the storage on 'open', so that 'read_next' returns the first message after the last.
In these Cases, should we start the time stamp at the beginning? Or increase the timestamp continuously?
Any propositions or ideas are very welcome.
Closes https://github.com/ros2/rosbag2/issues/292.