### PR TITLE
Move qos utilities to their own compilation unit

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -191,8 +191,8 @@ Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(
 
   ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
     "Not all original publishers on topic " << topic_name << " offered the same QoS profiles. "
-    "Rosbag2 cannot yet choose an adapted profile to offer for this mixed case. "
-    "Falling back to the rosbag2_transport default publisher offer.");
+      "Rosbag2 cannot yet choose an adapted profile to offer for this mixed case. "
+      "Falling back to the rosbag2_transport default publisher offer.");
   return default_offer;
 }
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <vector>
+
 #include "rosbag2_transport/logging.hpp"
 
 #include "qos.hpp"
@@ -73,7 +76,6 @@ bool convert<rosbag2_transport::Rosbag2QoS>::decode(
 
 namespace rosbag2_transport
 {
-
 Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   const std::string & topic_name, const std::vector<rclcpp::TopicEndpointInfo> & endpoints)
 {
@@ -91,10 +93,9 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   }
 
   // We set policies in order as defined in rmw_qos_profile_t
-  Rosbag2QoS request_qos;
+  Rosbag2QoS request_qos{};
   // Policy: history, depth
   // History does not affect compatibility
-  request_qos.default_history();
 
   // Policy: reliability
   if (reliability_reliable_endpoints_count == num_endpoints) {
@@ -188,5 +189,4 @@ Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(const std::vector<Rosbag2Q
     "Falling back to the rosbag2_transport default publisher offer.");
   return Rosbag2QoS{};
 }
-
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -79,9 +79,8 @@ namespace rosbag2_transport
 Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   const std::string & topic_name, const std::vector<rclcpp::TopicEndpointInfo> & endpoints)
 {
-  static const Rosbag2QoS default_request{};
   if (endpoints.empty()) {
-    return default_request;
+    return Rosbag2QoS{};
   }
   size_t num_endpoints = endpoints.size();
   size_t reliability_reliable_endpoints_count = 0;
@@ -97,7 +96,7 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   }
 
   // We set policies in order as defined in rmw_qos_profile_t
-  Rosbag2QoS request_qos = default_request;
+  Rosbag2QoS request_qos{};
   // Policy: history, depth
   // History does not affect compatibility
 
@@ -153,6 +152,10 @@ bool operator==(const rmw_time_t & lhs, const rmw_time_t & rhs)
   return lhs.sec == rhs.sec && lhs.nsec == rhs.nsec;
 }
 
+/** Check if all QoS profiles in the vector are identical when only looking at
+  * policies that affect compatibility.
+  * This means it excludes history and lifespan from the equality check.
+  */
 bool all_profiles_effectively_same(const std::vector<Rosbag2QoS> & profiles)
 {
   auto iterator = profiles.begin();
@@ -180,9 +183,8 @@ bool all_profiles_effectively_same(const std::vector<Rosbag2QoS> & profiles)
 Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(
   const std::string & topic_name, const std::vector<Rosbag2QoS> & profiles)
 {
-  static const Rosbag2QoS default_offer{};
   if (profiles.empty()) {
-    return default_offer;
+    return Rosbag2QoS{};
   }
   if (all_profiles_effectively_same(profiles)) {
     auto result = profiles[0];
@@ -193,6 +195,6 @@ Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(
     "Not all original publishers on topic " << topic_name << " offered the same QoS profiles. "
       "Rosbag2 cannot yet choose an adapted profile to offer for this mixed case. "
       "Falling back to the rosbag2_transport default publisher offer.");
-  return default_offer;
+  return Rosbag2QoS{};
 }
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -79,8 +79,9 @@ namespace rosbag2_transport
 Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   const std::string & topic_name, const std::vector<rclcpp::TopicEndpointInfo> & endpoints)
 {
+  static const Rosbag2QoS default_request{};
   if (endpoints.empty()) {
-    return Rosbag2QoS{};
+    return default_request;
   }
   size_t num_endpoints = endpoints.size();
   size_t reliability_reliable_endpoints_count = 0;
@@ -96,7 +97,7 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   }
 
   // We set policies in order as defined in rmw_qos_profile_t
-  Rosbag2QoS request_qos{};
+  Rosbag2QoS request_qos = default_request;
   // Policy: history, depth
   // History does not affect compatibility
 
@@ -176,10 +177,12 @@ bool all_profiles_effectively_same(const std::vector<Rosbag2QoS> & profiles)
 }
 }  // unnamed namespace
 
-Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(const std::vector<Rosbag2QoS> & profiles)
+Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(
+  const std::string & topic_name, const std::vector<Rosbag2QoS> & profiles)
 {
+  static const Rosbag2QoS default_offer{};
   if (profiles.empty()) {
-    return Rosbag2QoS{};
+    return default_offer;
   }
   if (all_profiles_effectively_same(profiles)) {
     auto result = profiles[0];
@@ -187,9 +190,9 @@ Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(const std::vector<Rosbag2Q
   }
 
   ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
-    "Not all original publishers offered the same QoS profiles. "
+    "Not all original publishers on topic " << topic_name << " offered the same QoS profiles. "
     "Rosbag2 cannot yet choose an adapted profile to offer for this mixed case. "
     "Falling back to the rosbag2_transport default publisher offer.");
-  return Rosbag2QoS{};
+  return default_offer;
 }
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -79,6 +79,9 @@ namespace rosbag2_transport
 Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   const std::string & topic_name, const std::vector<rclcpp::TopicEndpointInfo> & endpoints)
 {
+  if (endpoints.empty()) {
+    return Rosbag2QoS{};
+  }
   size_t num_endpoints = endpoints.size();
   size_t reliability_reliable_endpoints_count = 0;
   size_t durability_transient_local_endpoints_count = 0;

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rosbag2_transport/logging.hpp"
+
 #include "qos.hpp"
 
 namespace YAML
@@ -68,3 +70,123 @@ bool convert<rosbag2_transport::Rosbag2QoS>::decode(
   return true;
 }
 }  // namespace YAML
