### PR TITLE
CompressionReader/Writer use correct relative path logic

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
@@ -70,20 +70,12 @@ public:
 
 protected:
   /**
-   * Increment the current file iterator to point to the next file in the list of relative file
-   * paths.
-   *
-   * Expected usage:
-   * if (has_next_file()) load_next_file();
-   */
-  void load_next_file() override;
-
-  /**
-   * Initializes the decompressor if a compression mode is specified in the metadata.
+   * Decompress the current bagfile so that it is openable by the storage implementation.
+   * Initializes the decompressor if it has not been created yet.
    *
    * \throws std::invalid_argument If compression format doesn't exist.
    */
-  virtual void setup_decompression();
+  virtual void preprocess_current_file() override;
 
 private:
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
@@ -75,7 +75,7 @@ protected:
    *
    * \throws std::invalid_argument If compression format doesn't exist.
    */
-  virtual void preprocess_current_file() override;
+  void preprocess_current_file() override;
 
 private:
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -124,9 +124,10 @@ protected:
    * Compress a file and update the metadata file path.
    *
    * \param compressor An initialized compression context.
-   * \param message The URI of the file to compress.
+   * \param file_relative_to_bag Relative path of the file to compress, as stored in metadata -
+   *   meaning the path is relative to the bag base folder.
    */
-  virtual void compress_file(BaseCompressorInterface & compressor, const std::string & file);
+  virtual void compress_file(BaseCompressorInterface & compressor, const std::string & file_relative_to_bag);
 
   /**
    * Checks if the compression by message option is specified and a compressor exists.

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -127,7 +127,9 @@ protected:
    * \param file_relative_to_bag Relative path of the file to compress, as stored in metadata -
    *   meaning the path is relative to the bag base folder.
    */
