### PR TITLE
add wait for closed file handles on Windows

### DIFF
--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -15,6 +15,7 @@
 import contextlib
 from pathlib import Path
 import re
+import sys
 import tempfile
 import time
 
@@ -66,7 +67,14 @@ class TestRos2BagRecord(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.tmpdir.cleanup()
+        try:
+            cls.tmpdir.cleanup()
+        except PermissionError:
+            if sys.platform != 'win32':
+                raise
+            # HACK to allow Windows to close pending file handles
+            time.sleep(3)
+            cls.tmpdir.cleanup()
 
     def test_qos_simple(self):
         profile_path = PROFILE_PATH / 'qos_profile.yaml'


### PR DESCRIPTION
Follow up of https://github.com/ros2/rosbag2/pull/466#issuecomment-661122726.

Only testing `ros2bag` on Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11570)](https://ci.ros2.org/job/ci_windows/11570/)