### PR TITLE
Zstd should not install internal headers

### DIFF
--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -41,7 +41,10 @@ macro(build_zstd)
       -DZSTD_BUILD_PROGRAMS=OFF
       ${extra_cmake_args}
     # Note: zstd v1.4.6 will include the following fix. When that is released, upgrade and remove this patch.
-    PATCH_COMMAND patch -p1 -d . < ${CMAKE_CURRENT_SOURCE_DIR}/cmake_minimum_required_2.8.12.patch)
+    PATCH_COMMAND
+      patch -p1 -d . < ${CMAKE_CURRENT_SOURCE_DIR}/cmake_minimum_required_2.8.12.patch &&
+      patch -p1 -d . < ${CMAKE_CURRENT_SOURCE_DIR}/no_internal_headers.patch
+  )
 
   install(
     DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/

--- a/zstd_vendor/no_internal_headers.patch
+++ b/zstd_vendor/no_internal_headers.patch
@@ -1,0 +1,28 @@
+From f1153100884e580dce331e8dd56b260ffb2f04d5 Mon Sep 17 00:00:00 2001
+From: Emerson Knapp <eknapp@amazon.com>
+Date: Tue, 2 Feb 2021 17:47:46 -0800
+Subject: [PATCH] Don't install internal headers
+
+Signed-off-by: Emerson Knapp <eknapp@amazon.com>
+---
+ build/cmake/lib/CMakeLists.txt | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/build/cmake/lib/CMakeLists.txt b/build/cmake/lib/CMakeLists.txt
+index 7adca875..0c2d777e 100644
+--- a/build/cmake/lib/CMakeLists.txt
++++ b/build/cmake/lib/CMakeLists.txt
+@@ -147,10 +147,6 @@ endif ()
+ # install target
+ install(FILES
+     ${LIBRARY_DIR}/zstd.h
+-    ${LIBRARY_DIR}/deprecated/zbuff.h
+-    ${LIBRARY_DIR}/dictBuilder/zdict.h
+-    ${LIBRARY_DIR}/dictBuilder/cover.h
+-    ${LIBRARY_DIR}/common/zstd_errors.h
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+ 
+ if (ZSTD_BUILD_SHARED)
+-- 
+2.17.1
+


### PR DESCRIPTION
Some of them try include others that aren't installed. We don't use them. Avoid the situation entirely.

Specific case: `cover.h` includes `mem.h`, which isn't installed. This causes the ABI/API checkers on PR builds to fail because they can't find `mem.h`