### PR TITLE
Revert "use serialized message (#386)"

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"  // rclcpp must be included before the Windows specific includes.
-#include "rclcpp/serialization.hpp"
 
 #include "memory_management.hpp"
 
@@ -55,7 +54,7 @@ public:
       subscriber_node_->create_subscription<MessageT>(
         topic_name,
         qos,
-        [this, topic_name](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+        [this, topic_name](std::shared_ptr<rmw_serialized_message_t> msg) {
           subscribed_messages_[topic_name].push_back(msg);
         },
         options));
@@ -64,13 +63,10 @@ public:
   template<typename MessageT>
   std::vector<std::shared_ptr<MessageT>> get_received_messages(const std::string & topic_name)
   {
-    static rclcpp::Serialization<MessageT> serializer;
     auto messages = subscribed_messages_[topic_name];
     auto received_messages_on_topic = std::vector<std::shared_ptr<MessageT>>();
-    for (const auto & serialized_msg : messages) {
-      auto msg = std::make_shared<MessageT>();
-      serializer.deserialize_message(serialized_msg.get(), msg.get());
-      received_messages_on_topic.push_back(msg);
+    for (const auto & msg : messages) {
+      received_messages_on_topic.push_back(memory_management_.deserialize_message<MessageT>(msg));
     }
     return received_messages_on_topic;
   }
@@ -98,7 +94,7 @@ private:
 
   std::vector<rclcpp::SubscriptionBase::SharedPtr> subscriptions_;
   std::unordered_map<std::string,
-    std::vector<std::shared_ptr<rclcpp::SerializedMessage>>> subscribed_messages_;
+    std::vector<std::shared_ptr<rmw_serialized_message_t>>> subscribed_messages_;
   std::unordered_map<std::string, size_t> expected_topics_with_size_;
   rclcpp::Node::SharedPtr subscriber_node_;
   MemoryManagement memory_management_;

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
@@ -40,7 +40,7 @@ GenericSubscription::GenericSubscription(
   const rosidl_message_type_support_t & ts,
   const std::string & topic_name,
   const rclcpp::QoS & qos,
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+  std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback)
 : SubscriptionBase(
     node_base,
     ts,
@@ -57,7 +57,7 @@ std::shared_ptr<void> GenericSubscription::create_message()
   return create_serialized_message();
 }
 
-std::shared_ptr<rclcpp::SerializedMessage> GenericSubscription::create_serialized_message()
+std::shared_ptr<rmw_serialized_message_t> GenericSubscription::create_serialized_message()
 {
   return borrow_serialized_message(0);
 }
@@ -66,7 +66,7 @@ void GenericSubscription::handle_message(
   std::shared_ptr<void> & message, const rclcpp::MessageInfo & message_info)
 {
   (void) message_info;
-  auto typed_message = std::static_pointer_cast<rclcpp::SerializedMessage>(message);
+  auto typed_message = std::static_pointer_cast<rmw_serialized_message_t>(message);
   callback_(typed_message);
 }
 
@@ -79,12 +79,12 @@ void GenericSubscription::handle_loaned_message(
 
 void GenericSubscription::return_message(std::shared_ptr<void> & message)
 {
-  auto typed_message = std::static_pointer_cast<rclcpp::SerializedMessage>(message);
+  auto typed_message = std::static_pointer_cast<rmw_serialized_message_t>(message);
   return_serialized_message(typed_message);
 }
 
 void GenericSubscription::return_serialized_message(
-  std::shared_ptr<rclcpp::SerializedMessage> & message)
+  std::shared_ptr<rmw_serialized_message_t> & message)
 {
   message.reset();
 }
@@ -94,10 +94,28 @@ const rclcpp::QoS & GenericSubscription::qos_profile() const
   return qos_;
 }
 
-std::shared_ptr<rclcpp::SerializedMessage>
+std::shared_ptr<rmw_serialized_message_t>
 GenericSubscription::borrow_serialized_message(size_t capacity)
 {
-  return std::make_shared<rclcpp::SerializedMessage>(capacity);
+  auto message = new rmw_serialized_message_t;
+  *message = rmw_get_zero_initialized_serialized_message();
+  auto init_return = rmw_serialized_message_init(message, capacity, &default_allocator_);
+  if (init_return != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(init_return);
+  }
+
+  auto serialized_msg = std::shared_ptr<rmw_serialized_message_t>(
+    message,
+    [](rmw_serialized_message_t * msg) {
+      auto fini_return = rmw_serialized_message_fini(msg);
+      delete msg;
+      if (fini_return != RCL_RET_OK) {
+        ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
+          "Failed to destroy serialized message: " << rcl_get_error_string().str);
+      }
+    });
+
+  return serialized_msg;
 }
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
@@ -20,7 +20,6 @@
 
 #include "rclcpp/any_subscription_callback.hpp"
 #include "rclcpp/macros.hpp"
