### PR TITLE
read yaml config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ Currently, the only `compression-format` available is `zstd`. Both the mode and 
 
 It is recommended to use this feature with the splitting options.
 
+#### Recording with a storage configuration
+
+Storage configuration can be specified in a YAML file passed through the `--storage-config-file` option.
+This can be used to optimize performance for specific use-cases.
+
+For the default storage plugin (sqlite3), the file has a following syntax:
+```
+read:
+  pragmas: <list of pragma settings for read-only>
+write:
+  pragmas: <list of pragma settings for read/write>
+```
+Please refer to [documentation of pragmas](https://www.sqlite.org/pragma.html).
+Settings are fully exposed to the user and should be applied with understanding.
+
+An example configuration file could look like this:
+
+```
+write:
+  pragmas: ["journal_mode = MEMORY", "synchronous = OFF", "schema.cache_size = 1000", "schema.page_size = 4096"]
+
+```
+
 ### Replaying data
 
 After recording data, the next logical step is to replay this data:

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -58,7 +58,12 @@ class PlayVerb(VerbExtension):
                  '"old_topic1:=new_topic1 old_topic2:=new_topic2 etc." ')
         parser.add_argument(
             '--storage-config-file', type=FileType('r'),
-            help='Path to a yaml file defining storage specific configurations.')
+            help='Path to a yaml file defining storage specific configurations. '
+                 'For the default storage plugin settings are specified through syntax:'
+                 'read:'
+                 '  pragmas: [\"<setting_name>\" = <setting_value>]'
+                 'Note that applicable settings are limited to read-only for ros2 bag play.'
+                 'For a list of sqlite3 settings, refer to sqlite3 documentation')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -92,7 +92,11 @@ class RecordVerb(VerbExtension):
         )
         parser.add_argument(
             '--storage-config-file', type=FileType('r'),
-            help='Path to a yaml file defining storage specific configurations.')
+            help='Path to a yaml file defining storage specific configurations. '
+                 'For the default storage plugin settings are specified through syntax:'
+                 'write:'
+                 '  pragmas: [\"<setting_name>\" = <setting_value>]'
+                 'For a list of sqlite3 settings, refer to sqlite3 documentation')
         self._subparser = parser
 
     def main(self, *, args):  # noqa: D102

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/benchmark.sh
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/benchmark.sh
@@ -17,7 +17,7 @@ summary_file=${test_dir}/results.csv
 
 freq=100; #Hz
 
-for cache in 0 10 100 1000
+for cache in 0 1000000 10000000 100000000
 do
   for sz in 1000 10000 100000 1000000
   do

--- a/rosbag2_storage_default_plugins/CMakeLists.txt
+++ b/rosbag2_storage_default_plugins/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(sqlite3_vendor REQUIRED)
 find_package(SQLite3 REQUIRED)  # provided by sqlite3_vendor
+find_package(yaml_cpp_vendor REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -34,11 +35,12 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp)
 
 ament_target_dependencies(${PROJECT_NAME}
+  pluginlib
   rosbag2_storage
   rcpputils
   rcutils
   SQLite3
-  pluginlib)
+  yaml_cpp_vendor)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp
@@ -177,7 +177,7 @@ private:
     bool is_already_accessed_;
   };
 
-  std::shared_ptr<SqliteStatementWrapper> execute_and_reset();
+  std::shared_ptr<SqliteStatementWrapper> execute_and_reset(bool assert_return_value = false);
   template<typename ... Columns>
   QueryResult<Columns ...> execute_query();
 

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <string>
-#include <vector>
+#include <unordered_map>
 
 #include "rcutils/types.h"
 #include "rosbag2_storage/serialized_bag_message.hpp"
@@ -38,7 +38,7 @@ public:
   SqliteWrapper(
     const std::string & uri,
     rosbag2_storage::storage_interfaces::IOFlag io_flag,
-    std::vector<std::string> && pragmas = {});
+    std::unordered_map<std::string, std::string> && pragmas = {});
   SqliteWrapper();
   ~SqliteWrapper();
 
@@ -50,7 +50,7 @@ public:
 
 private:
   void apply_pragma_settings(
-    std::vector<std::string> & pragmas,
+    std::unordered_map<std::string, std::string> & pragmas,
     rosbag2_storage::storage_interfaces::IOFlag io_flag);
 
   DBPtr db_ptr;

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -49,6 +49,10 @@ public:
   operator bool();
 
 private:
