### PR TITLE
Fix Action CI tests to pass reliably

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -27,7 +27,6 @@
 #include "rosbag2_test_common/subscription_manager.hpp"
 
 #include "rosbag2_transport/rosbag2_transport.hpp"
-#include "rosbag2_transport/logging.hpp"
 
 #include "test_msgs/msg/arrays.hpp"
 #include "test_msgs/msg/basic_types.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -27,6 +27,7 @@
 #include "rosbag2_test_common/subscription_manager.hpp"
 
 #include "rosbag2_transport/rosbag2_transport.hpp"
+#include "rosbag2_transport/logging.hpp"
 
 #include "test_msgs/msg/arrays.hpp"
 #include "test_msgs/msg/basic_types.hpp"
@@ -127,6 +128,15 @@ public:
   RosBag2PlayQosOverrideTestFixture()
   : RosBag2PlayTestFixture()
   {
+    // Because this test only cares about compatibility (receiving any messages at all)
+    // We publish one more message than we expect to receive, to avoid caring about
+    // shutdown edge behaviors that are not explicitly being tested here.
+    const size_t num_msgs_to_publish = num_msgs_to_wait_for_ + 1;
+    topic_timestamps_ms_.reserve(num_msgs_to_publish);
+    for (size_t i = 0; i < num_msgs_to_publish; i++) {
+      topic_timestamps_ms_.push_back(start_time_ms_ + message_spacing_ms_ * i);
+    }
+
     messages_.reserve(topic_timestamps_ms_.size());
     for (const auto topic_timestamp : topic_timestamps_ms_) {
       messages_.push_back(serialize_test_message(topic_name_, topic_timestamp, basic_msg_));
@@ -139,55 +149,66 @@ public:
 
   const std::string topic_name_{"/test_topic"};
   const std::string msg_type_{"test_msgs/BasicTypes"};
-  const size_t num_msgs_{3};
+  const size_t num_msgs_to_wait_for_{3};
   test_msgs::msg::BasicTypes::SharedPtr basic_msg_{get_messages_basic_types()[0]};
   const std::vector<rosbag2_storage::TopicMetadata> topic_types_{
     {topic_name_, msg_type_, "" /*serialization_format*/, "" /*offered_qos_profiles*/}
   };
-  const std::vector<int64_t> topic_timestamps_ms_ = {500, 700, 900};
+  const int64_t start_time_ms_{500};
+  const int64_t message_spacing_ms_{200};
+  std::vector<int64_t> topic_timestamps_ms_{};
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages_;
 };
 
-TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden)
+TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overridden)
 {
-  const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.best_effort();
-  sub_->add_subscription<test_msgs::msg::BasicTypes>(topic_name_, num_msgs_, qos_request);
-  auto await_received_messages = sub_->spin_subscriptions();
+  // By default playback uses DURABILITY_VOLATILE.
+  // When we request DURABILITY_TRANSIENT_LOCAL, we should expect no connection because that
+  // request is incompatible.
+  // However, if we override playback to offer DURABILITY_TRANSIENT_LOCAL, now we should expect
+  // to receive messages.
+  const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.reliable().transient_local();
+  const auto qos_playback_override = rclcpp::QoS{rclcpp::KeepAll()}.reliable().transient_local();
 
-  // The previous subscriber requested reliability BEST_EFFORT.
-  // We override the requested reliability to RELIABLE so that we can receive messages.
-  // If the previous subscription requested BEST_EFFORT and we overrode with RELIABLE, then we
-  // would not receive any messages.
-  const auto qos_override = rclcpp::QoS{rclcpp::KeepAll()}.reliable();
   const auto topic_qos_profile_overrides = std::unordered_map<std::string, rclcpp::QoS>{
-    std::pair<std::string, rclcpp::QoS>{topic_name_, qos_override},
+    std::pair<std::string, rclcpp::QoS>{topic_name_, qos_playback_override},
   };
+
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(
+    topic_name_, num_msgs_to_wait_for_, qos_request);
+  auto await_received_messages = sub_->spin_subscriptions();
   play_options_.topic_qos_profile_overrides = topic_qos_profile_overrides;
 
   Rosbag2Transport rosbag2_transport{reader_, writer_, info_};
   rosbag2_transport.play(storage_options_, play_options_);
-  await_received_messages.get();
+
+  // This should normally take less than 1s - just making it shorter than 60s default
+  const auto future_result = await_received_messages.wait_for(5s);
+  EXPECT_NE(future_result, std::future_status::timeout);
   rosbag2_transport.shutdown();
 
   const auto received_messages =
     sub_->get_received_messages<test_msgs::msg::BasicTypes>(topic_name_);
-  EXPECT_GT(received_messages.size(), 0u);
+  EXPECT_FALSE(received_messages.empty());
 }
 
-TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overriden_incompatible)
+TEST_F(RosBag2PlayQosOverrideTestFixture, topic_qos_profiles_overridden_incompatible)
 {
+  // By default playback offers RELIABILITY_RELIABLE
+  // We request RELIABILITY_RELIABLE here, which should be compatible.
+  // However, we override the playback to offer RELIABILITY_BEST_EFFORT,
+  // which should not be a compatible offer and therefore we should receive no messages.
   const auto qos_request = rclcpp::QoS{rclcpp::KeepAll()}.reliable();
-  sub_->add_subscription<test_msgs::msg::BasicTypes>(topic_name_, num_msgs_, qos_request);
-  auto await_received_messages = sub_->spin_subscriptions();
+  const auto qos_playback_override = rclcpp::QoS{rclcpp::KeepAll()}.best_effort();
 
-  // The previous subscriber requested reliability RELIABLE.
-  // We override the requested reliability to BEST_EFFORT.
-  // Since they are incompatible policies, we will not receive any messages.
-  const auto qos_override = rclcpp::QoS{rclcpp::KeepAll()}.best_effort();
   const auto topic_qos_profile_overrides = std::unordered_map<std::string, rclcpp::QoS>{
-    std::pair<std::string, rclcpp::QoS>{topic_name_, qos_override},
+    std::pair<std::string, rclcpp::QoS>{topic_name_, qos_playback_override},
   };
   play_options_.topic_qos_profile_overrides = topic_qos_profile_overrides;
+
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(
+    topic_name_, num_msgs_to_wait_for_, qos_request);
+  auto await_received_messages = sub_->spin_subscriptions();
 
   Rosbag2Transport rosbag2_transport{reader_, writer_, info_};
   rosbag2_transport.play(storage_options_, play_options_);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -44,7 +44,9 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
     static_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
   auto recorded_messages = writer.get_messages();
 
-  ASSERT_THAT(recorded_messages, SizeIs(4));
+  // We may receive additional messages from rosout, it doesn't matter,
+  // as long as we have received at least as many total messages as we expect
+  EXPECT_THAT(recorded_messages, SizeIs(Ge(4u)));
   auto string_messages = filter_messages<test_msgs::msg::Strings>(
     recorded_messages, string_topic);
   auto array_messages = filter_messages<test_msgs::msg::Arrays>(


### PR DESCRIPTION
Note: this description is updated over the original PR

In our regular CI runs, since the upgrade to Fast-RTPS 1.10.x (), we have been seeing consistent failures in the following tests on our Action CI:

```
2020-04-14T20:21:18.5513377Z The following tests FAILED:
2020-04-14T20:21:18.5513644Z 	 11 - test_record_all__rmw_fastrtps_cpp (Failed)
2020-04-14T20:21:18.5513914Z 	 18 - test_play__rmw_fastrtps_cpp (Failed)
2020-04-14T20:21:18.5514188Z 	 20 - test_record_all__rmw_fastrtps_dynamic_cpp (Failed)
2020-04-14T20:21:18.5514448Z 	 27 - test_play__rmw_fastrtps_dynamic_cpp (Failed)
```

The `test_play` failure is receiving one fewer message than it testing that a specific number of messages arrive, when we only really care that any messages arrive at all for that test. The [upgrade to Fast-RTPS 1.10.x](https://github.com/ros2/ros2/pull/888) introduced a some nondeterministic behavior on shutdown and made it uncertain whether the final message in a playback would be delivered. This particular test doesn't care about that behavior so it has been modified to expect fewer messages. 

The `test_record_all` failure is receiving _more_ messages than it expects. The extra message is a warning passed on `/rosout` (introduced here https://app.chime.aws/meetings/7596499512) - the warning is irrelevant to the test, I change it to expect _at least_ the number of messages we are looking for, the specific by-type checks are sufficient.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>