+
+namespace rosbag2_transport
+{
+
+Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
+  const std::string & topic_name, const std::vector<rclcpp::TopicEndpointInfo> & endpoints)
+{
+  size_t num_endpoints = endpoints.size();
+  size_t reliability_reliable_endpoints_count = 0;
+  size_t durability_transient_local_endpoints_count = 0;
+  for (const auto & endpoint : endpoints) {
+    const auto & profile = endpoint.qos_profile().get_rmw_qos_profile();
+    if (profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
+      reliability_reliable_endpoints_count++;
+    }
+    if (profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
+      durability_transient_local_endpoints_count++;
+    }
+  }
+
+  // We set policies in order as defined in rmw_qos_profile_t
+  Rosbag2QoS request_qos;
+  // Policy: history, depth
+  // History does not affect compatibility
+  request_qos.default_history();
+
+  // Policy: reliability
+  if (reliability_reliable_endpoints_count == num_endpoints) {
+    request_qos.reliable();
+  } else {
+    if (reliability_reliable_endpoints_count > 0) {
+      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+        "Some, but not all, publishers on topic \"" << topic_name << "\" "
+          "are offering RMW_QOS_POLICY_RELIABILITY_RELIABLE. "
+          "Falling back to RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT "
+          "as it will connect to all publishers. "
+          "Some messages from Reliable publishers could be dropped.");
+    }
+    request_qos.best_effort();
+  }
+
+  // Policy: durability
+  // If all publishers offer transient_local, we can request it and receive latched messages
+  if (durability_transient_local_endpoints_count == num_endpoints) {
+    request_qos.transient_local();
+  } else {
+    if (durability_transient_local_endpoints_count > 0) {
+      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+        "Some, but not all, publishers on topic \"" << topic_name << "\" "
+          "are offering RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL. "
+          "Falling back to RMW_QOS_POLICY_DURABILITY_VOLATILE "
+          "as it will connect to all publishers. "
+          "Previously-published latched messages will not be retrieved.");
+    }
+    request_qos.durability_volatile();
+  }
+  // Policy: deadline
+  // Deadline does not affect delivery of messages,
+  // and we do not record Deadline"Missed events.
+  // We can always use unspecified deadline, which will be compatible with all publishers.
+
+  // Policy: lifespan
+  // Lifespan does not affect compatibiliy
+
+  // Policy: liveliness, liveliness_lease_duration
+  // Liveliness does not affect delivery of messages,
+  // and we do not record LivelinessChanged events.
+  // We can always use unspecified liveliness, which will be compatible with all publishers.
+  return request_qos;
+}
+
+namespace
+{
+bool operator==(const rmw_time_t & lhs, const rmw_time_t & rhs)
+{
+  return lhs.sec == rhs.sec && lhs.nsec == rhs.nsec;
+}
+
+bool all_profiles_effectively_same(const std::vector<Rosbag2QoS> & profiles)
+{
+  auto iterator = profiles.begin();
+  const auto p_ref = iterator->get_rmw_qos_profile();
+  iterator++;
+  for (; iterator != profiles.end(); iterator++) {
+    const auto p_next = iterator->get_rmw_qos_profile();
+    bool compatibility_equals_previous = (
+      // excluding history
+      p_ref.reliability == p_next.reliability &&
+      p_ref.durability == p_next.durability &&
+      p_ref.deadline == p_next.deadline &&
+      // excluding lifespan
+      p_ref.liveliness == p_next.liveliness &&
+      p_ref.liveliness_lease_duration == p_next.liveliness_lease_duration
+    );
+    if (!compatibility_equals_previous) {
+      return false;
+    }
+  }
+  return true;
+}
+}  // unnamed namespace
+
+Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(const std::vector<Rosbag2QoS> & profiles)
+{
+  if (profiles.empty()) {
+    return Rosbag2QoS{};
+  }
+  if (all_profiles_effectively_same(profiles)) {
+    auto result = profiles[0];
+    return result.default_history();
+  }
+
+  ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+    "Not all original publishers offered the same QoS profiles. "
+    "Rosbag2 cannot yet choose an adapted profile to offer for this mixed case. "
+    "Falling back to the rosbag2_transport default publisher offer.");
+  return Rosbag2QoS{};
+}
+
+}  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_TRANSPORT__QOS_HPP_
 #define ROSBAG2_TRANSPORT__QOS_HPP_
 
+#include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/qos.hpp"
 
 #ifdef _WIN32
@@ -46,6 +47,28 @@ public:
     keep_last(rmw_qos_profile_default.depth);
     return *this;
   }
+
+  // Create an adaptive QoS profile to use for subscribing to a set of offers from publishers.
+  /**
+    * - Uses rosbag2_transport defaults for History since they do not affect compatibility.
+    * - Adapts Durability and Reliability, falling back to the least strict publisher when there
+    * is a mixed offer. This behavior errs on the side of forming connections with all publishers.
+    * - Does not specify Lifespan, Deadline, or Liveliness to be maximally compatible, because
+    * these policies do not affect message delivery.
+    */
+  static Rosbag2QoS adapt_request_to_offers(
+    const std::string & topic_name,
+    const std::vector<rclcpp::TopicEndpointInfo> & endpoints);
+
+  // Create a QoS profile to offer for playback.
+  /**
+    * This logic exists because rosbag2 does not record on a per-publisher basis, so we try to
+    * get as close as possible to the original system's behavior, given a single publisher.
+    * If all profiles are the same (excepting History & Lifespan, which are purely local),
+    * that exact value is returned.
+    * Otherwise, fall back to the rosbag2 default and emit a warning.
+    */
+  static Rosbag2QoS adapt_offer_to_recorded_offers(const std::vector<Rosbag2QoS> & profiles);
 };
 }  // namespace rosbag2_transport
 

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -71,7 +71,9 @@ public:
     * that exact value is returned.
     * Otherwise, fall back to the rosbag2 default and emit a warning.
     */
