### PR TITLE
Stay compliant with std::filesystem API

### DIFF
--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -253,7 +253,7 @@ std::string MetadataIo::get_metadata_file_name(const std::string & uri)
 
 bool MetadataIo::metadata_file_exists(const std::string & uri)
 {
-  return rcpputils::fs::path(get_metadata_file_name(uri)).exists();
+  return rcpputils::fs::exists(rcpputils::fs::path(get_metadata_file_name(uri)));
 }
 
 }  // namespace rosbag2_storage


### PR DESCRIPTION
I've been investigating making the `rcpputils::fs` functionality more compliant with `std::filesystem` in anticipation of switching and came across this use of `path::exists()`, which [doesn't exist](https://en.cppreference.com/w/cpp/filesystem/path) in std::filesystem. This only changes to the non-member function in `rcpputils::fs` and so can be merged independent of any other change.