### PR TITLE
[foxy backport] resolve memory leak for serialized message (#502)

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -136,6 +136,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
   EXPECT_EQ(recorded_topics.size(), 1u);
   EXPECT_FALSE(recorded_messages.empty());
 }
+
 TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
 {
   // Ensure rosbag2 can receive Transient Local Durability "latched messages"


### PR DESCRIPTION
backports #502 to Foxy.