### PR TITLE
Fix the tests on cyclonedds by translating qos duration values

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,15 +187,18 @@ Below is an example profile set to the default ROS2 QoS settings.
   reliability: reliable
   durability: volatile
   deadline:
-    sec: 2147483647   # LONG_MAX
-    nsec: 4294967295  # ULONG_MAX
+    # unspecified/infinity
+    sec: 0
+    nsec: 0
   lifespan:
-    sec: 2147483647
-    nsec: 4294967295
+    # unspecified/infinity
+    sec: 0
+    nsec: 0
   liveliness: system_default
   liveliness_lease_duration:
-    sec: 2147483647
-    nsec: 4294967295
+    # unspecified/infinity
+    sec: 0
+    nsec: 0
   avoid_ros_namespace_conventions: false
 ```
 

--- a/ros2bag/test/resources/empty_bag/metadata.yaml
+++ b/ros2bag/test/resources/empty_bag/metadata.yaml
@@ -13,13 +13,13 @@ rosbag2_bagfile_information:
         name: /parameter_events
         type: rcl_interfaces/msg/ParameterEvent
         serialization_format: cdr
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 0\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 0
     - topic_metadata:
         name: /rosout
         type: rcl_interfaces/msg/Log
         serialization_format: cdr
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 1\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 10\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 1\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 10\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 0
   compression_format: ""
   compression_mode: ""

--- a/ros2bag/test/resources/incomplete_qos_duration.yaml
+++ b/ros2bag/test/resources/incomplete_qos_duration.yaml
@@ -4,4 +4,4 @@
   reliability: reliable
   durability: volatile
   deadline:
-    sec: 0
+    sec: 2

--- a/ros2bag/test/resources/incomplete_qos_duration.yaml
+++ b/ros2bag/test/resources/incomplete_qos_duration.yaml
@@ -4,4 +4,4 @@
   reliability: reliable
   durability: volatile
   deadline:
-    sec: 2147483647  # LONG_MAX
+    sec: 0

--- a/ros2bag/test/resources/qos_profile.yaml
+++ b/ros2bag/test/resources/qos_profile.yaml
@@ -4,13 +4,13 @@
   reliability: reliable
   durability: transient_local
   deadline:
-    sec: 2147483647
-    nsec: 4294967295
+    sec: 0
+    nsec: 0
   lifespan:
-    sec: 2147483647
-    nsec: 4294967295
+    sec: 0
+    nsec: 0
   liveliness: automatic
   liveliness_lease_duration:
-    sec: 2147483647
-    nsec: 4294967295
+    sec: 0
+    nsec: 0
   avoid_ros_namespace_conventions: false

--- a/ros2bag/test/resources/qos_profile.yaml
+++ b/ros2bag/test/resources/qos_profile.yaml
@@ -4,13 +4,16 @@
   reliability: reliable
   durability: transient_local
   deadline:
+    # unspecified/infinity
     sec: 0
     nsec: 0
   lifespan:
+    # unspecified/infinity
     sec: 0
     nsec: 0
   liveliness: automatic
   liveliness_lease_duration:
+    # unspecified/infinity
     sec: 0
     nsec: 0
   avoid_ros_namespace_conventions: false

--- a/rosbag2_py/resources/talker/metadata.yaml
+++ b/rosbag2_py/resources/talker/metadata.yaml
@@ -13,19 +13,19 @@ rosbag2_bagfile_information:
         name: /topic
         type: std_msgs/msg/String
         serialization_format: cdr
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 0\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 10
     - topic_metadata:
         name: /rosout
         type: rcl_interfaces/msg/Log
         serialization_format: cdr
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 1\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 10\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 1\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 10\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 10
     - topic_metadata:
         name: /parameter_events
         type: rcl_interfaces/msg/ParameterEvent
         serialization_format: cdr
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 0\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 0
   compression_format: ""
   compression_mode: ""

--- a/rosbag2_tests/resources/cdr_test/metadata.yaml
+++ b/rosbag2_tests/resources/cdr_test/metadata.yaml
@@ -13,13 +13,13 @@ rosbag2_bagfile_information:
         name: /test_topic
         type: test_msgs/msg/BasicTypes
         serialization_format: cdr
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 0\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 3
     - topic_metadata:
         name: /array_topic
         type: test_msgs/msg/Arrays
         serialization_format: cdr
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 0\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 4
   compression_format: ""
   compression_mode: ""

--- a/rosbag2_tests/resources/wrong_rmw_test/metadata.yaml
+++ b/rosbag2_tests/resources/wrong_rmw_test/metadata.yaml
@@ -13,13 +13,13 @@ rosbag2_bagfile_information:
         name: /test_topic
         type: test_msgs/msg/BasicTypes
         serialization_format: wrong_format
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 0\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 3
     - topic_metadata:
         name: /array_topic
         type: test_msgs/msg/Arrays
         serialization_format: wrong_format
-        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 2147483647\n    nsec: 4294967295\n  lifespan:\n    sec: 2147483647\n    nsec: 4294967295\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 2147483647\n    nsec: 4294967295\n  avoid_ros_namespace_conventions: false"
+        offered_qos_profiles: "- history: 3\n  depth: 0\n  reliability: 1\n  durability: 2\n  deadline:\n    sec: 0\n    nsec: 0\n  lifespan:\n    sec: 0\n    nsec: 0\n  liveliness: 1\n  liveliness_lease_duration:\n    sec: 0\n    nsec: 0\n  avoid_ros_namespace_conventions: false"
       message_count: 4
   compression_format: ""
   compression_mode: ""


### PR DESCRIPTION
Makes the build start passing again - it has been failing since https://github.com/ros2/rosbag2/actions/runs/479072133 on 1/11 due to https://github.com/ros2/ros2/pull/1058

Should unblock other open PRs - notably #603 #543 #605

Here's the full breakdown:

* Providing 0 as input duration to a publisher results in 'unspecified' for all rmw implementations for all currently supported QoS policies
* FastDDS reports this special value (2147483647, 4294967295)  when you query a publisher that has an 'unspecified' duration 
  * FastDDS accepts this value as 'unspecified' when creating a publisher (the same as it does 0) - but it WON'T parse the CycloneDDS value
* CycloneDDS reports the special value (9223372036, 854775807) when you query a publisher that has an 'unspecified' duration
  * CycloneDDS accepts this value as 'unspecified' when creating a publisher (the same as it does 0) - but it WON'T parse the FastDDS value

The `rmw_cyclonedds_cpp` error looks like this when trying to read a bag recorded with `rmw_fastrtps_cpp`
```
2021-01-12T01:40:46.2371892Z 2: 1610415583.125080 [0] dq.builtin: invalid parameter list (vendor 1.16, version 2.1): pid 23 (DEADLINE) invalid, input = 3,0,0,128,6,250,130,75
2021-01-12T01:40:46.2372518Z 2: 1610415583.125090 [0] dq.builtin: SPDP (vendor 1.16): invalid qos/parameters
2021-01-12T01:40:46.2373131Z 2: 1610415583.126850 [0] dq.builtin: invalid parameter list (vendor 1.16, version 2.1): pid 23 (DEADLINE) invalid, input = 3,0,0,128,6,250,130,75
2021-01-12T01:40:46.2373762Z 2: 1610415583.126857 [0] dq.builtin: SPDP (vendor 1.16): invalid qos/parameters
```

The `rmw_fastrtps_cpp` error looks like this when trying to read a bag recorded with `rmw_cyclonedds_cpp`
```
[WARN] [1611257485.439465477] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
[WARN] [1611257485.439495434] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
[WARN] [1611257485.439502850] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
[WARN] [1611257485.440722168] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
[WARN] [1611257485.440737894] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
[WARN] [1611257485.440758600] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
[WARN] [1611257485.441663946] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
[WARN] [1611257485.441677598] [rmw_dds_common]: nanoseconds value too large for 32-bits, saturated at UINT_MAX
```

This is a bad situation - I think we need to definitively resolve  https://github.com/ros2/rmw/pull/255 in order to actually solve this problem. It seems I may need to bump up the priority on that.

FOR TODAY - I think the unblocking resolution is to just make the test-sample data use "0" across the board, which can be parsed and tested on any implementation - and track the fact that QoS profiles aren't cross-implementation parseable.