### PR TITLE
[backport foxy] Deduplicate SequentialCompressionReader business logic, add fallback to find bagfiles in incorrectly-written metadata #612

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
@@ -70,22 +70,21 @@ public:
 
 protected:
   /**
-   * Increment the current file iterator to point to the next file in the list of relative file
-   * paths.
-   *
-   * Expected usage:
-   * if (has_next_file()) load_next_file();
+   * Decompress the current bagfile so that it can be opened by the storage implementation.
    */
-  void load_next_file() override;
+  void preprocess_current_file() override;
 
+private:
   /**
    * Initializes the decompressor if a compression mode is specified in the metadata.
    *
-   * \throws std::invalid_argument If compression format doesn't exist.
+   * \throw std::invalid_argument If compression mode is NONE
+   * \throw std::invalid_argument If compression format could not be found
+   * \throw rcpputils::IllegalStateException if the decompressor could not be initialized for
+   *        any other reason
    */
-  virtual void setup_decompression();
+  void setup_decompression();
 
-private:
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};
   rosbag2_compression::CompressionMode compression_mode_{
     rosbag2_compression::CompressionMode::NONE};

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -69,11 +69,11 @@ void SequentialCompressionReader::preprocess_current_file()
      * Because we have no way to check whether the bag was written correctly,
      * check for the existence of the prefixed file as a fallback.
      */
