### PR TITLE
rename rosidl_generator_cpp namespace to rosidl_runtime_cpp

### DIFF
--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.cpp
@@ -25,7 +25,7 @@
 
 #include "rosbag2_cpp/types.hpp"
 
-#include "rosidl_generator_cpp/message_type_support_decl.hpp"
+#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
 #include "../logging.hpp"
 

--- a/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.hpp
+++ b/rosbag2_converter_default_plugins/src/rosbag2_converter_default_plugins/cdr/cdr_converter.hpp
@@ -20,7 +20,7 @@
 
 #include "rmw/types.h"
 
-#include "rosidl_generator_cpp/message_type_support_decl.hpp"
+#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
 #include "rcpputils/shared_library.hpp"
 

--- a/rosbag2_cpp/include/rosbag2_cpp/typesupport_helpers.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/typesupport_helpers.hpp
@@ -24,7 +24,7 @@
 
 #include "rcpputils/shared_library.hpp"
 
-#include "rosidl_generator_cpp/message_type_support_decl.hpp"
+#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
 namespace rosbag2_cpp
 {

--- a/rosbag2_cpp/src/rosbag2_cpp/types/introspection_message.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/types/introspection_message.cpp
@@ -42,7 +42,7 @@ allocate_introspection_message(
   raw_ros2_message->message = raw_ros2_message->allocator.zero_allocate(
     1, intro_ts_members->size_of_, raw_ros2_message->allocator.state);
   intro_ts_members->init_function(
-    raw_ros2_message->message, rosidl_generator_cpp::MessageInitialization::ALL);
+    raw_ros2_message->message, rosidl_runtime_cpp::MessageInitialization::ALL);
 
   auto deleter = [introspection_ts](rosbag2_introspection_message_t * msg) {
       deallocate_introspection_message(msg, introspection_ts);

--- a/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/typesupport_helpers.cpp
@@ -26,7 +26,7 @@
 
 #include "rcpputils/shared_library.hpp"
 
-#include "rosidl_generator_cpp/message_type_support_decl.hpp"
+#include "rosidl_runtime_cpp/message_type_support_decl.hpp"
 
 namespace rosbag2_cpp
 {


### PR DESCRIPTION
Related to ros2/rosidl#456.