### PR TITLE
Update GitHub workflows to use Docker, and Focal

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,8 @@
 # Run linters automatically on pull requests.
+#
+# ros-tooling/actino-ros-lint is relying on the latest APT binary packages.
+# As of 2020-05-01, Eloquent is the latest release for which APT binary
+# packages are available, which is why the Docker image is based on Eloquent.
 name: Lint rosbag2
 on:
   pull_request:
@@ -6,11 +10,14 @@ on:
 jobs:
   ament_copyright:
     name: ament_copyright
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-lint@0.0.5
+    # TODO(setup-ros-docker#7): calling chown is necessary for now
+    - run: sudo chown -R rosbuild:rosbuild "$HOME" .
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: copyright
         package-name: |
@@ -25,11 +32,14 @@ jobs:
 
   ament_xmllint:
     name: ament_xmllint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-lint@0.0.5
+    # TODO(setup-ros-docker#7): calling chown is necessary for now
+    - run: sudo chown -R rosbuild:rosbuild "$HOME" .
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: xmllint
         package-name: |
@@ -46,15 +56,18 @@ jobs:
 
   ament_lint_cpp: # Linters applicable to C++ packages
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
           linter: [cppcheck, cpplint, uncrustify]
     steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-lint@0.0.5
+    # TODO(setup-ros-docker#7): calling chown is necessary for now
+    - run: sudo chown -R rosbuild:rosbuild "$HOME" .
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}
         package-name: |
@@ -68,15 +81,18 @@ jobs:
 
   ament_lint_python: # Linters applicable to Python packages
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
           linter: [flake8, pep257]
     steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-lint@0.0.5
+    # TODO(setup-ros-docker#7): calling chown is necessary for now
+    - run: sudo chown -R rosbuild:rosbuild "$HOME" .
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}
         package-name: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,13 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
-    - uses: ros-tooling/setup-ros@0.0.13
-    - uses: ros-tooling/action-ros-ci@0.0.13
+    # TODO(setup-ros-docker#7): calling chown is necessary for now
+    - run: sudo chown -R rosbuild:rosbuild "$HOME" .
+    - uses: ros-tooling/action-ros-ci@0.0.16
       with:
         package-name: |
           ros2bag


### PR DESCRIPTION
This pull request introduces two changes:

a/ lint.yml is using the latest version of action-ros-lint, and runs it on
   a Docker image built by ros-tooling/setup-ros-docker.
   Using a docker image instead of ros-tooling/setup-ros removes the
   need for running APT, and other commands which requires internet
   connectivity and may become a source of flakyness in the CI pipeline.
   Instead, the worker runs a Docker image with the linter
   pre-installed.

b/ test.yml now uses a Focal docker image. This also allows us to skip
   invoking ros-tooling/setup-ros, which speeds up the CI, and reduces
   risks of flakyness.