-    const rcpputils::fs::path base{base_folder_};
+    rcpputils::fs::path base{base_folder_};
     const rcpputils::fs::path relative{get_current_file()};
     const auto resolved = base / relative;
     if (!resolved.exists()) {
-      const auto base_stripped = relative.filename();
+      auto base_stripped = relative.filename();
       const auto resolved_stripped = base / base_stripped;
       ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
         "Unable to find specified bagfile " << resolved.string() <<

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "rcpputils/asserts.hpp"
 #include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/compression_options.hpp"
@@ -44,15 +45,49 @@ SequentialCompressionReader::~SequentialCompressionReader()
 
 void SequentialCompressionReader::setup_decompression()
 {
-  compression_mode_ = rosbag2_compression::compression_mode_from_string(metadata_.compression_mode);
-  if (compression_mode_ != rosbag2_compression::CompressionMode::NONE) {
-    decompressor_ = compression_factory_->create_decompressor(metadata_.compression_format);
-    // Decompress the first file so that it is readable.
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
+  if (decompressor_) {
+    return;
+  }
+
+  compression_mode_ = compression_mode_from_string(metadata_.compression_mode);
+  rcpputils::require_true(
+    compression_mode_ != rosbag2_compression::CompressionMode::NONE,
+    "SequentialCompressionReader should not be initialized with NONE compression mode.");
+
+  decompressor_ = compression_factory_->create_decompressor(metadata_.compression_format);
+  rcpputils::check_true(decompressor_ != nullptr, "Couldn't initialize decompressor.");
+}
+
+void SequentialCompressionReader::preprocess_current_file()
+{
+  setup_decompression();
+
+  if (metadata_.version == 4) {
+    /*
+     * Rosbag2 was released with incorrect relative file naming for compressed bags
+     * which were written as v4, using v3 logic which had the bag name prefixed on the file path.
+     * Because we have no way to check whether the bag was written correctly,
+     * check for the existence of the prefixed file as a fallback.
+     */
+    const rcpputils::fs::path base{base_folder_};
+    const rcpputils::fs::path relative{get_current_file()};
+    const auto resolved = base / relative;
+    if (!resolved.exists()) {
+      const auto base_stripped = relative.filename();
+      const auto resolved_stripped = base / base_stripped;
+      ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
+        "Unable to find specified bagfile " << resolved.string() <<
+          ". Falling back to checking for " << resolved_stripped.string());
+      rcpputils::require_true(
+        resolved_stripped.exists(),
+        "Unable to resolve relative file path either as a V3 or V4 relative path");
+      *current_file_iterator_ = resolved_stripped.string();
+    }
+  }
+
+  if (compression_mode_ == CompressionMode::FILE) {
+    ROSBAG2_COMPRESSION_LOG_INFO_STREAM("Decompressing " << get_current_file().c_str());
     *current_file_iterator_ = decompressor_->decompress_uri(get_current_file());
-  } else {
-    throw std::invalid_argument{
-            "SequentialCompressionReader requires a CompressionMode that is not NONE!"};
   }
 }
 
@@ -60,43 +95,13 @@ void SequentialCompressionReader::open(
   const rosbag2_cpp::StorageOptions & storage_options,
   const rosbag2_cpp::ConverterOptions & converter_options)
 {
-  if (metadata_io_->metadata_file_exists(storage_options.uri)) {
-    metadata_ = metadata_io_->read_metadata(storage_options.uri);
-    if (metadata_.relative_file_paths.empty()) {
-      ROSBAG2_COMPRESSION_LOG_WARN("No file paths were found in metadata.");
-      return;
-    }
-    file_paths_ = metadata_.relative_file_paths;
-    current_file_iterator_ = file_paths_.begin();
-    setup_decompression();
-
-    storage_ = storage_factory_->open_read_only(
-      *current_file_iterator_, metadata_.storage_identifier);
-    if (!storage_) {
-      std::stringstream errmsg;
-      errmsg << "No storage could be initialized for: \"" <<
-        storage_options.uri << "\".";
-
-      throw std::runtime_error{errmsg.str()};
-    }
-  } else {
+  if (!metadata_io_->metadata_file_exists(storage_options.uri)) {
     std::stringstream errmsg;
     errmsg << "Could not find metadata for bag: \"" << storage_options.uri <<
-      "\". Legacy bag files are not supported if this is a ROS 1 bag file.";
+      "\". Bags without metadata (such as from ROS 1) not supported by rosbag2 decompression.";
     throw std::runtime_error{errmsg.str()};
   }
-  const auto & topics = metadata_.topics_with_message_count;
-  if (topics.empty()) {
-    ROSBAG2_COMPRESSION_LOG_WARN("No topics were listed in metadata.");
-    return;
-  }
-  fill_topics_metadata();
-
-  // Currently a bag file can only be played if all topics have the same serialization format.
-  check_topics_serialization_formats(topics);
-  check_converter_serialization_format(
-    converter_options.output_serialization_format,
-    topics[0].topic_metadata.serialization_format);
+  SequentialReader::open(storage_options, converter_options);
 }
 
 std::shared_ptr<rosbag2_storage::SerializedBagMessage> SequentialCompressionReader::read_next()
@@ -111,28 +116,4 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> SequentialCompressionRead
   throw std::runtime_error{"Bag is not open. Call open() before reading."};
 }
 
-
-void SequentialCompressionReader::load_next_file()
-{
-  if (current_file_iterator_ == file_paths_.end()) {
-    throw std::runtime_error{"Cannot load next file; already on last file!"};
-  }
-
-  if (compression_mode_ == rosbag2_compression::CompressionMode::NONE) {
-    throw std::runtime_error{"Cannot use SequentialCompressionReader with NONE compression mode."};
-  }
-
-  ++current_file_iterator_;
-  if (compression_mode_ == rosbag2_compression::CompressionMode::FILE) {
-    if (decompressor_ == nullptr) {
-      throw std::runtime_error{
-              "The bag file was not properly opened. "
-              "Somehow the compression mode was set without opening a decompressor."
-      };
-    }
-
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Decompressing " << get_current_file().c_str());
-    *current_file_iterator_ = decompressor_->decompress_uri(get_current_file());
-  }
-}
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -14,10 +14,13 @@
 
 #include <gmock/gmock.h>
 
+#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/sequential_compression_reader.hpp"
 
@@ -37,27 +40,43 @@ class SequentialCompressionReaderTest : public Test
 {
 public:
   SequentialCompressionReaderTest()
-  : storage_factory_{std::make_unique<StrictMock<MockStorageFactory>>()},
+  : storage_factory_{std::make_unique<NiceMock<MockStorageFactory>>()},
     storage_{std::make_shared<NiceMock<MockStorage>>()},
     converter_factory_{std::make_shared<StrictMock<MockConverterFactory>>()},
     metadata_io_{std::make_unique<NiceMock<MockMetadataIo>>()},
-    storage_serialization_format_{"rmw1_format"}
+    storage_serialization_format_{"rmw1_format"},
+    tmp_dir_{rcpputils::fs::temp_directory_path() / bag_name_},
+    converter_options_{"", storage_serialization_format_}
   {
+    rcpputils::fs::remove_all(tmp_dir_);
+    storage_options_.uri = tmp_dir_.string();
     topic_with_type_ = rosbag2_storage::TopicMetadata{
       "topic", "test_msgs/BasicTypes", storage_serialization_format_, ""};
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type_};
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type_.name;
 
+    metadata_ = construct_default_bag_metadata();
+    ON_CALL(*metadata_io_, read_metadata).WillByDefault(
+      [this](auto /*uri*/) {
+        return metadata_;
+      });
+    ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
+
     ON_CALL(*storage_, get_all_topics_and_types()).WillByDefault(Return(topics_and_types));
     ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
     ON_CALL(*storage_factory_, open_read_only(_, _)).WillByDefault(Return(storage_));
+    initialize_dummy_storage_files();
   }
 
   rosbag2_storage::BagMetadata construct_default_bag_metadata() const
   {
     rosbag2_storage::BagMetadata metadata;
-    metadata.relative_file_paths = {"/path/to/storage"};
+    metadata.version = 4;
+    metadata.relative_file_paths = {
+      "bagfile_0.zstd",
+      "bagfile_1.zstd"
+    };
     metadata.topics_with_message_count.push_back({{topic_with_type_}, 1});
     metadata.compression_format = "zstd";
     metadata.compression_mode =
@@ -65,21 +84,54 @@ public:
     return metadata;
   }
 
-  std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
-  std::shared_ptr<NiceMock<MockStorage>> storage_;
-  std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
-  std::unique_ptr<NiceMock<MockMetadataIo>> metadata_io_;
+  void initialize_dummy_storage_files()
+  {
+    // Initialize some dummy files so that they can be found
+    rcpputils::fs::create_directories(tmp_dir_);
+    for (auto relative : metadata_.relative_file_paths) {
+      std::ofstream output((tmp_dir_ / relative).string());
+      output << "Fake storage data" << std::endl;
+    }
+  }
+
+  std::unique_ptr<rosbag2_compression::SequentialCompressionReader> create_reader()
+  {
+    auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
+    ON_CALL(*decompressor, decompress_uri).WillByDefault(
+      [](auto uri) {
+        auto path = rcpputils::fs::path(uri);
+        EXPECT_TRUE(path.exists());
+        return rcpputils::fs::remove_extension(path).string();
+      });
+    auto compression_factory = std::make_unique<NiceMock<MockCompressionFactory>>();
+    ON_CALL(*compression_factory, create_decompressor(_))
+    .WillByDefault(Return(ByMove(std::move(decompressor))));
+    return std::make_unique<rosbag2_compression::SequentialCompressionReader>(
+      std::move(compression_factory),
+      std::move(storage_factory_),
+      converter_factory_,
+      std::move(metadata_io_));
+  }
+
+  std::unique_ptr<MockStorageFactory> storage_factory_;
+  std::shared_ptr<MockStorage> storage_;
+  std::shared_ptr<MockConverterFactory> converter_factory_;
+  std::unique_ptr<MockMetadataIo> metadata_io_;
   std::unique_ptr<rosbag2_cpp::Reader> reader_;
   std::string storage_serialization_format_;
   rosbag2_storage::TopicMetadata topic_with_type_;
+  const std::string bag_name_ = "SequentialCompressionReaderTest";
+  rcpputils::fs::path tmp_dir_;
+  rosbag2_storage::StorageOptions storage_options_;
+  rosbag2_storage::BagMetadata metadata_;
+  rosbag2_cpp::ConverterOptions converter_options_;
 };
 
 TEST_F(SequentialCompressionReaderTest, open_throws_if_unsupported_compressor)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  metadata.compression_format = "bad_format";
