### PR TITLE
[Test] Expose the MessageInfo to the GenericSubscription to potentially use to match messages to QoS

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.cpp
@@ -40,7 +40,7 @@ GenericSubscription::GenericSubscription(
   const rosidl_message_type_support_t & ts,
   const std::string & topic_name,
   const rclcpp::QoS & qos,
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+  GenericSubscriptionCallback callback)
 : SubscriptionBase(
     node_base,
     ts,
@@ -67,7 +67,7 @@ void GenericSubscription::handle_message(
 {
   (void) message_info;
   auto typed_message = std::static_pointer_cast<rclcpp::SerializedMessage>(message);
-  callback_(typed_message);
+  callback_(typed_message, message_info);
 }
 
 void GenericSubscription::handle_loaned_message(

--- a/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_subscription.hpp
@@ -26,6 +26,10 @@
 namespace rosbag2_transport
 {
 
+typedef std::function<void(
+  std::shared_ptr<rclcpp::SerializedMessage>,
+  const rclcpp::MessageInfo & message_info
+)> GenericSubscriptionCallback;
 /**
  * This class is an implementation of an rclcpp::Subscription for serialized messages whose topic
  * is not known at compile time (hence templating does not work).
@@ -52,7 +56,7 @@ public:
     const rosidl_message_type_support_t & ts,
     const std::string & topic_name,
     const rclcpp::QoS & qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
+    GenericSubscriptionCallback callback);
 
   // Same as create_serialized_message() as the subscription is to serialized_messages only
   std::shared_ptr<void> create_message() override;
@@ -79,7 +83,7 @@ private:
 
   std::shared_ptr<rclcpp::SerializedMessage> borrow_serialized_message(size_t capacity);
   rcutils_allocator_t default_allocator_;
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback_;
+  GenericSubscriptionCallback callback_;
   const rclcpp::QoS qos_;
 };
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -180,7 +180,10 @@ Recorder::create_subscription(
     topic_name,
     topic_type,
     qos,
-    [this, topic_name](std::shared_ptr<rclcpp::SerializedMessage> message) {
+    [this, topic_name](std::shared_ptr<rclcpp::SerializedMessage> message, const rclcpp::MessageInfo & message_info) {
+      const auto & mi = message_info.get_rmw_message_info();
+      ROSBAG2_TRANSPORT_LOG_INFO_STREAM("MESSAGE INFO on " << topic_name << ": pubgid " << mi.publisher_gid.data);
+
       auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
       // the serialized bag message takes ownership of the incoming rclcpp serialized message
       // we therefore have to make sure to cleanup that memory in a custom deleter.

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<GenericSubscription> Rosbag2Node::create_generic_subscription(
   const std::string & topic,
   const std::string & type,
   const rclcpp::QoS & qos,
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+  GenericSubscriptionCallback callback)
 {
   library_generic_subscriptor_ = rosbag2_cpp::get_typesupport_library(
     type, "rosidl_typesupport_cpp");

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
@@ -51,7 +51,7 @@ public:
     const std::string & topic,
     const std::string & type,
     const rclcpp::QoS & qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
+    GenericSubscriptionCallback callback);
 
   std::unordered_map<std::string, std::string>
   get_topics_with_types(const std::vector<std::string> & topic_names);

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -75,7 +75,7 @@ public:
     size_t counter = 0;
     auto subscription = node_->create_generic_subscription(
       topic_name, type, rosbag2_transport::Rosbag2QoS{},
-      [&counter, &messages](std::shared_ptr<rclcpp::SerializedMessage> message) {
+      [&counter, &messages](std::shared_ptr<rclcpp::SerializedMessage> message, const rclcpp::MessageInfo & /* message_info */) {
         test_msgs::msg::Strings string_message;
         rclcpp::Serialization<test_msgs::msg::Strings> serializer;
         serializer.deserialize_message(message.get(), &string_message);
@@ -163,7 +163,7 @@ TEST_F(RosBag2NodeFixture, generic_subscription_uses_qos)
   auto publisher = node_->create_publisher<test_msgs::msg::Strings>(topic_name, qos);
   auto subscription = node_->create_generic_subscription(
     topic_name, topic_type, qos,
-    [](std::shared_ptr<rclcpp::SerializedMessage>/* message */) {});
+    [](std::shared_ptr<rclcpp::SerializedMessage>/* message */, const rclcpp::MessageInfo & /* message_info */) {});
   auto connected = [publisher, subscription]() -> bool {
       return publisher->get_subscription_count() && subscription->get_publisher_count();
     };


### PR DESCRIPTION
Experiment for https://github.com/ros2/rosbag2/issues/629 to see how hard it is to receive message metadata to potentially correlate incoming messages with a specific publisher. Looks very promising

Briefly tested, 2 publishers on `/foo`, and one on `/bar` - the print statement in the message callback gives output like:

```
$ ros2 bag record -a -o bagSeesMessageInfo
[INFO] [1612406764.918839725] [rosbag2_storage]: Opened database 'bagSeesMessageInfo/bagSeesMessageInfo_0.db3' for READ_WRITE.
[INFO] [1612406764.926742967] [rosbag2_transport]: Listening for topics...
[INFO] [1612406764.928994114] [rosbag2_transport]: Subscribed to topic '/rosout'
[INFO] [1612406764.930462463] [rosbag2_transport]: Subscribed to topic '/foo'
[INFO] [1612406764.932862746] [rosbag2_transport]: Subscribed to topic '/parameter_events'
[INFO] [1612406764.934140601] [rosbag2_transport]: Subscribed to topic '/bar'
[INFO] [1612406765.247710249] [rosbag2_transport]: MESSAGE INFO on /bar: pubgid !$g
[INFO] [1612406765.322675283] [rosbag2_transport]: MESSAGE INFO on /foo: pubgid NrE[0m
[INFO] [1612406765.504592903] [rosbag2_transport]: MESSAGE INFO on /foo: pubgid ^b
[INFO] [1612406766.247643351] [rosbag2_transport]: MESSAGE INFO on /bar: pubgid !$g
[INFO] [1612406766.322676287] [rosbag2_transport]: MESSAGE INFO on /foo: pubgid NrE[0m
[INFO] [1612406766.504602200] [rosbag2_transport]: MESSAGE INFO on /foo: pubgid ^b
[INFO] [1612406767.247675681] [rosbag2_transport]: MESSAGE INFO on /bar: pubgid !$g
[INFO] [1612406767.322470858] [rosbag2_transport]: MESSAGE INFO on /foo: pubgid NrE[0m
```