### PR TITLE
add missing test dependency

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -96,6 +96,7 @@ ament_export_dependencies(rosbag2_storage rcutils zstd_vendor)
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  find_package(rclcpp REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
@@ -136,7 +137,7 @@ if(BUILD_TESTING)
     test/rosbag2_compression/test_zstd_compressor.cpp)
   target_include_directories(test_zstd_compressor PUBLIC include)
   target_link_libraries(test_zstd_compressor ${PROJECT_NAME}_zstd)
-  ament_target_dependencies(test_zstd_compressor rosbag2_test_common rosbag2_storage)
+  ament_target_dependencies(test_zstd_compressor rclcpp rosbag2_test_common rosbag2_storage)
 
   ament_add_gmock(test_compression_options
     test/rosbag2_compression/test_compression_options.cpp)

--- a/rosbag2_compression/package.xml
+++ b/rosbag2_compression/package.xml
@@ -18,6 +18,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rclcpp</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
 
   <export>

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -138,6 +138,7 @@ function(create_tests_for_rmw_implementation)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
     AMENT_DEPS
+      rclcpp
       rosbag2_test_common
       yaml_cpp_vendor)
 


### PR DESCRIPTION
Related to ros2/ros2#904.

Usage https://github.com/ros2/rosbag2/blob/70d153fff183e9ecdb4aa100c91a73d87104cc67/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp#L20