### PR TITLE
Add pytest.ini back to ros2bag.

### DIFF
--- a/ros2bag/pytest.ini
+++ b/ros2bag/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

It looks like #442 probably had a bad merge and lost this, which caused all builds last night to fail.  This restores pytest.ini in the ros2bag directory.  @Karsten1987 FYI