### PR TITLE
[backport foxy] Fix relative metadata paths in SequentialCompressionWriter (#613)

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -25,7 +25,7 @@
 #include "rosbag2_cpp/serialization_format_converter_factory.hpp"
 #include "rosbag2_cpp/serialization_format_converter_factory_interface.hpp"
 #include "rosbag2_cpp/storage_options.hpp"
-#include "rosbag2_cpp/writer_interfaces/base_writer_interface.hpp"
+#include "rosbag2_cpp/writers/sequential_writer.hpp"
 
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
@@ -48,7 +48,7 @@ namespace rosbag2_compression
 {
 
 class ROSBAG2_COMPRESSION_PUBLIC SequentialCompressionWriter
-  : public rosbag2_cpp::writer_interfaces::BaseWriterInterface
+  : public rosbag2_cpp::writers::SequentialWriter
 {
 public:
   explicit SequentialCompressionWriter(
@@ -132,38 +132,24 @@ protected:
   virtual void setup_compression();
 
 private:
-  std::string base_folder_;
-  std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_{};
-  std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory_{};
-  std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> storage_{};
-  std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_{};
-  std::unique_ptr<rosbag2_cpp::Converter> converter_{};
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};
   std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
-
-  // Used in bagfile splitting; specifies the best-effort maximum sub-section of a bagfile in bytes.
-  uint64_t max_bagfile_size_{rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT};
-
-  // Used to track topic -> message count
-  std::unordered_map<std::string, rosbag2_storage::TopicInformation> topics_names_to_info_{};
-
-  rosbag2_storage::BagMetadata metadata_{};
 
   rosbag2_compression::CompressionOptions compression_options_{};
 
   bool should_compress_last_file_{true};
 
   // Closes the current backed storage and opens the next bagfile.
-  void split_bagfile();
+  void split_bagfile() override;
 
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
-  bool should_split_bagfile() const;
+  bool should_split_bagfile() const override;
 
   // Prepares the metadata by setting initial values.
-  void init_metadata();
+  void init_metadata() override;
 
   // Record TopicInformation into metadata
-  void finalize_metadata();
+  void finalize_metadata() override;
 };
 }  // namespace rosbag2_compression
 #endif  // ROSBAG2_COMPRESSION__SEQUENTIAL_COMPRESSION_WRITER_HPP_

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -231,7 +231,7 @@ void SequentialCompressionWriter::split_bagfile()
   }
   try {
     SequentialWriter::split_bagfile();
-  } catch (std::runtime_error err) {
+  } catch (const std::runtime_error & err) {
     should_compress_last_file_ = false;
     throw err;
   }

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -23,6 +24,8 @@
 #include "rosbag2_compression/sequential_compression_writer.hpp"
 
 #include "rosbag2_cpp/writer.hpp"
+
+#include "rcpputils/filesystem_helper.hpp"
 
 #include "mock_converter_factory.hpp"
 #include "mock_metadata_io.hpp"
@@ -41,36 +44,111 @@ public:
     storage_{std::make_shared<NiceMock<MockStorage>>()},
     converter_factory_{std::make_shared<StrictMock<MockConverterFactory>>()},
     metadata_io_{std::make_unique<NiceMock<MockMetadataIo>>()},
-    storage_options_{},
+    tmp_dir_storage_options_{},
     serialization_format_{"rmw_format"}
   {
+    tmp_dir_storage_options_.uri = tmp_dir_.string();
+    rcpputils::fs::remove_all(tmp_dir_);
     ON_CALL(*storage_factory_, open_read_write(_, _)).WillByDefault(Return(storage_));
     EXPECT_CALL(*storage_factory_, open_read_write(_, _)).Times(AtLeast(0));
+    // intercept the metadata write so we can analyze it.
+    ON_CALL(*metadata_io_, write_metadata).WillByDefault(
+      [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
+        intercepted_metadata_ = metadata;
+      });
   }
 
