### PR TITLE
find rosbag2_cpp (tinyxml2) before rcl

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -22,12 +22,14 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
+# TODO(Karsten1987) rosbag2_cpp has to be found first here
+# See https://github.com/ros2/ros2/issues/927
+find_package(rosbag2_cpp REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosbag2_compression REQUIRED)
-find_package(rosbag2_cpp REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(shared_queues_vendor REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)


### PR DESCRIPTION
Connects to https://github.com/ros2/ros2/issues/927 and should hopefully unblock the failing windows ci packaging jobs.

Note that this job only fails when `ENABLE_TESTING=OFF` for rosbag2_transport. 

/cc @jacobperron 