### PR TITLE
minimal c++ API test

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -206,8 +206,8 @@ void SequentialWriter::write(std::shared_ptr<rosbag2_storage::SerializedBagMessa
     ++topics_names_to_info_.at(message->topic_name).message_count;
   } catch (const std::out_of_range & oor) {
     std::stringstream errmsg;
-    errmsg << "Failed to write on topic '" << message->topic_name
-      << "'. Call create_topic() before first write.";
+    errmsg << "Failed to write on topic '" << message->topic_name <<
+      "'. Call create_topic() before first write.";
     throw std::runtime_error(errmsg.str());
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -202,7 +202,14 @@ void SequentialWriter::write(std::shared_ptr<rosbag2_storage::SerializedBagMessa
   }
 
   // Update the message count for the Topic.
-  ++topics_names_to_info_.at(message->topic_name).message_count;
+  try {
+    ++topics_names_to_info_.at(message->topic_name).message_count;
+  } catch (const std::out_of_range & oor) {
+    std::stringstream errmsg;
+    errmsg << "Failed to write on topic '" << message->topic_name
+      << "'. Call create_topic() before first write.";
+    throw std::runtime_error(errmsg.str());
+  }
 
   if (should_split_bagfile()) {
     split_bagfile();

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -87,6 +87,19 @@ if(BUILD_TESTING)
         test_msgs)
     endif()
   endif()
+
+  ament_add_gmock(test_rosbag2_cpp_api
+    test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_rosbag2_cpp_api)
+    ament_target_dependencies(test_rosbag2_cpp_api
+      rclcpp
+      rosbag2_cpp
+      rosbag2_storage
+      rosbag2_storage_default_plugins
+      rosbag2_test_common
+      test_msgs)
+  endif()
 endif()
 
 ament_package()

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -1,0 +1,97 @@
+// Copyright 2020, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "rclcpp/serialization.hpp"
+#include "rclcpp/serialized_message.hpp"
+
+#include "rcpputils/filesystem_helper.hpp"
+#include "rcutils/time.h"
+
+#include "rosbag2_cpp/reader.hpp"
+#include "rosbag2_cpp/readers/sequential_reader.hpp"
+#include "rosbag2_cpp/writer.hpp"
+#include "rosbag2_cpp/writers/sequential_writer.hpp"
+
+#include "test_msgs/msg/basic_types.hpp"
+
+TEST(TestRosbag2CPPAPI, minimal_writer_example)
+{
+  using TestMsgT = test_msgs::msg::BasicTypes;
+  TestMsgT test_msg;
+  test_msg.float64_value = 12345.6789;
+  rclcpp::SerializedMessage serialized_msg;
+
+  rclcpp::Serialization<TestMsgT> serialization;
+  serialization.serialize_message(&test_msg, &serialized_msg);
+
+  auto rosbag_directory = rcpputils::fs::path("test_rosbag2_writer_api_bag");
+  // in case the bag was previously not cleaned up
+  rcpputils::fs::remove_all(rosbag_directory);
+  // See https://github.com/ros2/rosbag2/issues/448
+  rcpputils::fs::create_directories(rosbag_directory);
+
+  rosbag2_cpp::StorageOptions storage_options;
+  storage_options.uri = rosbag_directory.string();
+  storage_options.storage_id = "sqlite3";
+  storage_options.max_bagfile_size = 0;  // default
+  storage_options.max_cache_size = 0;  // default
+  rosbag2_cpp::ConverterOptions converter_options;
+  converter_options.input_serialization_format = "cdr";
+  converter_options.output_serialization_format = "cdr";
+
+  {
+    rosbag2_cpp::Writer writer(std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
+    writer.open(storage_options, converter_options);
+
+    auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+    auto ret = rcutils_system_time_now(&bag_message->time_stamp);
+    if (ret != RCL_RET_OK) {
+      FAIL() << "couldn't assign time rosbag message";
+    }
+
+    rosbag2_storage::TopicMetadata tm;
+    tm.name = "/my/test/topic";
+    tm.type = "test_msgs/msg/BasicTypes";
+    tm.serialization_format = "cdr";
+    writer.create_topic(tm);
+
+    bag_message->topic_name = tm.name;
+    bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
+      &serialized_msg.get_rcl_serialized_message(), [](rcutils_uint8_array_t * /* data */) {});
+
+    writer.write(bag_message);
+    // close on scope exit
+  }
+
+  {
+    rosbag2_cpp::Reader reader(std::make_unique<rosbag2_cpp::readers::SequentialReader>());
+    reader.open(storage_options, converter_options);
+    while (reader.has_next()) {
+      auto bag_message = reader.read_next();
+
+      TestMsgT extracted_test_msg;
+      rclcpp::SerializedMessage extracted_serialized_msg(*bag_message->serialized_data);
+      serialization.deserialize_message(
+          &extracted_serialized_msg, &extracted_test_msg);
+
+      EXPECT_EQ(test_msg, extracted_test_msg);
+    }
+    // close on scope exit
+  }
+
+  // remove the rosbag again after the test
+  EXPECT_TRUE(rcpputils::fs::remove_all(rosbag_directory));
+}

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -14,6 +14,9 @@
 
 #include <gmock/gmock.h>
 
+#include <memory>
+#include <string>
+
 #include "rclcpp/serialization.hpp"
 #include "rclcpp/serialized_message.hpp"
 
@@ -85,7 +88,7 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
       TestMsgT extracted_test_msg;
       rclcpp::SerializedMessage extracted_serialized_msg(*bag_message->serialized_data);
       serialization.deserialize_message(
-          &extracted_serialized_msg, &extracted_test_msg);
+        &extracted_serialized_msg, &extracted_test_msg);
 
       EXPECT_EQ(test_msg, extracted_test_msg);
     }


### PR DESCRIPTION
That's a first step into improving the general C++ API for writing and reading rosbags.

The set of API calls in the test are the minimal set I could come up with in order to write a MessageT into the bag file. IMHO, there's quite some room for making this more user friendly. 

* Making the `SequentialReader` and `SequentialWriter` the default implementation. That would allow for `rosbag2_cpp::Writer writer;` to simply work.
* Default the converter options. As seen in [here](https://github.com/ros2/rosbag2/issues/449) and [here](https://answers.ros.org/question/355764/ros2how-to-write-data-to-rosbag2-in-ros2-foxy/) the current converter API is rather confusing than helpful. A call to `open` with only specifying the `StorageOptions` should suffice and the converter functionality should be bypassed as such.
* Every topic has to be created beforehand. However, if you forget that you'll get a uncaught exception such as `unknown file: Failure C++ exception with description "unordered_map::at: key not found" thrown in the test body.` I've addressed that in this PR.
* Write bag messages which are allocated on the stack: There's currently no way of writing serialized data which was allocated on the stack, but has to be passed in via a shared pointer. That results in specifying a custom deleter which avoids to deallocate the data (`malloc: *** error for object 0x7ffeefbfdc88: pointer being freed was not allocated`).