### PR TITLE
Release 0.3.6 for Foxy

### DIFF
--- a/ros2bag/CHANGELOG.rst
+++ b/ros2bag/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2bag
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 * Add pytest.ini so local tests don't display warning. (`#446 <https://github.com/ros2/rosbag2/issues/446>`_) (`#514 <https://github.com/ros2/rosbag2/issues/514>`_)

--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>ros2bag</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>
     Entry point for rosbag in ROS 2
   </description>

--- a/ros2bag/setup.py
+++ b/ros2bag/setup.py
@@ -5,7 +5,7 @@ package_name = 'ros2bag'
 
 setup(
     name=package_name,
-    version='0.3.5',
+    version='0.3.6',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/rosbag2/CHANGELOG.rst
+++ b/rosbag2/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2/package.xml
+++ b/rosbag2/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbag2</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Meta package for rosbag2 related packages</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_compression/CHANGELOG.rst
+++ b/rosbag2_compression/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_compression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2_compression/package.xml
+++ b/rosbag2_compression/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rosbag2_compression</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Compression implementations for rosbag2 bags and messages.</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_converter_default_plugins/CHANGELOG.rst
+++ b/rosbag2_converter_default_plugins/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package rosbag2_converter_default_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2_converter_default_plugins/package.xml
+++ b/rosbag2_converter_default_plugins/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbag2_converter_default_plugins</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Package containing default plugins for format converters</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_cpp/CHANGELOG.rst
+++ b/rosbag2_cpp/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog for package rosbag2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Mutex around writer access in recorder (`#491 <https://github.com/ros2/rosbag2/issues/491>`_) (`#575 <https://github.com/ros2/rosbag2/issues/575>`_)
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo, Patrick Spieler
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2_cpp/package.xml
+++ b/rosbag2_cpp/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbag2_cpp</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>C++ ROSBag2 client library</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_storage/CHANGELOG.rst
+++ b/rosbag2_storage/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package rosbag2_storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2_storage/package.xml
+++ b/rosbag2_storage/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbag2_storage</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>ROS2 independent storage format to store serialized ROS2 messages</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_storage_default_plugins/CHANGELOG.rst
+++ b/rosbag2_storage_default_plugins/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package rosbag2_storage_default_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2_storage_default_plugins/package.xml
+++ b/rosbag2_storage_default_plugins/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbag2_storage_default_plugins</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>ROSBag2 SQLite3 storage plugin</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_test_common/CHANGELOG.rst
+++ b/rosbag2_test_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_test_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2_test_common/package.xml
+++ b/rosbag2_test_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rosbag2_test_common</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Commonly used test helper classes and fixtures for rosbag2</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_tests/CHANGELOG.rst
+++ b/rosbag2_tests/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package rosbag2_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/rosbag2_tests/package.xml
+++ b/rosbag2_tests/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rosbag2_tests</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Tests package for rosbag2</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/rosbag2_transport/CHANGELOG.rst
+++ b/rosbag2_transport/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package rosbag2_transport
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 * resolve memory leak for serialized message (`#502 <https://github.com/ros2/rosbag2/issues/502>`_) (`#518 <https://github.com/ros2/rosbag2/issues/518>`_)

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rosbag2_transport</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Layer encapsulating ROS middleware to allow rosbag2 to be used with or without middleware</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/shared_queues_vendor/CHANGELOG.rst
+++ b/shared_queues_vendor/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package shared_queues_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/shared_queues_vendor/package.xml
+++ b/shared_queues_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>shared_queues_vendor</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Vendor package for concurrent queues from moodycamel</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/sqlite3_vendor/CHANGELOG.rst
+++ b/sqlite3_vendor/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package sqlite3_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.3.6 (2021-01-05)
+------------------
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/sqlite3_vendor/package.xml
+++ b/sqlite3_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>sqlite3_vendor</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>SQLite 3 vendor package</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>

--- a/zstd_vendor/CHANGELOG.rst
+++ b/zstd_vendor/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package zstd_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.6 (2021-01-05)
+------------------
+* Patch zstd 1.4.4 to include cmake_minimum_version bump to 2.8.12 (`#579 <https://github.com/ros2/rosbag2/issues/579>`_) (`#587 <https://github.com/ros2/rosbag2/issues/587>`_)
+* Update maintainer list for Foxy (`#551 <https://github.com/ros2/rosbag2/issues/551>`_)
+* Contributors: Emerson Knapp, Jacob Perron, Michael Jeronimo
+
 0.3.5 (2020-08-31)
 ------------------
 

--- a/zstd_vendor/package.xml
+++ b/zstd_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>zstd_vendor</name>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <description>Zstd compression vendor package, providing a dependency for Zstd.</description>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>


### PR DESCRIPTION
In preparation for [upcoming sync](https://discourse.ros.org/t/preparing-for-foxy-sync-2020-01-07/18268).