### PR TITLE
disable sanitizer by default

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ if(WIN32)
   add_definitions(-DNOMINMAX)
 endif()
 
-option(DISABLE_SANITIZERS "disables the use of gcc sanitizers")
+option(DISABLE_SANITIZERS "disables the use of gcc sanitizers" ON)
 if(NOT DISABLE_SANITIZERS AND CMAKE_COMPILER_IS_GNUCXX)
   include(CheckCXXSourceCompiles)
   set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})


### PR DESCRIPTION
Related to https://github.com/ros2/rosbag2/pull/57#discussion_r476154546

Atm the test passes but the sanitizer fails to run within the CI builds inside Docker: see

* http://build.ros2.org/view/Rci/job/Rci__nightly-fastrtps_ubuntu_focal_amd64/58/testReport/(root)/projectroot/test_ros2_message/
* http://build.ros2.org/view/Rdev/job/Rdev__rosbag2__ubuntu_focal_amd64/31/testReport/(root)/projectroot/test_ros2_message/

I didn't find a way to conditionally enable the sanitizer and therefore this patch changes the default turning the sanitizer off. Since the CI builds can't run the leak sanitizer atm (see ros-infrastructure/ros_buildfarm#832) this only affect local builds.