### PR TITLE
Stabilize test_record by reducing copies of executors and messages

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/wait_for.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/wait_for.hpp
@@ -26,11 +26,13 @@ bool spin_and_wait_for(Timeout timeout, const Node & node, Condition condition)
 {
   using clock = std::chrono::system_clock;
   auto start = clock::now();
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node);
   while (!condition()) {
     if ((clock::now() - start) > timeout) {
       return false;
     }
-    rclcpp::spin_some(node);
+    exec.spin_some();
   }
   return true;
 }

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -51,17 +51,17 @@ public:
     messages_per_topic_[message->topic_name] += 1;
   }
 
-  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> get_messages()
+  const std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> & get_messages()
   {
     return messages_;
   }
 
-  std::unordered_map<std::string, size_t> messages_per_topic()
+  const std::unordered_map<std::string, size_t> & messages_per_topic()
   {
     return messages_per_topic_;
   }
 
-  std::unordered_map<std::string, rosbag2_storage::TopicMetadata> get_topics()
+  const std::unordered_map<std::string, rosbag2_storage::TopicMetadata> & get_topics()
   {
     return topics_;
   }

--- a/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
@@ -65,10 +65,15 @@ public:
   void run_publishers()
   {
     pub_man_.run_publishers(
-      [this](const std::string & topic_name) {
+      [this](const std::string & topic_name) -> size_t {
         MockSequentialWriter & writer =
         static_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
-        return writer.messages_per_topic()[topic_name];
+        const auto & messages = writer.messages_per_topic();
+        auto it = writer.messages_per_topic().find(topic_name);
+        if (it != messages.end()) {
+          return it->second;
+        }
+        return 0;
       });
   }
 


### PR DESCRIPTION
Fixes https://github.com/ros2/rosbag2/issues/528

Tested locally with 

```
stress -c 16
# and
colcon test --packages-select rosbag2_transport --retest-until-fail 10
```

As well as 1400 successful sequential runs (closed at that point, not failed) of `test_record__rmw_fastrtps_cpp`

Introduces 2 changes which both caused issues:

### Executor copies (wait_for.hpp)

Every time we called spin_some, a new executor was constructed. This would happen potentially a few thousand times per test. Given that the global context was not shutdown during this time, it would accumulate `on_shutdown_callbacks_`, one from each executor that was created. When this list was very large we would occasionally get `std::bad_function_call` for one of the callbacks in the shutdown.

With this change, the global `Context` has only 2 items in `on_shutdown_callbacks_`, and I am not able to reproduce `bad_function_call` any more.

After this change I still see a segfault, usually after 100-500 iterations of (for example) `RecordIntegrationTestFixture.records_sensor_data`. I'm still investigating this, but it is a separate error.

### STL container copies

The `MockSequentialWriter` used in `test_record` would pass its internal containers back to viewers by value. This created  many copies of the `shared_ptr<SerializedBagMessage>`s. Upon running repeatedly, this copy operation would occasionally end in a segfault. Since outside the `MockSequentialWriter`, the values are only observed, we are able to avoid that situation by never copying the values and returning const references to the existing structures.

### Conclusion

Though it's a little unclear _exactly_ what caused either issue at the cause end, both changes are best-practices more correct code and avoid the situations that brought about the problems, which improves performance and stability of these tests.

Recommended followups:
* find out why `rclcpp::Context` throws `bad_function_call` on shutdown when `on_shutdown_callbacks_` is very large. A simple repro case should be easy enough to construct
