### PR TITLE
Updating performance writer

### DIFF
--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/CMakeLists.txt
@@ -19,6 +19,7 @@ if(BUILD_ROSBAG2_BENCHMARKS)
   find_package(rosbag2_storage REQUIRED)
   find_package(rmw REQUIRED)
   find_package(std_msgs REQUIRED)
+  find_package(yaml_cpp_vendor REQUIRED)
 
   add_executable(writer_benchmark src/writer_benchmark.cpp src/main.cpp)
   target_include_directories(writer_benchmark
@@ -30,6 +31,7 @@ if(BUILD_ROSBAG2_BENCHMARKS)
     rclcpp
     std_msgs
     rosbag2_cpp
+    yaml_cpp_vendor
   )
 
   install(TARGETS writer_benchmark

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/include/rosbag2_performance_writer_benchmarking/message_queue.hpp
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/include/rosbag2_performance_writer_benchmarking/message_queue.hpp
@@ -40,7 +40,6 @@ public:
     std::lock_guard<std::mutex> lock(mutex_);
     if (queue_.size() > max_size_) {  // We skip the element and consider it "lost"
       ++unsuccessful_insert_count_;
-      std::cerr << "X" << std::flush;
       return;
     }
     queue_.push(elem);

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/include/rosbag2_performance_writer_benchmarking/writer_benchmark.hpp
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/include/rosbag2_performance_writer_benchmarking/writer_benchmark.hpp
@@ -50,7 +50,6 @@ private:
   std::vector<std::shared_ptr<ByteMessageQueue>> queues_;
 
   std::string compression_format_;
-  rosbag2_compression::CompressionMode compression_mode_;
   uint64_t compression_queue_size_;
   uint64_t compression_threads_;
   std::shared_ptr<rosbag2_cpp::writers::SequentialWriter> writer_;

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/include/rosbag2_performance_writer_benchmarking/writer_benchmark.hpp
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/include/rosbag2_performance_writer_benchmarking/writer_benchmark.hpp
@@ -36,13 +36,14 @@ private:
   void create_producers(const ProducerConfig & config);
   void create_writer();
   void start_producers();
-  void write_results(const unsigned int & total_missed) const;
+  void write_results() const;
+  int get_message_count_from_metadata() const;
 
   ProducerConfig config_;
-  unsigned int max_cache_size_;
   unsigned int instances_;
-  std::string db_folder_;
   std::string results_file_;
+
+  rosbag2_storage::StorageOptions storage_options_;
   std::shared_ptr<rosbag2_cpp::writers::SequentialWriter> writer_;
   std::vector<std::thread> producer_threads_;
   std::vector<std::unique_ptr<ByteProducer>> producers_;

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/package.xml
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/package.xml
@@ -15,6 +15,7 @@
   <depend>rosbag2_cpp</depend>
   <depend>rmw</depend>
   <depend>std_msgs</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/benchmark.sh
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/benchmark.sh
@@ -13,42 +13,53 @@ mkdir -p ${test_dir}
 echo "${test_dir} created"
 db_path=${test_dir}/bag
 rm -fr ${db_path}
-summary_file=${test_dir}/results.csv
+script_dir=$(dirname $(readlink -f "$0"))
 
-freq=100; #Hz
+storage_config_dir=${script_dir}/storage_config
+config_optimized_path=${storage_config_dir}/storage_optimized.yaml
+config_default_path=${storage_config_dir}/storage_default.yaml
 
-for cache in 0 1000000 10000000 100000000
+for storage_config_file_path in ${config_optimized_path} ${config_default_path}
 do
-  for sz in 1000 10000 100000 1000000
+  config_file_name=$(basename $storage_config_file_path)
+  summary_file=${test_dir}/results_${config_file_name}.csv
+  for cache in 0 1000000 100000000 500000000
   do
-    for inst in 1 10 100 1000
+    for sz in 10000 100000 1000000 5000000
     do
-      let total=$inst*$sz
-      if [[ $total -ne 1000000 ]]; then
-        #echo "skipping the case of ${inst} instances and size ${sz}"
-        continue
-      fi
-      echo "processing case of ${inst} instances and size ${sz} with cache ${cache}"
-      for try in 1 2 3 4 5
+      for inst in 1 10 100 1000
       do
+        freq=100; #Hz
+        let total=$inst*$sz*$freq
+        if [[ $total -lt 100000000 || $total -gt 500000000 ]]; then
+          #echo "skipping the case of ${inst} instances and size ${sz}"
+          continue
+        fi
+        echo "processing case of ${inst} instances and size ${sz} with cache ${cache} and config ${config_file_name}"
         outdir=${test_dir}/size${sz}_inst${inst}_cache${cache}
         mkdir -p ${outdir}
-        outfile=${outdir}/${try}.log
-        echo "Results will be written to file: ${outfile}"
-        ros2 run rosbag2_performance_writer_benchmarking writer_benchmark --ros-args \
-          -p frequency:=${freq} \
-          -p size:=${sz} \
-          -p instances:=${inst} \
-          -p max_cache_size:=${cache} \
-          -p db_folder:=${db_path} \
-          -p results_file:=${summary_file} \
-          --ros-args -r __node:=rosbag2_performance_writer_benchmarking_node_batch \
-          2> ${outfile}
-        rm -fr ${db_path}
-        if [[ $ctrlc_sent -eq 1 ]]; then
-          echo -e "\e[31mQuitting prematurely due to Ctrl-C - some results aren't saved and some won't be reliable\e[0m]"
-          exit
-        fi
+        for try in 1 2 3
+        do
+          outfile=${outdir}/${try}.log
+          echo "Results will be written to file: ${outfile}"
+          ros2 run rosbag2_performance_writer_benchmarking writer_benchmark --ros-args \
+            -p frequency:=${freq} \
+            -p size:=${sz} \
+            -p instances:=${inst} \
+            -p max_cache_size:=${cache} \
+            -p db_folder:=${db_path} \
+            -p storage_config_file:=${storage_config_file_path} \
+            -p results_file:=${summary_file} \
+            --ros-args -r __node:=rosbag2_performance_writer_benchmarking_node_batch \
+            2> ${outfile}
+          sleep 2 # making sure to flush both application and disk caches and have a fresh start
+          cp ${db_path}/metadata.yaml ${outdir}/${try}_metadata.yaml # preserve metadata from test
+          rm -fr ${db_path} # but remove large database file so we won't run out of disk space
+          if [[ $ctrlc_sent -eq 1 ]]; then
+            echo -e "\e[31mQuitting prematurely due to Ctrl-C - some results aren't saved and some won't be reliable\e[0m]"
+            exit
+          fi
+        done
       done
     done
   done

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/benchmark.sh
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/benchmark.sh
@@ -21,6 +21,10 @@ config_default_path=${storage_config_dir}/storage_default.yaml
 
 # Set this to "zstd" to test with compression
 compression_format=""
+compression_arg=""
+if [ -n "$compression_format" ]; then
+  compression_arg="-p compression_format:=${compression_format}"
+fi
 
 for storage_config_file_path in ${config_optimized_path} ${config_default_path}
 do
@@ -46,7 +50,7 @@ do
           outfile=${outdir}/${try}.log
           echo "Results will be written to file: ${outfile}"
           ros2 run rosbag2_performance_writer_benchmarking writer_benchmark --ros-args \
-            -p compression_format:=${compression_format} \
+            ${compression_arg} \
             -p frequency:=${freq} \
             -p size:=${sz} \
             -p instances:=${inst} \

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/storage_config/storage_default.yaml
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/storage_config/storage_default.yaml
@@ -1,0 +1,2 @@
+write:
+  pragmas: ["journal_mode = WAL", "synchronous = NORMAL"]

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/storage_config/storage_optimized.yaml
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/scripts/storage_config/storage_optimized.yaml
@@ -1,0 +1,2 @@
+write:
+  pragmas: ["journal_mode = MEMORY", "synchronous = OFF"]

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/src/writer_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/src/writer_benchmark.cpp
@@ -24,6 +24,8 @@
 
 #include "rosbag2_performance_writer_benchmarking/writer_benchmark.hpp"
 
+#include "yaml-cpp/yaml.h"
+
 using namespace std::chrono_literals;
 
 WriterBenchmark::WriterBenchmark(const std::string & name)
@@ -34,9 +36,11 @@ WriterBenchmark::WriterBenchmark(const std::string & name)
   this->declare_parameter("max_count", 1000);
   this->declare_parameter("size", 1000000);
   this->declare_parameter("instances", 1);
-  this->declare_parameter("max_cache_size", 1);
+  this->declare_parameter("max_cache_size", 10000000);
+  this->declare_parameter("max_bag_size", 0);
   this->declare_parameter("db_folder", default_bag_folder);
   this->declare_parameter("results_file", default_bag_folder + "/results.csv");
+  this->declare_parameter("storage_config_file", "");
 
   this->get_parameter("frequency", config_.frequency);
   if (config_.frequency == 0) {
@@ -45,8 +49,12 @@ WriterBenchmark::WriterBenchmark(const std::string & name)
     return;
   }
 
-  this->get_parameter("max_cache_size", max_cache_size_);
-  this->get_parameter("db_folder", db_folder_);
+  storage_options_.storage_id = "sqlite3";
+  this->get_parameter("max_cache_size", storage_options_.max_cache_size);
+  this->get_parameter("db_folder", storage_options_.uri);
+  this->get_parameter("storage_config_file", storage_options_.storage_config_uri);
+  this->get_parameter("max_bag_size", storage_options_.max_bagfile_size);
+
   this->get_parameter("results_file", results_file_);
   this->get_parameter("max_count", config_.max_count);
   this->get_parameter("size", config_.message_size);
@@ -58,7 +66,7 @@ WriterBenchmark::WriterBenchmark(const std::string & name)
 
 void WriterBenchmark::start_benchmark()
 {
-  RCLCPP_INFO(get_logger(), "Starting. A dot is a write, an X is a miss");
+  RCLCPP_INFO(get_logger(), "Starting");
   start_producers();
   while (rclcpp::ok()) {
     int count = 0;
@@ -99,7 +107,6 @@ void WriterBenchmark::start_benchmark()
         } catch (const std::runtime_error & e) {
           RCLCPP_ERROR_STREAM(get_logger(), "Failed to record: " << e.what());
         }
-        std::cerr << "." << std::flush;
         ++count;
       }
     }
