### PR TITLE
Make compressor implementations into a plugin via pluginlib

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -21,6 +21,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(pluginlib REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_cpp)
@@ -47,6 +48,7 @@ ament_target_dependencies(${PROJECT_NAME}_zstd
 target_compile_definitions(${PROJECT_NAME}_zstd
   PRIVATE
   ROSBAG2_COMPRESSION_BUILDING_DLL)
+pluginlib_export_plugin_description_file(rosbag2_compression plugin_description.xml)
 
 add_library(${PROJECT_NAME}
   SHARED
@@ -58,13 +60,16 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_zstd)
 ament_target_dependencies(${PROJECT_NAME}
+  pluginlib
   rcpputils
   rcutils
   rosbag2_cpp
   rosbag2_storage)
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROSBAG2_COMPRESSION_BUILDING_DLL)
+
+# prevent pluginlib from using boost
+target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 install(
   DIRECTORY include/
@@ -81,7 +86,7 @@ ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME} ${PROJECT_NAME}_zstd)
 ament_export_targets(export_${PROJECT_NAME})
 # order matters here, first vendor, then zstd
-ament_export_dependencies(rcpputils rcutils rosbag2_cpp rosbag2_storage zstd_vendor zstd)
+ament_export_dependencies(pluginlib rcpputils rcutils rosbag2_cpp rosbag2_storage zstd_vendor zstd)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)

--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -53,7 +53,7 @@ public:
    * \return A unique pointer to the newly created compressor.
    * \throw invalid_argument If the compression format does not exist.
    */
-  virtual std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
+  virtual std::shared_ptr<rosbag2_compression::BaseCompressorInterface>
   create_compressor(const std::string & compression_format);
 
   /**
@@ -63,7 +63,7 @@ public:
    * \return A unique pointer to the newly created decompressor.
    * \throw invalid_argument If the compression format does not exist.
    */
-  virtual std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
+  virtual std::shared_ptr<rosbag2_compression::BaseDecompressorInterface>
   create_decompressor(const std::string & compression_format);
 
 private:

--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -50,7 +50,7 @@ public:
    * Create a compressor based on the specified compression format.
    *
    * \param compression_format The compression format as a string.
-   * \return A unique pointer to the newly created compressor.
+   * \return A shared pointer to the newly created compressor.
    * \throw invalid_argument If the compression format does not exist.
    */
   virtual std::shared_ptr<rosbag2_compression::BaseCompressorInterface>
@@ -60,7 +60,7 @@ public:
    * Create a decompressor based on the specified compression format.
    *
    * \param compression_format The compression format as a string.
-   * \return A unique pointer to the newly created decompressor.
+   * \return A shared pointer to the newly created decompressor.
    * \throw invalid_argument If the compression format does not exist.
    */
   virtual std::shared_ptr<rosbag2_compression::BaseDecompressorInterface>

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
@@ -35,7 +35,6 @@
 
 #include "compression_factory.hpp"
 #include "visibility_control.hpp"
-#include "zstd_decompressor.hpp"
 
 
 #ifdef _WIN32

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
@@ -84,7 +84,7 @@ private:
    */
   void setup_decompression();
 
-  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};
+  std::shared_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};
   rosbag2_compression::CompressionMode compression_mode_{
     rosbag2_compression::CompressionMode::NONE};
   std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -151,12 +151,14 @@ protected:
    * Initializes the compressor if a compression mode is specified.
    *
    * \throws std::invalid_argument if compression_options isn't supported.
+   * \throws rcpputils::IllegalStateException if compressor could not be created
    */
   virtual void setup_compression();
 
   /**
    * Initializes a number of threads to do file or message compression equal to the
    * value of the compression_threads parameter.
+   * \throws rcpputils::IllegalStateException if compressor could not be created
    */
   virtual void setup_compressor_threads();
 

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -166,7 +166,7 @@ protected:
   virtual void stop_compressor_threads();
 
 private:
-  std::unique_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};
+  std::shared_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};
   std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
   std::mutex compressor_queue_mutex_;
   std::queue<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>

--- a/rosbag2_compression/plugin_description.xml
+++ b/rosbag2_compression/plugin_description.xml
@@ -1,0 +1,14 @@
+<library path="rosbag2_compression_zstd">
+  <class
+    name="zstd"
+    type="rosbag2_compression::ZstdCompressor"
+    base_class_type="rosbag2_compression::BaseCompressorInterface">
+    <description>Zstd implementation for rosbag2 compressor</description>
+  </class>
+  <class
+    name="zstd"
+    type="rosbag2_compression::ZstdDecompressor"
+    base_class_type="rosbag2_compression::BaseDecompressorInterface">
+    <description>Zstd implementation for rosbag2 decompressor</description>
+  </class>
+</library>

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
@@ -27,13 +27,13 @@ CompressionFactory::CompressionFactory()
 
 CompressionFactory::~CompressionFactory() = default;
 
