### PR TITLE
add the possibility to play back bagfiles with unknown message types

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -56,6 +56,10 @@ class PlayVerb(VerbExtension):
             '--remap', '-m', default='', nargs='+',
             help='list of topics to be remapped: in the form '
                  '"old_topic1:=new_topic1 old_topic2:=new_topic2 etc." ')
+        parser.add_argument(
+            '--ignore-unknown-types', action='store_true',
+            help='enables playing back bag files with unknown messages, skipping the message '
+                 'types that are unknown.')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -82,4 +86,5 @@ class PlayVerb(VerbExtension):
             topics=args.topics,
             qos_profile_overrides=qos_profile_overrides,
             loop=args.loop,
-            topic_remapping=args.remap)
+            topic_remapping=args.remap,
+            ignore_unknown_types=args.ignore_unknown_types)

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -40,6 +40,7 @@ public:
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides = {};
   bool loop = false;
   std::vector<std::string> topic_remapping_options = {};
+  bool ignore_unknown_types = false;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -21,6 +21,7 @@
 #include <queue>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "moodycamel/readerwriterqueue.h"
 
@@ -62,6 +63,8 @@ private:
   void prepare_publishers(const PlayOptions & options);
   static constexpr double read_ahead_lower_bound_percentage_ = 0.9;
   static const std::chrono::milliseconds queue_read_wait_period_;
+  std::vector<std::string> update_topics_to_filter_to_play_messages_with_unknwon_types(
+    const std::vector<std::string> & topics_to_filter);
 
   std::shared_ptr<rosbag2_cpp::Reader> reader_;
   moodycamel::ReaderWriterQueue<ReplayableMessage> message_queue_;

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -233,6 +233,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
     "qos_profile_overrides",
     "loop",
     "topic_remapping",
+    "ignore_unknown_types",
     nullptr
   };
 
@@ -245,8 +246,10 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   PyObject * qos_profile_overrides{nullptr};
   bool loop = false;
   PyObject * topic_remapping = nullptr;
+  bool ignore_unknown_types = false;
+
   if (!PyArg_ParseTupleAndKeywords(
-      args, kwargs, "sss|kfOObO", const_cast<char **>(kwlist),
+      args, kwargs, "sss|kfOObOb", const_cast<char **>(kwlist),
       &uri,
       &storage_id,
       &node_prefix,
@@ -255,7 +258,8 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
       &topics,
       &qos_profile_overrides,
       &loop,
-      &topic_remapping))
+      &topic_remapping,
+      &ignore_unknown_types))
   {
     return nullptr;
   }
@@ -267,6 +271,7 @@ rosbag2_transport_play(PyObject * Py_UNUSED(self), PyObject * args, PyObject * k
   play_options.read_ahead_queue_size = read_ahead_queue_size;
   play_options.rate = rate;
   play_options.loop = loop;
+  play_options.ignore_unknown_types = ignore_unknown_types;
 
   if (topics) {
     PyObject * topic_iterator = PyObject_GetIter(topics);

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -42,7 +42,7 @@ public:
       return num_read_ < messages_.size();
     }
 
-    while (num_read_ < messages_.size()) {
+    while (num_read_ < messages_.size() - 1) {
       for (const auto & filter_topic : filter_.topics) {
         if (!messages_[num_read_ + 1]->topic_name.compare(filter_topic)) {
           return true;


### PR DESCRIPTION
With the option --ignore-unknown-types it is now possible to skip messages, for which we don't have the sources.

The implementation is based on topic filtering, in the sense that at first we check which topics can be actually played and those are filtered, and we create publishers only for these topics.
One small problem is that with the current implementation of the topic_filter an empty topics_to_filter vector means that all topics should be played, but with the idea of my implementation when the topics_to_filter vector is empty that would mean that we can not play any topic. I found a solution for this but I think it would be better to change the meaning of an empty topics_to_filter vector so that it would mean no topic should be played.
Closes https://github.com/ros2/rosbag2/issues/307.