### PR TITLE
Shared publisher handle.

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/generic_publisher.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_publisher.cpp
@@ -41,7 +41,7 @@ GenericPublisher::GenericPublisher(
 void GenericPublisher::publish(std::shared_ptr<rmw_serialized_message_t> message)
 {
   auto return_code = rcl_publish_serialized_message(
-    get_publisher_handle(), message.get(), NULL);
+    get_publisher_handle().get(), message.get(), NULL);
 
   if (return_code != RCL_RET_OK) {
     rclcpp::exceptions::throw_from_rcl_error(return_code, "failed to publish serialized message");

--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -28,7 +28,7 @@ macro(build_zstd)
 
   include(ExternalProject)
   # The CMakeLists.txt file for zstd is in a subdirectory.
-  # We need to configure the CMake command to build from there instead. 
+  # We need to configure the CMake command to build from there instead.
   ExternalProject_Add(zstd-1.4.4
     URL https://github.com/facebook/zstd/archive/v1.4.4.zip
     URL_MD5 3a5c3a535280b7f4dfdbd739fcc7173f


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Switch to getting the raw handle since `get_publisher_handle` now returns a shared_ptr.

Goes along with https://github.com/ros2/rclcpp/pull/1119 ; more discussion and CI is there.