+  void apply_pragma_settings(
+    std::vector<std::string> & pragmas,
+    rosbag2_storage::storage_interfaces::IOFlag io_flag);
+
   DBPtr db_ptr;
 };
 

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -35,7 +35,10 @@ using DBPtr = sqlite3 *;
 class ROSBAG2_STORAGE_DEFAULT_PLUGINS_PUBLIC SqliteWrapper
 {
 public:
-  SqliteWrapper(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag);
+  SqliteWrapper(
+    const std::string & uri,
+    rosbag2_storage::storage_interfaces::IOFlag io_flag,
+    std::vector<std::string> && pragmas = {});
   SqliteWrapper();
   ~SqliteWrapper();
 

--- a/rosbag2_storage_default_plugins/package.xml
+++ b/rosbag2_storage_default_plugins/package.xml
@@ -15,6 +15,7 @@
   <depend>rcutils</depend>
   <depend>rosbag2_storage</depend>
   <depend>sqlite3_vendor</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp
@@ -52,7 +52,8 @@ SqliteStatementWrapper::~SqliteStatementWrapper()
   }
 }
 
-std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_reset()
+std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_reset(
+  bool assert_return_value)
 {
   int return_code = sqlite3_step(statement_);
   if (!is_query_ok(return_code)) {
@@ -62,6 +63,20 @@ std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_rese
 
     throw SqliteException{errmsg.str()};
   }
+
+  if (assert_return_value) {
+    bool no_result = return_code == SQLITE_DONE || sqlite3_column_count(statement_) == 0;
+
+    if (no_result || sqlite3_column_type(statement_, 0) == SQLITE_NULL) {
+      // No result or result is null means that no such pragma exists
+      std::stringstream errmsg;
+      errmsg << "Statement returned empty value while result was expected: \'" <<
+        sqlite3_sql(statement_) << "\'";
+
+      throw SqliteException{errmsg.str()};
+    }
+  }
+
   return reset();
 }
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -33,6 +33,19 @@
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp"
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_exception.hpp"
 
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
+
 #include "../logging.hpp"
 
 namespace
@@ -75,9 +88,29 @@ void SqliteStorage::open(
   const rosbag2_storage::StorageOptions & storage_options,
   rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
+  std::vector<std::string> pragmas;
   if (!storage_options.storage_config_uri.empty()) {
-    fprintf(stderr, "going to open config file: %s\n", storage_options.storage_config_uri.c_str());
-    throw std::runtime_error("storage specific config file is not yet implemented.");
+    try {
+      auto key =
+        io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY ? "read" : "write";
+      YAML::Node yaml_file = YAML::LoadFile(storage_options.storage_config_uri);
+      pragmas = yaml_file[key]["pragmas"].as<std::vector<std::string>>();
+    } catch (const YAML::Exception & ex) {
+      throw std::runtime_error(std::string("Exception on parsing info file: ") + ex.what());
+    }
+    // poor developer's sqlinjection prevention ;-)
+    std::string invalid_characters = {"';\""};
+    auto throw_on_invalid_character = [](const auto & pragmas, const auto & invalid_characters) {
+        for (const auto & pragma_string : pragmas) {
+          auto pos = pragma_string.find_first_of(invalid_characters);
+          if (pos != std::string::npos) {
+            throw std::runtime_error(
+                    std::string("Invalid characters in sqlite3 config file: ") +
+                    pragma_string[pos]);
+          }
+        }
+      };
+    throw_on_invalid_character(pragmas, invalid_characters);
   }
 
   if (is_read_write(io_flag)) {
@@ -99,7 +132,7 @@ void SqliteStorage::open(
   }
 
   try {
-    database_ = std::make_unique<SqliteWrapper>(relative_path_, io_flag);
+    database_ = std::make_unique<SqliteWrapper>(relative_path_, io_flag, std::move(pragmas));
   } catch (const SqliteException & e) {
     throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));
   }

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -80,7 +80,9 @@ inline std::vector<std::string> parse_pragmas(
       YAML::Node yaml_file = YAML::LoadFile(storage_config_uri);
       pragmas = yaml_file[key]["pragmas"].as<std::vector<std::string>>();
     } catch (const YAML::Exception & ex) {
-      throw std::runtime_error(std::string("Exception on parsing info file: ") + ex.what());
+      throw std::runtime_error(
+              std::string("Exception on parsing sqlite3 config file: ") +
+              ex.what());
     }
     // poor developer's sqlinjection prevention ;-)
     std::string invalid_characters = {"';\""};
