### PR TITLE
Create bag serializer and deserializer

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -32,18 +32,25 @@ find_package(ament_index_cpp REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(rmw REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
+find_package(std_msgs REQUIRED)
+find_package(test_msgs REQUIRED)
+
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/converter.cpp
+  src/rosbag2_cpp/deserializer.cpp
   src/rosbag2_cpp/info.cpp
   src/rosbag2_cpp/reader.cpp
   src/rosbag2_cpp/readers/sequential_reader.cpp
+  src/rosbag2_cpp/serializer.cpp
   src/rosbag2_cpp/serialization_format_converter_factory.cpp
+  src/rosbag2_cpp/type_names.cpp
   src/rosbag2_cpp/types/introspection_message.cpp
   src/rosbag2_cpp/typesupport_helpers.cpp
   src/rosbag2_cpp/types/introspection_message.cpp
@@ -55,11 +62,14 @@ ament_target_dependencies(${PROJECT_NAME}
   pluginlib
   rcpputils
   rcutils
+  rmw
   rosbag2_storage
   rosidl_runtime_c
   rosidl_runtime_cpp
   rosidl_typesupport_introspection_cpp
   rosidl_typesupport_cpp
+  std_msgs
+  test_msgs
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -97,6 +107,7 @@ ament_export_dependencies(pluginlib
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  find_package(std_msgs REQUIRED)
   find_package(test_msgs REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
@@ -182,6 +193,13 @@ if(BUILD_TESTING)
     test/rosbag2_cpp/test_multifile_reader.cpp)
   if(TARGET test_multifile_reader)
     target_link_libraries(test_multifile_reader ${PROJECT_NAME})
+  endif()
+
+  ament_add_gmock(test_serialization
+    test/rosbag2_cpp/test_serialization.cpp)
+  if(TARGET test_serialization)
+    target_link_libraries(test_serialization ${PROJECT_NAME})
+    ament_target_dependencies(test_serialization std_msgs test_msgs)
   endif()
 endif()
 

--- a/rosbag2_cpp/include/rosbag2_cpp/deserializer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/deserializer.hpp
@@ -1,0 +1,86 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_CPP__DESERIALIZER_HPP_
+#define ROSBAG2_CPP__DESERIALIZER_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rcpputils/shared_library.hpp"
+
+#include "rosbag2_cpp/converter_interfaces/serialization_format_deserializer.hpp"
+#include "rosbag2_cpp/serialization_format_converter_factory.hpp"
+#include "rosbag2_cpp/type_names.hpp"
+#include "rosbag2_cpp/types/introspection_message.hpp"
+#include "rosbag2_cpp/typesupport_helpers.hpp"
+#include "rosbag2_cpp/visibility_control.hpp"
+
+
+namespace rosbag2_cpp
+{
+
+class ROSBAG2_CPP_PUBLIC Deserializer
+{
+public:
+  explicit Deserializer();
+  ~Deserializer() = default;
+
+  /// \brief Simple method to extract message data from a SerializedBagMessage
+  /// \param message Bag message with the data to be extracted
+  template<class T>
+  T deserialize(const std::shared_ptr<rosbag2_storage::SerializedBagMessage> message)
+  {
+    // Initialize a few strings
+    const std::string topic_name = message->topic_name;
+    const std::string message_type = type_names<T>();
+
+    // Get required type support
+    const rosidl_message_type_support_t * support =
+      rosbag2_cpp::get_typesupport(message_type, introspection_string_, introspection_library_);
+    const rosidl_message_type_support_t * typeSupport =
+      rosbag2_cpp::get_typesupport(message_type, type_support_string_, type_support_library_);
+
+    // Initialize a message to deserialize into
+    std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t> output_message(
+      rosbag2_cpp::allocate_introspection_message(support, &allocator_));
+    output_message->time_stamp = 1;
+    rosbag2_cpp::introspection_message_set_topic_name(output_message.get(), topic_name.c_str());
+
+    // Deserialize the message
+    deserializer_->deserialize(message, typeSupport, output_message);
+
+    return *(static_cast<T *>(output_message->message));
+  }
+
+private:
+  /// Serialization factory. This seems to need to stay in scope
+  rosbag2_cpp::SerializationFormatConverterFactory factory_;
+  /// Deserializer object
+  std::unique_ptr<rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer> deserializer_;
+  /// A generic allocator for deserialization
+  const rcutils_allocator_t allocator_;
+  /// Shared library for introspection type support
+  std::shared_ptr<rcpputils::SharedLibrary> introspection_library_;
+  /// Shared library for type support
+  std::shared_ptr<rcpputils::SharedLibrary> type_support_library_;
+  /// Introspection type support string
+  const std::string introspection_string_;
+  /// Type support string
+  const std::string type_support_string_;
+};
+
+}  // namespace rosbag2_cpp
+
+#endif  // ROSBAG2_CPP__DESERIALIZER_HPP_

--- a/rosbag2_cpp/include/rosbag2_cpp/serializer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/serializer.hpp
@@ -1,0 +1,103 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_CPP__SERIALIZER_HPP_
+#define ROSBAG2_CPP__SERIALIZER_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rcpputils/shared_library.hpp"
+
+#include "rmw/serialized_message.h"
+
+#include "rosbag2_cpp/converter_interfaces/serialization_format_deserializer.hpp"
+#include "rosbag2_cpp/serialization_format_converter_factory.hpp"
+#include "rosbag2_cpp/type_names.hpp"
+#include "rosbag2_cpp/typesupport_helpers.hpp"
+#include "rosbag2_cpp/visibility_control.hpp"
+
+
+namespace rosbag2_cpp
+{
+
+/// \brief A simple class to serialize ros messages into SerializedBagMessages
+class ROSBAG2_CPP_PUBLIC Serializer
+{
+public:
+  explicit Serializer();
+  ~Serializer() = default;
+
+  /// \brief Serialize a ros messages into a SerializedBagMessage
+  /// \param to_serialize The data message to be serialized
+  /// \param topic_name Name of the topic to pack into the bag message
+  template<class T>
+  std::shared_ptr<rosbag2_storage::SerializedBagMessage> serialize(
+    const T & to_serialize, const std::string & topic_name)
+  {
+    // Initialize the type string
+    const std::string message_type = type_names<T>();
+
+    // Get required type support
+    const rosidl_message_type_support_t * support =
+      rosbag2_cpp::get_typesupport(message_type, introspection_string_, introspection_library_);
+    const rosidl_message_type_support_t * type_support =
+      rosbag2_cpp::get_typesupport(message_type, type_support_string_, type_support_library_);
+
+    // Initialize the message to serialize into
+    std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t> output_message =
+      rosbag2_cpp::allocate_introspection_message(support, &allocator_);
+    output_message->time_stamp = 1;
+    rosbag2_cpp::introspection_message_set_topic_name(output_message.get(), topic_name.c_str());
+
+    // Fill in the message contents
+    T * correctlyTypedMessage = reinterpret_cast<T *>(output_message->message);
+    *correctlyTypedMessage = to_serialize;
+
+    // Copy the data into the actual bag message object
+    std::shared_ptr<rosbag2_storage::SerializedBagMessage> bag_message =
+      std::make_shared<rosbag2_storage::SerializedBagMessage>();
+    bag_message->serialized_data =
+      std::shared_ptr<rmw_serialized_message_t>(new rmw_serialized_message_t());
+    auto ret = rmw_serialized_message_init(bag_message->serialized_data.get(), 0, &allocator_);
+    if (ret != RCUTILS_RET_OK) {
+      return nullptr;
+    }
+
+    // Serialize the message
+    serializer_->serialize(output_message, type_support, bag_message);
+
+    return bag_message;
+  }
+
+private:
+  /// Serialization factory. This seems to need to stay in scope
+  rosbag2_cpp::SerializationFormatConverterFactory factory_;
+  /// Serializer object
+  std::unique_ptr<rosbag2_cpp::converter_interfaces::SerializationFormatSerializer> serializer_;
+  /// A generic allocator for deserialization
+  const rcutils_allocator_t allocator_;
+  /// Shared library for introspection type support
+  std::shared_ptr<rcpputils::SharedLibrary> introspection_library_;
+  /// Shared library for type support
+  std::shared_ptr<rcpputils::SharedLibrary> type_support_library_;
+  /// Introspection type support string
+  const std::string type_support_string_;
+  /// Type support string
+  const std::string introspection_string_;
+};
+
+}  // namespace rosbag2_cpp
+
+#endif  // ROSBAG2_CPP__SERIALIZER_HPP_

--- a/rosbag2_cpp/include/rosbag2_cpp/type_names.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/type_names.hpp
@@ -1,0 +1,46 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_CPP__TYPE_NAMES_HPP_
+#define ROSBAG2_CPP__TYPE_NAMES_HPP_
+
+#include <string>
+
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/byte.hpp"
+#include "std_msgs/msg/char.hpp"
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include "std_msgs/msg/int8.hpp"
+#include "std_msgs/msg/u_int8.hpp"
+#include "std_msgs/msg/int16.hpp"
+#include "std_msgs/msg/u_int16.hpp"
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+#include "std_msgs/msg/int64.hpp"
+#include "std_msgs/msg/u_int64.hpp"
+
+#include "test_msgs/msg/basic_types.hpp"
+
+
+namespace rosbag2_cpp
+{
+
+/// \brief Simple function to return names in "package/type" format
+template<class T>
+std::string type_names();
+
+}  // namespace rosbag2_cpp
+
+#endif  // ROSBAG2_CPP__TYPE_NAMES_HPP_

--- a/rosbag2_cpp/src/rosbag2_cpp/deserializer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/deserializer.cpp
@@ -1,0 +1,39 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_cpp/deserializer.hpp"
+
+namespace
+{
+/// Default serialization format is CDR
+const char * const kSerializationFormat = "cdr";
+/// A string for creating introspection type support
+const char * const kIntrospectionString = "rosidl_typesupport_introspection_cpp";
+/// A string for creating type support
+const char * const kTypeSupportString = "rosidl_typesupport_cpp";
+}
+
+namespace rosbag2_cpp
+{
+
+Deserializer::Deserializer()
+: factory_(),
+  deserializer_(factory_.load_deserializer(kSerializationFormat)),
+  allocator_(rcutils_get_default_allocator()),
+  introspection_string_(kIntrospectionString),
+  type_support_string_(kTypeSupportString)
+{
+}
+
+}  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/serializer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/serializer.cpp
@@ -1,0 +1,41 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_cpp/serializer.hpp"
+
+namespace
+{
+/// Default serialization format is CDR
+const char * const kSerializationFormat = "cdr";
+/// A string for creating introspection type support
+const char * const kIntrospectionString = "rosidl_typesupport_introspection_cpp";
+/// A string for creating type support
+const char * const kTypeSupportString = "rosidl_typesupport_cpp";
+}
+
+namespace rosbag2_cpp
+{
+
+Serializer::Serializer()
+: factory_(),
+  serializer_(factory_.load_serializer(kSerializationFormat)),
+  allocator_(rcutils_get_default_allocator()),
+  introspection_library_(),
+  type_support_library_(),
+  type_support_string_(kTypeSupportString),
+  introspection_string_(kIntrospectionString)
+{
+}
+
+}  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/type_names.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/type_names.cpp
@@ -1,0 +1,94 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "rosbag2_cpp/type_names.hpp"
+
+namespace rosbag2_cpp
+{
+
+template<>
+std::string type_names<std_msgs::msg::Bool>()
+{
+  return "std_msgs/Bool";
+}
+template<>
+std::string type_names<std_msgs::msg::Byte>()
+{
+  return "std_msgs/Byte";
+}
+template<>
+std::string type_names<std_msgs::msg::Char>()
+{
+  return "std_msgs/Char";
+}
+template<>
+std::string type_names<std_msgs::msg::Float32>()
+{
+  return "std_msgs/Float32";
+}
+template<>
+std::string type_names<std_msgs::msg::Float64>()
+{
+  return "std_msgs/Float64";
+}
+template<>
+std::string type_names<std_msgs::msg::Int8>()
+{
+  return "std_msgs/Int8";
+}
+template<>
+std::string type_names<std_msgs::msg::UInt8>()
+{
+  return "std_msgs/UInt8";
+}
+template<>
+std::string type_names<std_msgs::msg::Int16>()
+{
+  return "std_msgs/Int16";
+}
+template<>
+std::string type_names<std_msgs::msg::UInt16>()
+{
+  return "std_msgs/UInt16";
+}
+template<>
+std::string type_names<std_msgs::msg::Int32>()
+{
+  return "std_msgs/Int32";
+}
+template<>
+std::string type_names<std_msgs::msg::UInt32>()
+{
+  return "std_msgs/UInt32";
+}
+template<>
+std::string type_names<std_msgs::msg::Int64>()
+{
+  return "std_msgs/Int64";
+}
+template<>
+std::string type_names<std_msgs::msg::UInt64>()
+{
+  return "std_msgs/UInt64";
+}
+
+template<>
+std::string type_names<test_msgs::msg::BasicTypes>()
+{
+  return "test_msgs/BasicTypes";
+}
+
+}  // namespace rosbag2_cpp

--- a/rosbag2_cpp/test/rosbag2_cpp/test_serialization.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_serialization.cpp
@@ -1,0 +1,133 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/byte.hpp"
+#include "std_msgs/msg/char.hpp"
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include "std_msgs/msg/int8.hpp"
+#include "std_msgs/msg/u_int8.hpp"
+#include "std_msgs/msg/int16.hpp"
+#include "std_msgs/msg/u_int16.hpp"
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+#include "std_msgs/msg/int64.hpp"
+#include "std_msgs/msg/u_int64.hpp"
+
+#include "rosbag2_cpp/deserializer.hpp"
+#include "rosbag2_cpp/serializer.hpp"
+
+#include "test_msgs/message_fixtures.hpp"
+
+
+using namespace ::testing;  // NOLINT
+using namespace rosbag2_cpp;  // NOLINT
+
+const char * const kGenericTopic = "generic";
+
+TEST(SerializeDeserialize, basic_types) {
+  Deserializer deserializer;
+  Serializer serializer;
+
+  for (test_msgs::msg::BasicTypes::SharedPtr msg : get_messages_basic_types()) {
+    // Check all the message components
+    std_msgs::msg::builder::Init_Bool_data boolBuilder;
+    std_msgs::msg::Bool boolValue = boolBuilder.data(msg->bool_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Bool>(
+        serializer.serialize(boolValue, kGenericTopic)),
+      boolValue);
+    std_msgs::msg::builder::Init_Byte_data byteBuilder;
+    std_msgs::msg::Byte byteValue = byteBuilder.data(msg->byte_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Byte>(
+        serializer.serialize(byteValue, kGenericTopic)),
+      byteValue);
+    std_msgs::msg::builder::Init_Char_data charBuilder;
+    std_msgs::msg::Char charValue = charBuilder.data(msg->char_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Char>(
+        serializer.serialize(charValue, kGenericTopic)),
+      charValue);
+    std_msgs::msg::builder::Init_Float32_data float32Builder;
+    std_msgs::msg::Float32 float32Value = float32Builder.data(msg->float32_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Float32>(
+        serializer.serialize(float32Value, kGenericTopic)),
+      float32Value);
+    std_msgs::msg::builder::Init_Float64_data float64Builder;
+    std_msgs::msg::Float64 float64Value = float64Builder.data(msg->float64_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Float64>(
+        serializer.serialize(float64Value, kGenericTopic)),
+      float64Value);
+    std_msgs::msg::builder::Init_Int8_data int8Builder;
+    std_msgs::msg::Int8 int8Value = int8Builder.data(msg->int8_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Int8>(
+        serializer.serialize(int8Value, kGenericTopic)),
+      int8Value);
+    std_msgs::msg::builder::Init_UInt8_data uint8Builder;
+    std_msgs::msg::UInt8 uint8Value = uint8Builder.data(msg->uint8_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::UInt8>(
+        serializer.serialize(uint8Value, kGenericTopic)),
+      uint8Value);
+    std_msgs::msg::builder::Init_Int16_data int16Builder;
+    std_msgs::msg::Int16 int16Value = int16Builder.data(msg->int16_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Int16>(
+        serializer.serialize(int16Value, kGenericTopic)),
+      int16Value);
+    std_msgs::msg::builder::Init_UInt16_data uint16Builder;
+    std_msgs::msg::UInt16 uint16Value = uint16Builder.data(msg->uint16_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::UInt16>(
+        serializer.serialize(uint16Value, kGenericTopic)),
+      uint16Value);
+    std_msgs::msg::builder::Init_Int32_data int32Builder;
+    std_msgs::msg::Int32 int32Value = int32Builder.data(msg->int32_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Int32>(
+        serializer.serialize(int32Value, kGenericTopic)),
+      int32Value);
+    std_msgs::msg::builder::Init_UInt32_data uint32Builder;
+    std_msgs::msg::UInt32 uint32Value = uint32Builder.data(msg->uint32_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::UInt32>(
+        serializer.serialize(uint32Value, kGenericTopic)),
+      uint32Value);
+    std_msgs::msg::builder::Init_Int64_data int64Builder;
+    std_msgs::msg::Int64 int64Value = int64Builder.data(msg->int64_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::Int64>(
+        serializer.serialize(int64Value, kGenericTopic)),
+      int64Value);
+    std_msgs::msg::builder::Init_UInt64_data uint64Builder;
+    std_msgs::msg::UInt64 uint64Value = uint64Builder.data(msg->uint64_value);
+    EXPECT_EQ(
+      deserializer.deserialize<std_msgs::msg::UInt64>(
+        serializer.serialize(uint64Value, kGenericTopic)),
+      uint64Value);
+
+    // Check the full message end to end
+    EXPECT_EQ(
+      deserializer.deserialize<test_msgs::msg::BasicTypes>(
+        serializer.serialize<test_msgs::msg::BasicTypes>(*msg, kGenericTopic)),
+      *msg);
+  }
+}


### PR DESCRIPTION
This change introduces two helper classes to make serializing and deserializing bag messages easier. To enable testing I've created a type_names function to get the string types of messages, but before merging I'll need to find out the proper way to get these strings.