### PR TITLE
 Workaround pybind11 bug on Windows when CMAKE_BUILD_TYPE=RelWithDebInfo

### DIFF
--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -54,13 +54,13 @@ function(clean_windows_flags target)
   # - https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=vs-2019
 
   if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
-    get_target_property(target_link_flags ${target} LINK_FLAGS)
-    string(REPLACE "-LTCG" "" target_link_flags ${target_link_flags})
-    set_target_properties(${target} PROPERTIES LINK_FLAGS ${target_link_flags})
+    get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
+    string(REPLACE "-LTCG" "" target_link_libraries ${target_link_libraries})
+    set_target_properties(${target} PROPERTIES LINK_LIBRARIES ${target_link_libraries})
 
-    get_target_property(target_compile_flags ${target} COMPILE_FLAGS)
-    string(REPLACE "/GL" "" target_compile_flags ${target_compile_flags})
-    set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${target_compile_flags})
+    get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
+    string(REPLACE "/GL" "" target_compile_options ${target_compile_options})
+    set_target_properties(${target} PROPERTIES COMPILE_OPTIONS ${target_compile_options})
   endif()
 endfunction()
 

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -56,11 +56,11 @@ function(clean_windows_flags target)
   if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
     list(REMOVE_ITEM target_link_libraries "-LTCG")
-    set_target_properties(${target} PROPERTIES LINK_LIBRARIES ${target_link_libraries})
+    set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${target_link_libraries}")
 
     get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
     list(REMOVE_ITEM target_compile_options "/GL")
-    set_target_properties(${target} PROPERTIES COMPILE_OPTIONS ${target_compile_options})
+    set_target_properties(${target} PROPERTIES COMPILE_OPTIONS "${target_compile_options}")
   endif()
 endfunction()
 

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -54,12 +54,13 @@ function(clean_windows_link_flags target)
   # - https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=vs-2019
 
   if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
-    get_target_property(target_link_flags ${target_name} LINK_FLAGS)
-    get_target_property(target_compile_flags ${target_name} COMPILE_FLAGS)
-    string(REPLACE "/GL" "" target_compile_flags ${target_compile_flags})
+    get_target_property(target_link_flags ${target} LINK_FLAGS)
     string(REPLACE "-LTCG" "" target_link_flags ${target_link_flags})
-    set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${target_compile_flags})
     set_target_properties(${target} PROPERTIES LINK_FLAGS ${target_link_flags})
+
+    get_target_property(target_compile_flags ${target} COMPILE_FLAGS)
+    string(REPLACE "/GL" "" target_compile_flags ${target_compile_flags})
+    set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${target_compile_flags})
   endif()
 endfunction()
 

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -55,11 +55,11 @@ function(clean_windows_flags target)
 
   if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
-    list(REMOVE_ITEM target_link_libraries "-LTCG")
+    list(REMOVE_ITEM target_link_libraries "$<$<NOT:$<CONFIG:Debug>>:-LTCG>")
     set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${target_link_libraries}")
 
     get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
-    list(REMOVE_ITEM target_compile_options "/GL")
+    list(REMOVE_ITEM target_compile_options "$<$<NOT:$<CONFIG:Debug>>:/GL>")
     set_target_properties(${target} PROPERTIES COMPILE_OPTIONS "${target_compile_options}")
   endif()
 endfunction()

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -40,6 +40,29 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
 endif()
 
