### PR TITLE
Use v1 of upload action in build workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           sqlite3_vendor
           rosbag2_test_common
           rosbag2_tests
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs
         path: ros_ws/log


### PR DESCRIPTION
Closes ros-tooling/action-ros-ci#190

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>