### PR TITLE
Remove mjeronimo from CODEOWNERS in favor of having him on the reviewing team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Reviewers (and by extension approvers) will be the default owners for everything in the repo.
 # Unless a later match takes precedence, @reviewers will be requested for review when someone opens a pull request.
-* @ros2/tooling-reviewers @mjeronimo
+* @ros2/tooling-reviewers


### PR DESCRIPTION
This way you won't be assigned to every single review - my mistake!