### PR TITLE
Remove relative paths from includes

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/mock_converter.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_converter.hpp
@@ -1,0 +1,45 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__MOCK_CONVERTER_HPP_
+#define ROSBAG2_COMPRESSION__MOCK_CONVERTER_HPP_
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include "rosbag2_cpp/converter_interfaces/serialization_format_converter.hpp"
+
+#include "rosbag2_storage/serialized_bag_message.hpp"
+
+class MockConverter : public rosbag2_cpp::converter_interfaces::SerializationFormatConverter
+{
+public:
+  MOCK_METHOD3(
+    deserialize,
+    void(
+      std::shared_ptr<const rosbag2_storage::SerializedBagMessage>,
+      const rosidl_message_type_support_t *,
+      std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t>));
+
+  MOCK_METHOD3(
+    serialize,
+    void(
+      std::shared_ptr<const rosbag2_cpp::rosbag2_introspection_message_t>,
+      const rosidl_message_type_support_t *,
+      std::shared_ptr<rosbag2_storage::SerializedBagMessage>));
+};
+
+#endif  // ROSBAG2_COMPRESSION__MOCK_CONVERTER_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_converter_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_converter_factory.hpp
@@ -1,0 +1,39 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__MOCK_CONVERTER_FACTORY_HPP_
+#define ROSBAG2_COMPRESSION__MOCK_CONVERTER_FACTORY_HPP_
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include "rosbag2_cpp/serialization_format_converter_factory_interface.hpp"
+
+class MockConverterFactory : public rosbag2_cpp::SerializationFormatConverterFactoryInterface
+{
+public:
+  MOCK_METHOD1(
+    load_serializer,
+    std::unique_ptr<rosbag2_cpp::converter_interfaces::SerializationFormatSerializer>(
+      const std::string &));
+
+  MOCK_METHOD1(
+    load_deserializer,
+    std::unique_ptr<rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer>(
+      const std::string &));
+};
+
+#endif  // ROSBAG2_COMPRESSION__MOCK_CONVERTER_FACTORY_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_metadata_io.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_metadata_io.hpp
@@ -1,0 +1,35 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__MOCK_METADATA_IO_HPP_
+#define ROSBAG2_COMPRESSION__MOCK_METADATA_IO_HPP_
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/metadata_io.hpp"
+
+class MockMetadataIo : public rosbag2_storage::MetadataIo
+{
+public:
+  MOCK_METHOD2(write_metadata, void(const std::string &, const rosbag2_storage::BagMetadata &));
+  MOCK_METHOD1(read_metadata, rosbag2_storage::BagMetadata(const std::string &));
+  MOCK_METHOD1(metadata_file_exists, bool(const std::string &));
+};
+
+#endif  // ROSBAG2_COMPRESSION__MOCK_METADATA_IO_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
@@ -1,0 +1,52 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__MOCK_STORAGE_HPP_
+#define ROSBAG2_COMPRESSION__MOCK_STORAGE_HPP_
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/storage_filter.hpp"
+#include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
+
+class MockStorage : public rosbag2_storage::storage_interfaces::ReadWriteInterface
+{
+public:
+  MOCK_METHOD2(open, void(const std::string &, rosbag2_storage::storage_interfaces::IOFlag));
+  MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
+  MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
+  MOCK_METHOD0(has_next, bool());
+  MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());
+  MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
+  MOCK_METHOD1(
+    write,
+    void(const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>&));
+  MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
+  MOCK_METHOD0(get_metadata, rosbag2_storage::BagMetadata());
+  MOCK_METHOD0(reset_filter, void());
+  MOCK_METHOD1(set_filter, void(const rosbag2_storage::StorageFilter &));
+  MOCK_CONST_METHOD0(get_bagfile_size, uint64_t());
+  MOCK_CONST_METHOD0(get_relative_file_path, std::string());
+  MOCK_CONST_METHOD0(get_storage_identifier, std::string());
+  MOCK_CONST_METHOD0(get_minimum_split_file_size, uint64_t());
+};
+
+#endif  // ROSBAG2_COMPRESSION__MOCK_STORAGE_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
@@ -1,0 +1,40 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_COMPRESSION__MOCK_STORAGE_FACTORY_HPP_
+#define ROSBAG2_COMPRESSION__MOCK_STORAGE_FACTORY_HPP_
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include "rosbag2_storage/storage_factory_interface.hpp"
+#include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
+#include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
+
+class MockStorageFactory : public rosbag2_storage::StorageFactoryInterface
+{
+public:
+  MOCK_METHOD2(
+    open_read_only,
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>(
+      const std::string &, const std::string &));
+  MOCK_METHOD2(
+    open_read_write,
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
+      const std::string &, const std::string &));
+};
+
+#endif  // ROSBAG2_COMPRESSION__MOCK_STORAGE_FACTORY_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -23,10 +23,10 @@
 
 #include "rosbag2_cpp/reader.hpp"
 
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_converter_factory.hpp"
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_metadata_io.hpp"
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp"
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp"
+#include "mock_converter_factory.hpp"
+#include "mock_metadata_io.hpp"
+#include "mock_storage.hpp"
+#include "mock_storage_factory.hpp"
 
 #include "mock_compression.hpp"
 #include "mock_compression_factory.hpp"

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -24,10 +24,10 @@
 
 #include "rosbag2_cpp/writer.hpp"
 
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_converter_factory.hpp"
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_metadata_io.hpp"
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp"
-#include "../../rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp"
+#include "mock_converter_factory.hpp"
+#include "mock_metadata_io.hpp"
+#include "mock_storage.hpp"
+#include "mock_storage_factory.hpp"
 
 #include "mock_compression_factory.hpp"
 


### PR DESCRIPTION
## Description
~~Adds `rosbag2_cpp/test` path to includes in `rosbag2_compression` to replace relative includes.~~
Duplicate mocks from `rosbag2_cpp` in `rosbag2_compression` so relative includes can be removed.

This should resolve this issue: https://github.com/ros2/rosbag2/issues/404

Follow-up work should be done to de-duplicate this code.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>