### PR TITLE
Add user provided split size to error

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -123,7 +123,8 @@ void SequentialCompressionWriter::open(
   {
     std::stringstream error;
     error << "Invalid bag splitting size given. Please provide a value greater than " <<
-      storage_->get_minimum_split_file_size();
+      storage_->get_minimum_split_file_size() << ". Specified value of " <<
+      storage_options.max_bagfile_size;
     throw std::runtime_error{error.str()};
   }
 

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -82,7 +82,7 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_invalid_splitting_size)
   rosbag2_compression::CompressionOptions compression_options{
     "zstd", rosbag2_compression::CompressionMode::FILE};
   auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-  auto storage_options = rosbag2_cpp::StorageOptions{}
+  auto storage_options = rosbag2_cpp::StorageOptions{};
   // 0 indicates that bagfile splitting will not be used so use 1 byte which is the
   // smallest invalid size possible.
   storage_options.max_bagfile_size = 1;  

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -82,10 +82,13 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_invalid_splitting_size)
   rosbag2_compression::CompressionOptions compression_options{
     "zstd", rosbag2_compression::CompressionMode::FILE};
   auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
+
+  // Set minimum file size greater than max bagfile size option
+  const uint64_t min_split_file_size = 10;
+  const uint64_t max_bagfile_size = 5;
+  ON_CALL(*storage_, get_minimum_split_file_size()).WillByDefault(Return(min_split_file_size));
   auto storage_options = rosbag2_cpp::StorageOptions{};
-  // 0 indicates that bagfile splitting will not be used so use 1 byte which is the
-  // smallest invalid size possible.
-  storage_options.max_bagfile_size = 1;  
+  storage_options.max_bagfile_size = max_bagfile_size;
 
   auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
     compression_options,

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -77,6 +77,29 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_bad_compression_format)
     std::invalid_argument);
 }
 
+TEST_F(SequentialCompressionWriterTest, open_throws_on_invalid_splitting_size)
+{
+  rosbag2_compression::CompressionOptions compression_options{
+    "zstd", rosbag2_compression::CompressionMode::FILE};
+  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
+  auto storage_options = rosbag2_cpp::StorageOptions{}
+  // 0 indicates that bagfile splitting will not be used so use 1 byte which is the
+  // smallest invalid size possible.
+  storage_options.max_bagfile_size = 1;  
+
+  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
+    compression_options,
+    std::move(compression_factory),
+    std::move(storage_factory_),
+    converter_factory_,
+    std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  EXPECT_THROW(
+    writer_->open(storage_options, {serialization_format_, serialization_format_}),
+    std::runtime_error);
+}
+
 TEST_F(SequentialCompressionWriterTest, open_succeeds_on_supported_compression_format)
 {
   rosbag2_compression::CompressionOptions compression_options{

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -107,7 +107,8 @@ void SequentialWriter::open(
   {
     std::stringstream error;
     error << "Invalid bag splitting size given. Please provide a value greater than " <<
-      storage_->get_minimum_split_file_size();
+      storage_->get_minimum_split_file_size() << ". Specified value of " <<
+      storage_options.max_bagfile_size;
     throw std::runtime_error{error.str()};
   }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -158,7 +158,7 @@ TEST_F(SequentialWriterTest, open_throws_error_on_invalid_splitting_size) {
 
   std::string rmw_format = "rmw_format";
 
-  EXPECT_ANY_THROW(writer_->open(storage_options_, {rmw_format, rmw_format}));
+  EXPECT_THROW(writer_->open(storage_options_, {rmw_format, rmw_format}), std::runtime_error);
 }
 
 TEST_F(SequentialWriterTest, bagfile_size_is_checked_on_every_write) {


### PR DESCRIPTION
* Add the user defined split size to the splitting error.
* Address comment on catching only `std::runtime_error` in tests.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>