### PR TITLE
Add missing test_depend ament_cmake_gmock

### DIFF
--- a/rosbag2_compression_zstd/package.xml
+++ b/rosbag2_compression_zstd/package.xml
@@ -19,6 +19,7 @@
   <depend>rosbag2_compression</depend>
   <depend>zstd_vendor</depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>


### PR DESCRIPTION
Fixes failure to build Rolling CI introduced in #636

https://build.ros2.org/job/Rci__nightly-connext_ubuntu_focal_amd64/221/console
https://build.ros2.org/job/Rci__nightly-cyclonedds_ubuntu_focal_amd64/225/console

````
03:28:18 CMake Error at CMakeLists.txt:64 (find_package):
03:28:18   By not providing "Findament_cmake_gmock.cmake" in CMAKE_MODULE_PATH this
03:28:18   project has asked CMake to find a package configuration file provided by
03:28:18   "ament_cmake_gmock", but CMake did not find one.
03:28:18 
03:28:18   Could not find a package configuration file provided by "ament_cmake_gmock"
03:28:18   with any of the following names:
03:28:18 
03:28:18     ament_cmake_gmockConfig.cmake
03:28:18     ament_cmake_gmock-config.cmake
03:28:18 
03:28:18   Add the installation prefix of "ament_cmake_gmock" to CMAKE_PREFIX_PATH or
03:28:18   set "ament_cmake_gmock_DIR" to a directory containing one of the above
03:28:18   files.  If "ament_cmake_gmock" provides a separate development package or
03:28:18   SDK, be sure it has been installed.
```

