### PR TITLE
Fix --topics flag for ros2 bag play being ignored for all bags after the first one.

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -144,6 +144,7 @@ protected:
   std::unique_ptr<Converter> converter_{};
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
   rosbag2_storage::BagMetadata metadata_{};
+  rosbag2_storage::StorageFilter topics_filter_{};
   std::vector<rosbag2_storage::TopicMetadata> topics_metadata_{};
   std::vector<std::string> file_paths_{};  // List of database files.
   std::vector<std::string>::iterator current_file_iterator_{};  // Index of file to read from

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -144,6 +144,7 @@ bool SequentialReader::has_next()
       storage_options_.uri = get_current_file();
 
       storage_ = storage_factory_->open_read_only(storage_options_);
+      storage_->set_filter(topics_filter_);
     }
 
     return storage_->has_next();
@@ -175,8 +176,9 @@ std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and
 void SequentialReader::set_filter(
   const rosbag2_storage::StorageFilter & storage_filter)
 {
+  topics_filter_ = storage_filter;
   if (storage_) {
-    storage_->set_filter(storage_filter);
+    storage_->set_filter(topics_filter_);
     return;
   }
   throw std::runtime_error(
@@ -185,6 +187,7 @@ void SequentialReader::set_filter(
 
 void SequentialReader::reset_filter()
 {
+  topics_filter_ = rosbag2_storage::StorageFilter();
   if (storage_) {
     storage_->reset_filter();
     return;

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -23,6 +23,7 @@
 #include "rcutils/filesystem.h"
 #include "rosbag2_compression/zstd_decompressor.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
+#include "rosbag2_test_common/subscription_manager.hpp"
 #include "rosbag2_test_common/process_execution_helpers.hpp"
 
 #include "record_fixture.hpp"
@@ -633,4 +634,65 @@ TEST_F(RecordFixture, record_end_to_end_test_with_cache) {
   auto test_topic_messages =
     get_messages_for_topic<test_msgs::msg::Strings>(topic_name);
   EXPECT_THAT(test_topic_messages, SizeIs(Ge(expected_test_messages)));
+}
+
+TEST_F(RecordFixture, rosbag2_record_and_play_multiple_topics_with_filter) {
+  constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
+
+  std::stringstream command_record;
+  command_record << "ros2 bag record" <<
+    " --output " << root_bag_path_.string() <<
+    " --max-bag-size " << bagfile_split_size <<
+    " -a";
+  auto process_handle = start_execution(command_record.str());
+
+  wait_for_db();
+
+  constexpr const char first_topic_name[] = "/test_topic0";
+  constexpr const char second_topic_name[] = "/test_topic1";
+  constexpr const int expected_splits = 4;
+  constexpr const char message_str[] = "Test";
+  constexpr const int message_size = 1024 * 1024;  // 1MB
+  constexpr const int message_count = bagfile_split_size * expected_splits / message_size;
+  const auto message = create_string_message(message_str, message_size);
+  constexpr const int message_batch_size = message_count / 2;
+  {
+    pub_man_.run_scoped_publisher(
+      first_topic_name,
+      message,
+      50ms,
+      message_batch_size);
+
+    pub_man_.run_scoped_publisher(
+      second_topic_name,
+      message,
+      50ms,
+      message_batch_size);
+  }
+
+  stop_execution(process_handle);
+
+  wait_for_metadata();
+
+  auto sub = std::make_unique<SubscriptionManager>();
+  sub->add_subscription<test_msgs::msg::Strings>(
+    first_topic_name,
+    message_batch_size);
+  auto sub_future = sub->spin_subscriptions();
+
+  std::stringstream command_play;
+  command_play << "ros2 bag play " << root_bag_path_.string() << " --topics " <<
+    second_topic_name;
+
+  int exit_code = execute_and_wait_until_completion(command_play.str(), ".");
+  EXPECT_THAT(exit_code, Eq(EXIT_SUCCESS));
+
+  sub_future.wait_for(1s);
+
+  auto first_topic_msgs = sub->get_received_messages<test_msgs::msg::Strings>(first_topic_name);
+
+  EXPECT_THAT(first_topic_msgs, SizeIs(Eq(0u)));
+
+  // stops thread
+  sub->add_subscription<test_msgs::msg::Strings>(first_topic_name, 0);
 }


### PR DESCRIPTION
How to reproduce:

We need to have some [splitted](https://github.com/ros2/rosbag2#splitting-recorded-bag-files) log. I can't provide our own log, but I think any log with any messages recorded for 2 topics will be good.

File structure of our log looks like:
```
metadata.yaml      rosbag_12.db3      rosbag_15.db3-shm  rosbag_18.db3-wal  rosbag_21.db3      rosbag_24.db3-shm  rosbag_27.db3-wal  rosbag_30.db3      rosbag_3.db3-shm  rosbag_6.db3-wal
rosbag_0.db3       rosbag_12.db3-shm  rosbag_15.db3-wal  rosbag_19.db3      rosbag_21.db3-shm  rosbag_24.db3-wal  rosbag_28.db3      rosbag_30.db3-shm  rosbag_3.db3-wal  rosbag_7.db3
rosbag_0.db3-shm   rosbag_12.db3-wal  rosbag_16.db3      rosbag_19.db3-shm  rosbag_21.db3-wal  rosbag_25.db3      rosbag_28.db3-shm  rosbag_30.db3-wal  rosbag_4.db3      rosbag_7.db3-shm
rosbag_0.db3-wal   rosbag_13.db3      rosbag_16.db3-shm  rosbag_19.db3-wal  rosbag_22.db3      rosbag_25.db3-shm  rosbag_28.db3-wal  rosbag_31.db3      rosbag_4.db3-shm  rosbag_7.db3-wal
rosbag_10.db3      rosbag_13.db3-shm  rosbag_16.db3-wal  rosbag_1.db3       rosbag_22.db3-shm  rosbag_25.db3-wal  rosbag_29.db3      rosbag_31.db3-shm  rosbag_4.db3-wal  rosbag_8.db3
rosbag_10.db3-shm  rosbag_13.db3-wal  rosbag_17.db3      rosbag_1.db3-shm   rosbag_22.db3-wal  rosbag_26.db3      rosbag_29.db3-shm  rosbag_31.db3-wal  rosbag_5.db3      rosbag_8.db3-shm
rosbag_10.db3-wal  rosbag_14.db3      rosbag_17.db3-shm  rosbag_1.db3-wal   rosbag_23.db3      rosbag_26.db3-shm  rosbag_29.db3-wal  rosbag_32.db3      rosbag_5.db3-shm  rosbag_8.db3-wal
rosbag_11.db3      rosbag_14.db3-shm  rosbag_17.db3-wal  rosbag_20.db3      rosbag_23.db3-shm  rosbag_26.db3-wal  rosbag_2.db3       rosbag_32.db3-shm  rosbag_5.db3-wal  rosbag_9.db3
rosbag_11.db3-shm  rosbag_14.db3-wal  rosbag_18.db3      rosbag_20.db3-shm  rosbag_23.db3-wal  rosbag_27.db3      rosbag_2.db3-shm   rosbag_32.db3-wal  rosbag_6.db3      rosbag_9.db3-shm
rosbag_11.db3-wal  rosbag_15.db3      rosbag_18.db3-shm  rosbag_20.db3-wal  rosbag_24.db3      rosbag_27.db3-shm  rosbag_2.db3-wal   rosbag_3.db3       rosbag_6.db3-shm  rosbag_9.db3-wal
```

For example there are 2 topics recorded: `/topic1` and `/topic2`.
According to code I need to call `ros2 bag play --topics /topic1` to play messages only from `/topic1`. So I've started playing in 1st terminal and start echoing messages in second one, like `ros2 topic echo /topic2`

In 1st terminal I got message something like
```
[INFO] [1611763978.658416823] [rosbag2_storage]: Opened database './rosbag_0.db3' for READ_ONLY.
[INFO] [1611763978.708594529] [rosbag2_storage]: Opened database './rosbag_1.db3' for READ_ONLY.
```

And when messages from `rosbag_1.db3` starts playing I've got messages in 2nd terminal. But in 2nd terminal I was listening for `/topic2` messages!