### PR TITLE
Re-enable Action CI for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test rosbag2
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
     - uses: ros-tooling/action-ros-ci@0.1.0
       with:
@@ -29,6 +29,7 @@ jobs:
           sqlite3_vendor
           rosbag2_test_common
           rosbag2_tests
+        target-ros2-distro: rolling
     - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs


### PR DESCRIPTION
We disabled Action CI a while back because the tests were unreliable (much more so here than on ci.ros2.org) and did not want to block/confuse contributors. They seem to be working well now so this PR tests re-enabling that check.

I am still seeing ~1/6 (4/24) of the last day's runs failing https://github.com/ros2/rosbag2/actions?query=workflow%3A%22Test+rosbag2%22 - so maybe this isn't quite ready for prime-time.