-std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
+std::shared_ptr<rosbag2_compression::BaseCompressorInterface>
 CompressionFactory::create_compressor(const std::string & compression_format)
 {
   return impl_->create_compressor(compression_format);
 }
 
-std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
+std::shared_ptr<rosbag2_compression::BaseDecompressorInterface>
 CompressionFactory::create_decompressor(const std::string & compression_format)
 {
   return impl_->create_decompressor(compression_format);

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -56,7 +56,7 @@ get_class_loader()
 }
 
 template<typename InterfaceT>
-std::unique_ptr<InterfaceT>
+std::shared_ptr<InterfaceT>
 get_interface_instance(
   std::shared_ptr<pluginlib::ClassLoader<InterfaceT>> class_loader,
   const std::string & compression_format)
@@ -70,10 +70,9 @@ get_interface_instance(
     return nullptr;
   }
 
-  std::unique_ptr<InterfaceT> instance = nullptr;
+  std::shared_ptr<InterfaceT> instance = nullptr;
   try {
-    auto unmanaged_instance = class_loader->createUnmanagedInstance(compression_format);
-    instance = std::unique_ptr<InterfaceT>(unmanaged_instance);
+    instance = class_loader->createSharedInstance(compression_format);
   } catch (const std::runtime_error & ex) {
     ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
       "Unable to load instance of compression interface: " << ex.what());
@@ -105,7 +104,7 @@ public:
   virtual ~CompressionFactoryImpl() = default;
 
   /// See CompressionFactory::create_compressor for documentation.
-  std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
+  std::shared_ptr<rosbag2_compression::BaseCompressorInterface>
   create_compressor(const std::string & compression_format)
   {
     auto instance = get_interface_instance(compressor_class_loader_, compression_format);
@@ -117,7 +116,7 @@ public:
   }
 
   /// See CompressionFactory::create_decompressor for documentation.
-  std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
+  std::shared_ptr<rosbag2_compression::BaseDecompressorInterface>
   create_decompressor(const std::string & compression_format)
   {
     auto instance = get_interface_instance(decompressor_class_loader_, compression_format);

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -51,8 +51,9 @@ template<typename InterfaceT>
 std::shared_ptr<pluginlib::ClassLoader<InterfaceT>>
 get_class_loader()
 {
-  const char * lookup_name = CompressionTraits<InterfaceT>::name;
-  return std::make_shared<pluginlib::ClassLoader<InterfaceT>>("rosbag2_compression", lookup_name);
+  const auto lookup_name = CompressionTraits<InterfaceT>::name;
+  return std::make_shared<pluginlib::ClassLoader<InterfaceT>>(
+    "rosbag2_compression", lookup_name);
 }
 
 template<typename InterfaceT>
@@ -65,8 +66,8 @@ get_interface_instance(
   auto class_iter = std::find(
     registered_classes.begin(), registered_classes.end(), compression_format);
   if (class_iter == registered_classes.end()) {
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
-      "Requested compression format '" << compression_format << "' does not exist");
+    ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
+      "No registered plugin found for compression format '" << compression_format << "'");
     return nullptr;
   }
 
@@ -111,6 +112,7 @@ public:
     if (instance == nullptr) {
       ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
         "Could not load/open plugin for compression format '" << compression_format << "'");
+      return nullptr;
     }
     return instance;
   }

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -20,67 +20,117 @@
 #include <stdexcept>
 #include <string>
 
+#include "pluginlib/class_loader.hpp"
+
 #include "logging.hpp"
 #include "rosbag2_compression/compression_factory.hpp"