-  virtual void compress_file(BaseCompressorInterface & compressor, const std::string & file_relative_to_bag);
+  virtual void compress_file(
+    BaseCompressorInterface & compressor,
+    const std::string & file_relative_to_bag);
 
   /**
    * Checks if the compression by message option is specified and a compressor exists.

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -44,7 +44,7 @@ SequentialCompressionReader::~SequentialCompressionReader()
 void SequentialCompressionReader::preprocess_current_file()
 {
   if (!decompressor_) {
-    compression_mode_ = rosbag2_compression::compression_mode_from_string(metadata_.compression_mode);
+    compression_mode_ = compression_mode_from_string(metadata_.compression_mode);
     if (compression_mode_ == rosbag2_compression::CompressionMode::NONE) {
       throw std::invalid_argument{
               "SequentialCompressionReader requires a CompressionMode that is not NONE!"};

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -41,20 +41,22 @@ SequentialCompressionReader::SequentialCompressionReader(
 SequentialCompressionReader::~SequentialCompressionReader()
 {}
 
-void SequentialCompressionReader::setup_decompression()
+void SequentialCompressionReader::preprocess_current_file()
 {
-  compression_mode_ = rosbag2_compression::compression_mode_from_string(metadata_.compression_mode);
-  if (compression_mode_ != rosbag2_compression::CompressionMode::NONE) {
-    decompressor_ = compression_factory_->create_decompressor(metadata_.compression_format);
-    // Decompress the first file so that it is readable; don't need to do anything for
-    // per-message encryption.
-    if (compression_mode_ == CompressionMode::FILE) {
-      ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
-      *current_file_iterator_ = decompressor_->decompress_uri(get_current_file());
+  if (!decompressor_) {
+    compression_mode_ = rosbag2_compression::compression_mode_from_string(metadata_.compression_mode);
+    if (compression_mode_ == rosbag2_compression::CompressionMode::NONE) {
+      throw std::invalid_argument{
+              "SequentialCompressionReader requires a CompressionMode that is not NONE!"};
     }
-  } else {
-    throw std::invalid_argument{
-            "SequentialCompressionReader requires a CompressionMode that is not NONE!"};
+    decompressor_ = compression_factory_->create_decompressor(metadata_.compression_format);
+    if (!decompressor_) {
+      throw std::runtime_error{"Couldn't initialize decompressor."};
+    }
+  }
+  if (compression_mode_ == CompressionMode::FILE) {
+    ROSBAG2_COMPRESSION_LOG_INFO_STREAM("Decompressing " << get_current_file().c_str());
+    *current_file_iterator_ = decompressor_->decompress_uri(get_current_file());
   }
 }
 
@@ -62,45 +64,13 @@ void SequentialCompressionReader::open(
   const rosbag2_storage::StorageOptions & storage_options,
   const rosbag2_cpp::ConverterOptions & converter_options)
 {
-  storage_options_ = storage_options;
-
-  if (metadata_io_->metadata_file_exists(storage_options.uri)) {
-    metadata_ = metadata_io_->read_metadata(storage_options.uri);
-    if (metadata_.relative_file_paths.empty()) {
-      ROSBAG2_COMPRESSION_LOG_WARN("No file paths were found in metadata.");
-      return;
-    }
-    file_paths_ = metadata_.relative_file_paths;
-    current_file_iterator_ = file_paths_.begin();
-    setup_decompression();
-
-    storage_options_.uri = *current_file_iterator_;
-    storage_ = storage_factory_->open_read_only(storage_options);
-    if (!storage_) {
-      std::stringstream errmsg;
-      errmsg << "No storage could be initialized for: \"" <<
-        storage_options.uri << "\".";
-
-      throw std::runtime_error{errmsg.str()};
-    }
-  } else {
+  if (!metadata_io_->metadata_file_exists(storage_options.uri)) {
     std::stringstream errmsg;
     errmsg << "Could not find metadata for bag: \"" << storage_options.uri <<
-      "\". Legacy bag files are not supported if this is a ROS 1 bag file.";
+      "\". Legacy ROS 1 bag files aren't supported by rosbag2 decompression.";
     throw std::runtime_error{errmsg.str()};
   }
-  const auto & topics = metadata_.topics_with_message_count;
-  if (topics.empty()) {
-    ROSBAG2_COMPRESSION_LOG_WARN("No topics were listed in metadata.");
-    return;
-  }
-  fill_topics_metadata();
-
-  // Currently a bag file can only be played if all topics have the same serialization format.
-  check_topics_serialization_formats(topics);
-  check_converter_serialization_format(
-    converter_options.output_serialization_format,
-    topics[0].topic_metadata.serialization_format);
+  SequentialReader::open(storage_options, converter_options);
 }
 
 std::shared_ptr<rosbag2_storage::SerializedBagMessage> SequentialCompressionReader::read_next()
@@ -115,28 +85,4 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SequentialCompressionRead
   throw std::runtime_error{"Bag is not open. Call open() before reading."};
 }
 
-
-void SequentialCompressionReader::load_next_file()
-{
-  if (current_file_iterator_ == file_paths_.end()) {
-    throw std::runtime_error{"Cannot load next file; already on last file!"};
-  }
-
-  if (compression_mode_ == rosbag2_compression::CompressionMode::NONE) {
-    throw std::runtime_error{"Cannot use SequentialCompressionReader with NONE compression mode."};
-  }
-
-  ++current_file_iterator_;
-  if (compression_mode_ == rosbag2_compression::CompressionMode::FILE) {
-    if (decompressor_ == nullptr) {
-      throw std::runtime_error{
-              "The bag file was not properly opened. "
-              "Somehow the compression mode was set without opening a decompressor."
-      };
-    }
-
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
-    *current_file_iterator_ = decompressor_->decompress_uri(get_current_file());
-  }
-}
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -231,15 +231,7 @@ void SequentialCompressionWriter::compress_file(
   auto file_relative_to_pwd = path(base_folder_) / file_relative_to_bag;
   ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Compressing file: " << file_relative_to_pwd.string());
 
-  if (!file_relative_to_pwd.exists()) {
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
-      "Removing last file: \"" << file_relative_to_pwd.string() <<
-        "\" because it does not exist.");
-  } else if (file_relative_to_pwd.file_size() == 0u) {
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
-      "Removing last file: \"" << file_relative_to_pwd.string() <<
-        "\" because it is empty.");
-  } else {
+  if (file_relative_to_pwd.exists() && file_relative_to_pwd.file_size() > 0u) {
     const auto compressed_uri = compressor.compress_uri(file_relative_to_pwd.string());
     const auto relative_compressed_uri = path(compressed_uri).filename();
     {
@@ -264,6 +256,10 @@ void SequentialCompressionWriter::compress_file(
       ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
         "Failed to remove uncompressed bag: \"" << file_relative_to_pwd.string() << "\"");
     }
+  } else {
+    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
+      "Removing last file: \"" << file_relative_to_pwd.string() <<
+        "\" because it either is empty or does not exist.");
   }
 }
 

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -14,10 +14,13 @@
 
 #include <gmock/gmock.h>
 
+#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/sequential_compression_reader.hpp"
 
@@ -41,28 +44,36 @@ public:
     storage_{std::make_shared<NiceMock<MockStorage>>()},
     converter_factory_{std::make_shared<StrictMock<MockConverterFactory>>()},
     metadata_io_{std::make_unique<NiceMock<MockMetadataIo>>()},
-    storage_serialization_format_{"rmw1_format"}
+    storage_serialization_format_{"rmw1_format"},
+    tmp_dir_{rcpputils::fs::temp_directory_path() / bag_name_},
+    converter_options_{"", storage_serialization_format_}
   {
+    storage_options_.uri = tmp_dir_.string();
     topic_with_type_ = rosbag2_storage::TopicMetadata{
       "topic", "test_msgs/BasicTypes", storage_serialization_format_, ""};
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type_};
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type_.name;
 
+    metadata_.relative_file_paths = {
+      "bagfile_0.zstd",
+      "bagfile_1.zstd"
+    };
+    metadata_.topics_with_message_count.push_back({{topic_with_type_}, 1});
+    metadata_.compression_format = "zstd";
+    metadata_.compression_mode =
+      rosbag2_compression::compression_mode_to_string(rosbag2_compression::CompressionMode::FILE);
+
+    // Initialize some dummy files so that they can be found
+    rcpputils::fs::create_directories(tmp_dir_);
+    for (auto relative : metadata_.relative_file_paths) {
+      std::ofstream output((tmp_dir_ / relative).string());
+      output << "Fake storage data" << std::endl;
+    }
+
     ON_CALL(*storage_, get_all_topics_and_types()).WillByDefault(Return(topics_and_types));
     ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
     ON_CALL(*storage_factory_, open_read_only(_)).WillByDefault(Return(storage_));
-  }
-
-  rosbag2_storage::BagMetadata construct_default_bag_metadata() const
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.relative_file_paths = {"/path/to/storage"};
-    metadata.topics_with_message_count.push_back({{topic_with_type_}, 1});
-    metadata.compression_format = "zstd";
-    metadata.compression_mode =
-      rosbag2_compression::compression_mode_to_string(rosbag2_compression::CompressionMode::FILE);
-    return metadata;
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
@@ -72,13 +83,17 @@ public:
   std::unique_ptr<rosbag2_cpp::Reader> reader_;
   std::string storage_serialization_format_;
   rosbag2_storage::TopicMetadata topic_with_type_;
+  const std::string bag_name_ = "SequentialCompressionReaderTest";
+  rcpputils::fs::path tmp_dir_;
+  rosbag2_storage::StorageOptions storage_options_;
+  rosbag2_storage::BagMetadata metadata_;
+  rosbag2_cpp::ConverterOptions converter_options_;
 };
 
 TEST_F(SequentialCompressionReaderTest, open_throws_if_unsupported_compressor)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  metadata.compression_format = "bad_format";
-  EXPECT_CALL(*metadata_io_, read_metadata(_)).WillRepeatedly(Return(metadata));
+  metadata_.compression_format = "bad_format";
+  EXPECT_CALL(*metadata_io_, read_metadata(_)).WillRepeatedly(Return(metadata_));
   EXPECT_CALL(*metadata_io_, metadata_file_exists(_)).WillRepeatedly(Return(true));
   auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
 
@@ -90,14 +105,13 @@ TEST_F(SequentialCompressionReaderTest, open_throws_if_unsupported_compressor)
 
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(sequential_reader));
   EXPECT_THROW(
-    reader_->open(rosbag2_storage::StorageOptions(), {"", storage_serialization_format_}),
+    reader_->open(storage_options_, converter_options_),
     std::invalid_argument);
 }
 
 TEST_F(SequentialCompressionReaderTest, returns_all_topics_and_types)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
+  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata_));
   ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
 
   auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
@@ -114,8 +128,7 @@ TEST_F(SequentialCompressionReaderTest, returns_all_topics_and_types)
     converter_factory_,
     std::move(metadata_io_));
 
-  compression_reader->open(
-    rosbag2_storage::StorageOptions(), {"", storage_serialization_format_});
+  compression_reader->open(storage_options_, converter_options_);
 
   auto topics_and_types = compression_reader->get_all_topics_and_types();
   EXPECT_FALSE(topics_and_types.empty());
@@ -123,8 +136,7 @@ TEST_F(SequentialCompressionReaderTest, returns_all_topics_and_types)
 
 TEST_F(SequentialCompressionReaderTest, open_supports_zstd_compressor)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
+  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata_));
   ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
   auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
 
@@ -137,14 +149,13 @@ TEST_F(SequentialCompressionReaderTest, open_supports_zstd_compressor)
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(sequential_reader));
   // Throws runtime_error b/c compressor can't read
   EXPECT_THROW(
-    reader_->open(rosbag2_storage::StorageOptions(), {"", storage_serialization_format_}),
+    reader_->open(storage_options_, converter_options_),
     std::runtime_error);
 }
 
 TEST_F(SequentialCompressionReaderTest, reader_calls_create_decompressor)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
+  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata_));
   ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
 
   auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
@@ -164,29 +175,21 @@ TEST_F(SequentialCompressionReaderTest, reader_calls_create_decompressor)
     std::move(metadata_io_));
 
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(sequential_reader));
-  reader_->open(
-    rosbag2_storage::StorageOptions(), {"", storage_serialization_format_});
+  reader_->open(storage_options_, converter_options_);
 }
 
-TEST_F(SequentialCompressionReaderTest, compression_called_when_splitting_bagfile)
+TEST_F(SequentialCompressionReaderTest, compression_called_when_loading_split_bagfile)
 {
-  const auto relative_path_1 = "/path/to/storage1";
-  const auto relative_path_2 = "/path/to/storage2";
-  rosbag2_storage::BagMetadata metadata;
-  metadata.relative_file_paths = {relative_path_1, relative_path_2};
-  metadata.topics_with_message_count.push_back({{topic_with_type_}, 10});
-  metadata.bag_size = 512000;
-  metadata.compression_format = "zstd";
-  metadata.compression_mode =
-    rosbag2_compression::compression_mode_to_string(rosbag2_compression::CompressionMode::FILE);
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
+  metadata_.topics_with_message_count.push_back({{topic_with_type_}, 10});
+  metadata_.bag_size = 512000;
+  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata_));
   ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
 
   auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
-  // We are mocking two splits, so only file decompression should occur twice
+  // We are mocking two splits, so file decompression should occur twice
   EXPECT_CALL(*decompressor, decompress_uri(_)).Times(2)
-  .WillOnce(Return(relative_path_1))
-  .WillOnce(Return(relative_path_2));
+  .WillOnce(Return(metadata_.relative_file_paths[0]))
+  .WillOnce(Return(metadata_.relative_file_paths[1]));
   EXPECT_CALL(*decompressor, decompress_serialized_bag_message(_)).Times(0);
 
   auto compression_factory = std::make_unique<StrictMock<MockCompressionFactory>>();
@@ -206,8 +209,7 @@ TEST_F(SequentialCompressionReaderTest, compression_called_when_splitting_bagfil
     converter_factory_,
     std::move(metadata_io_));
 
-  compression_reader->open(
-    rosbag2_storage::StorageOptions(), {"", storage_serialization_format_});
+  compression_reader->open(storage_options_, converter_options_);
   EXPECT_EQ(compression_reader->has_next_file(), true);
   EXPECT_EQ(compression_reader->has_next(), true);
   compression_reader->read_next();

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -51,7 +51,7 @@ public:
     serialization_format_{"rmw_format"}
   {
     tmp_dir_storage_options_.uri = tmp_dir_.string();
-    EXPECT_TRUE(rcpputils::fs::remove_all(tmp_dir_));
+    rcpputils::fs::remove_all(tmp_dir_);
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(Return(storage_));
     EXPECT_CALL(*storage_factory_, open_read_write(_)).Times(AtLeast(0));
     // intercept the metadata write so we can analyze it.
@@ -59,16 +59,56 @@ public:
       [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
         intercepted_metadata_ = metadata;
       });
+  }
+
+  void initializeFakeFileStorage() {
+    // Mock functionality for storage initialization when opening a new bagfile
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(
       DoAll(
         Invoke(
           [this](const rosbag2_storage::StorageOptions & storage_options) {
             fake_storage_size_ = 0;
             fake_storage_uri_ = storage_options.uri;
+            // Touch the file
             std::ofstream output(storage_options.uri);
+            // Put some arbitrary bytes in the file so it isn't interpreted as being empty
             output << "Fake storage data";
           }),
         Return(storage_)));
+    // Mock functioality for writing a single message
+    ON_CALL(
+      *storage_,
+      write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
+      [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+        fake_storage_size_ += 1;
+      });
+    // Mock functionality for providing bagfile's current size
+    ON_CALL(*storage_, get_bagfile_size).WillByDefault(
+      [this]() {
+        return fake_storage_size_;
+      });
+    // Mock function for providing current relative bagfile path
+    ON_CALL(*storage_, get_relative_file_path).WillByDefault(
+      [this]() {
+        return fake_storage_uri_;
+      });
+  }
+
+  void initializeWriter(
+    const rosbag2_compression::CompressionOptions & compression_options,
+    std::unique_ptr<rosbag2_compression::CompressionFactory> custom_compression_factory = nullptr
+  ) {
+    auto compression_factory = std::move(custom_compression_factory);
+    if (!compression_factory) {
+      compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
+    }
+    auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
+      compression_options,
+      std::move(compression_factory),
+      std::move(storage_factory_),
+      converter_factory_,
+      std::move(metadata_io_));
+    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
   }
 
   const std::string bag_name_ = "SequentialCompressionWriterTest";
@@ -93,15 +133,7 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_empty_storage_options_uri
   rosbag2_compression::CompressionOptions compression_options{
     "zstd", rosbag2_compression::CompressionMode::FILE,
     kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeWriter(compression_options);
 
   EXPECT_THROW(
     writer_->open(
@@ -115,15 +147,7 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_bad_compression_format)
   rosbag2_compression::CompressionOptions compression_options{
     "bad_format", rosbag2_compression::CompressionMode::FILE,
     kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeWriter(compression_options);
 
   EXPECT_THROW(
     writer_->open(tmp_dir_storage_options_, {serialization_format_, serialization_format_}),
@@ -134,27 +158,19 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_bad_compression_format)
 
 TEST_F(SequentialCompressionWriterTest, open_throws_on_invalid_splitting_size)
 {
-  rosbag2_compression::CompressionOptions compression_options{
-    "zstd", rosbag2_compression::CompressionMode::FILE,
-    kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-
   // Set minimum file size greater than max bagfile size option
   const uint64_t min_split_file_size = 10;
   const uint64_t max_bagfile_size = 5;
   ON_CALL(*storage_, get_minimum_split_file_size()).WillByDefault(Return(min_split_file_size));
-  auto storage_options = rosbag2_storage::StorageOptions{};
+
+  rosbag2_compression::CompressionOptions compression_options{
+    "zstd", rosbag2_compression::CompressionMode::FILE,
+    kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
+  initializeWriter(compression_options);
+
+  rosbag2_storage::StorageOptions storage_options{};
   storage_options.max_bagfile_size = max_bagfile_size;
   storage_options.uri = "foo.bar";
-
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
-
   EXPECT_THROW(
     writer_->open(storage_options, {serialization_format_, serialization_format_}),
     std::runtime_error);
@@ -165,15 +181,7 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_on_supported_compression_f
   rosbag2_compression::CompressionOptions compression_options{
     "zstd", rosbag2_compression::CompressionMode::FILE,
     kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeWriter(compression_options);
 
   auto tmp_dir = rcpputils::fs::temp_directory_path() / "path_not_empty";
   auto storage_options = rosbag2_storage::StorageOptions();
@@ -193,13 +201,7 @@ TEST_F(SequentialCompressionWriterTest, writer_calls_create_compressor)
   auto compression_factory = std::make_unique<StrictMock<MockCompressionFactory>>();
   EXPECT_CALL(*compression_factory, create_compressor(_)).Times(1);
 
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeWriter(compression_options, std::move(compression_factory));
 
   // This will throw an exception because the MockCompressionFactory does not actually create
   // a compressor.
@@ -217,40 +219,18 @@ TEST_F(SequentialCompressionWriterTest, writer_creates_correct_metadata_relative
   // and subsequent paths, which are created in the splitting logic
   const std::string test_topic_name = "test_topic";
   const std::string test_topic_type = "test_msgs/BasicTypes";
-
-  ON_CALL(
-    *storage_,
-    write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
-      fake_storage_size_ += 1;
-    });
-
-  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
-    [this]() {
-      return fake_storage_size_;
-    });
-  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-    [this]() {
-      return fake_storage_uri_;
-    });
-
   rosbag2_compression::CompressionOptions compression_options {
-    "zstd", rosbag2_compression::CompressionMode::FILE,
-    kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads
+    "zstd",
+    rosbag2_compression::CompressionMode::FILE,
+    kDefaultCompressionQueueSize,
+    kDefaultCompressionQueueThreads
   };
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
 
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeFakeFileStorage();
+  initializeWriter(compression_options);
 
   tmp_dir_storage_options_.max_bagfile_size = 1;
-  writer_->open(tmp_dir_storage_options_, {"rmw_format", "rmw_format"});
-
+  writer_->open(tmp_dir_storage_options_);
   writer_->create_topic({test_topic_name, test_topic_type, "", ""});
 
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -61,8 +61,10 @@ public:
       });
   }
 
-  void initializeFakeFileStorage() {
-    // Mock functionality for storage initialization when opening a new bagfile
+  void initializeFakeFileStorage()
+  {
+    // Create mock implementation of the storage, using files and a size of 1 per message
+    // initialize values when opening a new bagfile
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(
       DoAll(
         Invoke(
@@ -75,19 +77,16 @@ public:
             output << "Fake storage data";
           }),
         Return(storage_)));
-    // Mock functioality for writing a single message
     ON_CALL(
       *storage_,
       write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
       [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
         fake_storage_size_ += 1;
       });
-    // Mock functionality for providing bagfile's current size
     ON_CALL(*storage_, get_bagfile_size).WillByDefault(
       [this]() {
         return fake_storage_size_;
       });
-    // Mock function for providing current relative bagfile path
     ON_CALL(*storage_, get_relative_file_path).WillByDefault(
       [this]() {
         return fake_storage_uri_;
@@ -96,8 +95,8 @@ public:
 
   void initializeWriter(
     const rosbag2_compression::CompressionOptions & compression_options,
-    std::unique_ptr<rosbag2_compression::CompressionFactory> custom_compression_factory = nullptr
-  ) {
+    std::unique_ptr<rosbag2_compression::CompressionFactory> custom_compression_factory = nullptr)
+  {
     auto compression_factory = std::move(custom_compression_factory);
     if (!compression_factory) {
       compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -74,7 +74,7 @@ public:
             // Touch the file
             std::ofstream output(storage_options.uri);
             // Put some arbitrary bytes in the file so it isn't interpreted as being empty
-            output << "Fake storage data";
+            output << "Fake storage data" << std::endl;
           }),
         Return(storage_)));
     ON_CALL(

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -133,6 +133,12 @@ protected:
     */
   virtual void fill_topics_metadata();
 
+  /**
+    * Prepare current file for opening by the storage implementation.
+    * This may be used by subclasses, for example decompressing
+    */
+  virtual void preprocess_current_file() {}
+
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_{};
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_{};
   std::unique_ptr<Converter> converter_{};

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -99,6 +99,8 @@ void SequentialReader::open(
       storage_options.uri, metadata_.relative_file_paths, metadata_.version);
     current_file_iterator_ = file_paths_.begin();
 
+    preprocess_current_file();
+
     storage_options_.uri = get_current_file();
     storage_ = storage_factory_->open_read_only(storage_options_);
     if (!storage_) {
@@ -199,6 +201,7 @@ void SequentialReader::load_next_file()
 {
   assert(current_file_iterator_ != file_paths_.end());
   current_file_iterator_++;
+  preprocess_current_file();
 }
 
 std::string SequentialReader::get_current_file() const


### PR DESCRIPTION
Fixes #557

Most fixes are accomplished by removing duplicated code from compressionreader/writer, in favor of calling the superclass. 
This gets us closer to being able to factor them out entirely.

While adding new test to verify the functionality, deduplicate that as well.

TODO: still needs some "fallback" code to read v4 files that were created with existing code that have incorrect relative paths