### PR TITLE
Performance benchmarking improvements

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/scripts/report_gen.py
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/scripts/report_gen.py
@@ -106,12 +106,16 @@ class PostprocessStorageConfig(Postprocess):
                     cache_samples[sample[0]['cache_size']].append(
                         int(sample[0]['total_recorded_count'])/sample_total_produced)
 
-                cache_avg_recorded_percentage = {
-                    cache: statistics.mean(samples)
+                cache_recorded_percentage_stats = {
+                    cache: {
+                        'avg': statistics.mean(samples),
+                        'min': min(samples),
+                        'max': max(samples)
+                    }
                     for cache, samples in cache_samples.items()
                 }
                 cache_data_per_storage_conf.update(
-                    {storage_cfg_name: cache_avg_recorded_percentage}
+                    {storage_cfg_name: cache_recorded_percentage_stats}
                 )
 
             result = {
@@ -135,9 +139,11 @@ class PostprocessStorageConfig(Postprocess):
             for storage_cfg, caches in result['cache_data'].items():
                 print('\t\tstorage config: {}:'.format(pathlib.Path(storage_cfg).name))
                 for cache, percent_recorded in caches.items():
-                    print('\t\t\tcache [bytes]: {:,}: {:.2%} recorded'.format(
+                    print('\t\t\tcache {:,} - min: {:.2%}, average: {:.2%}, max: {:.2%}'.format(
                         int(cache),
-                        percent_recorded))
+                        percent_recorded['min'],
+                        percent_recorded['avg'],
+                        percent_recorded['max']))
 
         [
             __process_test(

--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
@@ -43,8 +43,8 @@ void load_qos_configuration(
   // TODO(adamdbrw) - error handling / map string to function
   if (qos_reliability == "reliable") {group_config.qos.reliable();}
   if (qos_reliability == "best_effort") {group_config.qos.best_effort();}
-  if (qos_reliability == "transient_local") {group_config.qos.transient_local();}
-  if (qos_reliability == "volatile") {group_config.qos.durability_volatile();}
+  if (qos_durability == "transient_local") {group_config.qos.transient_local();}
+  if (qos_durability == "volatile") {group_config.qos.durability_volatile();}
 }
 
 bool wait_for_subscriptions_from_node_parameters(rclcpp::Node & node)


### PR DESCRIPTION
A small pack of few quality of life improvements and one fix for performance benchmarking:

- wait 5 secs between tests (to let disks "cool down" a bit and flush their internal caches),
- removing bagfiles now leaves an informative file about deleted file size + additional file about total bag size (both in MB),
- (FIX) updated `ros2 bag record` to properly use new `--regex` syntax ( `-a` which is used currently causing sometimes over 100% recorded output when unnecessary topics like ` /rosout` are recorded),
- `report_gen.py` tool additionally returns "min" and "max" percents of recorded messages, not only average.