### PR TITLE
[ros2bag test_record] Gets rid of time.sleep and move to using command.wait_for_output

### DIFF
--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -36,7 +36,6 @@ import pytest
 PROFILE_PATH = Path(__file__).parent / 'resources'
 TEST_NODE = 'ros2bag_record_qos_profile_test_node'
 TEST_NAMESPACE = 'ros2bag_record_qos_profile'
-ERROR_STRING = r'\[ERROR] \[ros2bag]:'
 
 
 @pytest.mark.rostest
@@ -84,12 +83,13 @@ class TestRos2BagRecord(unittest.TestCase):
         expected_string_regex = re.compile(
             r'\[rosbag2_storage]: Opened database .* for READ_WRITE')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(
+            bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
                 timeout=5)
-            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
+        matches = expected_string_regex.search(bag_command.output)
+        assert matches, print('ros2bag CLI did not produce the expected output')
 
     def test_incomplete_qos_profile(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_profile.yaml'
@@ -99,12 +99,13 @@ class TestRos2BagRecord(unittest.TestCase):
         expected_string_regex = re.compile(
             r'\[rosbag2_storage]: Opened database .* for READ_WRITE')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(
+            bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
                 timeout=5)
-            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
+        matches = expected_string_regex.search(bag_command.output)
+        assert matches, print('ros2bag CLI did not produce the expected output')
 
     def test_incomplete_qos_duration(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_duration.yaml'
@@ -114,13 +115,14 @@ class TestRos2BagRecord(unittest.TestCase):
         expected_string_regex = re.compile(
             r'\[ERROR] \[ros2bag]: Time overrides must include both')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(
+            bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
                 timeout=5)
-            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
+        matches = expected_string_regex.search(bag_command.output)
+        assert matches, print('ros2bag CLI did not produce the expected output')
 
     def test_nonexistent_qos_profile(self):
         profile_path = PROFILE_PATH / 'foobar.yaml'
@@ -130,10 +132,11 @@ class TestRos2BagRecord(unittest.TestCase):
         expected_string_regex = re.compile(
             r'ros2 bag record: error: argument --qos-profile-overrides-path: can\'t open')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(
+            bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
                 timeout=5)
-            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
+        matches = expected_string_regex.search(bag_command.output)
+        assert matches, print('ros2bag CLI did not produce the expected output')

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -81,52 +81,53 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_basic'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
+
+        expected_string_regex = re.compile(r"\[rosbag2_storage]: Opened database .* for READ_WRITE")
+        output_condition = lambda output: expected_string_regex.search(output) is not None
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            time.sleep(3)
+            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
-        expected_string_regex = re.compile(ERROR_STRING)
-        matches = expected_string_regex.search(bag_command.output)
-        assert not matches, print('ros2bag CLI did not produce the expected output')
 
     def test_incomplete_qos_profile(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_profile.yaml'
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
+        expected_string_regex = re.compile(r"\[rosbag2_storage]: Opened database .* for READ_WRITE")
+        output_condition = lambda output: expected_string_regex.search(output) is not None
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            time.sleep(3)
+            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
-        expected_string_regex = re.compile(ERROR_STRING)
-        matches = expected_string_regex.search(bag_command.output)
-        assert not matches, print('ros2bag CLI did not produce the expected output')
 
     def test_incomplete_qos_duration(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_duration.yaml'
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete_duration'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
+        expected_string_regex = re.compile(r"\[ERROR] \[ros2bag]: Time overrides must include both")
+        output_condition = lambda output: expected_string_regex.search(output) is not None 
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            time.sleep(3)
+            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
-        expected_string_regex = re.compile(ERROR_STRING)
-        matches = expected_string_regex.search(bag_command.output)
-        assert matches, print('ros2bag CLI did not produce the expected output')
 
     def test_nonexistent_qos_profile(self):
         profile_path = PROFILE_PATH / 'foobar.yaml'
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_nonexistent'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
+        expected_string_regex = re.compile(
+            r"ros2 bag record: error: argument --qos-profile-overrides-path: can't open")
+        output_condition = lambda output: expected_string_regex.search(output) is not None
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            time.sleep(3)
+            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
-        expected_string_regex = re.compile(
-            r"ros2 bag record: error: argument --qos-profile-overrides-path: can't open")
-        matches = expected_string_regex.search(bag_command.output)
-        assert matches, print('ros2bag CLI did not produce the expected output')

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -36,7 +36,11 @@ import pytest
 PROFILE_PATH = Path(__file__).parent / 'resources'
 TEST_NODE = 'ros2bag_record_qos_profile_test_node'
 TEST_NAMESPACE = 'ros2bag_record_qos_profile'
+ERROR_STRING_MSG = 'ros2bag CLI did not produce the expected output'\
+        '\n Expected output pattern: {}\n Actual output: {}'
 
+OUTPUT_WAIT_TIMEOUT = 10
+SHUTDOWN_TIMEOUT = 5
 
 @pytest.mark.rostest
 @launch_testing.markers.keep_alive
@@ -85,11 +89,12 @@ class TestRos2BagRecord(unittest.TestCase):
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
-                timeout=5)
-        bag_command.wait_for_shutdown(timeout=5)
+                timeout=OUTPUT_WAIT_TIMEOUT)
+        bag_command.wait_for_shutdown(timeout=SHUTDOWN_TIMEOUT)
         assert bag_command.terminated
         matches = expected_string_regex.search(bag_command.output)
-        assert matches, print('ros2bag CLI did not produce the expected output')
+        assert matches, print(
+                ERROR_STRING_MSG.format(expected_string_regex.pattern, bag_command.output))
 
     def test_incomplete_qos_profile(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_profile.yaml'
@@ -101,11 +106,12 @@ class TestRos2BagRecord(unittest.TestCase):
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
-                timeout=5)
-        bag_command.wait_for_shutdown(timeout=5)
+                timeout=OUTPUT_WAIT_TIMEOUT)
+        bag_command.wait_for_shutdown(timeout=SHUTDOWN_TIMEOUT)
         assert bag_command.terminated
         matches = expected_string_regex.search(bag_command.output)
-        assert matches, print('ros2bag CLI did not produce the expected output')
+        assert matches, print(
+                ERROR_STRING_MSG.format(expected_string_regex.pattern, bag_command.output))
 
     def test_incomplete_qos_duration(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_duration.yaml'
@@ -117,12 +123,13 @@ class TestRos2BagRecord(unittest.TestCase):
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
-                timeout=5)
-        bag_command.wait_for_shutdown(timeout=5)
+                timeout=OUTPUT_WAIT_TIMEOUT)
+        bag_command.wait_for_shutdown(timeout=SHUTDOWN_TIMEOUT)
         assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
         matches = expected_string_regex.search(bag_command.output)
