### PR TITLE
Deduplicate code in SequentialCompressionReader

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -101,7 +101,6 @@ protected:
   */
   virtual void load_next_file();
 
-private:
   /**
    * Checks if all topics in the bagfile have the same RMW serialization format.
    * Currently a bag file can only be played if all topics have the same serialization format.

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -126,13 +126,15 @@ protected:
     const std::string & storage_serialization_format);
 
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_{};
-  std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_{};
   std::unique_ptr<Converter> converter_{};
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
   rosbag2_storage::BagMetadata metadata_{};
   std::vector<std::string> file_paths_{};  // List of database files.
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
+
+private:
+  std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 };
 
 }  // namespace readers

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -61,9 +61,9 @@ SequentialReader::SequentialReader(
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory,
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
 : storage_factory_(std::move(storage_factory)),
-  converter_factory_(std::move(converter_factory)),
   converter_(nullptr),
-  metadata_io_(std::move(metadata_io))
+  metadata_io_(std::move(metadata_io)),
+  converter_factory_(std::move(converter_factory))
 {}
 
 SequentialReader::~SequentialReader()


### PR DESCRIPTION
Change the SequentialReader interfaces from `private` to `protected`. Then, delete all identical code from `SequentialCompressionReader`.

I'm about to add a new `BaseReaderInterface` function signature and don't want to duplicate it.

The existing test suite on these classes should cover the change.

Depends on https://github.com/ros2/rosbag2/pull/373
Starts replacing https://github.com/ros2/rosbag2/pull/371
In support of work towards #125 

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>