### PR TITLE
add topic remapping option to rosbag2 play

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -52,6 +52,10 @@ class PlayVerb(VerbExtension):
             '-l', '--loop', action='store_true',
             help='enables loop playback when playing a bagfile: it starts back at the beginning '
                  'on reaching the end and plays indefinitely.')
+        parser.add_argument(
+            '--remap', '-m', default='', nargs='+',
+            help='list of topics to be remapped: in the form '
+                 '"old_topic1:=new_topic1 old_topic2:=new_topic2 etc." ')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -77,4 +81,5 @@ class PlayVerb(VerbExtension):
             rate=args.rate,
             topics=args.topics,
             qos_profile_overrides=qos_profile_overrides,
-            loop=args.loop)
+            loop=args.loop,
+            topic_remapping=args.remap)

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -169,6 +169,11 @@ function(create_tests_for_rmw_implementation)
     LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common)
 
+  rosbag2_transport_add_gmock(test_play_topic_remap
+    test/rosbag2_transport/test_play_topic_remap.cpp
+    ${SKIP_TEST}
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
 endfunction()
 
 if(BUILD_TESTING)

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -39,6 +39,7 @@ public:
 
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides = {};
   bool loop = false;
+  std::vector<std::string> topic_remapping_options = {};
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
@@ -85,7 +85,9 @@ public:
   void print_bag_info(const std::string & uri, const std::string & storage_id);
 
 private:
-  std::shared_ptr<Rosbag2Node> setup_node(std::string node_prefix = "");
+  std::shared_ptr<Rosbag2Node> setup_node(
+    std::string node_prefix = "",
+    const std::vector<std::string> & topic_remapping_options = {});
 
   std::shared_ptr<rosbag2_cpp::Reader> reader_;
   std::shared_ptr<rosbag2_cpp::Writer> writer_;

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -37,6 +37,10 @@ Rosbag2Node::Rosbag2Node(const std::string & node_name)
 : rclcpp::Node(node_name)
 {}
 
+Rosbag2Node::Rosbag2Node(const std::string & node_name, const rclcpp::NodeOptions & options)
+: rclcpp::Node(node_name, options)
+{}
+
 std::shared_ptr<GenericPublisher> Rosbag2Node::create_generic_publisher(
   const std::string & topic, const std::string & type, const rclcpp::QoS & qos)
 {

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
@@ -23,6 +23,7 @@
 
 #include "rclcpp/node.hpp"
 #include "rclcpp/serialized_message.hpp"
+#include "rclcpp/node_options.hpp"
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/types.h"
 
@@ -36,6 +37,9 @@ class Rosbag2Node : public rclcpp::Node
 {
 public:
   explicit Rosbag2Node(const std::string & node_name);
+  explicit Rosbag2Node(
+    const std::string & node_name,
+    const rclcpp::NodeOptions & options);
   ~Rosbag2Node() override = default;
 
   std::shared_ptr<GenericPublisher>

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -82,10 +82,13 @@ void Rosbag2Transport::record(
   }
 }
 
-std::shared_ptr<Rosbag2Node> Rosbag2Transport::setup_node(std::string node_prefix)
+std::shared_ptr<Rosbag2Node> Rosbag2Transport::setup_node(
+  std::string node_prefix,
+  const std::vector<std::string> & topic_remapping_options)
 {
   if (!transport_node_) {
-    transport_node_ = std::make_shared<Rosbag2Node>(node_prefix + "_rosbag2");
+    auto node_options = rclcpp::NodeOptions().arguments(topic_remapping_options);
+    transport_node_ = std::make_shared<Rosbag2Node>(node_prefix + "_rosbag2", node_options);
   }
   return transport_node_;
 }
@@ -94,9 +97,9 @@ void Rosbag2Transport::play(
   const StorageOptions & storage_options, const PlayOptions & play_options)
 {
   try {
-    auto transport_node = setup_node(play_options.node_prefix);
+    auto transport_node =
+      setup_node(play_options.node_prefix, play_options.topic_remapping_options);
     Player player(reader_, transport_node);
-
     do {
       reader_->open(storage_options, {"", rmw_get_serialization_format()});
       player.play(play_options);

--- a/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
@@ -19,11 +19,9 @@
 #include <future>
 #include <memory>
 #include <string>
-#include <thread>
-#include <vector>
 #include <utility>
+#include <vector>
 
-#include "rclcpp/rclcpp.hpp"
 
 #include "rosbag2_test_common/subscription_manager.hpp"
 
@@ -34,52 +32,44 @@
 
 #include "rosbag2_play_test_fixture.hpp"
 
-TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
+
+TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
   //  test constants
-  const int test_value = 42;
-  const size_t num_messages = 3;
-  const int64_t time_stamp_in_milliseconds = 700;
-  const size_t expected_number_of_messages = num_messages * 2;
-  const size_t read_ahead_queue_size = 1000;
-  const float rate = 1.0;
-  const bool loop_playback = true;
+  const std::string original_topic = "/topic_before_remap";
+  const std::string remapped_topic = "/topic_after_remap";
+  const int32_t test_value = 42;
+  const int64_t timestamp_in_milliseconds = 700;
+  const size_t expected_number_of_messages = 1;
+  play_options_.topic_remapping_options =
+  {"--ros-args", "--remap", "topic_before_remap:=topic_after_remap"};
 
   auto primitive_message1 = get_messages_basic_types()[0];
   primitive_message1->int32_value = test_value;
 
   auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
-    {"loop_test_topic", "test_msgs/BasicTypes", "", ""}
+    {original_topic, "test_msgs/BasicTypes", "", ""}
   };
 
-  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages(num_messages,
-    serialize_test_message("loop_test_topic", time_stamp_in_milliseconds, primitive_message1));
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {serialize_test_message(original_topic, timestamp_in_milliseconds, primitive_message1), };
 
   auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
   prepared_mock_reader->prepare(messages, topic_types);
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
 
-  sub_->add_subscription<test_msgs::msg::BasicTypes>(
-    "/loop_test_topic",
-    expected_number_of_messages);
-
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(remapped_topic, expected_number_of_messages);
   auto await_received_messages = sub_->spin_subscriptions();
 
-  auto rosbag2_transport_ptr = std::make_shared<rosbag2_transport::Rosbag2Transport>(
-    reader_,
-    writer_,
-    info_);
-  std::thread loop_thread(&rosbag2_transport::Rosbag2Transport::play, rosbag2_transport_ptr,
-    storage_options_,
-    rosbag2_transport::PlayOptions{read_ahead_queue_size, "", rate, {}, {}, loop_playback, {}});
+  rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
+
+  rosbag2_transport.play(
+    storage_options_, play_options_);
 
   await_received_messages.get();
-  rclcpp::shutdown();
-  loop_thread.join();
 
   auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
-    "/loop_test_topic");
-
-  EXPECT_THAT(replayed_test_primitives.size(), Ge(expected_number_of_messages));
+    remapped_topic);
+  EXPECT_THAT(replayed_test_primitives, SizeIs(Ge(expected_number_of_messages)));
   EXPECT_THAT(
     replayed_test_primitives,
     Each(Pointee(Field(&test_msgs::msg::BasicTypes::int32_value, test_value))));


### PR DESCRIPTION
With the option --remap or -m it's now possible to do topic remapping in rosbag2 play.
This is done by passing the remapping options to the play node.

Closes https://github.com/ros2/rosbag2/issues/326.