-#include "rclcpp/serialization.hpp"
 #include "rclcpp/subscription.hpp"
 
 namespace rosbag2_transport
@@ -51,12 +50,12 @@ public:
     const rosidl_message_type_support_t & ts,
     const std::string & topic_name,
     const rclcpp::QoS & qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
+    std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback);
 
   // Same as create_serialized_message() as the subscription is to serialized_messages only
   std::shared_ptr<void> create_message() override;
 
-  std::shared_ptr<rclcpp::SerializedMessage> create_serialized_message() override;
+  std::shared_ptr<rmw_serialized_message_t> create_serialized_message() override;
 
   void handle_message(
     std::shared_ptr<void> & message, const rclcpp::MessageInfo & message_info) override;
@@ -67,7 +66,7 @@ public:
   // Same as return_serialized_message() as the subscription is to serialized_messages only
   void return_message(std::shared_ptr<void> & message) override;
 
-  void return_serialized_message(std::shared_ptr<rclcpp::SerializedMessage> & message) override;
+  void return_serialized_message(std::shared_ptr<rmw_serialized_message_t> & message) override;
 
   // Provide a const reference to the QoS Profile used to create this subscription.
   const rclcpp::QoS & qos_profile() const;
@@ -75,9 +74,9 @@ public:
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
 
-  std::shared_ptr<rclcpp::SerializedMessage> borrow_serialized_message(size_t capacity);
+  std::shared_ptr<rmw_serialized_message_t> borrow_serialized_message(size_t capacity);
   rcutils_allocator_t default_allocator_;
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback_;
+  std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback_;
   const rclcpp::QoS qos_;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -164,10 +164,9 @@ Recorder::create_subscription(
     topic_name,
     topic_type,
     qos,
-    [this, topic_name](std::shared_ptr<rclcpp::SerializedMessage> message) {
+    [this, topic_name](std::shared_ptr<rmw_serialized_message_t> message) {
       auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-      bag_message->serialized_data =
-      std::make_shared<rcl_serialized_message_t>(message->release_rcl_serialized_message());
+      bag_message->serialized_data = message;
       bag_message->topic_name = topic_name;
       rcutils_time_point_value_t time_stamp;
       int error = rcutils_system_time_now(&time_stamp);

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<GenericSubscription> Rosbag2Node::create_generic_subscription(
   const std::string & topic,
   const std::string & type,
   const rclcpp::QoS & qos,
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+  std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback)
 {
   auto type_support = rosbag2_cpp::get_typesupport(
     type, "rosidl_typesupport_cpp",

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "rclcpp/node.hpp"
-#include "rclcpp/serialized_message.hpp"
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/types.h"
 
@@ -47,7 +46,7 @@ public:
     const std::string & topic,
     const std::string & type,
     const rclcpp::QoS & qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
+    std::function<void(std::shared_ptr<rmw_serialized_message_t>)> callback);
 
   std::unordered_map<std::string, std::string>
   get_topics_with_types(const std::vector<std::string> & topic_names);

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -74,11 +74,10 @@ public:
     size_t counter = 0;
     auto subscription = node_->create_generic_subscription(
       topic_name, type, rosbag2_transport::Rosbag2QoS{},
-      [&counter, &messages](std::shared_ptr<rclcpp::SerializedMessage> message) {
-        test_msgs::msg::Strings string_message;
-        rclcpp::Serialization<test_msgs::msg::Strings> serializer;
-        serializer.deserialize_message(message.get(), &string_message);
-        messages.push_back(string_message.string_value);
+      [this, &counter, &messages](std::shared_ptr<rmw_serialized_message_t> message) {
+        auto string_message =
+        memory_management_.deserialize_message<test_msgs::msg::Strings>(message);
+        messages.push_back(string_message->string_value);
         counter++;
       });
 
@@ -162,7 +161,7 @@ TEST_F(RosBag2NodeFixture, generic_subscription_uses_qos)
   auto publisher = node_->create_publisher<test_msgs::msg::Strings>(topic_name, qos);
   auto subscription = node_->create_generic_subscription(
     topic_name, topic_type, qos,
-    [](std::shared_ptr<rclcpp::SerializedMessage>/* message */) {});
+    [](std::shared_ptr<rmw_serialized_message_t>/* message */) {});
   auto connected = [publisher, subscription]() -> bool {
       return publisher->get_subscription_count() && subscription->get_publisher_count();
     };


### PR DESCRIPTION
Reverts #386.

See https://github.com/ros2/rclcpp/pull/1090.