### PR TITLE
Improve help message for CLI verbs

### DIFF
--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -18,7 +18,7 @@ from ros2bag.verb import VerbExtension
 
 
 class InfoVerb(VerbExtension):
-    """ros2 bag info."""
+    """Print info about a bag to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -18,7 +18,7 @@ from ros2bag.verb import VerbExtension
 
 
 class InfoVerb(VerbExtension):
-    """Print info about a bag to the screen."""
+    """Print information about a bag to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -25,7 +25,7 @@ import yaml
 
 
 class PlayVerb(VerbExtension):
-    """ros2 bag play."""
+    """Play back ROS data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -26,7 +26,7 @@ import yaml
 
 
 class RecordVerb(VerbExtension):
-    """ros2 bag record."""
+    """Record ROS data to a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(


### PR DESCRIPTION
E.g. when running `ros2 bag -h`.

Before:

```
usage: ros2 bag [-h] Call `ros2 bag <command> -h` for more detailed usage. ...

Various rosbag related sub-commands

optional arguments:
  -h, --help            show this help message and exit

Commands:
  info    ros2 bag info
  play    ros2 bag play
  record  ros2 bag record

  Call `ros2 bag <command> -h` for more detailed usage.
```

After:

```
usage: ros2 bag [-h] Call `ros2 bag <command> -h` for more detailed usage. ...

Various rosbag related sub-commands

optional arguments:
  -h, --help            show this help message and exit

Commands:
  info    Print info about a bag to the screen
  play    Play back ROS data from a bag
  record  Record ROS data to a bag

  Call `ros2 bag <command> -h` for more detailed usage.
```