### PR TITLE
Remove some code duplication between SequentialWriter and SequentialCompressionWriter

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -65,6 +65,17 @@ public:
   ~SequentialCompressionWriter() override;
 
   /**
+   * Opens a new bagfile and prepare it for writing messages. The bagfile must not exist.
+   * This must be called before any other function is used.
+   *
+   * \param storage_options Options to configure the storage
+   * \param converter_options options to define in which format incoming messages are stored
+   **/
+  void open(
+    const rosbag2_cpp::StorageOptions & storage_options,
+    const rosbag2_cpp::ConverterOptions & converter_options) override;
+
+  /**
    * Attempt to compress the last open file and reset the storage and storage factory.
    * This method must be exception safe because it is called by the destructor.
    */
@@ -92,10 +103,6 @@ protected:
    * \throws std::invalid_argument if compression_options isn't supported.
    */
   virtual void setup_compression();
-
-  void prepare_to_open(
-    const rosbag2_cpp::StorageOptions & storage_options,
-    const rosbag2_cpp::ConverterOptions & converter_options) override;
 
 private:
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -25,7 +25,7 @@
 #include "rosbag2_cpp/serialization_format_converter_factory.hpp"
 #include "rosbag2_cpp/serialization_format_converter_factory_interface.hpp"
 #include "rosbag2_cpp/storage_options.hpp"
