### PR TITLE
Expose BaseReaderInterface's BagMetadata 

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -25,6 +25,7 @@
 #include "rosbag2_cpp/visibility_control.hpp"
 
 #include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 
 // This is necessary because of using stl types here. It is completely safe, because
@@ -88,12 +89,20 @@ public:
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next();
 
   /**
+    * Ask bagfile for its full metadata.
+    *
+    * \return a const reference to a BagMetadata owned by the Reader
+    * \throws runtime_error if the Reader is not open.
+    */
+  const rosbag2_storage::BagMetadata & get_metadata() const;
+
+  /**
    * Ask bagfile for all topics (including their type identifier) that were recorded.
    *
    * \return vector of topics with topic name and type as std::string
    * \throws runtime_error if the Reader is not open.
    */
-  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types();
+  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() const;
 
   reader_interfaces::BaseReaderInterface & get_implementation_handle() const
   {

--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -24,8 +24,8 @@
 #include "rosbag2_cpp/storage_options.hpp"
 #include "rosbag2_cpp/visibility_control.hpp"
 
-#include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 
 // This is necessary because of using stl types here. It is completely safe, because

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -47,6 +47,7 @@ public:
   virtual std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() = 0;
 
   virtual const rosbag2_storage::BagMetadata & get_metadata() const = 0;
+
   virtual std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() = 0;
 
   virtual void set_filter(const rosbag2_storage::StorageFilter & storage_filter) = 0;

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -22,6 +22,7 @@
 #include "rosbag2_cpp/storage_options.hpp"
 #include "rosbag2_cpp/visibility_control.hpp"
 
+#include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_storage/storage_filter.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
@@ -45,6 +46,7 @@ public:
 
   virtual std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() = 0;
 
+  virtual const rosbag2_storage::BagMetadata & get_metadata() const = 0;
   virtual std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() = 0;
 
   virtual void set_filter(const rosbag2_storage::StorageFilter & storage_filter) = 0;

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -48,7 +48,7 @@ public:
 
   virtual const rosbag2_storage::BagMetadata & get_metadata() const = 0;
 
-  virtual std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() = 0;
+  virtual std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() const = 0;
 
   virtual void set_filter(const rosbag2_storage::StorageFilter & storage_filter) = 0;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -68,6 +68,7 @@ public:
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
 
   const rosbag2_storage::BagMetadata & get_metadata() const override;
+
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   void set_filter(const rosbag2_storage::StorageFilter & storage_filter) override;
@@ -136,6 +137,8 @@ protected:
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
 
 private:
+  void fill_topics_and_types();
+
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 };
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -137,8 +137,6 @@ protected:
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
 
 private:
-  void fill_topics_and_types();
-
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 };
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -67,6 +67,7 @@ public:
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
 
+  const rosbag2_storage::BagMetadata & get_metadata() const override;
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   void set_filter(const rosbag2_storage::StorageFilter & storage_filter) override;
@@ -130,6 +131,7 @@ protected:
   std::unique_ptr<Converter> converter_{};
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
   rosbag2_storage::BagMetadata metadata_{};
+  std::vector<rosbag2_storage::TopicMetadata> topics_metadata_{};
   std::vector<std::string> file_paths_{};  // List of database files.
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -69,7 +69,7 @@ public:
 
   const rosbag2_storage::BagMetadata & get_metadata() const override;
 
-  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
+  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() const override;
 
   void set_filter(const rosbag2_storage::StorageFilter & storage_filter) override;
 

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -51,7 +51,12 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> Reader::read_next()
   return reader_impl_->read_next();
 }
 