@@ -114,23 +121,36 @@ void WriterBenchmark::start_benchmark()
     prod_thread.join();
   }
 
-  unsigned int total_missed_messages = 0;
-  for (const auto & queue : queues_) {
-    total_missed_messages += queue->get_missed_elements_count();
-  }
-  write_results(total_missed_messages);
+  writer_->reset();
+  write_results();
 }
 
-void WriterBenchmark::write_results(const unsigned int & total_missed) const
+int WriterBenchmark::get_message_count_from_metadata() const
 {
+  int total_recorded_count = 0;
+  std::string metadata_filename(rosbag2_storage::MetadataIo::metadata_filename);
+  std::string metadata_path = storage_options_.uri + "/" + metadata_filename;
+  try {
+    YAML::Node yaml_file = YAML::LoadFile(metadata_path);
+    total_recorded_count = yaml_file["rosbag2_bagfile_information"]["message_count"].as<int>();
+  } catch (const YAML::Exception & ex) {
+    throw std::runtime_error(
+            std::string("Exception on parsing metadata file to get total message count: ") +
+            metadata_path + " " +
+            ex.what());
+  }
+  return total_recorded_count;
+}
+
+void WriterBenchmark::write_results() const
+{
+  int total_recorded_count = get_message_count_from_metadata();
   auto total_messages_sent = config_.max_count * producers_.size();
-  float percentage_recorded = 100.0f - static_cast<float>(total_missed * 100.0f) /
+  float percentage_recorded = static_cast<float>(total_recorded_count * 100.0f) /
     total_messages_sent;
 
-  RCLCPP_INFO(get_logger(), "\nWriterBenchmark terminating");
-  RCLCPP_INFO_STREAM(get_logger(), "Total missed messages: " << total_missed);
   RCLCPP_INFO_STREAM(
-    get_logger(), "Percentage of all message that was successfully recorded: " <<
+    get_logger(), "Percentage of all messages that was successfully recorded: " <<
       percentage_recorded);
 
   bool new_file = false;
@@ -151,18 +171,17 @@ void WriterBenchmark::write_results(const unsigned int & total_missed) const
 
   if (new_file) {
     output_file << "instances frequency message_size cache_size total_messages_sent ";
-    output_file << "total_messages_missed percentage_recorded\n";
+    output_file << "percentage_recorded\n";
   }
 
   // configuration of the test. TODO(adamdbrw) wrap into a dict and define << operator.
   output_file << instances_ << " ";
   output_file << config_.frequency << " ";
   output_file << config_.message_size << " ";
-  output_file << max_cache_size_ << " ";
+  output_file << storage_options_.max_cache_size << " ";
   output_file << total_messages_sent << " ";
 
   // results of the test. Use std::setprecision if preferred
-  output_file << total_missed << " ";
   output_file << percentage_recorded << std::endl;
 }
 