-  static Rosbag2QoS adapt_offer_to_recorded_offers(const std::vector<Rosbag2QoS> & profiles);
+  static Rosbag2QoS adapt_offer_to_recorded_offers(
+    const std::string & topic_name,
+    const std::vector<Rosbag2QoS> & profiles);
 };
 }  // namespace rosbag2_transport
 

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -15,6 +15,9 @@
 #ifndef ROSBAG2_TRANSPORT__QOS_HPP_
 #define ROSBAG2_TRANSPORT__QOS_HPP_
 
+#include <string>
+#include <vector>
+
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/qos.hpp"
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -201,77 +201,9 @@ rclcpp::QoS Recorder::subscription_qos_for_topic(const std::string & topic_name)
   if (topic_qos_profile_overrides_.count(topic_name)) {
     ROSBAG2_TRANSPORT_LOG_INFO_STREAM("Overriding subscription profile for " << topic_name);
     return topic_qos_profile_overrides_.at(topic_name);
-  } else {
-    return adapt_qos_to_publishers(topic_name);
   }
-  return adapt_qos_to_publishers(topic_name);
-}
-
-rclcpp::QoS Recorder::adapt_qos_to_publishers(const std::string & topic_name) const
-{
-  auto endpoints = node_->get_publishers_info_by_topic(topic_name);
-  size_t num_endpoints = endpoints.size();
-  size_t reliability_reliable_endpoints_count = 0;
-  size_t durability_transient_local_endpoints_count = 0;
-  for (const auto & endpoint : endpoints) {
-    const auto & profile = endpoint.qos_profile().get_rmw_qos_profile();
-    if (profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
-      reliability_reliable_endpoints_count++;
-    }
-    if (profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
-      durability_transient_local_endpoints_count++;
-    }
-  }
-
-  // We set policies in order as defined in rmw_qos_profile_t
-  Rosbag2QoS request_qos;
-  // Policy: history, depth
-  // History does not affect compatibility
-  request_qos.default_history();
-
-  // Policy: reliability
-  if (reliability_reliable_endpoints_count == num_endpoints) {
-    request_qos.reliable();
-  } else {
-    if (reliability_reliable_endpoints_count > 0) {
-      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
-        "Some, but not all, publishers on topic \"" << topic_name << "\" "
-          "are offering RMW_QOS_POLICY_RELIABILITY_RELIABLE. "
-          "Falling back to RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT "
-          "as it will connect to all publishers. "
-          "Some messages from Reliable publishers could be dropped.");
-    }
-    request_qos.best_effort();
-  }
-
-  // Policy: durability
-  // If all publishers offer transient_local, we can request it and receive latched messages
-  if (durability_transient_local_endpoints_count == num_endpoints) {
-    request_qos.transient_local();
-  } else {
-    if (durability_transient_local_endpoints_count > 0) {
-      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
-        "Some, but not all, publishers on topic \"" << topic_name << "\" "
-          "are offering RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL. "
-          "Falling back to RMW_QOS_POLICY_DURABILITY_VOLATILE "
-          "as it will connect to all publishers. "
-          "Previously-published latched messages will not be retrieved.");
-    }
-    request_qos.durability_volatile();
-  }
-  // Policy: deadline
-  // Deadline does not affect delivery of messages,
-  // and we do not record Deadline"Missed events.
-  // We can always use unspecified deadline, which will be compatible with all publishers.
-
-  // Policy: lifespan
-  // Lifespan does not affect compatibiliy
-
-  // Policy: liveliness, liveliness_lease_duration
-  // Liveliness does not affect delivery of messages,
-  // and we do not record LivelinessChanged events.
-  // We can always use unspecified liveliness, which will be compatible with all publishers.
-  return request_qos;
+  return Rosbag2QoS::adapt_request_to_offers(
+    topic_name, node_->get_publishers_info_by_topic(topic_name));
 }
 
 void Recorder::warn_if_new_qos_for_subscribed_topic(const std::string & topic_name)

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -88,21 +88,13 @@ private:
   /**
    * Find the QoS profile that should be used for subscribing.
    *
-   * Profiles are prioritized by:
-   *   1. The override specified in the record_options, if one exists for the topic.
-   *   2. Adapted subscription via `adapt_qos_to_publishers`
+   * Uses the override from record_options, if it is specified for this topic.
+   * Otherwise, falls back to Rosbag2QoS::adapt_request_to_offers
    *
    *   \param topic_name The full name of the topic, with namespace (ex. /arm/joint_status).
    *   \return The QoS profile to be used for subscribing.
    */
   rclcpp::QoS subscription_qos_for_topic(const std::string & topic_name) const;
