### PR TITLE
move wait_for_shutdown() call out of the context manager

### DIFF
--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -16,6 +16,7 @@ import contextlib
 from pathlib import Path
 import re
 import tempfile
+import time
 
 import unittest
 
@@ -73,7 +74,9 @@ class TestRos2BagRecord(unittest.TestCase):
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            bag_command.wait_for_shutdown(timeout=5)
+            time.sleep(3)
+        bag_command.wait_for_shutdown(timeout=5)
+        assert bag_command.terminated
         expected_string_regex = re.compile(ERROR_STRING)
         matches = expected_string_regex.search(bag_command.output)
         assert not matches, print('ros2bag CLI did not produce the expected output')
@@ -84,7 +87,9 @@ class TestRos2BagRecord(unittest.TestCase):
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            bag_command.wait_for_shutdown(timeout=5)
+            time.sleep(3)
+        bag_command.wait_for_shutdown(timeout=5)
+        assert bag_command.terminated
         expected_string_regex = re.compile(ERROR_STRING)
         matches = expected_string_regex.search(bag_command.output)
         assert not matches, print('ros2bag CLI did not produce the expected output')
@@ -95,7 +100,9 @@ class TestRos2BagRecord(unittest.TestCase):
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            bag_command.wait_for_shutdown(timeout=5)
+            time.sleep(3)
+        bag_command.wait_for_shutdown(timeout=5)
+        assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
         expected_string_regex = re.compile(ERROR_STRING)
         matches = expected_string_regex.search(bag_command.output)
@@ -107,7 +114,9 @@ class TestRos2BagRecord(unittest.TestCase):
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            bag_command.wait_for_shutdown(timeout=5)
+            time.sleep(3)
+        bag_command.wait_for_shutdown(timeout=5)
+        assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
         expected_string_regex = re.compile(
             r"ros2 bag record: error: argument --qos-profile-overrides-path: can't open")


### PR DESCRIPTION
Hopefully fixes (no, it doesn't) #454 this time.

The subprocess started by `launch_testing.tools.launch_process()` is only signaled to terminate when the context exits. Therefore calling `wait_for_shutdown()` within the `with` block doesn't do anything but wait for the timeout. Afterwards it was a race if the process terminated quickly enough so that the file handles from the subprocess where released before the tear down function of the test tries to delete the temporary directory.

Moving the `wait_for_shutdown()` call outside the `with` block ensures to give the shutdown event enough time to be processed.

Windows build testing `ros2bag` with `--retest-until-fail 10`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11481)](https://ci.ros2.org/job/ci_windows/11481/)

Full CI just because:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11545)](http://ci.ros2.org/job/ci_linux/11545/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6708)](http://ci.ros2.org/job/ci_linux-aarch64/6708/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9443)](http://ci.ros2.org/job/ci_osx/9443/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11480)](http://ci.ros2.org/job/ci_windows/11480/)