@@ -172,7 +191,8 @@ void WriterBenchmark::create_producers(const ProducerConfig & config)
     get_logger(), "\nWriterBenchmark: creating " << instances_ <<
       " message producers with frequency " << config.frequency <<
       " and message size in bytes " << config.message_size <<
-      ". Cache is " << max_cache_size_ << ". Each will send " << config.max_count <<
+      ". Cache is " << storage_options_.max_cache_size <<
+      ". Each will send " << config.max_count <<
       " messages before terminating");
   const unsigned int queue_max_size = 10;
   for (unsigned int i = 0; i < instances_; ++i) {
@@ -188,15 +208,10 @@ void WriterBenchmark::create_producers(const ProducerConfig & config)
 void WriterBenchmark::create_writer()
 {
   writer_ = std::make_shared<rosbag2_cpp::writers::SequentialWriter>();
-  rosbag2_storage::StorageOptions storage_options{};
-  storage_options.uri = db_folder_;
-  storage_options.storage_id = "sqlite3";
-  storage_options.max_bagfile_size = 0;
-  storage_options.max_cache_size = max_cache_size_;
 
   // TODO(adamdbrw) generalize if converters are to be included in benchmarks
   std::string serialization_format = rmw_get_serialization_format();
-  writer_->open(storage_options, {serialization_format, serialization_format});
+  writer_->open(storage_options_, {serialization_format, serialization_format});
 
   for (const auto & queue : queues_) {
     rosbag2_storage::TopicMetadata topic;

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/src/writer_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/src/writer_benchmark.cpp
@@ -150,7 +150,7 @@ void WriterBenchmark::write_results() const
     total_messages_sent;
 
   RCLCPP_INFO_STREAM(
-    get_logger(), "Percentage of all messages that was successfully recorded: " <<
+    get_logger(), "Percentage of all messages that were successfully recorded: " <<
       percentage_recorded);
 
   bool new_file = false;

--- a/rosbag2_performance/rosbag2_performance_writer_benchmarking/src/writer_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_performance_writer_benchmarking/src/writer_benchmark.cpp
@@ -26,7 +26,18 @@
 
 #include "rosbag2_performance_writer_benchmarking/writer_benchmark.hpp"
 
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
 #include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
This is still the "clunky" script. While the refactoring of performance writer is scheduled, this PR contains several important updates that make the performance benchmarking packages usable with recent changes: 
- uses `--storage-config-file `option with two examples (optimized and non-optimized). This enables testing of other pragma settings easily at will.
- message lost statistic is now read from metadata yaml file. This is more correct and also makes performance benchmarking ready for cache double-buffers PR 546.
- removed performance-affecting outputs (writing '.' and 'X' on writes and misses affected performance, especially with multiple instances & lots of small messages). 
- supports bag splitting in benchmarking by exposing max_bagfile_size parameter to the script.

This PR does not replace the necessary work to be done in performance packages (replacing the script with launch files, expanding parametrization), but still serves as a strict upgrade over the current state. Some of these changes should have been a part of earlier PRs.