-std::vector<rosbag2_storage::TopicMetadata> Reader::get_all_topics_and_types()
+const rosbag2_storage::BagMetadata & Reader::get_metadata() const
+{
+  return reader_impl_->get_metadata();
+}
+
+std::vector<rosbag2_storage::TopicMetadata> Reader::get_all_topics_and_types() const
 {
   return reader_impl_->get_all_topics_and_types();
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -30,6 +30,7 @@ void fill_topics_and_types(
   const rosbag2_storage::BagMetadata & metadata,
   std::vector<rosbag2_storage::TopicMetadata> & topics_and_types)
 {
+  topics_and_types.clear();
   topics_and_types.reserve(metadata.topics_with_message_count.size());
   for (const auto & topic_information : metadata.topics_with_message_count) {
     topics_and_types.push_back(topic_information.topic_metadata);

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -155,7 +155,10 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SequentialReader::read_ne
 
 const rosbag2_storage::BagMetadata & SequentialReader::get_metadata() const
 {
-  return metadata_;
+  if (storage_) {
+    return metadata_;
+  }
+  throw std::runtime_error("Bag is not open. Call open() before reading.");
 }
 
 
@@ -167,9 +170,12 @@ void SequentialReader::fill_topics_and_types()
   }
 }
 
-std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and_types()
+std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and_types() const
 {
-  return topics_metadata_;
+  if (storage_) {
+    return topics_metadata_;
+  }
+  throw std::runtime_error("Bag is not open. Call open() before reading.");
 }
 
 void SequentialReader::set_filter(

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -119,6 +119,7 @@ void SequentialReader::open(
     ROSBAG2_CPP_LOG_WARN("No topics were listed in metadata.");
     return;
   }
+  fill_topics_and_types();
 
   // Currently a bag file can only be played if all topics have the same serialization format.
   check_topics_serialization_formats(topics);

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -161,8 +161,7 @@ std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and
 {
   topics_metadata_.clear();
   topics_metadata_.reserve(metadata_.topics_with_message_count.size());
-  for (const auto & topic_information : metadata_.topics_with_message_count)
-  {
+  for (const auto & topic_information : metadata_.topics_with_message_count) {
     topics_metadata_.push_back(topic_information.topic_metadata);
   }
   return topics_metadata_;

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -24,6 +24,19 @@
 #include "rosbag2_cpp/logging.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
 
+namespace
+{
+void fill_topics_and_types(
+  const rosbag2_storage::BagMetadata & metadata,
+  std::vector<rosbag2_storage::TopicMetadata> & topics_and_types)
+{
+  topics_and_types.reserve(metadata.topics_with_message_count.size());
+  for (const auto & topic_information : metadata.topics_with_message_count) {
+    topics_and_types.push_back(topic_information.topic_metadata);
+  }
+}
+}  // unnamed namespace
+
 namespace rosbag2_cpp
 {
 namespace readers
@@ -119,7 +132,7 @@ void SequentialReader::open(
     ROSBAG2_CPP_LOG_WARN("No topics were listed in metadata.");
     return;
   }
-  fill_topics_and_types();
+  fill_topics_and_types(metadata_, topics_metadata_);
 
   // Currently a bag file can only be played if all topics have the same serialization format.
   check_topics_serialization_formats(topics);
@@ -155,27 +168,14 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SequentialReader::read_ne
 
 const rosbag2_storage::BagMetadata & SequentialReader::get_metadata() const
 {
-  if (storage_) {
-    return metadata_;
-  }
-  throw std::runtime_error("Bag is not open. Call open() before reading.");
-}
-
-
-void SequentialReader::fill_topics_and_types()
-{
-  topics_metadata_.reserve(metadata_.topics_with_message_count.size());
-  for (const auto & topic_information : metadata_.topics_with_message_count) {
-    topics_metadata_.push_back(topic_information.topic_metadata);
-  }
+  rcpputils::check_true(storage_ != nullptr, "Bag is not open. Call open() before reading.");
+  return metadata_;
 }
 
 std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and_types() const
 {
-  if (storage_) {
-    return topics_metadata_;
-  }
-  throw std::runtime_error("Bag is not open. Call open() before reading.");
+  rcpputils::check_true(storage_ != nullptr, "Bag is not open. Call open() before reading.");
+  return topics_metadata_;
 }
 
 void SequentialReader::set_filter(

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -152,12 +152,20 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SequentialReader::read_ne
   throw std::runtime_error("Bag is not open. Call open() before reading.");
 }
 
+const rosbag2_storage::BagMetadata & SequentialReader::get_metadata() const
+{
+  return metadata_;
+}
+
 std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and_types()
 {
-  if (storage_) {
-    return storage_->get_all_topics_and_types();
+  topics_metadata_.clear();
+  topics_metadata_.reserve(metadata_.topics_with_message_count.size());
+  for (const auto & topic_information : metadata_.topics_with_message_count)
+  {
+    topics_metadata_.push_back(topic_information.topic_metadata);
   }
-  throw std::runtime_error("Bag is not open. Call open() before reading.");
+  return topics_metadata_;
 }
 
 void SequentialReader::set_filter(

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -157,13 +157,17 @@ const rosbag2_storage::BagMetadata & SequentialReader::get_metadata() const
   return metadata_;
 }
 
-std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and_types()
+
+void SequentialReader::fill_topics_and_types()
 {
-  topics_metadata_.clear();
   topics_metadata_.reserve(metadata_.topics_with_message_count.size());
   for (const auto & topic_information : metadata_.topics_with_message_count) {
     topics_metadata_.push_back(topic_information.topic_metadata);
   }
+}
+
+std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and_types()
+{
   return topics_metadata_;
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -201,9 +201,30 @@ TEST_F(MultifileReaderTest, read_next_throws_if_no_storage)
   EXPECT_ANY_THROW(reader_->read_next());
 }
 
-TEST_F(MultifileReaderTest, get_all_topics_and_types_throws_if_no_storage)
+TEST_F(MultifileReaderTest, get_metadata_throws_if_not_open)
 {
   init();
+  EXPECT_ANY_THROW(reader_->get_metadata());
+}
 
+TEST_F(MultifileReaderTest, get_all_topics_and_types_throws_if_not_open)
+{
+  init();
   EXPECT_ANY_THROW(reader_->get_all_topics_and_types());
+}
+
+TEST_F(MultifileReaderTest, get_metadata_returns_metadata_from_io)
+{
+  init();
+  reader_->open(default_storage_options_, {"", storage_serialization_format_});
+  const auto & metadata = reader_->get_metadata();
+  EXPECT_FALSE(metadata.topics_with_message_count.empty());
+}
+
+TEST_F(MultifileReaderTest, get_all_topics_and_types_returns_from_io_metadata)
+{
+  init();
+  reader_->open(default_storage_options_, {"", storage_serialization_format_});
+  const auto all_topics_and_types = reader_->get_all_topics_and_types();
+  EXPECT_FALSE(all_topics_and_types.empty());
 }

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -57,6 +57,11 @@ public:
     return messages_[num_read_++];
   }
 
+  const rosbag2_storage::BagMetadata & get_metadata() const override
+  {
+    return metadata_;
+  }
+
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override
   {
     return topics_;
@@ -82,6 +87,7 @@ public:
 
 private:
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages_;
+  rosbag2_storage::BagMetadata metadata_;
   std::vector<rosbag2_storage::TopicMetadata> topics_;
   size_t num_read_;
   rosbag2_storage::StorageFilter filter_;

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -62,7 +62,7 @@ public:
     return metadata_;
   }
 
-  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override
+  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() const override
   {
     return topics_;
   }


### PR DESCRIPTION
Add `get_metadata` interface to BaseReaderInterface (so that Player can use it) - and provide the TopicMetadata list from it (which comes from YAML file), instead of calling the storage plugin (e.g. database) which provides an outdated version of the data.

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>