### PR TITLE
Patch zstd 1.4.4 to include cmake_minimum_version bump to 2.8.12

### DIFF
--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -39,7 +39,9 @@ macro(build_zstd)
       -DZSTD_BUILD_STATIC=OFF
       -DZSTD_BUILD_SHARED=ON
       -DZSTD_BUILD_PROGRAMS=OFF
-      ${extra_cmake_args})
+      ${extra_cmake_args}
+    # Note: zstd v1.4.6 will include the following fix. When that is released, upgrade and remove this patch.
+    PATCH_COMMAND patch -p1 -d . < ${CMAKE_CURRENT_SOURCE_DIR}/cmake_minimum_required_2.8.12.patch)
 
   install(
     DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/

--- a/zstd_vendor/cmake_minimum_required_2.8.12.patch
+++ b/zstd_vendor/cmake_minimum_required_2.8.12.patch
@@ -1,0 +1,26 @@
+From eca046fb11a29fa9ace41844f7797bc4e21540ac Mon Sep 17 00:00:00 2001
+From: Emerson Knapp <eknapp@amazon.com>
+Date: Fri, 4 Dec 2020 17:07:23 -0800
+Subject: [PATCH] Update cmake_minimum_required to 2.8.12
+
+Signed-off-by: Emerson Knapp <eknapp@amazon.com>
+---
+ build/cmake/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/cmake/CMakeLists.txt b/build/cmake/CMakeLists.txt
+index 9d0e7fb0..20df1dcf 100644
+--- a/build/cmake/CMakeLists.txt
++++ b/build/cmake/CMakeLists.txt
+@@ -7,7 +7,7 @@
+ # in the COPYING file in the root directory of this source tree).
+ # ################################################################
+ 
+-cmake_minimum_required(VERSION 2.8.9 FATAL_ERROR)
++cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+   
+ # As of 2018-12-26 ZSTD has been validated to build with cmake version 3.13.2 new policies. 
+ # Set and use the newest cmake policies that are validated to work 
+-- 
+2.17.1
+


### PR DESCRIPTION
Fixes #573

This eliminates CMake warnings on the Windows build (see https://ci.ros2.org/job/ci_windows/13244/cmake/#issuesContent)

We can remove the patch when a new zstd version gets released