### PR TITLE
Include what you use

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <sstream>
 #include <unordered_map>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
This stopped building correctly after modification in https://github.com/ros2/rcpputils/pull/118 because of the missing include.