+  ~SequentialCompressionWriterTest()
+  {
+    rcpputils::fs::remove_all(tmp_dir_);
+  }
+
+  void initializeFakeFileStorage()
+  {
+    // Create mock implementation of the storage, using files and a size of 1 per message
+    // initialize values when opening a new bagfile
+    ON_CALL(*storage_factory_, open_read_write(_, _)).WillByDefault(
+      DoAll(
+        Invoke(
+          [this](const std::string & uri, const std::string &) {
+            fake_storage_size_ = 0;
+            fake_storage_uri_ = uri;
+            // Touch the file
+            std::ofstream output(uri);
+            ASSERT_TRUE(output.is_open());
+            // Put some arbitrary bytes in the file so it isn't interpreted as being empty
+            output << "Fake storage data" << std::endl;
+            output.close();
+          }),
+        Return(storage_)));
+    ON_CALL(
+      *storage_,
+      write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
+      [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+        fake_storage_size_ += 1;
+      });
+    ON_CALL(*storage_, get_bagfile_size).WillByDefault(
+      [this]() {
+        return fake_storage_size_;
+      });
+    ON_CALL(*storage_, get_relative_file_path).WillByDefault(
+      [this]() {
+        return fake_storage_uri_;
+      });
+  }
+
+  void initializeWriter(
+    const rosbag2_compression::CompressionOptions & compression_options,
+    std::unique_ptr<rosbag2_compression::CompressionFactory> custom_compression_factory = nullptr)
+  {
+    auto compression_factory = std::move(custom_compression_factory);
+    if (!compression_factory) {
+      compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
+    }
+    auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
+      compression_options,
+      std::move(compression_factory),
+      std::move(storage_factory_),
+      converter_factory_,
+      std::move(metadata_io_));
+    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  }
+
+  const std::string bag_name_ = "SequentialCompressionWriterTest";
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
   std::shared_ptr<NiceMock<MockStorage>> storage_;
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<MockMetadataIo> metadata_io_;
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
-  rosbag2_cpp::StorageOptions storage_options_;
+  rcpputils::fs::path tmp_dir_;
+  rosbag2_cpp::StorageOptions tmp_dir_storage_options_;
+  rosbag2_storage::BagMetadata intercepted_metadata_;
   std::string serialization_format_;
+  uint64_t fake_storage_size_;
+  std::string fake_storage_uri_;
+
+  const uint64_t kDefaultCompressionQueueSize = 1;
+  const uint64_t kDefaultCompressionQueueThreads = 4;
 };
 
