### PR TITLE
Reenable flake8 linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          linter: [pep257] # TODO re-enable flake8 when it is fixed
+          linter: [pep257, flake8]
     steps:
     # TODO(setup-ros-docker#7): calling chown is necessary for now
     - run: sudo chown -R rosbuild:rosbuild "$HOME" .


### PR DESCRIPTION
This was disabled in https://github.com/ros2/rosbag2/pull/440 - the upstream problem has been addressed, so we can reenable the check now.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>