### PR TITLE
resolve memory leak for serialized message

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -166,6 +166,8 @@ Recorder::create_subscription(
     qos,
     [this, topic_name](std::shared_ptr<rclcpp::SerializedMessage> message) {
       auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+      // the serialized bag message takes ownership of the incoming rclcpp serialized message
+      // we therefore have to make sure to cleanup that memory in a custom deleter.
       bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
         new rcutils_uint8_array_t,
         [](rcutils_uint8_array_t * msg) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -166,8 +166,17 @@ Recorder::create_subscription(
     qos,
     [this, topic_name](std::shared_ptr<rclcpp::SerializedMessage> message) {
       auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-      bag_message->serialized_data =
-      std::make_shared<rcl_serialized_message_t>(message->release_rcl_serialized_message());
+      bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
+        new rcutils_uint8_array_t,
+        [](rcutils_uint8_array_t * msg) {
+          auto fini_return = rcutils_uint8_array_fini(msg);
+          delete msg;
+          if (fini_return != RCUTILS_RET_OK) {
+            ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
+              "Failed to destroy serialized message: " << rcutils_get_error_string().str);
+          }
+        });
+      *bag_message->serialized_data = message->release_rcl_serialized_message();
       bag_message->topic_name = topic_name;
       rcutils_time_point_value_t time_stamp;
       int error = rcutils_system_time_now(&time_stamp);

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -136,6 +136,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
   EXPECT_EQ(recorded_topics.size(), 1u);
   EXPECT_FALSE(recorded_messages.empty());
 }
+
 TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
 {
   // Ensure rosbag2 can receive Transient Local Durability "latched messages"


### PR DESCRIPTION
addressed #499 

as stated in https://github.com/ros2/rosbag2/issues/499#issuecomment-671629881, the change to `rclcpp::SerializedMessage` introduced this regression in which we transfer ownership, the smart pointer however doesn't cleanup the transferred memory. Specifically this change here:
https://github.com/ros2/rosbag2/pull/386/files#diff-1a63843318260f13eda07d98c90c9c66L107-L116

