### PR TITLE
Don't allow user to specify unimplemented compression mode 'message'

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -67,8 +67,8 @@ class RecordVerb(VerbExtension):
         )
         parser.add_argument(
             '--compression-mode', type=str, default='none',
-            choices=['none', 'file', 'message'],
-            help="Determine whether to compress by file or message. Default is 'none'."
+            choices=['none', 'file'],
+            help='Determine whether to compress bag files. Default is "none".'
         )
         parser.add_argument(
             '--compression-format', type=str, default='', choices=['zstd'],


### PR DESCRIPTION
Currently the user can specify `--compression-mode message` and an "unimplemented" runtime exception is raised upon actually trying to compress the first message. Remove the option to try and use the unimplemented feature.

Fixes https://github.com/ros2/rosbag2/issues/413
Follow up issue https://github.com/ros2/rosbag2/issues/414

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>