### PR TITLE
Fix deadlock race condition on compression shutdown

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -166,7 +166,7 @@ private:
   compressor_message_queue_ RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_);
   std::queue<std::string> compressor_file_queue_ RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_);
   std::vector<std::thread> compression_threads_;
-  std::atomic_bool compression_is_running_{false};
+  std::atomic_bool compression_is_running_{false} RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_);
   std::recursive_mutex storage_mutex_;
   std::condition_variable compressor_condition_;
 

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -166,7 +166,10 @@ private:
   compressor_message_queue_ RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_);
   std::queue<std::string> compressor_file_queue_ RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_);
   std::vector<std::thread> compression_threads_;
-  std::atomic_bool compression_is_running_{false} RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_);
+  /* *INDENT-OFF* */  // uncrustify doesn't understand the macro + brace initializer
+  std::atomic_bool compression_is_running_
+    RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_) {false};
+  /* *INDENT-ON* */
   std::recursive_mutex storage_mutex_;
   std::condition_variable compressor_condition_;
 

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -170,10 +170,8 @@ void SequentialCompressionWriter::stop_compressor_threads()
     {
       std::unique_lock<std::mutex> lock(compressor_queue_mutex_);
       compression_is_running_ = false;
-      // Normally you are better off not holding the mutex when calling notify -
-      // but the behavior is still correct, and we need it to synchronize these two variables
-      compressor_condition_.notify_all();
     }
+    compressor_condition_.notify_all();
     for (auto & thread : compression_threads_) {
       thread.join();
     }


### PR DESCRIPTION
When running the test `test_sequential_compression_writer` repeatedly, the test sometimes hangs on shutdown, due to a gap in the threading synchronization between the compressor threads and the main thread.

The order of operations is:
* Worker thread N: `compressor_thread_fn` reads `while(compression_is_running_)` to be `true`, so it enters the while block
* Main thread: `stop_compressor_threads` runs `compression_is_running_=false; compressor_condition_.notify_all()`, notifying any _currently waiting_ compression threads to wake up, which lets them exit after finding no work to do
    * main thread then calls `.join()` on all the threads
* Worker thread N: `compressor_thread_fn`, having entered the while loop successfully, initializes some variables, acquires the `compressor_queue_mutex_`, and calls `compressor_condition_.wait()`
* Because the compressor_thread has called `wait` _after_ the final `notify_all`, it will never receive a notification, and the `.join()` call waits forever for this waiting thread to exit

This PR fixes the problem by synchronizing the checks of both exit conditions so that the main thread can't interleave the notifications in a way that causes the deadlock.

NOTE: I am not sure how to add a repeatable regression test for this - the way I can reproduce it is by running the following, which reliably makes it happen quite quickly (within a second). After my change it'll run indefinitely without failure.

```
build/rosbag2_compression/test_sequential_compression_writer --gtest_repeat=-1 --gtest_throw_on_failure
```