### PR TITLE
Fix rosbag2_py on Windows debug and stop ignoring the package

### DIFF
--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -16,12 +16,29 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(pybind11 REQUIRED)
-find_package(python_cmake_module REQUIRED)
 find_package(rosbag2_compression REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_storage REQUIRED)
+
+# Find python before pybind11
+find_package(python_cmake_module REQUIRED)
+find_package(PythonExtra REQUIRED)
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # Set the python debug interpreter.
+  # pybind11 will setup the build for debug now.
+  set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+endif()
+
+find_package(pybind11 REQUIRED)
+
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # pybind11 logic for setting up a debug build when both a debug and release
+  # python interpreter are present in the system seems to be pretty much broken.
+  # This works around the issue.
+  set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
+endif()
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -79,9 +96,10 @@ if(BUILD_TESTING)
       PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}
       ${other_environment_vars}
   )
-  ament_add_pytest_test(test_sequential_writer_py "test/test_sequential_writer.py"
+  ament_add_pytest_test(test_sequential_writer_py
+    "test/test_sequential_writer.py"
     PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
-    APPEND_ENV "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}" ${other_environment_vars}
+    APPEND_ENV "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}" ${other_environment_vars}
   )
 endif()
 

--- a/rosbag2_py/package.xml
+++ b/rosbag2_py/package.xml
@@ -11,9 +11,10 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <depend>pybind11_vendor</depend>
-  <depend>python_cmake_module</depend>
   <depend>rosbag2_compression</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>
@@ -27,9 +28,7 @@
   <test_depend>rclpy</test_depend>
   <test_depend>rosbag2_converter_default_plugins</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>
-  <test_depend>rosbag2_storage</test_depend>
   <test_depend>rosidl_runtime_py</test_depend>
-  <test_depend>rpyutils</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
~~Depends on https://github.com/ros2/rosbag2/pull/529~~.

Fixes #504.
This deletes the `AMENT_IGNORE` file in `rosbag2_py` folder, as the two issues has been fixed now.