### PR TITLE
Make split size error clearer

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -121,8 +121,10 @@ void SequentialCompressionWriter::open(
   if (storage_options.max_bagfile_size != 0 &&
     storage_options.max_bagfile_size < storage_->get_minimum_split_file_size())
   {
-    throw std::invalid_argument{
-            "Invalid bag splitting size given. Please provide a different value."};
+    std::stringstream error;
+    error << "Invalid bag splitting size given. Please provide a value greater than " <<
+      storage_->get_minimum_split_file_size();
+    throw std::runtime_error{error.str()};
   }
 
   setup_compression();

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -105,8 +105,10 @@ void SequentialWriter::open(
   if (max_bagfile_size_ != 0 &&
     max_bagfile_size_ < storage_->get_minimum_split_file_size())
   {
-    throw std::runtime_error(
-            "Invalid bag splitting size given. Please provide a different value.");
+    std::stringstream error;
+    error << "Invalid bag splitting size given. Please provide a value greater than " <<
+      storage_->get_minimum_split_file_size();
+    throw std::runtime_error{error.str()};
   }
 
   init_metadata();

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -154,7 +154,7 @@ TEST_F(SequentialWriterTest, open_throws_error_on_invalid_splitting_size) {
   ON_CALL(*storage_, get_minimum_split_file_size()).WillByDefault(Return(min_split_file_size));
   storage_options_.max_bagfile_size = max_bagfile_size;
 
-  EXPECT_CALL(*storage_, get_minimum_split_file_size).Times(1);
+  EXPECT_CALL(*storage_, get_minimum_split_file_size).Times(2);
 
   std::string rmw_format = "rmw_format";
 


### PR DESCRIPTION
Make the error for setting the split bag file size state the minimum bag file size.

Current error is:

```
terminating with uncaught exception of type std::invalid_argument:
Invalid bag splitting size given. Please provide a different value.
```

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>