-#include "rosbag2_cpp/writer_interfaces/base_writer_interface.hpp"
+#include "rosbag2_cpp/writers/sequential_writer.hpp"
 
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
@@ -48,7 +48,7 @@ namespace rosbag2_compression
 {
 
 class ROSBAG2_COMPRESSION_PUBLIC SequentialCompressionWriter
-  : public rosbag2_cpp::writer_interfaces::BaseWriterInterface
+  : public rosbag2_cpp::writers::SequentialWriter
 {
 public:
   explicit SequentialCompressionWriter(
@@ -82,25 +82,6 @@ public:
   void reset() override;
 
   /**
-   * Create a new topic in the underlying storage. Needs to be called for every topic used within
-   * a message which is passed to write(...).
-   *
-   * \param topic_with_type name and type identifier of topic to be created
-   * \throws runtime_error if the Writer is not open.
-   */
-  void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type) override;
-
-  /**
-   * Remove a new topic in the underlying storage.
-   * If creation of subscription fails remove the topic
-   * from the db (more of cleanup)
-   *
-   * \param topic_with_type name and type identifier of topic to be created
-   * \throws runtime_error if the Writer is not open.
-   */
-  void remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type) override;
-
-  /**
    * Write a message to a bagfile. The topic needs to have been created before writing is possible.
    *
    * \param message to be written to the bagfile
@@ -132,38 +113,20 @@ protected:
   virtual void setup_compression();
 
 private:
-  std::string base_folder_;
-  std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_{};
-  std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory_{};
-  std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_{};
-  std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
-  std::unique_ptr<rosbag2_cpp::Converter> converter_{};
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};
   std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
-
-  // Used in bagfile splitting; specifies the best-effort maximum sub-section of a bagfile in bytes.
-  uint64_t max_bagfile_size_{rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT};
-
-  // Used to track topic -> message count
-  std::unordered_map<std::string, rosbag2_storage::TopicInformation> topics_names_to_info_{};
-
-  rosbag2_storage::BagMetadata metadata_{};
 
   rosbag2_compression::CompressionOptions compression_options_{};
 
   bool should_compress_last_file_{true};
 
   // Closes the current backed storage and opens the next bagfile.
-  void split_bagfile();
-
-  // Checks if the current recording bagfile needs to be split and rolled over to a new file.
-  bool should_split_bagfile() const;
+  void split_bagfile() override;
 
   // Prepares the metadata by setting initial values.
-  void init_metadata();
-
-  // Record TopicInformation into metadata
-  void finalize_metadata();
+  void init_metadata() override;
 };
+
 }  // namespace rosbag2_compression
+
 #endif  // ROSBAG2_COMPRESSION__SEQUENTIAL_COMPRESSION_WRITER_HPP_

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -65,17 +65,6 @@ public:
   ~SequentialCompressionWriter() override;
 
   /**
-   * Opens a new bagfile and prepare it for writing messages. The bagfile must not exist.
-   * This must be called before any other function is used.
-   *
-   * \param storage_options Options to configure the storage
-   * \param converter_options options to define in which format incoming messages are stored
-   **/
-  void open(
-    const rosbag2_cpp::StorageOptions & storage_options,
-    const rosbag2_cpp::ConverterOptions & converter_options) override;
-
-  /**
    * Attempt to compress the last open file and reset the storage and storage factory.
    * This method must be exception safe because it is called by the destructor.
    */
@@ -103,6 +92,10 @@ protected:
    * \throws std::invalid_argument if compression_options isn't supported.
    */
   virtual void setup_compression();
+
+  void prepare_to_open(
+    const rosbag2_cpp::StorageOptions & storage_options,
+    const rosbag2_cpp::ConverterOptions & converter_options) override;
 
 private:
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -81,14 +81,6 @@ public:
    */
   void reset() override;
 
-  /**
-   * Write a message to a bagfile. The topic needs to have been created before writing is possible.
-   *
-   * \param message to be written to the bagfile
-   * \throws runtime_error if the Writer is not open.
-   */
-  void write(std::shared_ptr<rosbag2_storage::SerializedBagMessage> message) override;
-
 protected:
   /**
    * Compress the most recent file and update the metadata file path.
@@ -125,6 +117,13 @@ private:
 
   // Prepares the metadata by setting initial values.
   void init_metadata() override;
+
+  // Helper method used by write to get the message in a format that is ready to be written.
+  // Common use cases include converting the message using the converter or
+  // performing other operations like compression on it
+  std::shared_ptr<rosbag2_storage::SerializedBagMessage>
+  get_writeable_message(
+    std::shared_ptr<rosbag2_storage::SerializedBagMessage> message) override;
 };
 
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -95,13 +95,12 @@ void SequentialCompressionWriter::setup_compression()
   compressor_ = compression_factory_->create_compressor(compression_options_.compression_format);
 }
 
-void SequentialCompressionWriter::open(
+void SequentialCompressionWriter::prepare_to_open(
   const rosbag2_cpp::StorageOptions & storage_options,
   const rosbag2_cpp::ConverterOptions & converter_options)
 {
-  prepare_to_open(storage_options, converter_options);
+  SequentialWriter::prepare_to_open(storage_options, converter_options);
   setup_compression();
-  init_metadata();
 }
 
 void SequentialCompressionWriter::reset()

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -53,9 +53,7 @@ std::string format_storage_uri(const std::string & base_folder, uint64_t storage
 
 SequentialCompressionWriter::SequentialCompressionWriter(
   const rosbag2_compression::CompressionOptions & compression_options)
-: storage_factory_{std::make_unique<rosbag2_storage::StorageFactory>()},
-  converter_factory_{std::make_shared<rosbag2_cpp::SerializationFormatConverterFactory>()},
-  metadata_io_{std::make_unique<rosbag2_storage::MetadataIo>()},
+: SequentialWriter(),
   compression_factory_{std::make_unique<rosbag2_compression::CompressionFactory>()},
   compression_options_{compression_options}
 {}
@@ -66,9 +64,7 @@ SequentialCompressionWriter::SequentialCompressionWriter(
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
   std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory,
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
-: storage_factory_{std::move(storage_factory)},
-  converter_factory_{std::move(converter_factory)},
-  metadata_io_{std::move(metadata_io)},
+: SequentialWriter(std::move(storage_factory), converter_factory, std::move(metadata_io)),
   compression_factory_{std::move(compression_factory)},
   compression_options_{compression_options}
 {}
@@ -103,46 +99,7 @@ void SequentialCompressionWriter::open(
   const rosbag2_cpp::StorageOptions & storage_options,
   const rosbag2_cpp::ConverterOptions & converter_options)
 {
-  max_bagfile_size_ = storage_options.max_bagfile_size;
-  base_folder_ = storage_options.uri;
-
-  if (converter_options.output_serialization_format !=
-    converter_options.input_serialization_format)
-  {
-    converter_ = std::make_unique<rosbag2_cpp::Converter>(converter_options, converter_factory_);
-  }
-
-  rcpputils::fs::path db_path(base_folder_);
-  if (db_path.is_directory()) {
-    std::stringstream error;
-    error << "Database directory already exists (" << db_path.string() <<
-      "), can't overwrite existing database";
-    throw std::runtime_error{error.str()};
-  }
-
-  bool dir_created = rcpputils::fs::create_directories(db_path);
-  if (!dir_created) {
-    std::stringstream error;
-    error << "Failed to create database directory (" << db_path.string() << ").";
-    throw std::runtime_error{error.str()};
-  }
-
-  const auto storage_uri = format_storage_uri(base_folder_, 0);
-  storage_ = storage_factory_->open_read_write(storage_uri, storage_options.storage_id);
-  if (!storage_) {
-    throw std::runtime_error{"No storage could be initialized. Abort"};
-  }
-
-  if (max_bagfile_size_ != 0 &&
-    max_bagfile_size_ < storage_->get_minimum_split_file_size())
-  {
-    std::stringstream error;
-    error << "Invalid bag splitting size given. Please provide a value greater than " <<
-      storage_->get_minimum_split_file_size() << ". Specified value of " <<
-      storage_options.max_bagfile_size;
-    throw std::runtime_error{error.str()};
-  }
-
+  prepare_to_open(storage_options, converter_options);
   setup_compression();
   init_metadata();
 }
@@ -168,52 +125,6 @@ void SequentialCompressionWriter::reset()
 
   storage_.reset();  // Necessary to ensure that the storage is destroyed before the factory
   storage_factory_.reset();
-}
-
-void SequentialCompressionWriter::create_topic(
-  const rosbag2_storage::TopicMetadata & topic_with_type)
-{
-  if (!storage_) {
-    throw std::runtime_error{"Bag is not open. Call open() before writing."};
-  }
-
-  if (converter_) {
-    converter_->add_topic(topic_with_type.name, topic_with_type.type);
-  }
-
-  if (topics_names_to_info_.find(topic_with_type.name) ==
-    topics_names_to_info_.end())
-  {
-    rosbag2_storage::TopicInformation info{};
-    info.topic_metadata = topic_with_type;
-
-    const auto insert_res = topics_names_to_info_.insert(
-      std::make_pair(topic_with_type.name, info));
-
-    if (!insert_res.second) {
-      std::stringstream errmsg;
-      errmsg << "Failed to insert topic \"" << topic_with_type.name << "\"!";
-      throw std::runtime_error{errmsg.str()};
-    }
-
-    storage_->create_topic(topic_with_type);
-  }
-}
-
-void SequentialCompressionWriter::remove_topic(
-  const rosbag2_storage::TopicMetadata & topic_with_type)
-{
-  if (!storage_) {
-    throw std::runtime_error{"Bag is not open. Call open() before removing."};
-  }
-
-  if (topics_names_to_info_.erase(topic_with_type.name) > 0) {
-    storage_->remove_topic(topic_with_type);
-  } else {
-    std::stringstream errmsg;
-    errmsg << "Failed to remove the non-existing topic \"" << topic_with_type.name << "\"!";
-    throw std::runtime_error{errmsg.str()};
-  }
 }
 
 void SequentialCompressionWriter::compress_last_file()
@@ -309,37 +220,6 @@ void SequentialCompressionWriter::write(
   }
 
   storage_->write(converted_message);
-}
-
-bool SequentialCompressionWriter::should_split_bagfile() const
-{
-  if (max_bagfile_size_ == rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT) {
-    return false;
-  } else {
-    return storage_->get_bagfile_size() > max_bagfile_size_;
-  }
-}
-
-void SequentialCompressionWriter::finalize_metadata()
-{
-  metadata_.bag_size = 0;
-
-  for (const auto & path : metadata_.relative_file_paths) {
-    const auto bag_path = rcpputils::fs::path{path};
-
-    if (bag_path.exists()) {
-      metadata_.bag_size += bag_path.file_size();
-    }
-  }
-
-  metadata_.topics_with_message_count.clear();
-  metadata_.topics_with_message_count.reserve(topics_names_to_info_.size());
-  metadata_.message_count = 0;
-
-  for (const auto & topic : topics_names_to_info_) {
-    metadata_.topics_with_message_count.push_back(topic.second);
-    metadata_.message_count += topic.second.message_count;
-  }
 }
 
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -95,13 +95,14 @@ void SequentialCompressionWriter::setup_compression()
   compressor_ = compression_factory_->create_compressor(compression_options_.compression_format);
 }
 
-void SequentialCompressionWriter::prepare_to_open(
+void SequentialCompressionWriter::open(
   const rosbag2_cpp::StorageOptions & storage_options,
   const rosbag2_cpp::ConverterOptions & converter_options)
 {
-  SequentialWriter::prepare_to_open(storage_options, converter_options);
+  SequentialWriter::open(storage_options, converter_options);
   setup_compression();
 }
+
 
 void SequentialCompressionWriter::reset()
 {

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -139,10 +139,6 @@ protected:
   // Record TopicInformation into metadata
   void finalize_metadata();
 
-  // Helper function used by open
-  virtual void prepare_to_open(
-    const StorageOptions & storage_options, const ConverterOptions & converter_options);
-
   // Helper method used by write to get the message in a format that is ready to be written.
   // Common use cases include converting the message using the converter or
   // performing other operations like compression on it

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -140,7 +140,7 @@ protected:
   void finalize_metadata();
 
   // Helper function used by open
-  void prepare_to_open(
+  virtual void prepare_to_open(
     const StorageOptions & storage_options, const ConverterOptions & converter_options);
 
   // Helper method used by write to get the message in a format that is ready to be written.

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -142,6 +142,13 @@ protected:
   // Helper function used by open
   void prepare_to_open(
     const StorageOptions & storage_options, const ConverterOptions & converter_options);
+
+  // Helper method used by write to get the message in a format that is ready to be written.
+  // Common use cases include converting the message using the converter or
+  // performing other operations like compression on it
+  virtual std::shared_ptr<rosbag2_storage::SerializedBagMessage>
+  get_writeable_message(
+    std::shared_ptr<rosbag2_storage::SerializedBagMessage> message);
 };
 
 }  // namespace writers

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -102,7 +102,7 @@ public:
    */
   void write(std::shared_ptr<rosbag2_storage::SerializedBagMessage> message) override;
 
-private:
+protected:
   std::string base_folder_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
@@ -128,16 +128,20 @@ private:
   rosbag2_storage::BagMetadata metadata_;
 
   // Closes the current backed storage and opens the next bagfile.
-  void split_bagfile();
+  virtual void split_bagfile();
 
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
   bool should_split_bagfile() const;
 
   // Prepares the metadata by setting initial values.
-  void init_metadata();
+  virtual void init_metadata();
 
   // Record TopicInformation into metadata
   void finalize_metadata();
+
+  // Helper function used by open
+  void prepare_to_open(
+    const StorageOptions & storage_options, const ConverterOptions & converter_options);
 };
 
 }  // namespace writers

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -81,7 +81,7 @@ void SequentialWriter::init_metadata()
   metadata_.relative_file_paths = {strip_parent_path(storage_->get_relative_file_path())};
 }
 
