### PR TITLE
Explicitly add DLL directories for Windows before importing

### DIFF
--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -15,6 +15,7 @@
   <depend>rosbag2_compression</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rmw</depend>
+  <depend>rpyutils</depend>
   <depend>shared_queues_vendor</depend>
   <depend>yaml_cpp_vendor</depend>
 

--- a/rosbag2_transport/rosbag2_transport/__init__.py
+++ b/rosbag2_transport/rosbag2_transport/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import os
 
 from rpyutils import add_dll_directories_from_env
 
@@ -32,5 +33,6 @@ def _import(name):
                 (e.path, 'https://index.ros.org/doc/ros2/Troubleshooting/'
                          '#import-failing-even-with-library-present-on-the-system')
         raise
+
 
 rosbag2_transport_py = _import('._rosbag2_transport_py')

--- a/rosbag2_transport/rosbag2_transport/__init__.py
+++ b/rosbag2_transport/rosbag2_transport/__init__.py
@@ -13,21 +13,17 @@
 # limitations under the License.
 
 import importlib
-import os
+
+from rpyutils import add_dll_directories_from_env
 
 
 def _import(name):
-    # New in Python 3.8: on Windows we should call 'add_dll_directory()' for directories
-    # containing DLLs we depend on.
-    # https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
-    dll_dir_handles = []
-    if os.name == 'nt' and hasattr(os, 'add_dll_directory'):
-        path_env = os.environ['PATH'].split(';')
-        for prefix_path in path_env:
-            if os.path.exists(prefix_path):
-                dll_dir_handles.append(os.add_dll_directory(prefix_path))
     try:
-        return importlib.import_module(name, package='rosbag2_transport')
+        # Since Python 3.8, on Windows we should ensure DLL directories are explicitly added
+        # to the search path.
+        # See https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
+        with add_dll_directories_from_env('PATH'):
+            return importlib.import_module(name, package='rosbag2_transport')
     except ImportError as e:
         if e.path is not None and os.path.isfile(e.path):
             e.msg += \
@@ -36,9 +32,5 @@ def _import(name):
                 (e.path, 'https://index.ros.org/doc/ros2/Troubleshooting/'
                          '#import-failing-even-with-library-present-on-the-system')
         raise
-    finally:
-        for handle in dll_dir_handles:
-            handle.close()
-
 
 rosbag2_transport_py = _import('._rosbag2_transport_py')


### PR DESCRIPTION
New in Python 3.8, we should call os.add_dll_directory for directories
containing the DLLs we intend to import as well as their recursive
dependencies.

Connects to https://github.com/ros2/ci/pull/432