### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/rosbag2_storage/cmake/rosbag2_storage_register_storage_plugin.cmake
+++ b/rosbag2_storage/cmake/rosbag2_storage_register_storage_plugin.cmake
@@ -56,7 +56,9 @@ macro(rosbag2_storage_register_storage_plugin target)
   endforeach()
 
   if(_ARG_SKIP_INSTALL)
-    ament_index_register_resource("rosbag2_storage_plugins" CONTENT ${_STORAGE_PLUGINS} AMENT_INDEX_BINARY_DIR "${CMAKE_BINARY_DIR}/ament_cmake_index_$<CONFIG>" SKIP_INSTALL)
+    ament_index_register_resource("rosbag2_storage_plugins" CONTENT ${_STORAGE_PLUGINS}
+      AMENT_INDEX_BINARY_DIR "${CMAKE_BINARY_DIR}/ament_cmake_index_$<CONFIG>"
+      SKIP_INSTALL)
   else()
     ament_index_register_resource("rosbag2_storage_plugins" CONTENT ${_STORAGE_PLUGINS})
   endif()


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13645)](http://ci.ros2.org/job/ci_linux/13645/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8525)](http://ci.ros2.org/job/ci_linux-aarch64/8525/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11360)](http://ci.ros2.org/job/ci_osx/11360/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13709)](http://ci.ros2.org/job/ci_windows/13709/)