-  EXPECT_CALL(*metadata_io_, read_metadata(_)).WillRepeatedly(Return(metadata));
-  EXPECT_CALL(*metadata_io_, metadata_file_exists(_)).WillRepeatedly(Return(true));
+  metadata_.compression_format = "bad_format";
+  EXPECT_CALL(*metadata_io_, read_metadata(_)).Times(1);
+  EXPECT_CALL(*metadata_io_, metadata_file_exists(_)).Times(AtLeast(1));
   auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
 
   auto sequential_reader = std::make_unique<rosbag2_compression::SequentialCompressionReader>(
@@ -88,18 +140,13 @@ TEST_F(SequentialCompressionReaderTest, open_throws_if_unsupported_compressor)
     converter_factory_,
     std::move(metadata_io_));
 
-  reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(sequential_reader));
   EXPECT_THROW(
-    reader_->open(rosbag2_cpp::StorageOptions(), {"", storage_serialization_format_}),
+    sequential_reader->open(storage_options_, converter_options_),
     std::invalid_argument);
 }
 
 TEST_F(SequentialCompressionReaderTest, returns_all_topics_and_types)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
-  ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
-
   auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
   auto compression_factory = std::make_unique<StrictMock<MockCompressionFactory>>();
 
@@ -114,8 +161,7 @@ TEST_F(SequentialCompressionReaderTest, returns_all_topics_and_types)
     converter_factory_,
     std::move(metadata_io_));
 