-  /**
-    * Try to subscribe using publishers' offered QoS policies.
-    *
-    * Fall back to sensible defaults when we can't adapt robustly,
-    * erring in favor of creating compatible connections.
-    */
-  rclcpp::QoS adapt_qos_to_publishers(const std::string & topic_name) const;
 
   // Serialize all currently offered QoS profiles for a topic into a YAML list.
   std::string serialized_offered_qos_profiles_for_topic(const std::string & topic_name);

--- a/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
@@ -96,6 +96,8 @@ TEST(TestQoS, detect_new_qos_fields)
   EXPECT_EQ(profile.history, RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT);  // fix "unused variable"
 }
 
+
+using rosbag2_transport::Rosbag2QoS;  // NOLINT
 class AdaptiveQoSTest : public ::testing::Test
 {
 public:
@@ -128,14 +130,12 @@ public:
 
 TEST_F(AdaptiveQoSTest, adapt_request_empty_returns_default)
 {
-  using rosbag2_transport::Rosbag2QoS;
   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
   EXPECT_EQ(default_request_, adapted_request);
 }
 
 TEST_F(AdaptiveQoSTest, adapt_request_single_offer_returns_same_values)
 {
-  using rosbag2_transport::Rosbag2QoS;
   // Set up this offer to use nondefault reliability and durability,
   // expect to see those values in the output
   auto nondefault_offer = Rosbag2QoS{}.best_effort().transient_local();
@@ -151,7 +151,6 @@ TEST_F(AdaptiveQoSTest, adapt_request_single_offer_returns_same_values)
 
 TEST_F(AdaptiveQoSTest, adapt_request_multiple_similar_offers_returns_same_values)
 {
-  using rosbag2_transport::Rosbag2QoS;
   auto nondefault_offer = Rosbag2QoS{}.best_effort().transient_local();
   const size_t num_endpoints{3};
   for (size_t i = 0; i < num_endpoints; i++) {
@@ -168,7 +167,6 @@ TEST_F(AdaptiveQoSTest, adapt_request_multiple_similar_offers_returns_same_value
 
 TEST_F(AdaptiveQoSTest, adapt_request_mixed_reliability_offers_return_best_effort)
 {
-  using rosbag2_transport::Rosbag2QoS;
   add_endpoint(Rosbag2QoS{}.best_effort());
   add_endpoint(Rosbag2QoS{}.reliable());
   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
@@ -178,7 +176,6 @@ TEST_F(AdaptiveQoSTest, adapt_request_mixed_reliability_offers_return_best_effor
 
 TEST_F(AdaptiveQoSTest, adapt_request_mixed_durability_offers_return_volatile)
 {
-  using rosbag2_transport::Rosbag2QoS;
   add_endpoint(Rosbag2QoS{}.transient_local());
   add_endpoint(Rosbag2QoS{}.durability_volatile());
   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
@@ -187,14 +184,12 @@ TEST_F(AdaptiveQoSTest, adapt_request_mixed_durability_offers_return_volatile)
 
 TEST_F(AdaptiveQoSTest, adapt_offer_empty_returns_default)
 {
-  using rosbag2_transport::Rosbag2QoS;
   auto adapted_offer = Rosbag2QoS::adapt_offer_to_recorded_offers(topic_name_, {});
   EXPECT_EQ(adapted_offer, default_offer_);
 }
 
 TEST_F(AdaptiveQoSTest, adapt_offer_single_offer_returns_same_values)
 {
-  using rosbag2_transport::Rosbag2QoS;
   // Set up this offer to use nondefault reliability and durability,
   // expect to see those values in the output
   auto nondefault_offer = Rosbag2QoS{Rosbag2QoS{}.best_effort().transient_local()};
@@ -206,7 +201,6 @@ TEST_F(AdaptiveQoSTest, adapt_offer_single_offer_returns_same_values)
 
 TEST_F(AdaptiveQoSTest, adapt_offer_multiple_offers_with_same_settings_return_identical)
 {
-  using rosbag2_transport::Rosbag2QoS;
   auto nondefault_offer = Rosbag2QoS{Rosbag2QoS{}.best_effort().transient_local()};
   auto adapted_offer = Rosbag2QoS::adapt_offer_to_recorded_offers(
     topic_name_, {nondefault_offer, nondefault_offer, nondefault_offer});
@@ -217,7 +211,6 @@ TEST_F(AdaptiveQoSTest, adapt_offer_mixed_compatibility_returns_default)
 {
   // When the offers have mixed values for policies that affect compatibility,
   // it should fall back to the default.
-  using rosbag2_transport::Rosbag2QoS;
   std::vector<Rosbag2QoS> offers = {
     Rosbag2QoS{Rosbag2QoS{}.best_effort()},
     Rosbag2QoS{Rosbag2QoS{}.reliable()},
@@ -230,7 +223,6 @@ TEST_F(AdaptiveQoSTest, adapt_offer_mixed_non_compatibility_returns_first)
 {
   // Some QoS policies don't affect compatibility, so even if their values are mixed we should
   // receive the first value.
-  using rosbag2_transport::Rosbag2QoS;
   rclcpp::Duration nonstandard_duration(12, 34);
   size_t nonstandard_history{20};
   std::vector<Rosbag2QoS> offers = {

--- a/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
@@ -99,10 +99,7 @@ TEST(TestQoS, detect_new_qos_fields)
 class AdaptiveQoSTest : public ::testing::Test
 {
 public:
-  explicit AdaptiveQoSTest()
-  {
-    memset(endpoint_gid_, 0, RMW_GID_STORAGE_SIZE);
-  }
+  AdaptiveQoSTest() = default;
 
   rclcpp::TopicEndpointInfo make_endpoint(const rclcpp::QoS & qos)
   {
@@ -131,7 +128,11 @@ TEST_F(AdaptiveQoSTest, adapt_request_empty_returns_default)
 {
   using rosbag2_transport::Rosbag2QoS;
   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
-  EXPECT_EQ(Rosbag2QoS{}, adapted_request);
+
+  auto expected = Rosbag2QoS{}.get_rmw_qos_profile();
+  auto actual = adapted_request.get_rmw_qos_profile();
+  EXPECT_EQ(expected.reliability, actual.reliability);
+  EXPECT_EQ(expected.durability, actual.durability);
 }
 
 TEST_F(AdaptiveQoSTest, adapt_request_single_offer_returns_same_values)
@@ -139,9 +140,7 @@ TEST_F(AdaptiveQoSTest, adapt_request_single_offer_returns_same_values)
   using rosbag2_transport::Rosbag2QoS;
   // Set up this offer to use nondefault reliability and durability,
   // expect to see those values in the output
-  auto nondefault_offer = Rosbag2QoS{}
-    .best_effort()
-    .transient_local();
+  auto nondefault_offer = Rosbag2QoS{}.best_effort().transient_local();
   add_endpoint(nondefault_offer);
 
   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
@@ -152,39 +151,38 @@ TEST_F(AdaptiveQoSTest, adapt_request_single_offer_returns_same_values)
   EXPECT_EQ(expected.durability, actual.durability);
 }
 
-// TEST_F(AdaptiveQoSTest, adapt_request_multiple_offers_with_same_settings_return_identical)
-// {
-//   using rosbag2_transport::Rosbag2QoS;
-//   auto nondefault_offer = Rosbag2QoS{}
-//     .best_effort()
-//     .transient_local();
-//   const size_t num_endpoints{3};
-//   for (size_t i = 0; i < num_endpoints; i++) {
-//     add_endpoint(nondefault_offer);
-//   }
-//
-//   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
-//
-//   auto expected = nondefault_offer.get_rmw_qos_profile();
-//   auto actual = adapted_request.get_rmw_qos_profile();
-//   EXPECT_EQ(expected.reliability, actual.reliability);
-//   EXPECT_EQ(expected.durability, actual.durability);
-// }
+TEST_F(AdaptiveQoSTest, adapt_request_multiple_offers_with_same_settings_return_identical)
+{
+  using rosbag2_transport::Rosbag2QoS;
+  auto nondefault_offer = Rosbag2QoS{}.best_effort().transient_local();
+  const size_t num_endpoints{3};
+  for (size_t i = 0; i < num_endpoints; i++) {
+    add_endpoint(nondefault_offer);
+  }
 
-// TEST_F(AdaptiveQoSTest, adapt_request_mixed_reliability_offers_return_best_effort)
-// {
-//   using rosbag2_transport::Rosbag2QoS;
-//   add_endpoint(Rosbag2QoS{}.best_effort());
-//   add_endpoint(Rosbag2QoS{}.reliable());
-//   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
-//   EXPECT_EQ(adapted_request.get_rmw_qos_profile().reliability, RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
-// }
-//
-// TEST_F(AdaptiveQoSTest, adapt_request_mixed_durability_offers_return_volatile)
-// {
-//   using rosbag2_transport::Rosbag2QoS;
-//   add_endpoint(Rosbag2QoS{}.transient_local());
-//   add_endpoint(Rosbag2QoS{}.durability_volatile());
-//   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
-//   EXPECT_EQ(adapted_request.get_rmw_qos_profile().durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-// }
+  auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
+
+  auto expected = nondefault_offer.get_rmw_qos_profile();
+  auto actual = adapted_request.get_rmw_qos_profile();
+  EXPECT_EQ(expected.reliability, actual.reliability);
+  EXPECT_EQ(expected.durability, actual.durability);
+}
+
+TEST_F(AdaptiveQoSTest, adapt_request_mixed_reliability_offers_return_best_effort)
+{
+  using rosbag2_transport::Rosbag2QoS;
+  add_endpoint(Rosbag2QoS{}.best_effort());
+  add_endpoint(Rosbag2QoS{}.reliable());
+  auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
+  EXPECT_EQ(
+    adapted_request.get_rmw_qos_profile().reliability, RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
+}
+
+TEST_F(AdaptiveQoSTest, adapt_request_mixed_durability_offers_return_volatile)
+{
+  using rosbag2_transport::Rosbag2QoS;
+  add_endpoint(Rosbag2QoS{}.transient_local());
+  add_endpoint(Rosbag2QoS{}.durability_volatile());
+  auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
+  EXPECT_EQ(adapted_request.get_rmw_qos_profile().durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
@@ -186,3 +186,8 @@ TEST_F(AdaptiveQoSTest, adapt_request_mixed_durability_offers_return_volatile)
   auto adapted_request = Rosbag2QoS::adapt_request_to_offers(topic_name_, endpoints_);
   EXPECT_EQ(adapted_request.get_rmw_qos_profile().durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }
+
+TEST_F(AdaptiveQoSTest, adapt_offer)
+{
+  
+}


### PR DESCRIPTION
Part of #125 

Moves the adaptive QoS logic into the QoS compilation unit and adds explicit unit tests for it.

This removes this qos-specific knowledge from Recorder (and upcoming Player). Eventually an even more generic version of this should make it into rclcpp, possibly as part of the `GenericPublisher`/`GenericSubscription` push - adaptive QoS is a necessary part of a generic transport in ROS 2

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>