### PR TITLE
Only dereference the data pointer if it is valid.

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/types/test_ros2_message.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/types/test_ros2_message.cpp
@@ -76,9 +76,9 @@ TEST_F(Ros2MessageTest, allocate_ros2_message_allocates_strings_message_with_emp
   auto data = static_cast<test_msgs::msg::Strings *>(message->message);
   if (!data) {
     fprintf(stderr, "allocation failed for string\n");
+  } else {
+    data->string_value = "";
   }
-
-  data->string_value = "";
 }
 
 TEST_F(Ros2MessageTest, allocate_ros2_message_allocates_strings_message_with_big_string_no_SSO) {


### PR DESCRIPTION
If the static_cast returned a nullptr, then just print the
message and don't attempt to deference it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>