### PR TITLE
introduce ros2 bag list <plugins>

### DIFF
--- a/ros2bag/ros2bag/verb/list.py
+++ b/ros2bag/ros2bag/verb/list.py
@@ -1,0 +1,64 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from xml.dom import minidom
+
+from ament_index_python import get_resource
+from ament_index_python import get_resources
+
+from ros2bag.verb import VerbExtension
+
+
+class ListVerb(VerbExtension):
+    """Print information about a bag to the screen."""
+
+    def add_arguments(self, parser, cli_name):  # noqa: D102
+        parser.add_argument(
+            'plugin_type', help='lists available plugins (storage plugins or converter plugins',
+            choices=['storage', 'converter'])
+        parser.add_argument(
+            '--verbose', help='output verbose information about the available plugin',
+            action='store_true')
+
+    def main(self, *, args):  # noqa: D102
+        # the following is the resource index which is created when installing a pluginlib xml file
+        if args.plugin_type == 'storage':
+            pluginlib_resource_index = 'rosbag2_storage__pluginlib__plugin'
+        else:
+            pluginlib_resource_index = 'rosbag2_cpp__pluginlib__plugin'
+
+        resources = get_resources(pluginlib_resource_index)
+        if args.verbose:
+            print('available %s plugins are:' % args.plugin_type)
+        for resource in resources:
+            plugin_xml_file_paths, base_folder = get_resource(pluginlib_resource_index, resource)
+            for file_path in list(filter(None, plugin_xml_file_paths.split('\n'))):
+                abs_path = os.path.join(base_folder, file_path)
+                if not os.path.exists(abs_path):
+                    return 'path does not exist: %s' % abs_path
+
+                xmldoc = minidom.parse(abs_path)
+                class_item = xmldoc.getElementsByTagName('class')[0]
+                class_name = class_item.attributes['name']
+                type_name = class_item.attributes['type']
+                base_class_name = class_item.attributes['base_class_type']
+                description = xmldoc.getElementsByTagName('description')[0]
+
+                print('%s%s' % (('name: ' if args.verbose else ''), class_name.value))
+                if args.verbose:
+                    print('\t%s' % description.childNodes[0].data)
+                    print('\ttype: %s' % type_name.value)
+                    print('\tbase_class: %s' % base_class_name.value)

--- a/ros2bag/ros2bag/verb/list.py
+++ b/ros2bag/ros2bag/verb/list.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ from ros2bag.verb import VerbExtension
 
 
 class ListVerb(VerbExtension):
-    """Print information about a bag to the screen."""
+    """Print information about available plugins to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(

--- a/ros2bag/setup.py
+++ b/ros2bag/setup.py
@@ -39,6 +39,7 @@ The package provides the rosbag command for the ROS 2 command line tools.""",
         ],
         'ros2bag.verb': [
             'info = ros2bag.verb.info:InfoVerb',
+            'list = ros2bag.verb.list:ListVerb',
             'play = ros2bag.verb.play:PlayVerb',
             'record = ros2bag.verb.record:RecordVerb',
         ],


### PR DESCRIPTION
Fixes #80 

This introduces a new verb for `ros2 bag` called `list` which lets you choose between the various types of plugins currently featured in rosbag2. At the time of writing this is `storage` and `converter`.

A `--verbose` output looks like:

```
 ➭ ros2 bag list storage --verbose
available storage plugins are:
name: sqlite3
	Plugin to write to SQLite3 databases
	type: rosbag2_storage_plugins::SqliteStorage
	base_class: rosbag2_storage::storage_interfaces::ReadWriteInterface
name: my_test_plugin
	This is a test storage plugin.
	type: TestPlugin
	base_class: rosbag2_storage::storage_interfaces::ReadWriteInterface
```

which is essentially parsing the pluginlib xml file found in the ament resource index.