### PR TITLE
Add per-message ZSTD compression

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -67,8 +67,8 @@ class RecordVerb(VerbExtension):
         )
         parser.add_argument(
             '--compression-mode', type=str, default='none',
-            choices=['none', 'file'],
-            help='Determine whether to compress bag files. Default is "none".'
+            choices=['none', 'file', 'message'],
+            help="Determine whether to compress by file or message. Default is 'none'."
         )
         parser.add_argument(
             '--compression-format', type=str, default='', choices=['zstd'],

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -29,7 +29,6 @@
 
 namespace rosbag2_compression
 {
-
 SequentialCompressionReader::SequentialCompressionReader(
   std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory,
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
@@ -47,9 +46,12 @@ void SequentialCompressionReader::setup_decompression()
   compression_mode_ = rosbag2_compression::compression_mode_from_string(metadata_.compression_mode);
   if (compression_mode_ != rosbag2_compression::CompressionMode::NONE) {
     decompressor_ = compression_factory_->create_decompressor(metadata_.compression_format);
-    // Decompress the first file so that it is readable.
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
-    *current_file_iterator_ = decompressor_->decompress_uri(get_current_file());
+    // Decompress the first file so that it is readable; don't need to do anything for
+    // per-message encryption.
+    if (compression_mode_ == CompressionMode::FILE) {
+      ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
+      *current_file_iterator_ = decompressor_->decompress_uri(get_current_file());
+    }
   } else {
     throw std::invalid_argument{
             "SequentialCompressionReader requires a CompressionMode that is not NONE!"};

--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -272,6 +272,8 @@ void ZstdCompressor::compress_serialized_bag_message(
     rcutils_uint8_array_resize(message->serialized_data.get(), compression_result);
   throw_on_rcutils_resize_error(resize_result);
 
+  // Note that rcutils_uint8_array_resize changes buffer_capacity but not buffer_length, we
+  // have to do that manually.
   message->serialized_data->buffer_length = compression_result;
   std::copy(compressed_buffer.begin(), compressed_buffer.end(), message->serialized_data->buffer);
 

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <sstream>
@@ -187,8 +188,7 @@ void throw_on_rcutils_resize_error(const rcutils_ret_t resize_result)
 
   std::stringstream error;
   error << "rcutils_uint8_array_resize error: ";
-  switch (resize_result)
-  {
+  switch (resize_result) {
     case RCUTILS_RET_INVALID_ARGUMENT:
       error << "Invalid Argument";
       break;
@@ -308,11 +308,14 @@ void ZstdDecompressor::decompress_serialized_bag_message(
 
   throw_on_zstd_error(decompression_result);
 
-  const auto resize_result = rcutils_uint8_array_resize(message->serialized_data.get(), decompression_result);
+  const auto resize_result =
+    rcutils_uint8_array_resize(message->serialized_data.get(), decompression_result);
   throw_on_rcutils_resize_error(resize_result);
 
   message->serialized_data->buffer_length = decompression_result;
-  std::copy(decompressed_buffer.begin(), decompressed_buffer.end(), message->serialized_data->buffer);
+  std::copy(
+    decompressed_buffer.begin(), decompressed_buffer.end(),
+    message->serialized_data->buffer);
 
   const auto end = std::chrono::high_resolution_clock::now();
   print_decompression_statistics(start, end, decompression_result, compressed_buffer_length);

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -38,8 +38,8 @@ constexpr const int kDefaultGarbageFileSize = 10;  // MiB
 
 /**
  * Writes 1M * size garbage data to a stream.
- * @param out
- * @param size
+ * \param out The stream to write to.
+ * \param size The number of times to write.
  */
 void write_garbage_stream(std::ostream & out, int size = kDefaultGarbageFileSize)
 {
@@ -64,6 +64,11 @@ void create_garbage_file(const std::string & uri, int size = kDefaultGarbageFile
   write_garbage_stream(out, size);
 }
 
+/**
+ * Creates a string of a certain size.
+ * \param size Size of the string in MiB.
+ * \return The string.
+ */
 std::string create_garbage_string(int size = kDefaultGarbageFileSize)
 {
   std::stringstream output;

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -36,7 +36,7 @@ namespace
 {
 constexpr const char kGarbageStatement[] = "garbage";
 constexpr const int kDefaultGarbageFileSize = 10;  // MiB
-constexpr const size_t kExpectedCompressedDataSize = 976; // manually calculated, could change
+constexpr const size_t kExpectedCompressedDataSize = 976;  // manually calculated, could change
                                                           // if compression params change
 
 /**

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -116,7 +116,8 @@ protected:
   std::string deserialize_message(std::shared_ptr<rcutils_uint8_array_t> serialized_message)
   {
     std::unique_ptr<uint8_t[]> copied(new uint8_t[serialized_message->buffer_length + 1]);
-    std::copy(serialized_message->buffer,
+    std::copy(
+      serialized_message->buffer,
       serialized_message->buffer + serialized_message->buffer_length,
       copied.get());
     copied.get()[serialized_message->buffer_length] = '\0';

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdio>
 #include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ constexpr const int kDefaultGarbageFileSize = 10;  // MiB
  * @param out
  * @param size
  */
-void write_garbage_stream(std::ostream& out, int size = kDefaultGarbageFileSize)
+void write_garbage_stream(std::ostream & out, int size = kDefaultGarbageFileSize)
 {
   const auto output_size = size * 1024 * 1024;
   const auto num_iterations = output_size / static_cast<int>(strlen(kGarbageStatement));
@@ -168,7 +169,7 @@ protected:
 
   rcutils_allocator_t allocator_;
   std::string message_;
-  size_t compressed_length_{991}; // manually calculated, could change if compression params change
+  size_t compressed_length_{991};  // manually calculated, could change if compression params change
 };
 
 TEST_F(CompressionHelperFixture, zstd_compress_file_uri)

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -37,7 +37,7 @@ namespace
 constexpr const char kGarbageStatement[] = "garbage";
 constexpr const int kDefaultGarbageFileSize = 10;  // MiB
 constexpr const size_t kExpectedCompressedDataSize = 976;  // manually calculated, could change
-                                                          // if compression params change
+                                                           // if compression params change
 
 /**
  * Writes 1M * size garbage data to a stream.

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -36,6 +36,8 @@ namespace
 {
 constexpr const char kGarbageStatement[] = "garbage";
 constexpr const int kDefaultGarbageFileSize = 10;  // MiB
+constexpr const size_t kExpectedCompressedDataSize = 976; // manually calculated, could change
+                                                          // if compression params change
 
 /**
  * Writes 1M * size garbage data to a stream.
@@ -127,7 +129,7 @@ protected:
 
   rcutils_allocator_t allocator_;
   std::string message_;
-  size_t compressed_length_{976};  // manually calculated, could change if compression params change
+  size_t compressed_length_{kExpectedCompressedDataSize};
 };
 
 TEST_F(CompressionHelperFixture, zstd_compress_file_uri)

--- a/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_zstd_compressor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <cstdio>
 #include <fstream>
 #include <memory>
@@ -25,7 +26,7 @@
 #include "rosbag2_compression/zstd_compressor.hpp"
 #include "rosbag2_compression/zstd_decompressor.hpp"
 
-#include <rosbag2_storage/ros_helper.hpp>
+#include "rosbag2_storage/ros_helper.hpp"
 
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
@@ -114,7 +115,7 @@ protected:
 
   std::string deserialize_message(std::shared_ptr<rcutils_uint8_array_t> serialized_message)
   {
-    std::unique_ptr<uint8_t[]> copied(new uint8_t[serialized_message->buffer_length+1]);
+    std::unique_ptr<uint8_t[]> copied(new uint8_t[serialized_message->buffer_length + 1]);
     std::copy(serialized_message->buffer,
       serialized_message->buffer + serialized_message->buffer_length,
       copied.get());

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -43,6 +43,9 @@ namespace rosbag2_cpp
 {
 namespace readers
 {
+void fill_topics_and_types(
+  const rosbag2_storage::BagMetadata & metadata,
+  std::vector<rosbag2_storage::TopicMetadata> & topics_and_types);
 
 class ROSBAG2_CPP_PUBLIC SequentialReader
   : public ::rosbag2_cpp::reader_interfaces::BaseReaderInterface

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -43,9 +43,6 @@ namespace rosbag2_cpp
 {
 namespace readers
 {
-void fill_topics_and_types(
-  const rosbag2_storage::BagMetadata & metadata,
-  std::vector<rosbag2_storage::TopicMetadata> & topics_and_types);
 
 class ROSBAG2_CPP_PUBLIC SequentialReader
   : public ::rosbag2_cpp::reader_interfaces::BaseReaderInterface


### PR DESCRIPTION
Fixes #414.

This implements the per-messages compression and decompression
functions for the ZSTD compressor and also adds unit tests
for them.

Distro A, OPSEC #2893

Signed-off-by: P. J. Reed <preed@swri.org>