### PR TITLE
Open sqlite-db in RW for reading

### DIFF
--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -37,7 +37,7 @@ SqliteWrapper::SqliteWrapper(
   if (io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     int rc = sqlite3_open_v2(
       uri.c_str(), &db_ptr,
-      SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nullptr);
+      SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX, nullptr);
     if (rc != SQLITE_OK) {
       std::stringstream errmsg;
       errmsg << "Could not read-only open database. SQLite error (" <<


### PR DESCRIPTION
This fixes playback on macOS when the *.db3-shm, *.db3-wal don't exist yet. See #485