### PR TITLE
use rclcpp serialized messages to write data

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
@@ -65,6 +66,7 @@ add_library(${PROJECT_NAME} SHARED
 ament_target_dependencies(${PROJECT_NAME}
   ament_index_cpp
   pluginlib
+  rclcpp
   rcpputils
   rcutils
   rmw
@@ -103,7 +105,9 @@ install(
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})
-ament_export_dependencies(pluginlib
+ament_export_dependencies(
+  pluginlib
+  rclcpp
   rmw
   rmw_implementation
   rosbag2_storage

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -21,6 +21,10 @@
 #include <unordered_map>
 #include <vector>
 
+#include "rclcpp/serialization.hpp"
+#include "rclcpp/serialized_message.hpp"
+#include "rclcpp/time.hpp"
+
 #include "rosbag2_cpp/converter_options.hpp"
 #include "rosbag2_cpp/visibility_control.hpp"
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
@@ -125,6 +129,35 @@ public:
     const std::string & topic_name,
     const std::string & type_name,
     const std::string & serialization_format = "cdr");
+
+  /**
+   * Write a serialized message to a bagfile.
+   * The topic needs to have been created before writing is possible.
+   *
+   * \param message rclcpp::SerializedMessage The serialized message to be written to the bagfile
+   * \param topic_name the string of the topic this messages belongs to
+   * \param type_name the string of the type associated with this message
+   * \param time The time stamp of the message
+   * \throws runtime_error if the Writer is not open.
+   */
+  void write(
+    const rclcpp::SerializedMessage & message,
+    const std::string & topic_name,
+    const std::string & type_name,
+    const rclcpp::Time & time);
+
+  template<class MessageT>
+  void write(
+    const MessageT & message,
+    const std::string & topic_name,
+    const rclcpp::Time & time)
+  {
+    rclcpp::SerializedMessage serialized_msg;
+
+    rclcpp::Serialization<MessageT> serialization;
+    serialization.serialize_message(&message, &serialized_msg);
+    return write(serialized_msg, topic_name, rosidl_generator_traits::name<MessageT>(), time);
+  }
 
   writer_interfaces::BaseWriterInterface & get_implementation_handle() const
   {

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -132,7 +132,7 @@ public:
 
   /**
    * Write a serialized message to a bagfile.
-   * The topic needs to have been created before writing is possible.
+   * Opposing a call to \sa write without topic metadata, the topic will be created.
    *
    * \param message rclcpp::SerializedMessage The serialized message to be written to the bagfile
    * \param topic_name the string of the topic this messages belongs to
@@ -146,6 +146,16 @@ public:
     const std::string & type_name,
     const rclcpp::Time & time);
 
+  /**
+   * Write a non-serialized message to a bagfile.
+   * Opposing a call to \sa write without topic metadata, the topic will be created.
+   *
+   * \param message MessageT The serialized message to be written to the bagfile
+   * \param topic_name the string of the topic this messages belongs to
+   * \param type_name the string of the type associated with this message
+   * \param time The time stamp of the message
+   * \throws runtime_error if the Writer is not open.
+   */
   template<class MessageT>
   void write(
     const MessageT & message,

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -116,7 +116,7 @@ public:
 
   /**
    * Write a message to a bagfile.
-   * Opposing a call to \sa write without topic metadata, the topic will be created.
+   * The topic will be created if it has not been created already.
    *
    * \param message to be written to the bagfile
    * \param topic_name the string of the topic this messages belongs to
@@ -132,7 +132,7 @@ public:
 
   /**
    * Write a serialized message to a bagfile.
-   * The topic will be created if it has not been created already 
+   * The topic will be created if it has not been created already.
    *
    * \param message rclcpp::SerializedMessage The serialized message to be written to the bagfile
    * \param topic_name the string of the topic this messages belongs to
@@ -148,7 +148,7 @@ public:
 
   /**
    * Write a non-serialized message to a bagfile.
-   * Opposing a call to \sa write without topic metadata, the topic will be created.
+   * The topic will be created if it has not been created already.
    *
    * \param message MessageT The serialized message to be written to the bagfile
    * \param topic_name the string of the topic this messages belongs to

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -132,7 +132,7 @@ public:
 
   /**
    * Write a serialized message to a bagfile.
-   * Opposing a call to \sa write without topic metadata, the topic will be created.
+   * The topic will be created if it has not been created already 
    *
    * \param message rclcpp::SerializedMessage The serialized message to be written to the bagfile
    * \param topic_name the string of the topic this messages belongs to

--- a/rosbag2_cpp/package.xml
+++ b/rosbag2_cpp/package.xml
@@ -12,6 +12,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
   <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <depend>rmw</depend>

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/serialization.hpp"
 #include "rclcpp/serialized_message.hpp"
 
@@ -74,6 +75,12 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
     bag_message->topic_name = "/my/other/topic";
     writer.write(bag_message, "/my/other/topic", "test_msgs/msg/BasicTypes");
 
+    // yet another alternative, writing the rclcpp::SerializedMessage directly
+    writer.write(serialized_msg, "/yet/another/topic", "test_msgs/msg/BasicTypes", rclcpp::Clock().now());
+
+    // writing a non-serialized message
+    writer.write(test_msg, "/a/ros2/message", rclcpp::Clock().now());
+
     // close on scope exit
   }
 
@@ -92,9 +99,11 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
 
       EXPECT_EQ(test_msg, extracted_test_msg);
     }
-    ASSERT_EQ(2u, topics.size());
+    ASSERT_EQ(4u, topics.size());
     EXPECT_EQ("/my/test/topic", topics[0]);
     EXPECT_EQ("/my/other/topic", topics[1]);
+    EXPECT_EQ("/yet/another/topic", topics[2]);
+    EXPECT_EQ("/a/ros2/message", topics[3]);
 
     // close on scope exit
   }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -76,7 +76,9 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
     writer.write(bag_message, "/my/other/topic", "test_msgs/msg/BasicTypes");
 
     // yet another alternative, writing the rclcpp::SerializedMessage directly
-    writer.write(serialized_msg, "/yet/another/topic", "test_msgs/msg/BasicTypes", rclcpp::Clock().now());
+    writer.write(
+      serialized_msg, "/yet/another/topic", "test_msgs/msg/BasicTypes",
+      rclcpp::Clock().now());
 
     // writing a non-serialized message
     writer.write(test_msg, "/a/ros2/message", rclcpp::Clock().now());
@@ -104,6 +106,18 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
     EXPECT_EQ("/my/other/topic", topics[1]);
     EXPECT_EQ("/yet/another/topic", topics[2]);
     EXPECT_EQ("/a/ros2/message", topics[3]);
+
+    // close on scope exit
+  }
+
+  // alternative reader
+  {
+    rosbag2_cpp::Reader reader;
+    reader.open(rosbag_directory.string());
+    while (reader.has_next()) {
+      TestMsgT extracted_test_msg = reader.read_next<TestMsgT>();
+      EXPECT_EQ(test_msg, extracted_test_msg);
+    }
 
     // close on scope exit
   }


### PR DESCRIPTION
~Next on the list towards a user-friendly C++ API. Sits on top of "defaults" branch.~

The implementation here is pretty straightforward even though we have to iterate over the existing data structures used here at some point, namely the `rosbag2_storage::SerializedBagMessage`. We're dealing with shared pointers here in order to ease the cleanup of the underlying `uint8` buffer. However, this prevents any stack allocations and makes it pretty cumbersome to integrate with the existing `rclcpp::SerializedMessage` API.

As a second point, I personally don't see a way around the `rclcpp` dependency at this point. Even though I'd like to keep the number of dependencies here fairly small, in order to eventually come up with a `template<class MsgT> void write(MsgT & msg)` API, we'd need to have that dependency.

I'll open this PR as a draft to start a discussion.