### PR TITLE
Regex and exclude fix for rosbag recorder

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -114,7 +114,9 @@ Recorder::get_requested_or_available_topics(const RecordOptions & record_options
   bool take = record_options.all;
   for (const auto & kv : unfiltered_topics) {
     // regex_match returns false for 'empty' regex
-    if (!record_options.regex.empty()) {take = std::regex_match(kv.first, topic_regex);}
+    if (!record_options.regex.empty()) {
+      take = std::regex_match(kv.first, topic_regex);
+    }
     if (take) {
       take = !std::regex_match(kv.first, exclude_regex);
     }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -113,9 +113,10 @@ Recorder::get_requested_or_available_topics(const RecordOptions & record_options
   std::regex exclude_regex(record_options.exclude);
   bool take = record_options.all;
   for (const auto & kv : unfiltered_topics) {
-    take = std::regex_search(kv.first, topic_regex);
+    // regex_match returns false for 'empty' regex
+    if (!record_options.regex.empty()) {take = std::regex_match(kv.first, topic_regex);}
     if (take) {
-      take = !std::regex_search(kv.first, exclude_regex);
+      take = !std::regex_match(kv.first, exclude_regex);
     }
     if (take) {
       filtered_by_regex.insert(kv);


### PR DESCRIPTION
There is a bug in rosbag recorder when using `--regex` parameter. Currently when `--regex` parameter is set and `--exclude` parameter is not (which is by default), none of the topics are marked to subscribe.

This is caused because of misused `regex_search` method which returns always `true` when passed with "empty regex". Because of that, every topic is always dropped as soon as it is discovered.

This PR changes `regex_search` with `regex_match` which is more suitable for this case. Additional test case is also included.