### PR TITLE
[Foxy backport] Mutex around writer access in recorder (#491)

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_CPP__WRITER_HPP_
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -95,6 +96,7 @@ public:
   }
 
 private:
+  std::mutex writer_mutex_;
   std::unique_ptr<rosbag2_cpp::writer_interfaces::BaseWriterInterface> writer_impl_;
 };
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -48,16 +48,19 @@ void Writer::open(
 
 void Writer::create_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
 {
+  std::lock_guard<std::mutex> writer_lock(writer_mutex_);
   writer_impl_->create_topic(topic_with_type);
 }
 
 void Writer::remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
 {
+  std::lock_guard<std::mutex> writer_lock(writer_mutex_);
   writer_impl_->remove_topic(topic_with_type);
 }
 
 void Writer::write(std::shared_ptr<rosbag2_storage::SerializedBagMessage> message)
 {
+  std::lock_guard<std::mutex> writer_lock(writer_mutex_);
   writer_impl_->write(message);
 }
 


### PR DESCRIPTION
* Mutex around writer access in recorder

Signed-off-by: Patrick Spieler <stapelzeiger@gmail.com>

* mutex in rosbag2_cpp writer for storage access

Signed-off-by: Patrick Spieler <stapelzeiger@gmail.com>

* Revert "Mutex around writer access in recorder"

This reverts commit 714141c338699dd546d4d607bc6edfaaa6c96aa8.

Signed-off-by: Patrick Spieler <stapelzeiger@gmail.com>

* alphabetical include order

Signed-off-by: Patrick Spieler <stapelzeiger@gmail.com>