-#include "rosbag2_compression/zstd_compressor.hpp"
-#include "rosbag2_compression/zstd_decompressor.hpp"
-
-namespace
-{
-
-constexpr const char kCompressionFormatZstd[] = "zstd";
-
-/// Verify whether two case-insensitive chars are equal
-bool compare_char(const char c1, const char c2)
-{
-  return c1 == c2 || std::tolower(c1) == std::tolower(c2);
-}
-
-/// Performs a case-insensitive comparison of two strings
-bool case_insensitive_compare(const std::string & str1, const std::string & str2) noexcept
-{
-  return (str1.size() == str2.size()) &&
-         std::equal(str1.begin(), str1.end(), str2.begin(), &compare_char);
-}
-}  // namespace
 
 namespace rosbag2_compression
 {
+
+using rosbag2_compression::BaseCompressorInterface;
+using rosbag2_compression::BaseDecompressorInterface;
+
+template<typename T>
+struct CompressionTraits
+{};
+
+template<>
+struct CompressionTraits<BaseCompressorInterface>
+{
+  static constexpr const char * name = "rosbag2_compression::BaseCompressorInterface";
+};
+
+template<>
+struct CompressionTraits<BaseDecompressorInterface>
+{
+  static constexpr const char * name = "rosbag2_compression::BaseDecompressorInterface";
+};
+
+template<typename InterfaceT>
+std::shared_ptr<pluginlib::ClassLoader<InterfaceT>>
+get_class_loader()
+{
+  const char * lookup_name = CompressionTraits<InterfaceT>::name;
+  return std::make_shared<pluginlib::ClassLoader<InterfaceT>>("rosbag2_compression", lookup_name);
+}
+
+template<typename InterfaceT>
+std::unique_ptr<InterfaceT>
+get_interface_instance(
+  std::shared_ptr<pluginlib::ClassLoader<InterfaceT>> class_loader,
+  const std::string & compression_format)
+{
+  const auto & registered_classes = class_loader->getDeclaredClasses();
+  auto class_iter = std::find(
+    registered_classes.begin(), registered_classes.end(), compression_format);
+  if (class_iter == registered_classes.end()) {
+    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
+      "Requested compression format '" << compression_format << "' does not exist");
+    return nullptr;
+  }
+
+  std::unique_ptr<InterfaceT> instance = nullptr;
+  try {
+    auto unmanaged_instance = class_loader->createUnmanagedInstance(compression_format);
+    instance = std::unique_ptr<InterfaceT>(unmanaged_instance);
+  } catch (const std::runtime_error & ex) {
+    ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
+      "Unable to load instance of compression interface: " << ex.what());
+  }
+  return instance;
+}
 
 /// Implementation of the CompressionFactory. See CompressionFactory for documentation.
 class CompressionFactoryImpl
 {
 public:
-  CompressionFactoryImpl() = default;
-  ~CompressionFactoryImpl() = default;
+  CompressionFactoryImpl()
+  {
+    try {
+      compressor_class_loader_ = get_class_loader<BaseCompressorInterface>();
+    } catch (const std::exception & e) {
+      ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Unable to create class loader instance: " << e.what());
+      throw e;
+    }
+
+    try {
+      decompressor_class_loader_ = get_class_loader<BaseDecompressorInterface>();
+    } catch (const std::exception & e) {
+      ROSBAG2_COMPRESSION_LOG_ERROR_STREAM("Unable to create class loader instance: " << e.what());
+      throw e;
+    }
+  }
+
+  virtual ~CompressionFactoryImpl() = default;
 
   /// See CompressionFactory::create_compressor for documentation.
   std::unique_ptr<rosbag2_compression::BaseCompressorInterface>
   create_compressor(const std::string & compression_format)
   {
-    if (case_insensitive_compare(compression_format, kCompressionFormatZstd)) {
-      return std::make_unique<rosbag2_compression::ZstdCompressor>();
-    } else {
-      std::stringstream errmsg;
-      errmsg << "Compression format \"" << compression_format << "\" is not supported.";
-      ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(errmsg.str());
-      throw std::invalid_argument{errmsg.str()};
+    auto instance = get_interface_instance(compressor_class_loader_, compression_format);
+    if (instance == nullptr) {
+      ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
+        "Could not load/open plugin for compression format '" << compression_format << "'");
     }
+    return instance;
   }
 
   /// See CompressionFactory::create_decompressor for documentation.
   std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>
   create_decompressor(const std::string & compression_format)
   {
-    if (case_insensitive_compare(compression_format, kCompressionFormatZstd)) {
-      return std::make_unique<rosbag2_compression::ZstdDecompressor>();
-    } else {
-      std::stringstream errmsg;
-      errmsg << "Compression format \"" << compression_format << "\" is not supported.";
-      ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(errmsg.str());
-      throw std::invalid_argument{errmsg.str()};
+    auto instance = get_interface_instance(decompressor_class_loader_, compression_format);
+    if (instance == nullptr) {
+      ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(
+        "Could not load/open plugin for compression format '" << compression_format << "'");
     }
+    return instance;
   }
+
+private:
+  std::shared_ptr<pluginlib::ClassLoader<BaseCompressorInterface>> compressor_class_loader_;
+  std::shared_ptr<pluginlib::ClassLoader<BaseDecompressorInterface>> decompressor_class_loader_;
 };
 }  // namespace rosbag2_compression
 

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -24,7 +24,6 @@
 #include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/compression_options.hpp"