@@ -90,7 +92,9 @@ inline std::vector<std::string> parse_pragmas(
           if (pos != std::string::npos) {
             throw std::runtime_error(
                     std::string("Invalid characters in sqlite3 config file: ") +
-                    pragma_string[pos]);
+                    pragma_string[pos] +
+                    ". Avoid following characters: " +
+                    invalid_characters);
           }
         }
       };

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -62,10 +62,7 @@ SqliteWrapper::SqliteWrapper(
     auto journal_mode_set = std::find_if(
       pragmas.begin(), pragmas.end(),
       [](const auto & pragma) {
-        if (pragma.rfind("journal_mode", 0) == 0) {
-          return true;
-        }
-        return false;
+        return pragma.rfind("journal_mode", 0) == 0;
       });
     if (journal_mode_set == pragmas.end()) {
       pragmas.push_back("journal_mode = WAL");
@@ -73,10 +70,7 @@ SqliteWrapper::SqliteWrapper(
     auto synchronous_set = std::find_if(
       pragmas.begin(), pragmas.end(),
       [](const auto & pragma) {
-        if (pragma.rfind("synchronous", 0) == 0) {
-          return true;
-        }
-        return false;
+        return pragma.rfind("synchronous", 0) == 0;
       });
     if (synchronous_set == pragmas.end()) {
       pragmas.push_back("synchronous = NORMAL");

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -19,6 +19,7 @@
 
 #include <cstdio>
 #include <iostream>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -134,6 +135,24 @@ public:
     }
 
     return read_messages;
+  }
+
+  rosbag2_storage::StorageOptions make_storage_options_with_config(
+    const std::string & config_yaml,
+    const std::string & plugin_id)
+  {
+    auto temp_dir = rcpputils::fs::path(temporary_dir_path_);
+    const auto storage_uri = (temp_dir / "rosbag").string();
+    const auto yaml_config = (temp_dir / "sqlite_config.yaml").string();
+
+    { // populate temporary config file
+      std::ofstream out(yaml_config);
+      out << config_yaml;
+    }
+
+    rosbag2_storage::StorageOptions storage_options{storage_uri, plugin_id, 0, 0, 0,
+      yaml_config};
+    return storage_options;
   }
 
 protected:

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -311,3 +311,25 @@ TEST_F(StorageTestFixture, get_relative_file_path_returns_db_name_with_ext) {
     rosbag2_storage::storage_interfaces::IOFlag::APPEND);
   EXPECT_EQ(append_storage->get_relative_file_path(), storage_filename);
 }
+
+TEST_F(StorageTestFixture, throws_on_ivalid_pragma_in_config_file) {
+  // Check that storage throws on invalid pragma statement in sqlite config
+  const auto invalid_yaml = "write:\n  pragmas: [\"unrecognized_pragma_name = 2\"]\n";
+  const auto writable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+
+  EXPECT_THROW(
+    writable_storage->open(
+      make_storage_options_with_config(invalid_yaml, kPluginID),
+      rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE),
+    std::runtime_error);
+}
+
+TEST_F(StorageTestFixture, loads_config_file) {
+  // Check that storage opens with correct sqlite config file
+  const auto valid_yaml = "write:\n  pragmas: [\"journal_mode = MEMORY\"]\n";
+  const auto writable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+  EXPECT_NO_THROW(
+    writable_storage->open(
+      make_storage_options_with_config(valid_yaml, kPluginID),
+      rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE));
+}

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -312,7 +312,17 @@ TEST_F(StorageTestFixture, get_relative_file_path_returns_db_name_with_ext) {
   EXPECT_EQ(append_storage->get_relative_file_path(), storage_filename);
 }
 
-TEST_F(StorageTestFixture, throws_on_ivalid_pragma_in_config_file) {
+TEST_F(StorageTestFixture, loads_config_file) {
+  // Check that storage opens with correct sqlite config file
+  const auto valid_yaml = "write:\n  pragmas: [\"journal_mode = MEMORY\"]\n";
+  const auto writable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+  EXPECT_NO_THROW(
+    writable_storage->open(
+      make_storage_options_with_config(valid_yaml, kPluginID),
+      rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE));
+}
+
+TEST_F(StorageTestFixture, throws_on_invalid_pragma_in_config_file) {
   // Check that storage throws on invalid pragma statement in sqlite config
   const auto invalid_yaml = "write:\n  pragmas: [\"unrecognized_pragma_name = 2\"]\n";
   const auto writable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
@@ -322,14 +332,4 @@ TEST_F(StorageTestFixture, throws_on_ivalid_pragma_in_config_file) {
       make_storage_options_with_config(invalid_yaml, kPluginID),
       rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE),
     std::runtime_error);
-}
-
-TEST_F(StorageTestFixture, loads_config_file) {
-  // Check that storage opens with correct sqlite config file
-  const auto valid_yaml = "write:\n  pragmas: [\"journal_mode = MEMORY\"]\n";
-  const auto writable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  EXPECT_NO_THROW(
-    writable_storage->open(
-      make_storage_options_with_config(valid_yaml, kPluginID),
-      rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE));
 }


### PR DESCRIPTION
implements to read a config file (`.yaml`) tailored for sqlite3. As for now, I've only implemented to read pragmas in the style of:

```
read:
  pragmas: ["schema_version"]
write:
  pragmas: ["synchronous = NORMAL", "journal_mode = WAL"]
```

I am struggling a bit to write tests for this as I have a hard time to introspect if these pragmas are actually affective. I can't really test for wrong pragmas either as [according to the sqlite documentation](https://www.sqlite.org/pragma.html#pragma_synchronous) "No error messages are generated if an unknown pragma is issued."