+function(clean_windows_link_flags target)
+  # More hacks to avoid pybind11 issues, similar to (but not the same)
+  # https://github.com/pybind/pybind11/issues/77.
+  # They are enabling /LTCG on Windows to reduce binary size,
+  # but that doesn't play well with incremental builds (default for Debug/RelWithDebInfo).
+  #
+  # Line of the bug (flags shouldn't be set when CONFIG is RELWITHDEBINFO).
+  # https://github.com/pybind/pybind11/blob/3b1dbebabc801c9cf6f0953a4c20b904d444f879/tools/pybind11Tools.cmake#L103-L108
+  #
+  # See:
+  # - https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=vs-2019
+  # - https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=vs-2019
+
+  if(MSVC AND ${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo)
+    get_target_property(target_link_flags ${target_name} LINK_FLAGS)
+    get_target_property(target_compile_flags ${target_name} COMPILE_FLAGS)
+    string(REPLACE "/GL" "" target_compile_flags ${target_compile_flags})
+    string(REPLACE "-LTCG" "" target_link_flags ${target_link_flags})
+    set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${target_compile_flags})
+    set_target_properties(${target} PROPERTIES LINK_FLAGS ${target_link_flags})
+  endif()
+endfunction()
+
 ament_python_install_package(${PROJECT_NAME})
 
 pybind11_add_module(_reader SHARED
@@ -49,6 +72,7 @@ ament_target_dependencies(_reader PUBLIC
   "rosbag2_compression"
   "rosbag2_cpp"
 )
+clean_windows_link_flags(_reader)
 
 pybind11_add_module(_storage SHARED
   src/rosbag2_py/_storage.cpp
@@ -57,6 +81,7 @@ ament_target_dependencies(_storage PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
+clean_windows_link_flags(_reader)
 
 pybind11_add_module(_writer SHARED
   src/rosbag2_py/_writer.cpp
@@ -65,6 +90,7 @@ ament_target_dependencies(_writer PUBLIC
   "rosbag2_compression"
   "rosbag2_cpp"
 )
+clean_windows_link_flags(_reader)
 
 # Install cython modules as sub-modules of the project
 install(

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -40,7 +40,7 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
 endif()
 
-function(clean_windows_link_flags target)
+function(clean_windows_flags target)
   # More hacks to avoid pybind11 issues, similar to (but not the same)
   # https://github.com/pybind/pybind11/issues/77.
   # They are enabling /LTCG on Windows to reduce binary size,
@@ -73,7 +73,7 @@ ament_target_dependencies(_reader PUBLIC
   "rosbag2_compression"
   "rosbag2_cpp"
 )
-clean_windows_link_flags(_reader)
+clean_windows_flags(_reader)
 
 pybind11_add_module(_storage SHARED
   src/rosbag2_py/_storage.cpp
@@ -82,7 +82,7 @@ ament_target_dependencies(_storage PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
-clean_windows_link_flags(_storage)
+clean_windows_flags(_storage)
 
 pybind11_add_module(_writer SHARED
   src/rosbag2_py/_writer.cpp
@@ -91,7 +91,7 @@ ament_target_dependencies(_writer PUBLIC
   "rosbag2_compression"
   "rosbag2_cpp"
 )
-clean_windows_link_flags(_writer)
+clean_windows_flags(_writer)
 
 # Install cython modules as sub-modules of the project
 install(

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -41,13 +41,14 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 function(clean_windows_flags target)
-  # More hacks to avoid pybind11 issues, similar to (but not the same)
-  # https://github.com/pybind/pybind11/issues/77.
+  # Hack to avoid pybind11 issue.
+  #
+  # TODO(ivanpauno):
+  # This can be deleted when we update `pybind11_vendor` to a version including
+  # https://github.com/pybind/pybind11/pull/2590.
+  #
   # They are enabling /LTCG on Windows to reduce binary size,
   # but that doesn't play well with MSVC incremental linking (default for Debug/RelWithDebInfo).
-  #
-  # Line of the bug (those options shouldn't be set when CONFIG is RELWITHDEBINFO).
-  # https://github.com/pybind/pybind11/blob/3b1dbebabc801c9cf6f0953a4c20b904d444f879/tools/pybind11Tools.cmake#L103-L108
   #
   # See:
   # - https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=vs-2019

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -53,7 +53,7 @@ function(clean_windows_link_flags target)
   # - https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=vs-2019
   # - https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=vs-2019
 
-  if(MSVC AND ${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo)
+  if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     get_target_property(target_link_flags ${target_name} LINK_FLAGS)
     get_target_property(target_compile_flags ${target_name} COMPILE_FLAGS)
     string(REPLACE "/GL" "" target_compile_flags ${target_compile_flags})

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -55,11 +55,11 @@ function(clean_windows_flags target)
 
   if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
-    string(REPLACE "-LTCG" "" target_link_libraries ${target_link_libraries})
+    list(REMOVE_ITEM target_link_libraries "-LTCG")
     set_target_properties(${target} PROPERTIES LINK_LIBRARIES ${target_link_libraries})
 
     get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
-    string(REPLACE "/GL" "" target_compile_options ${target_compile_options})
+    list(REMOVE_ITEM target_compile_options "/GL")
     set_target_properties(${target} PROPERTIES COMPILE_OPTIONS ${target_compile_options})
   endif()
 endfunction()

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -81,7 +81,7 @@ ament_target_dependencies(_storage PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
-clean_windows_link_flags(_reader)
+clean_windows_link_flags(_storage)
 
 pybind11_add_module(_writer SHARED
   src/rosbag2_py/_writer.cpp
@@ -90,7 +90,7 @@ ament_target_dependencies(_writer PUBLIC
   "rosbag2_compression"
   "rosbag2_cpp"
 )
-clean_windows_link_flags(_reader)
+clean_windows_link_flags(_writer)
 
 # Install cython modules as sub-modules of the project
 install(

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -44,9 +44,9 @@ function(clean_windows_flags target)
   # More hacks to avoid pybind11 issues, similar to (but not the same)
   # https://github.com/pybind/pybind11/issues/77.
   # They are enabling /LTCG on Windows to reduce binary size,
-  # but that doesn't play well with incremental builds (default for Debug/RelWithDebInfo).
+  # but that doesn't play well with MSVC incremental linking (default for Debug/RelWithDebInfo).
   #
-  # Line of the bug (flags shouldn't be set when CONFIG is RELWITHDEBINFO).
+  # Line of the bug (those options shouldn't be set when CONFIG is RELWITHDEBINFO).
   # https://github.com/pybind/pybind11/blob/3b1dbebabc801c9cf6f0953a4c20b904d444f879/tools/pybind11Tools.cmake#L103-L108
   #
   # See:


### PR DESCRIPTION
Another workaround for a pybind11 bug ...

I should start sending patches upstream (for this and https://github.com/ros2/rosbag2/issues/504).
When that gets included in a new pybind11 release, we can update our vendor package and get rid of these workarounds (I will open an issue to track that).

Though it failed in a packaging build, only `-DCMAKE_BUILD_TYPE=RelWithDebInfo` is needed to reproduce the issue:

* Windows RelWithDebInfo [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows/&build=12618)](http://ci.ros2.org/job/ci_windows/12618/)

~TODO: This still doesn't pass, I have to check more closely in a Windows VM.~ [CI is passing now](https://github.com/ros2/rosbag2/pull/538#issuecomment-706382379).

Fixes https://github.com/ros2/rosbag2/issues/537.