-#include "rosbag2_compression/zstd_decompressor.hpp"
 
 #include "logging.hpp"
 

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -22,11 +22,10 @@
 #include <string>
 #include <utility>
 
+#include "rcpputils/asserts.hpp"
 #include "rcpputils/filesystem_helper.hpp"
 
 #include "rcutils/filesystem.h"
-
-#include "rosbag2_compression/zstd_compressor.hpp"
 
 #include "rosbag2_cpp/info.hpp"
 
@@ -66,12 +65,7 @@ void SequentialCompressionWriter::compression_thread_fn()
   // Every thread needs to have its own compression context for thread safety.
   auto compressor = compression_factory_->create_compressor(
     compression_options_.compression_format);
-
-
-  if (!compressor) {
-    throw std::runtime_error{
-            "Cannot compress message; Writer is not open!"};
-  }
+  rcpputils::check_true(compressor != nullptr, "Could not create compressor.");
 
   while (true) {
     std::shared_ptr<rosbag2_storage::SerializedBagMessage> message;
@@ -154,10 +148,7 @@ void SequentialCompressionWriter::setup_compressor_threads()
   // throw an exception if the format is invalid.
   auto compressor = compression_factory_->create_compressor(
     compression_options_.compression_format);
-  if (!compressor) {
-    throw std::runtime_error{
-            "Cannot compress message; Writer is not open!"};
-  }
+  rcpputils::check_true(compressor != nullptr, "Could not create compressor.");
 
   for (uint64_t i = 0; i < compression_options_.compression_threads; i++) {
     compression_threads_.emplace_back([&] {compression_thread_fn();});

--- a/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_compressor.cpp
@@ -142,3 +142,8 @@ std::string ZstdCompressor::get_compression_identifier() const
 }
 
 }  // namespace rosbag2_compression
+
+#include "pluginlib/class_list_macros.hpp"  // NOLINT
+PLUGINLIB_EXPORT_CLASS(
+  rosbag2_compression::ZstdCompressor,
+  rosbag2_compression::BaseCompressorInterface)

--- a/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/zstd_decompressor.cpp
@@ -137,3 +137,8 @@ std::string ZstdDecompressor::get_decompression_identifier() const
   return kDecompressionIdentifier;
 }
 }  // namespace rosbag2_compression
+
+#include "pluginlib/class_list_macros.hpp"  // NOLINT
+PLUGINLIB_EXPORT_CLASS(
+  rosbag2_compression::ZstdDecompressor,
+  rosbag2_compression::BaseDecompressorInterface)