-        assert matches, print('ros2bag CLI did not produce the expected output')
+        assert matches, print(
+                ERROR_STRING_MSG.format(expected_string_regex.pattern, bag_command.output))
 
     def test_nonexistent_qos_profile(self):
         profile_path = PROFILE_PATH / 'foobar.yaml'
@@ -134,9 +141,11 @@ class TestRos2BagRecord(unittest.TestCase):
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_string_regex.search(output) is not None,
-                timeout=5)
-        bag_command.wait_for_shutdown(timeout=5)
+                timeout=OUTPUT_WAIT_TIMEOUT)
+        bag_command.wait_for_shutdown(timeout=SHUTDOWN_TIMEOUT)
         assert bag_command.terminated
         assert bag_command.exit_code != launch_testing.asserts.EXIT_OK
         matches = expected_string_regex.search(bag_command.output)
-        assert matches, print('ros2bag CLI did not produce the expected output')
+        assert matches, print(
+                ERROR_STRING_MSG.format(expected_string_regex.pattern, bag_command.output))
+

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -38,9 +38,9 @@ TEST_NODE = 'ros2bag_record_qos_profile_test_node'
 TEST_NAMESPACE = 'ros2bag_record_qos_profile'
 ERROR_STRING_MSG = 'ros2bag CLI did not produce the expected output'\
         '\n Expected output pattern: {}\n Actual output: {}'