-void SequentialWriter::prepare_to_open(
+void SequentialWriter::open(
   const StorageOptions & storage_options,
   const ConverterOptions & converter_options)
 {
@@ -129,13 +129,7 @@ void SequentialWriter::prepare_to_open(
       storage_options.max_bagfile_size;
     throw std::runtime_error{error.str()};
   }
-}
 
-void SequentialWriter::open(
-  const StorageOptions & storage_options,
-  const ConverterOptions & converter_options)
-{
-  prepare_to_open(storage_options, converter_options);
   init_metadata();
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -81,7 +81,7 @@ void SequentialWriter::init_metadata()
   metadata_.relative_file_paths = {strip_parent_path(storage_->get_relative_file_path())};
 }
 
-void SequentialWriter::open(
+void SequentialWriter::prepare_to_open(
   const StorageOptions & storage_options,
   const ConverterOptions & converter_options)
 {
@@ -129,7 +129,13 @@ void SequentialWriter::open(
       storage_options.max_bagfile_size;
     throw std::runtime_error{error.str()};
   }
+}
 
+void SequentialWriter::open(
+  const StorageOptions & storage_options,
+  const ConverterOptions & converter_options)
+{
+  prepare_to_open(storage_options, converter_options);
   init_metadata();
 }
 


### PR DESCRIPTION
[Edited] Major changes:
- `SequentialCompressionWriter` now inherits from `SequentialWriter`
- New method `get_writeable_message` inside of `SequentialWriter` to be called to get the message to be written to storage or cache