### PR TITLE
Change default cache size for sequential_writer to a non zero value

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -70,7 +70,8 @@ class RecordVerb(VerbExtension):
             '--max-cache-size', type=int, default=1024*1024,
             help='maximum size (in bytes) of messages to hold in cache before writing to disk. '
                  'Default is 1 mebibyte, everytime the cache size equals or exceeds 1MB, '
-                 'it will be written to disk'
+                 'it will be written to disk. If the value specified is 0, then every message is'
+                 'directly written to disk.'
         )
         parser.add_argument(
             '--compression-mode', type=str, default='none',

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -67,9 +67,10 @@ class RecordVerb(VerbExtension):
                   'the bag will split at whichever threshold is reached first.'
         )
         parser.add_argument(
-            '--max-cache-size', type=int, default=0,
-            help='maximum amount of messages to hold in cache before writing to disk. '
-                 'Default it is zero, writing every message directly to disk.'
+            '--max-cache-size', type=int, default=1024*1024,
+            help='maximum size (in bytes) of messages to hold in cache before writing to disk. '
+                 'Default is 1 mebibyte, everytime the cache size equals or exceeds 1MB, '
+                 'it will be written to disk'
         )
         parser.add_argument(
             '--compression-mode', type=str, default='none',

--- a/rosbag2_cpp/include/rosbag2_cpp/storage_options.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/storage_options.hpp
@@ -36,7 +36,7 @@ public:
 
   // The cache size indiciates how many messages can maximally be hold in cache
   // before these being written to disk.
-  // Defaults to 0, and effectively disables the caching.
+  // A value of 0 disables caching and every write happens directly to disk.
   uint64_t max_cache_size = 0;
 };
 

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -40,8 +40,6 @@ void Reader::open(const std::string & uri)
   rosbag2_cpp::StorageOptions storage_options;
   storage_options.uri = uri;
   storage_options.storage_id = "sqlite3";
-  storage_options.max_bagfile_size = 0;  // default
-  storage_options.max_cache_size = 0;  // default
 
   rosbag2_cpp::ConverterOptions converter_options{};
   return open(storage_options, converter_options);

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -67,6 +67,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
   cmd << "ros2 bag record" <<
     " --compression-mode file" <<
     " --compression-format zstd" <<
+    " --max-cache-size 0" <<
     " --output " << root_bag_path_.string() <<
     " " << topic_name;
 
@@ -117,7 +118,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   wrong_message->string_value = "wrong_content";
 
   auto process_handle = start_execution(
-    "ros2 bag record --output " + root_bag_path_.string() + " /test_topic");
+    "ros2 bag record --max-cache-size 0 --output " + root_bag_path_.string() + " /test_topic");
   wait_for_db();
 
   pub_man_.add_publisher("/test_topic", message, expected_test_messages);


### PR DESCRIPTION
**MERGE AFTER PR #530**

Currently, the default cache size for the `sequential_writer` is 0 which leads to a write to disk on every `write` call. This PR aims at changing that default value to 1MB [or any other value greater than 0]

Addresses #464 

_**A note on changing the default value**: This PR focuses on changing the default cache size when rosbag2 is invoked using the CLI. As for situations where a user might directly use the library, there is no mention of default but a note that a value of 0 will force all writes to disk._

For quick reference, these are all the files where `max_cache_size` is used/set:
- [rosbag2_py/_storage.cpp](https://github.com/ros2/rosbag2/blob/5150a736417ff6f0103f7e713dbb5001cad4949b/rosbag2_py/src/rosbag2_py/_storage.cpp#L47)
- [rosbag2_transport/rosbag2_transport_python.cpp](https://github.com/ros2/rosbag2/blob/19946e100dc19ae631966cd61fe1bb1d88c7080d/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp#L120)
- [rosbag2_cpp/storage_options.hpp](https://github.com/ros2/rosbag2/blob/19946e100dc19ae631966cd61fe1bb1d88c7080d/rosbag2_cpp/include/rosbag2_cpp/storage_options.hpp#L40)
- [rosbag2_cpp/reader.cpp](https://github.com/ros2/rosbag2/blob/546eb7c5182591a8c7f296c98ef3c06bb9aaccae/rosbag2_cpp/src/rosbag2_cpp/reader.cpp#L44)
- [ros2bag/verb/record.py](https://github.com/ros2/rosbag2/blob/d460c1f837a0a3030c26c45c9f563ee966ddb568/ros2bag/ros2bag/verb/record.py#L70)