### PR TITLE
Move include of Python.h to fix Arch build issue

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <Python.h>
 #include <chrono>
 #include <string>
 #include <vector>
+
+#include <Python.h>
 
 #include "rosbag2_transport/rosbag2_transport.hpp"
 #include "rosbag2_transport/record_options.hpp"


### PR DESCRIPTION
The include of Python.h needs to be rearranged. It cannot be imported first because it redefines _XOPEN_SOURCE

See issue #383