### PR TITLE
Recorder --regex and --exclude options

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -35,7 +35,7 @@ class RecordVerb(VerbExtension):
         parser.add_argument(
             'topics', nargs='*', default=None, help='topics to be recorded')
         parser.add_argument(
-            '-x', '--regex', default='', help='recording only topics '
+            '-e', '--regex', default='', help='recording only topics '
             'matching provided regular expression')
         parser.add_argument(
             '-o', '--output',

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -131,16 +131,17 @@ class RecordVerb(VerbExtension):
     def main(self, *, args):  # noqa: D102
         # both all and topics cannot be true
         if (args.all and (args.topics or args.regex)) or (args.topics and args.regex):
-            return print_error('Must specify only one option out of topics, regex or -a')
+            return print_error('Must specify only one option out of topics, --regex or --all')
         # one out of "all", "topics" and "regex" must be true
         if not(args.all or (args.topics and len(args.topics) > 0) or (args.regex)):
-            return print_error('Invalid choice: Must specify topic(s), regex or -a')
+            return print_error('Invalid choice: Must specify topic(s), --regex or --all')
 
         if args.topics and args.exclude:
-            return print_error('Exclude argument only works with -a or -e')
+            return print_error('--exclude argument cannot be used when specifying a list '
+                               'of topics explicitly')
 
         if args.exclude and not(args.regex or args.all):
-            return print_error('Exclude argument requires either -a or -e')
+            return print_error('--exclude argument requires either --all or --regex')
 
         uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
 

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -38,6 +38,10 @@ class RecordVerb(VerbExtension):
             '-e', '--regex', default='', help='recording only topics '
             'matching provided regular expression')
         parser.add_argument(
+            '-x', '--exclude', default='', help='exclude topics '
+            'matching provided regular expression. Works with -a and -e, '
+            'subtracting excluded topics')
+        parser.add_argument(
             '-o', '--output',
             help='destination of the bagfile to create, \
             defaults to a timestamped folder in the current directory')
@@ -132,6 +136,12 @@ class RecordVerb(VerbExtension):
         if not(args.all or (args.topics and len(args.topics) > 0) or (args.regex)):
             return print_error('Invalid choice: Must specify topic(s), regex or -a')
 
+        if args.topics and args.exclude:
+            return print_error('Exclude argument only works with -a or -e')
+
+        if args.exclude and not(args.regex or args.all):
+            return print_error('Exclude argument requires either -a or -e')
+
         uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
 
         if os.path.isdir(uri):
@@ -183,6 +193,7 @@ class RecordVerb(VerbExtension):
             max_cache_size=args.max_cache_size,
             topics=args.topics,
             regex=args.regex,