-
 OUTPUT_WAIT_TIMEOUT = 10
 SHUTDOWN_TIMEOUT = 5
+
 
 @pytest.mark.rostest
 @launch_testing.markers.keep_alive
@@ -148,4 +148,3 @@ class TestRos2BagRecord(unittest.TestCase):
         matches = expected_string_regex.search(bag_command.output)
         assert matches, print(
                 ERROR_STRING_MSG.format(expected_string_regex.pattern, bag_command.output))
-

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -81,11 +81,12 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_basic'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-
-        expected_string_regex = re.compile(r"\[rosbag2_storage]: Opened database .* for READ_WRITE")
-        output_condition = lambda output: expected_string_regex.search(output) is not None
+        expected_string_regex = re.compile(
+            r'\[rosbag2_storage]: Opened database .* for READ_WRITE')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            condition_result = bag_command.wait_for_output(
+                condition=lambda output: expected_string_regex.search(output) is not None,
+                timeout=5)
             assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
@@ -95,10 +96,12 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_string_regex = re.compile(r"\[rosbag2_storage]: Opened database .* for READ_WRITE")
-        output_condition = lambda output: expected_string_regex.search(output) is not None
+        expected_string_regex = re.compile(
+            r'\[rosbag2_storage]: Opened database .* for READ_WRITE')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            condition_result = bag_command.wait_for_output(
+                condition=lambda output: expected_string_regex.search(output) is not None,
+                timeout=5)
             assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
@@ -108,10 +111,12 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete_duration'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_string_regex = re.compile(r"\[ERROR] \[ros2bag]: Time overrides must include both")
-        output_condition = lambda output: expected_string_regex.search(output) is not None 
+        expected_string_regex = re.compile(
+            r'\[ERROR] \[ros2bag]: Time overrides must include both')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            condition_result = bag_command.wait_for_output(
+                condition=lambda output: expected_string_regex.search(output) is not None,
+                timeout=5)
             assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated
@@ -123,10 +128,11 @@ class TestRos2BagRecord(unittest.TestCase):
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         expected_string_regex = re.compile(
-            r"ros2 bag record: error: argument --qos-profile-overrides-path: can't open")
-        output_condition = lambda output: expected_string_regex.search(output) is not None
+            r'ros2 bag record: error: argument --qos-profile-overrides-path: can\'t open')
         with self.launch_bag_command(arguments=arguments) as bag_command:
-            condition_result = bag_command.wait_for_output(condition=output_condition, timeout=3)
+            condition_result = bag_command.wait_for_output(
+                condition=lambda output: expected_string_regex.search(output) is not None,
+                timeout=5)
             assert condition_result, print('ros2bag CLI did not produce the expected output')
         bag_command.wait_for_shutdown(timeout=5)
         assert bag_command.terminated


### PR DESCRIPTION
Tries to fix #454 

Looks to me that the original problem described at #454 was probably addressed by #466 
However, before #466, there was #462 which moved from using different temp directory per test to using one temp directory for all the tests - this PR also introduced the `time.sleep` within each test and also one within the cleanup block (which deletes the temp directory)

In this PR:
- I've moved from using `time.sleep` within each tests to using `bag_command.wait_for_output` which essentially waits for the given timeout number or seconds for the expected output. This waiting needs to be done one way or another to give the process enough time to execute and print whatever it needs to.
- I've also improved on the test conditions. For eg: `test_qos_simple` and `test_incomplete_qos_profile` were only testing if the `bag_command.output` was NOT of the format `[ERROR] [ros2bag]`. This causes a bug where the test will pass even if bag_command.output is empty ~ which can happen if the process is exited immediately i.e replace `time.sleep(3)` with a `pass`