+TEST_F(SequentialCompressionWriterTest, open_throws_on_empty_storage_options_uri)
+{
+  rosbag2_compression::CompressionOptions compression_options{
+    "zstd", rosbag2_compression::CompressionMode::FILE};
+  initializeWriter(compression_options);
+
+  EXPECT_THROW(
+    writer_->open(
+      rosbag2_cpp::StorageOptions(),
+      {serialization_format_, serialization_format_}),
+    std::runtime_error);
+}
 
 TEST_F(SequentialCompressionWriterTest, open_throws_on_bad_compression_format)
 {
   rosbag2_compression::CompressionOptions compression_options{
     "bad_format", rosbag2_compression::CompressionMode::FILE};
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeWriter(compression_options);
 
   EXPECT_THROW(
     writer_->open(rosbag2_cpp::StorageOptions(), {serialization_format_, serialization_format_}),
@@ -81,7 +159,6 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_invalid_splitting_size)
 {
   rosbag2_compression::CompressionOptions compression_options{
     "zstd", rosbag2_compression::CompressionMode::FILE};
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
 
   // Set minimum file size greater than max bagfile size option
   const uint64_t min_split_file_size = 10;
@@ -91,13 +168,7 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_invalid_splitting_size)
   storage_options.max_bagfile_size = max_bagfile_size;
   storage_options.uri = "foo.bar";
 
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeWriter(compression_options);
 
   EXPECT_THROW(
     writer_->open(storage_options, {serialization_format_, serialization_format_}),
@@ -108,18 +179,10 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_on_supported_compression_f
 {
   rosbag2_compression::CompressionOptions compression_options{
     "zstd", rosbag2_compression::CompressionMode::FILE};
-  auto compression_factory = std::make_unique<rosbag2_compression::CompressionFactory>();
-
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  initializeWriter(compression_options);
 
   EXPECT_NO_THROW(
-    writer_->open(rosbag2_cpp::StorageOptions(), {serialization_format_, serialization_format_}));
+    writer_->open(tmp_dir_storage_options_, {serialization_format_, serialization_format_}));
 }
 
 TEST_F(SequentialCompressionWriterTest, writer_calls_create_compressor)
@@ -129,12 +192,53 @@ TEST_F(SequentialCompressionWriterTest, writer_calls_create_compressor)
   auto compression_factory = std::make_unique<StrictMock<MockCompressionFactory>>();
   EXPECT_CALL(*compression_factory, create_compressor(_)).Times(1);
 
-  auto sequential_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-    compression_options,
-    std::move(compression_factory),
-    std::move(storage_factory_),
-    converter_factory_,
-    std::move(metadata_io_));
-  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
-  writer_->open(rosbag2_cpp::StorageOptions(), {serialization_format_, serialization_format_});
+  initializeWriter(compression_options, std::move(compression_factory));
+
+  // This will throw an exception because the MockCompressionFactory does not actually create
+  // a compressor.
+  EXPECT_THROW(
+    writer_->open(tmp_dir_storage_options_, {serialization_format_, serialization_format_}),
+    std::runtime_error);
+}
+
+TEST_F(SequentialCompressionWriterTest, writer_creates_correct_metadata_relative_filepaths)
+{
+  // In this test, check that the SequentialCompressionWriter creates relative filepaths correctly
+  // Check both the first path, which is created in init_metadata,
+  // and subsequent paths, which are created in the splitting logic
+  const std::string test_topic_name = "test_topic";
+  const std::string test_topic_type = "test_msgs/BasicTypes";
+  rosbag2_compression::CompressionOptions compression_options {
+    "zstd",
+    rosbag2_compression::CompressionMode::FILE,
+  };
+
+  initializeFakeFileStorage();
+  initializeWriter(compression_options);
+
+  tmp_dir_storage_options_.max_bagfile_size = 1;
+  writer_->open(tmp_dir_storage_options_, {"", ""});
+  writer_->create_topic({test_topic_name, test_topic_type, "", ""});
+
+  auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message->topic_name = test_topic_name;
+
+  writer_->write(message);
+  // bag size == max_bafile_size, no split yet
+  writer_->write(message);
+  // bag size > max_bagfile_size, split
+  writer_->write(message);
+  writer_.reset();
+
+  EXPECT_EQ(
+    intercepted_metadata_.relative_file_paths.size(), 2u);
+
+  const auto base_path = tmp_dir_storage_options_.uri;
+  int counter = 0;
+  for (const auto & path : intercepted_metadata_.relative_file_paths) {
+    std::stringstream ss;
+    ss << bag_name_ << "_" << counter << ".zstd";
+    counter++;
+    EXPECT_EQ(ss.str(), path);
+  }
 }

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -102,7 +102,7 @@ public:
    */
   void write(std::shared_ptr<rosbag2_storage::SerializedBagMessage> message) override;
 
-private:
+protected:
   std::string base_folder_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
@@ -124,16 +124,16 @@ private:
   rosbag2_storage::BagMetadata metadata_;
 
   // Closes the current backed storage and opens the next bagfile.
-  void split_bagfile();
+  virtual void split_bagfile();
 
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
-  bool should_split_bagfile() const;
+  virtual bool should_split_bagfile() const;
 
   // Prepares the metadata by setting initial values.
-  void init_metadata();
+  virtual void init_metadata();
 
   // Record TopicInformation into metadata
-  void finalize_metadata();
+  virtual void finalize_metadata();
 };
 
 }  // namespace writers

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -476,7 +476,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   for (const auto & path : metadata.relative_file_paths) {
-    const auto file_path = rcpputils::fs::path{path};
+    const auto file_path = root_bag_path_ / rcpputils::fs::path{path};
 
     EXPECT_TRUE(file_path.exists()) << "File: \"" <<
       file_path.string() << "\" does not exist!";


### PR DESCRIPTION
Backport of #613

Fixes the way relative paths are written in metadata by the SequentialCompressionWriter

Required changes from the original PRs due to code divergence, largely around the compression multithreading