### PR TITLE
reenable cppcheck for rosbag2_transport

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -183,8 +183,8 @@ if(BUILD_TESTING)
   find_package(test_msgs REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   include(cmake/rosbag2_transport_add_gmock.cmake)
-  # explicitly disable cppcheck
-  set(ament_cmake_cppcheck_FOUND TRUE)
+  get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS
+    rclcpp::rclcpp INTERFACE_INCLUDE_DIRECTORIES)
   ament_lint_auto_find_test_dependencies()
   call_for_each_rmw_implementation(create_tests_for_rmw_implementation)
 endif()

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -183,8 +183,6 @@ if(BUILD_TESTING)
   find_package(test_msgs REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   include(cmake/rosbag2_transport_add_gmock.cmake)
-  get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS
-    rclcpp::rclcpp INTERFACE_INCLUDE_DIRECTORIES)
   ament_lint_auto_find_test_dependencies()
   call_for_each_rmw_implementation(create_tests_for_rmw_implementation)
 endif()

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
@@ -35,6 +35,7 @@ namespace rosbag2_transport
 class GenericSubscription : public rclcpp::SubscriptionBase
 {
 public:
+  // cppcheck-suppress unknownMacro
   RCLCPP_SMART_PTR_DEFINITIONS(GenericSubscription)
 
   /**
@@ -73,6 +74,7 @@ public:
   const rclcpp::QoS & qos_profile() const;
 
 private:
+  // cppcheck-suppress unknownMacro
   RCLCPP_DISABLE_COPY(GenericSubscription)
 
   std::shared_ptr<rclcpp::SerializedMessage> borrow_serialized_message(size_t capacity);


### PR DESCRIPTION
I wasn't aware of it and not sure why it got disabled in the first place, but with the following patch `cppcheck` passes successfully locally on my OSX.
Alternatively, one can place a  `// cppcheck-suppress unknownMacro` above the two `RCLCPP` macros. 

This PR was inspired by https://github.com/ros2/rclpy/pull/577

CI (only testing `cppcheck` within `rosbag2_transport`):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11472)](http://ci.ros2.org/job/ci_linux/11472/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6677)](http://ci.ros2.org/job/ci_linux-aarch64/6677/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9408)](http://ci.ros2.org/job/ci_osx/9408/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11365)](http://ci.ros2.org/job/ci_windows/11365/)