+            exclude=args.exclude,
             include_hidden_topics=args.include_hidden_topics,
             qos_profile_overrides=qos_profile_overrides,
             storage_preset_profile=args.storage_preset_profile,

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -564,7 +564,7 @@ TEST_F(RecordFixture, record_fails_if_both_all_and_topic_list_is_specified) {
   auto error_output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
-  EXPECT_THAT(error_output, HasSubstr("Must specify only one option out of topics, regex or -a"));
+  EXPECT_FALSE(error_output.empty());
 }
 
 TEST_F(RecordFixture, record_fails_if_neither_all_nor_topic_list_are_specified) {
@@ -574,7 +574,7 @@ TEST_F(RecordFixture, record_fails_if_neither_all_nor_topic_list_are_specified) 
   auto output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
-  EXPECT_THAT(output, HasSubstr("Invalid choice: Must specify topic(s), regex or -a"));
+  EXPECT_FALSE(output.empty());
 }
 
 TEST_F(RecordFixture, record_fails_gracefully_if_plugin_for_given_encoding_does_not_exist) {

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -564,7 +564,7 @@ TEST_F(RecordFixture, record_fails_if_both_all_and_topic_list_is_specified) {
   auto error_output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
-  EXPECT_THAT(error_output, HasSubstr("Can not specify topics and -a at the same time."));
+  EXPECT_THAT(error_output, HasSubstr("Must specify only one option out of topics, regex or -a"));
 }
 
 TEST_F(RecordFixture, record_fails_if_neither_all_nor_topic_list_are_specified) {
@@ -574,7 +574,7 @@ TEST_F(RecordFixture, record_fails_if_neither_all_nor_topic_list_are_specified) 
   auto output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
-  EXPECT_THAT(output, HasSubstr("Invalid choice: Must specify topic(s) or -a"));
+  EXPECT_THAT(output, HasSubstr("Invalid choice: Must specify topic(s), regex or -a"));
 }
 
 TEST_F(RecordFixture, record_fails_gracefully_if_plugin_for_given_encoding_does_not_exist) {

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -161,6 +161,12 @@ function(create_tests_for_rmw_implementation)
     LINK_LIBS rosbag2_transport
     ${SKIP_TEST})
 
+  rosbag2_transport_add_gmock(test_record_regex
+    test/rosbag2_transport/test_record_regex.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common
+    ${SKIP_TEST})
+
   rosbag2_transport_add_gmock(test_play
     src/rosbag2_transport/qos.cpp
     test/rosbag2_transport/test_play.cpp

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -33,6 +33,7 @@ public:
   std::string rmw_serialization_format;
   std::chrono::milliseconds topic_polling_interval;
   std::string regex = "";
+  std::string exclude = "";
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -32,6 +32,7 @@ public:
   std::vector<std::string> topics;
   std::string rmw_serialization_format;
   std::chrono::milliseconds topic_polling_interval;
+  std::string regex = "";
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -99,12 +99,12 @@ void Recorder::topics_discovery(const RecordOptions & record_options)
 std::unordered_map<std::string, std::string>
 Recorder::get_requested_or_available_topics(const RecordOptions & record_options)
 {
-  auto tt = record_options.topics.empty() ?
+  auto unfiltered_topics = record_options.topics.empty() ?
     node_->get_all_topics_with_types(record_options.include_hidden_topics) :
     node_->get_topics_with_types(record_options.topics);
 
   if (record_options.regex.empty() && record_options.exclude.empty()) {
-    return tt;
+    return unfiltered_topics;
   }
 
   std::unordered_map<std::string, std::string> filtered_by_regex;
@@ -112,11 +112,9 @@ Recorder::get_requested_or_available_topics(const RecordOptions & record_options
   std::regex topic_regex(record_options.regex);
   std::regex exclude_regex(record_options.exclude);
   bool take = record_options.all;
-  for (const auto & kv : tt) {
-    if (!record_options.regex.empty()) {
-      take = std::regex_search(kv.first, topic_regex);
-    }
-    if (take && !record_options.exclude.empty()) {
+  for (const auto & kv : unfiltered_topics) {
+    take = std::regex_search(kv.first, topic_regex);
+    if (take) {
       take = !std::regex_search(kv.first, exclude_regex);
     }
     if (take) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -103,14 +103,23 @@ Recorder::get_requested_or_available_topics(const RecordOptions & record_options
     node_->get_all_topics_with_types(record_options.include_hidden_topics) :
     node_->get_topics_with_types(record_options.topics);
 
-  if (record_options.regex.empty()) {
+  if (record_options.regex.empty() && record_options.exclude.empty()) {
     return tt;
   }
 
   std::unordered_map<std::string, std::string> filtered_by_regex;
+
   std::regex topic_regex(record_options.regex);
+  std::regex exclude_regex(record_options.exclude);
+  bool take = record_options.all;
   for (const auto & kv : tt) {
-    if (std::regex_search(kv.first, topic_regex)) {
+    if (!record_options.regex.empty()) {
+      take = std::regex_search(kv.first, topic_regex);
+    }
+    if (take && !record_options.exclude.empty()) {
+      take = !std::regex_search(kv.first, exclude_regex);
+    }
+    if (take) {
       filtered_by_regex.insert(kv);
     }
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <future>
 #include <memory>
+#include <regex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -57,16 +58,13 @@ void Recorder::record(const RecordOptions & record_options)
   }
   serialization_format_ = record_options.rmw_serialization_format;
   ROSBAG2_TRANSPORT_LOG_INFO("Listening for topics...");
-  subscribe_topics(
-    get_requested_or_available_topics(record_options.topics, record_options.include_hidden_topics));
+  subscribe_topics(get_requested_or_available_topics(record_options));
 
   std::future<void> discovery_future;
   if (!record_options.is_discovery_disabled) {
     auto discovery = std::bind(
       &Recorder::topics_discovery, this,
-      record_options.topic_polling_interval,
-      record_options.topics,
-      record_options.include_hidden_topics);
+      record_options);
     discovery_future = std::async(std::launch::async, discovery);
   }
 
@@ -79,36 +77,44 @@ void Recorder::record(const RecordOptions & record_options)
   subscriptions_.clear();
 }
 
-void Recorder::topics_discovery(
-  std::chrono::milliseconds topic_polling_interval,
-  const std::vector<std::string> & requested_topics,
-  bool include_hidden_topics)
+void Recorder::topics_discovery(const RecordOptions & record_options)
 {
   while (rclcpp::ok()) {
     auto topics_to_subscribe =
-      get_requested_or_available_topics(requested_topics, include_hidden_topics);
+      get_requested_or_available_topics(record_options);
     for (const auto & topic_and_type : topics_to_subscribe) {
       warn_if_new_qos_for_subscribed_topic(topic_and_type.first);
     }
     auto missing_topics = get_missing_topics(topics_to_subscribe);
     subscribe_topics(missing_topics);
 
-    if (!requested_topics.empty() && subscriptions_.size() == requested_topics.size()) {
+    if (!record_options.topics.empty() && subscriptions_.size() == record_options.topics.size()) {
       ROSBAG2_TRANSPORT_LOG_INFO("All requested topics are subscribed. Stopping discovery...");
       return;
     }
-    std::this_thread::sleep_for(topic_polling_interval);
+    std::this_thread::sleep_for(record_options.topic_polling_interval);
   }
 }
 
 std::unordered_map<std::string, std::string>
-Recorder::get_requested_or_available_topics(
-  const std::vector<std::string> & requested_topics,
-  bool include_hidden_topics)
+Recorder::get_requested_or_available_topics(const RecordOptions & record_options)
 {
-  return requested_topics.empty() ?
-         node_->get_all_topics_with_types(include_hidden_topics) :
-         node_->get_topics_with_types(requested_topics);
+  auto tt = record_options.topics.empty() ?
+    node_->get_all_topics_with_types(record_options.include_hidden_topics) :
+    node_->get_topics_with_types(record_options.topics);
+
+  if (record_options.regex.empty()) {
+    return tt;
+  }
+
+  std::unordered_map<std::string, std::string> filtered_by_regex;
+  std::regex topic_regex(record_options.regex);
+  for (const auto & kv : tt) {
+    if (std::regex_search(kv.first, topic_regex)) {
+      filtered_by_regex.insert(kv);
+    }
+  }
+  return filtered_by_regex;
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -62,15 +62,10 @@ public:
   }
 
 private:
-  void topics_discovery(
-    std::chrono::milliseconds topic_polling_interval,
-    const std::vector<std::string> & requested_topics = {},
-    bool include_hidden_topics = false);
+  void topics_discovery(const RecordOptions & record_options);
 
   std::unordered_map<std::string, std::string>
-  get_requested_or_available_topics(
-    const std::vector<std::string> & requested_topics,
-    bool include_hidden_topics = false);
+  get_requested_or_available_topics(const RecordOptions & record_options);
 
   std::unordered_map<std::string, std::string>
   get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics);

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -103,6 +103,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
     "max_bagfile_duration",
     "max_cache_size",
     "topics",
+    "regex",
     "include_hidden_topics",
     "qos_profile_overrides",
     "storage_preset_profile",
@@ -125,12 +126,13 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   unsigned long long max_bagfile_duration = 0;  // NOLINT
   uint64_t max_cache_size = 0u;
   PyObject * topics = nullptr;
+  char * regex = nullptr;
   bool include_hidden_topics = false;
   char * storage_preset_profile = nullptr;
   char * storage_config_file = nullptr;
   if (
     !PyArg_ParseTupleAndKeywords(
-      args, kwargs, "ssssss|KKbbKKKKObOss", const_cast<char **>(kwlist),
+      args, kwargs, "ssssss|KKbbKKKKOsbOss", const_cast<char **>(kwlist),
       &uri,
       &storage_id,
       &serilization_format,
@@ -146,6 +148,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
       &max_bagfile_duration,
       &max_cache_size,
       &topics,
+      &regex,
       &include_hidden_topics,
       &qos_profile_overrides,
       &storage_preset_profile,
@@ -163,6 +166,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   storage_options.max_cache_size = max_cache_size;
   storage_options.storage_preset_profile = storage_preset_profile;
   record_options.all = all;
+  record_options.regex = regex;
   record_options.is_discovery_disabled = no_discovery;
   record_options.topic_polling_interval = std::chrono::milliseconds(polling_interval_ms);
   record_options.node_prefix = std::string(node_prefix);

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport_python.cpp
@@ -104,6 +104,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
     "max_cache_size",
     "topics",
     "regex",
+    "exclude",
     "include_hidden_topics",
     "qos_profile_overrides",
     "storage_preset_profile",
@@ -127,12 +128,13 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   uint64_t max_cache_size = 0u;
   PyObject * topics = nullptr;
   char * regex = nullptr;
+  char * exclude = nullptr;
   bool include_hidden_topics = false;
   char * storage_preset_profile = nullptr;
   char * storage_config_file = nullptr;
   if (
     !PyArg_ParseTupleAndKeywords(
-      args, kwargs, "ssssss|KKbbKKKKOsbOss", const_cast<char **>(kwlist),
+      args, kwargs, "ssssss|KKbbKKKKOssbOss", const_cast<char **>(kwlist),
       &uri,
       &storage_id,
       &serilization_format,
@@ -149,6 +151,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
       &max_cache_size,
       &topics,
       &regex,
+      &exclude,
       &include_hidden_topics,
       &qos_profile_overrides,
       &storage_preset_profile,
@@ -167,6 +170,7 @@ rosbag2_transport_record(PyObject * Py_UNUSED(self), PyObject * args, PyObject *
   storage_options.storage_preset_profile = storage_preset_profile;
   record_options.all = all;
   record_options.regex = regex;
+  record_options.exclude = exclude;
   record_options.is_discovery_disabled = no_discovery;
   record_options.topic_polling_interval = std::chrono::milliseconds(polling_interval_ms);
   record_options.node_prefix = std::string(node_prefix);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021, Robotec.ai sp. z o.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <regex>
+#include <string>
+
+#include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+#include "record_integration_fixture.hpp"
+
+TEST_F(RecordIntegrationTestFixture, only_regex_matching_topics_are_recorded)
+{
+  auto test_string_messages = get_messages_strings();
+  auto test_array_messages = get_messages_arrays();
+  std::string regex = "/[a-z]+_nice(_.*)";
+
+  // valid topics
+  std::string v1 = "/awesome_nice_topic";
+  std::string v2 = "/quite_nice_namespace/anything_else";
+  std::string v3 = "/still_nice_topic";
+
+  // topics that shouldn't match
+  std::string b1 = "/numberslike1arenot_nice";
+  std::string b2 = "/namespace_before/not_nice";
+  std::string b3 = "/invalid_topic";
+
+  // checking the test data itself
+  std::regex re(regex);
+  ASSERT_TRUE(std::regex_search(v1, re));
+  ASSERT_TRUE(std::regex_search(v2, re));
+  ASSERT_TRUE(std::regex_search(v3, re));
+  ASSERT_FALSE(std::regex_search(b1, re));
+  ASSERT_FALSE(std::regex_search(b2, re));
+  ASSERT_FALSE(std::regex_search(b3, re));
+
+  RecordOptions ro{false, false, {}, "rmw_format", 10ms};
+  ro.regex = regex;
+
+  start_recording(ro);
+
+  pub_man_.add_publisher<test_msgs::msg::Strings>(
+    v1, test_string_messages[0], 0);
+  pub_man_.add_publisher<test_msgs::msg::Strings>(
+    v2, test_string_messages[1], 0);
+  pub_man_.add_publisher<test_msgs::msg::Arrays>(
+    v3, test_array_messages[0], 0);
+
+  pub_man_.add_publisher<test_msgs::msg::Strings>(
+    b1, test_string_messages[0], 0);
+  pub_man_.add_publisher<test_msgs::msg::Strings>(
+    b2, test_string_messages[1], 0);
+  pub_man_.add_publisher<test_msgs::msg::Arrays>(
+    b3, test_array_messages[0], 0);
+
+  run_publishers();
+  stop_recording();
+
+  MockSequentialWriter & writer =
+    static_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
+  auto recorded_topics = writer.get_topics();
+
+  EXPECT_THAT(recorded_topics, SizeIs(3));
+
+  EXPECT_TRUE(recorded_topics.find(v1) != recorded_topics.end());
+  EXPECT_TRUE(recorded_topics.find(v2) != recorded_topics.end());
+  EXPECT_TRUE(recorded_topics.find(v3) != recorded_topics.end());
+}


### PR DESCRIPTION
Resolves issues #559 and #560. This is a minimal implementation that brings the regex filtering feature to rosbag2.

Implements ros2 bag record -e / --regex and -x / --exclude options to specify how topics are recorded.
- the --regex option is exclusive with -all and specifying topics
- the --exclude option can be applied together with either --regex or --all, but is exclusive with explicit topic list