-  compression_reader->open(
-    rosbag2_cpp::StorageOptions(), {"", storage_serialization_format_});
+  compression_reader->open(storage_options_, converter_options_);
 
   auto topics_and_types = compression_reader->get_all_topics_and_types();
   EXPECT_FALSE(topics_and_types.empty());
@@ -123,9 +169,6 @@ TEST_F(SequentialCompressionReaderTest, returns_all_topics_and_types)
 
 TEST_F(SequentialCompressionReaderTest, open_supports_zstd_compressor)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
-  ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
   auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
 
   auto sequential_reader = std::make_unique<rosbag2_compression::SequentialCompressionReader>(
@@ -137,16 +180,12 @@ TEST_F(SequentialCompressionReaderTest, open_supports_zstd_compressor)
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(sequential_reader));
   // Throws runtime_error b/c compressor can't read
   EXPECT_THROW(
-    reader_->open(rosbag2_cpp::StorageOptions(), {"", storage_serialization_format_}),
+    reader_->open(storage_options_, converter_options_),
     std::runtime_error);
 }
 
 TEST_F(SequentialCompressionReaderTest, reader_calls_create_decompressor)
 {
-  rosbag2_storage::BagMetadata metadata = construct_default_bag_metadata();
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
-  ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
-
   auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
   ON_CALL(*decompressor, decompress_uri(_)).WillByDefault(Return("some/path"));
   EXPECT_CALL(*decompressor, decompress_uri(_)).Times(1);
@@ -164,29 +203,19 @@ TEST_F(SequentialCompressionReaderTest, reader_calls_create_decompressor)
     std::move(metadata_io_));
 
   reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(sequential_reader));
-  reader_->open(
-    rosbag2_cpp::StorageOptions(), {"", storage_serialization_format_});
+  reader_->open(storage_options_, converter_options_);
 }
 
