### PR TITLE
Fix a crash in test_message_cache

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
@@ -131,6 +131,7 @@ TEST_F(MessageCacheTest, message_cache_changing_callback) {
   uint32_t counter = 0;
   for (uint32_t i = 0; i < message_count; ++i) {
     if (counter >= message_count / 2) {
+      mock_cache_consumer->close();
       mock_cache_consumer->change_consume_callback(cb2);
     }
     auto msg = make_test_msg();


### PR DESCRIPTION
Fix a crash in test_message_cache.
    
The cache consumer requires that you call close()
before calling change_consumer_callback().  The test
forgot the close() call, so was running into a race
where changing out the callback was not atomic.
Remember to call close() in the test, which should fix
some occasional failures in CI.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the occasional crashes we are seeing, like https://ci.ros2.org/view/nightly/job/nightly_osx_repeated/2240/testReport/junit/(root)/projectroot/test_message_cache/ .

While this change makes sense to me, and passes the unit tests, I am hesitant just because the previous code was so weird.  I'm not sure if I'm missing something.  @adamdbrw , @Karsten1987 , @mjeronimo , @emersonknapp review here is welcome.