--- a/rosbag2_compression/test/rosbag2_compression/mock_compression_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_compression_factory.hpp
@@ -27,12 +27,12 @@ class MockCompressionFactory : public rosbag2_compression::CompressionFactory
 public:
   MOCK_METHOD1(
     create_compressor,
-    std::unique_ptr<rosbag2_compression::BaseCompressorInterface>(
+    std::shared_ptr<rosbag2_compression::BaseCompressorInterface>(
       const std::string &));
 
   MOCK_METHOD1(
     create_decompressor,
-    std::unique_ptr<rosbag2_compression::BaseDecompressorInterface>(
+    std::shared_ptr<rosbag2_compression::BaseDecompressorInterface>(
       const std::string &));
 };
 

--- a/rosbag2_compression/test/rosbag2_compression/test_compression_factory.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_compression_factory.cpp
@@ -19,17 +19,6 @@
 
 #include "rosbag2_compression/compression_factory.hpp"
 
-namespace
-{
-
-std::string to_lower(const std::string & text)
-{
-  std::string lowercase_text = text;
-  std::transform(lowercase_text.begin(), lowercase_text.end(), lowercase_text.begin(), ::tolower);
-  return lowercase_text;
-}
-}  // namespace
-
 class CompressionFactoryTest : public ::testing::Test
 {
 public:
@@ -39,53 +28,23 @@ public:
 TEST_F(CompressionFactoryTest, creates_zstd_compressor) {
   const auto compression_format = "zstd";
   auto zstd_compressor = factory.create_compressor(compression_format);
+  ASSERT_TRUE(zstd_compressor != nullptr);
   ASSERT_EQ(compression_format, zstd_compressor->get_compression_identifier());
-}
-
-TEST_F(CompressionFactoryTest, creates_zstd_compressor_caseinsensitive)
-{
-  const auto compression_format = "ZsTd";
-  const auto lowercase_compression_format = to_lower(compression_format);
-  auto zstd_compressor = factory.create_compressor(compression_format);
-  ASSERT_EQ(lowercase_compression_format, zstd_compressor->get_compression_identifier());
-}
-
-TEST_F(CompressionFactoryTest, creates_zstd_compressor_uppercase)
-{
-  const auto compression_format = "ZSTD";
-  const auto lowercase_compression_format = to_lower(compression_format);
-  auto zstd_compressor = factory.create_compressor(compression_format);
-  ASSERT_EQ(lowercase_compression_format, zstd_compressor->get_compression_identifier());
 }
 
 TEST_F(CompressionFactoryTest, creates_zstd_decompressor) {
   const auto compression_format = "zstd";
   auto zstd_decompressor = factory.create_decompressor(compression_format);
+  ASSERT_TRUE(zstd_decompressor != nullptr);
   ASSERT_EQ(compression_format, zstd_decompressor->get_decompression_identifier());
-}
-
-TEST_F(CompressionFactoryTest, creates_zstd_decompressor_caseinsensitive)
-{
-  const auto compression_format = "ZsTd";
-  const auto lowercase_compression_format = to_lower(compression_format);
-  auto zstd_compressor = factory.create_decompressor(compression_format);
-  ASSERT_EQ(lowercase_compression_format, zstd_compressor->get_decompression_identifier());
-}
-
-TEST_F(CompressionFactoryTest, creates_zstd_decompressor_uppercase)
-{
-  const auto compression_format = "ZSTD";
-  const auto lowercase_compression_format = to_lower(compression_format);
-  auto zstd_compressor = factory.create_decompressor(compression_format);
-  ASSERT_EQ(lowercase_compression_format, zstd_compressor->get_decompression_identifier());
 }
 
 TEST_F(CompressionFactoryTest, throws_on_bad_compressor_format) {
   const auto compression_format = "foo";
-  ASSERT_THROW(factory.create_compressor(compression_format), std::invalid_argument);
+  ASSERT_EQ(factory.create_compressor(compression_format), nullptr);
 }
 
 TEST_F(CompressionFactoryTest, throws_on_bad_decompressor_format) {
   const auto compression_format = "bar";
-  ASSERT_THROW(factory.create_decompressor(compression_format), std::invalid_argument);
+  ASSERT_EQ(factory.create_decompressor(compression_format), nullptr);
 }

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "rcpputils/asserts.hpp"
 #include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/sequential_compression_reader.hpp"
@@ -143,7 +144,7 @@ TEST_F(SequentialCompressionReaderTest, open_throws_if_unsupported_compressor)
 
   EXPECT_THROW(
     sequential_reader->open(storage_options_, converter_options_),
-    std::invalid_argument);
+    rcpputils::IllegalStateException);
 }
 
 TEST_F(SequentialCompressionReaderTest, returns_all_topics_and_types)

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "rcpputils/asserts.hpp"
 #include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/compression_options.hpp"
@@ -157,7 +158,7 @@ TEST_F(SequentialCompressionWriterTest, open_throws_on_bad_compression_format)
 
   EXPECT_THROW(
     writer_->open(tmp_dir_storage_options_, {serialization_format_, serialization_format_}),
-    std::invalid_argument);
+    rcpputils::IllegalStateException);
 }
 
 TEST_F(SequentialCompressionWriterTest, open_throws_on_invalid_splitting_size)
@@ -210,7 +211,7 @@ TEST_F(SequentialCompressionWriterTest, writer_calls_create_compressor)
   // a compressor.
   EXPECT_THROW(
     writer_->open(tmp_dir_storage_options_, {serialization_format_, serialization_format_}),
-    std::runtime_error);
+    rcpputils::IllegalStateException);
 }
 
 TEST_F(SequentialCompressionWriterTest, writer_creates_correct_metadata_relative_filepaths)


### PR DESCRIPTION
Part of #598

This is incremental progress - the next step will be to create `rosbag2_compression_zstd` package and move the zstd implementation there.

Key point: Use the `shared_ptr` implementation of `pluginlib::ClassLoader` instead of either `unmanagedInstance` or `uniqueInstance`. The unique version has a custom deleter, meaning we would have to pass around a `pluginlib::UniquePtr` - requiring all uses to include the pluginlib headers, which seems a bit restrictive. The unmanaged instance means that pluginlib can't warn us if we destroy the loader before the instance - this can lead to segfaults on the `SequentialReader/Writer` destructors if the member variables `compressor_` and `compression_factory_` aren't declared in the right order (which they aren't in the current code). This makes the shared library the most desirable, as it allows pluginlib to clean up after itself while letting the rest of the code.