-TEST_F(SequentialCompressionReaderTest, compression_called_when_splitting_bagfile)
+TEST_F(SequentialCompressionReaderTest, compression_called_when_loading_split_bagfile)
 {
-  const auto relative_path_1 = "/path/to/storage1";
-  const auto relative_path_2 = "/path/to/storage2";
-  rosbag2_storage::BagMetadata metadata;
-  metadata.relative_file_paths = {relative_path_1, relative_path_2};
-  metadata.topics_with_message_count.push_back({{topic_with_type_}, 10});
-  metadata.bag_size = 512000;
-  metadata.compression_format = "zstd";
-  metadata.compression_mode =
-    rosbag2_compression::compression_mode_to_string(rosbag2_compression::CompressionMode::FILE);
-  ON_CALL(*metadata_io_, read_metadata(_)).WillByDefault(Return(metadata));
-  ON_CALL(*metadata_io_, metadata_file_exists(_)).WillByDefault(Return(true));
+  metadata_.topics_with_message_count.push_back({{topic_with_type_}, 10});
+  metadata_.bag_size = 512000;
 
   auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
-  // We are mocking two splits, so only file decompression should occur twice
+  // We are mocking two splits, so file decompression should occur twice
   EXPECT_CALL(*decompressor, decompress_uri(_)).Times(2)
-  .WillOnce(Return(relative_path_1))
-  .WillOnce(Return(relative_path_2));
+  .WillOnce(Return(metadata_.relative_file_paths[0]))
+  .WillOnce(Return(metadata_.relative_file_paths[1]));
   EXPECT_CALL(*decompressor, decompress_serialized_bag_message(_)).Times(0);
 
   auto compression_factory = std::make_unique<StrictMock<MockCompressionFactory>>();
@@ -206,9 +235,51 @@ TEST_F(SequentialCompressionReaderTest, compression_called_when_splitting_bagfil
     converter_factory_,
     std::move(metadata_io_));
 
-  compression_reader->open(
-    rosbag2_cpp::StorageOptions(), {"", storage_serialization_format_});
+  compression_reader->open(storage_options_, converter_options_);
   EXPECT_EQ(compression_reader->has_next_file(), true);
   EXPECT_EQ(compression_reader->has_next(), true);
   compression_reader->read_next();
+}
+
+TEST_F(SequentialCompressionReaderTest, can_find_v4_names)
+{
+  auto reader = create_reader();
+  reader->open(storage_options_, converter_options_);
+  EXPECT_TRUE(reader->has_next_file());
+}
+
+TEST_F(SequentialCompressionReaderTest, throws_on_incorrect_filenames)
+{
+  for (auto & relative_file_path : metadata_.relative_file_paths) {
+    relative_file_path = (
+      rcpputils::fs::path(bag_name_) / (relative_file_path + ".something")).string();
+  }
+  auto reader = create_reader();
+  EXPECT_THROW(reader->open(storage_options_, converter_options_), std::invalid_argument);
+}
+
+TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames)
+{
+  // By prefixing the bag name, this imitates the V3 filename logic
+  for (auto & relative_file_path : metadata_.relative_file_paths) {
+    relative_file_path = (rcpputils::fs::path(bag_name_) / relative_file_path).string();
+  }
+  auto reader = create_reader();
+
+  EXPECT_NO_THROW(reader->open(storage_options_, converter_options_));
+  EXPECT_TRUE(reader->has_next_file());
+}
+
+TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames_in_renamed_bag)
+{
+  // By prefixing a _different_ path than the bagname, we imitate the situation where the bag
+  // was recorded using V3 logic, then the directory was moved to be a new name - this is the
+  // use case the V4 relative path logic was intended to fix
+  for (auto & relative_file_path : metadata_.relative_file_paths) {
+    relative_file_path = (rcpputils::fs::path("OtherBagName") / relative_file_path).string();
+  }
+  auto reader = create_reader();
+
+  EXPECT_NO_THROW(reader->open(storage_options_, converter_options_));
+  EXPECT_TRUE(reader->has_next_file());
 }

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -122,7 +122,7 @@ public:
   rosbag2_storage::TopicMetadata topic_with_type_;
   const std::string bag_name_ = "SequentialCompressionReaderTest";
   rcpputils::fs::path tmp_dir_;
-  rosbag2_storage::StorageOptions storage_options_;
+  rosbag2_cpp::StorageOptions storage_options_;
   rosbag2_storage::BagMetadata metadata_;
   rosbag2_cpp::ConverterOptions converter_options_;
 };

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -132,6 +132,12 @@ protected:
     */
   virtual void fill_topics_metadata();
 
+  /**
+    * Prepare current file for opening by the storage implementation.
+    * This may be used by subclasses, for example decompressing
+    */
+  virtual void preprocess_current_file() {}
+
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_{};
   std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage_{};
   std::unique_ptr<Converter> converter_{};
@@ -140,6 +146,9 @@ protected:
   std::vector<rosbag2_storage::TopicMetadata> topics_metadata_{};
   std::vector<std::string> file_paths_{};  // List of database files.
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from
+
+  // Hang on to this because storage_options_ is mutated to point at individual files
+  std::string base_folder_;
 
 private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -82,6 +82,8 @@ void SequentialReader::reset()
 void SequentialReader::open(
   const StorageOptions & storage_options, const ConverterOptions & converter_options)
 {
+  base_folder_ = storage_options.uri;
+
   // If there is a metadata.yaml file present, load it.
   // If not, let's ask the storage with the given URI for its metadata.
   // This is necessary for non ROS2 bags (aka ROS1 legacy bags).
@@ -96,6 +98,7 @@ void SequentialReader::open(
       storage_options.uri, metadata_.relative_file_paths, metadata_.version);
     current_file_iterator_ = file_paths_.begin();
 
+    preprocess_current_file();
     storage_ = storage_factory_->open_read_only(
       get_current_file(), storage_options.storage_id);
     if (!storage_) {
@@ -196,6 +199,7 @@ void SequentialReader::load_next_file()
 {
   assert(current_file_iterator_ != file_paths_.end());
   current_file_iterator_++;
+  preprocess_current_file();
 }
 
 std::string SequentialReader::get_current_file() const


### PR DESCRIPTION
Backport of #612 to Foxy

This PR allows rosbag2 to correctly read the incorrect V4 metadata files being currently written by compressed bags. It removes most of the business logic from the SequentialCompressionReader in preparation for removing the class entirely.