### PR TITLE
More reliable topic remapping test

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
@@ -37,10 +37,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
   const std::string remapped_topic = "/topic_after_remap";
   const int32_t test_value = 42;
   const int64_t dt_in_milliseconds = 100;
-  // With ROS2 communication being undeterministic, we can only verify that topics arrive
-  // We can't verify how many though; The 60% below seem to be reliable.
   const size_t expected_number_of_outgoing_messages = 5;
-  const size_t expected_number_of_incoming_messages = 3;
   play_options_.topic_remapping_options =
   {"--ros-args", "--remap", "topic_before_remap:=topic_after_remap"};
 
@@ -60,8 +57,10 @@ TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
   prepared_mock_reader->prepare(messages, topic_types);
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
 
+  // We can't reliably test for an exact number of messages to arrive.
+  // Therefore, we test that at least one message is being received over the remapped topic.
   sub_->add_subscription<test_msgs::msg::BasicTypes>(
-    remapped_topic, expected_number_of_incoming_messages);
+    remapped_topic, 1u);
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
@@ -72,7 +71,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
 
   auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
     remapped_topic);
-  EXPECT_THAT(replayed_test_primitives, SizeIs(Ge(expected_number_of_incoming_messages)));
+  EXPECT_FALSE(replayed_test_primitives.empty());
   EXPECT_THAT(
     replayed_test_primitives,
     Each(Pointee(Field(&test_msgs::msg::BasicTypes::int32_value, test_value))));

--- a/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
@@ -22,7 +22,6 @@
 #include <utility>
 #include <vector>
 
-
 #include "rosbag2_test_common/subscription_manager.hpp"
 
 #include "rosbag2_transport/rosbag2_transport.hpp"
@@ -32,14 +31,16 @@
 
 #include "rosbag2_play_test_fixture.hpp"
 
-
 TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
   //  test constants
   const std::string original_topic = "/topic_before_remap";
   const std::string remapped_topic = "/topic_after_remap";
   const int32_t test_value = 42;
-  const int64_t timestamp_in_milliseconds = 700;
-  const size_t expected_number_of_messages = 1;
+  const int64_t dt_in_milliseconds = 100;
+  // With ROS2 communication being undeterministic, we can only verify that topics arrive
+  // We can't verify how many though; The 60% below seem to be reliable.
+  const size_t expected_number_of_outgoing_messages = 5;
+  const size_t expected_number_of_incoming_messages = 3;
   play_options_.topic_remapping_options =
   {"--ros-args", "--remap", "topic_before_remap:=topic_after_remap"};
 
@@ -50,26 +51,28 @@ TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
     {original_topic, "test_msgs/BasicTypes", "", ""}
   };
 
-  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
-  {serialize_test_message(original_topic, timestamp_in_milliseconds, primitive_message1), };
-
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages;
+  for (auto i = 1u; i <= expected_number_of_outgoing_messages; ++i) {
+    messages.push_back(
+      serialize_test_message(original_topic, dt_in_milliseconds * i, primitive_message1));
+  }
   auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
   prepared_mock_reader->prepare(messages, topic_types);
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
 
-  sub_->add_subscription<test_msgs::msg::BasicTypes>(remapped_topic, expected_number_of_messages);
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(
+    remapped_topic, expected_number_of_incoming_messages);
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_, info_);
 
-  rosbag2_transport.play(
-    storage_options_, play_options_);
+  rosbag2_transport.play(storage_options_, play_options_);
 
   await_received_messages.get();
 
   auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
     remapped_topic);
-  EXPECT_THAT(replayed_test_primitives, SizeIs(Ge(expected_number_of_messages)));
+  EXPECT_THAT(replayed_test_primitives, SizeIs(Ge(expected_number_of_incoming_messages)));
   EXPECT_THAT(
     replayed_test_primitives,
     Each(Pointee(Field(&test_msgs::msg::BasicTypes::int32_value, test_value))));


### PR DESCRIPTION
fixes #455 
As mentioned on the issue ticket, as long as we don't have a deterministic execution in ROS2, we can't test for an exact number of messages to be transported. 
I lowered the ration of expected messages to only 60 percent, which seems to be fairly reliable and still fulfills the purpose of the test, which is that topics being remapped upon replay.