### PR TITLE
Use foxy testing apt repos to install linters for Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,4 @@
 # Run linters automatically on pull requests.
-#
-# ros-tooling/actino-ros-lint is relying on the latest APT binary packages.
-# As of 2020-05-01, Eloquent is the latest release for which APT binary
-# packages are available, which is why the Docker image is based on Eloquent.
 name: Lint rosbag2
 on:
   pull_request:
@@ -12,7 +8,7 @@ jobs:
     name: ament_copyright
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
     steps:
     # TODO(setup-ros-docker#7): calling chown is necessary for now
     - run: sudo chown -R rosbuild:rosbuild "$HOME" .
@@ -34,7 +30,7 @@ jobs:
     name: ament_xmllint
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
     steps:
     # TODO(setup-ros-docker#7): calling chown is necessary for now
     - run: sudo chown -R rosbuild:rosbuild "$HOME" .
@@ -58,7 +54,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +79,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: copyright
+        distribution: foxy
         package-name: |
             ros2bag
             rosbag2_compression
@@ -38,6 +39,7 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: xmllint
+        distribution: foxy
         package-name: |
             ros2bag
             rosbag2
@@ -53,12 +55,12 @@ jobs:
   ament_lint_cpp: # Linters applicable to C++ packages
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
-    container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
     strategy:
       fail-fast: false
       matrix:
           linter: [cppcheck, cpplint, uncrustify]
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
     steps:
     # TODO(setup-ros-docker#7): calling chown is necessary for now
     - run: sudo chown -R rosbuild:rosbuild "$HOME" .
@@ -66,6 +68,7 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}
+        distribution: foxy
         package-name: |
             rosbag2_compression
             rosbag2_converter_default_plugins
@@ -91,5 +94,6 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}
+        distribution: foxy
         package-name: |
             ros2bag

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     name: ament_copyright
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
     steps:
     # TODO(setup-ros-docker#7): calling chown is necessary for now
     - run: sudo chown -R rosbuild:rosbuild "$HOME" .
@@ -30,7 +30,7 @@ jobs:
     name: ament_xmllint
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
     steps:
     # TODO(setup-ros-docker#7): calling chown is necessary for now
     - run: sudo chown -R rosbuild:rosbuild "$HOME" .
@@ -54,7 +54,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +79,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-foxy-ros-base-testing-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We were still using the Eloquent release of the linters, which is not accurate to the current code.

Depends on https://github.com/ros2/rosbag2/pull/461

Signed-off-by: Emerson Knapp <eknapp@amazon.com>