### PR TITLE
catch parent exception

### DIFF
--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -69,7 +69,7 @@ class TestRos2BagRecord(unittest.TestCase):
     def tearDownClass(cls):
         try:
             cls.tmpdir.cleanup()
-        except PermissionError:
+        except OSError:
             if sys.platform != 'win32':
                 raise
             # HACK to allow Windows to close pending file handles


### PR DESCRIPTION
Follow up of #470.

I am not planning to run CI builds for this change since the PR build ensures that the syntax is valid.

A single Windows build won't say anything if this actually catches the problem in the test since this is subject to a race. Hopefully the next nightlies will show an improvement.