### PR TITLE
CLI query rosbag2_py for available storage implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmake-build-release/
 build/
 venv/
 **/.pytest_cache/
+__pycache__/

--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -12,8 +12,8 @@
   <license>Apache License 2.0</license>
 
   <depend>ros2cli</depend>
-  <depend>rosbag2_transport</depend>
   <depend>rosbag2_py</depend>
+  <depend>rosbag2_transport</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -13,6 +13,7 @@
 
   <depend>ros2cli</depend>
   <depend>rosbag2_transport</depend>
+  <depend>rosbag2_py</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -21,6 +21,7 @@ from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
+from rosbag2_py import get_registered_readers
 import yaml
 
 
@@ -28,11 +29,14 @@ class PlayVerb(VerbExtension):
     """Play back ROS data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
+        reader_choices = get_registered_readers()
+        default_reader = 'sqlite3' if 'sqlite3' in reader_choices else reader_choices[0]
+
         parser.add_argument(
             'bag_file', type=check_path_exists, help='bag file to replay')
         parser.add_argument(
-            '-s', '--storage', default='sqlite3',
-            help="storage identifier to be used, defaults to 'sqlite3'")
+            '-s', '--storage', default=default_reader, choices=reader_choices,
+            help=f"storage identifier to be used, defaults to '{default_reader}'")
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -21,6 +21,7 @@ from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
+from rosbag2_py import get_registered_writers
 import yaml
 
 
@@ -28,6 +29,9 @@ class RecordVerb(VerbExtension):
     """Record ROS data to a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
+        writer_choices = get_registered_writers()
+        default_writer = 'sqlite3' if 'sqlite3' in writer_choices else writer_choices[0]
+
         parser.add_argument(
             '-a', '--all', action='store_true',
             help='recording all topics, required if no topics '
@@ -46,8 +50,8 @@ class RecordVerb(VerbExtension):
             help='destination of the bagfile to create, \
             defaults to a timestamped folder in the current directory')
         parser.add_argument(
-            '-s', '--storage', default='sqlite3',
-            help="storage identifier to be used, defaults to 'sqlite3'")
+            '-s', '--storage', default=default_writer, choices=writer_choices,
+            help=f"storage identifier to be used, defaults to '{default_writer}'")
         parser.add_argument(
             '-f', '--serialization-format', default='',
             help='rmw serialization format in which the messages are saved, defaults to the'

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
@@ -35,6 +35,8 @@ public:
     open_read_write,
     std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
       const rosbag2_storage::StorageOptions &));
+  std::vector<std::string> get_declared_read_only_plugins() const override { return {}; }
+  std::vector<std::string> get_declared_read_write_plugins() const override { return {}; }
 };
 
 #endif  // ROSBAG2_COMPRESSION__MOCK_STORAGE_FACTORY_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
@@ -28,18 +28,17 @@
 class MockStorageFactory : public rosbag2_storage::StorageFactoryInterface
 {
 public:
-  MOCK_METHOD(
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>,
+  MOCK_METHOD1(
     open_read_only,
-    (const rosbag2_storage::StorageOptions &),
-    (override));
-  MOCK_METHOD(
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>,
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>(
+      const rosbag2_storage::StorageOptions &));
+  MOCK_METHOD1(
     open_read_write,
-    (const rosbag2_storage::StorageOptions &),
-    (override));
-  std::vector<std::string> get_declared_read_only_plugins() const override {return {};}
-  std::vector<std::string> get_declared_read_write_plugins() const override {return {};}
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
+      const rosbag2_storage::StorageOptions &));
+
+  std::vector<std::string> get_declared_read_only_plugins() const {return {};}
+  std::vector<std::string> get_declared_read_write_plugins() const {return {};}
 };
 
 #endif  // ROSBAG2_COMPRESSION__MOCK_STORAGE_FACTORY_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
@@ -28,14 +28,16 @@
 class MockStorageFactory : public rosbag2_storage::StorageFactoryInterface
 {
 public:
-  MOCK_METHOD1(
+  MOCK_METHOD(
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>,
     open_read_only,
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>(
-      const rosbag2_storage::StorageOptions &));
-  MOCK_METHOD1(
+    (const rosbag2_storage::StorageOptions &),
+    (override));
+  MOCK_METHOD(
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>,
     open_read_write,
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
-      const rosbag2_storage::StorageOptions &));
+    (const rosbag2_storage::StorageOptions &),
+    (override));
   std::vector<std::string> get_declared_read_only_plugins() const override {return {};}
   std::vector<std::string> get_declared_read_write_plugins() const override {return {};}
 };

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage_factory.hpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_storage/storage_factory_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
@@ -35,8 +36,8 @@ public:
     open_read_write,
     std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
       const rosbag2_storage::StorageOptions &));
-  std::vector<std::string> get_declared_read_only_plugins() const override { return {}; }
-  std::vector<std::string> get_declared_read_write_plugins() const override { return {}; }
+  std::vector<std::string> get_declared_read_only_plugins() const override {return {};}
+  std::vector<std::string> get_declared_read_write_plugins() const override {return {};}
 };
 
 #endif  // ROSBAG2_COMPRESSION__MOCK_STORAGE_FACTORY_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
@@ -35,6 +35,9 @@ public:
     open_read_write,
     std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
       const rosbag2_storage::StorageOptions &));
+
+  std::vector<std::string> get_declared_read_only_plugins() const override { return {}; }
+  std::vector<std::string> get_declared_read_write_plugins() const override { return {}; }
 };
 
 #endif  // ROSBAG2_CPP__MOCK_STORAGE_FACTORY_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
@@ -28,15 +28,16 @@
 class MockStorageFactory : public rosbag2_storage::StorageFactoryInterface
 {
 public:
-  MOCK_METHOD1(
+  MOCK_METHOD(
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>,
     open_read_only,
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>(
-      const rosbag2_storage::StorageOptions &));
-  MOCK_METHOD1(
+    (const rosbag2_storage::StorageOptions &),
+    (override));
+  MOCK_METHOD(
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>,
     open_read_write,
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
-      const rosbag2_storage::StorageOptions &));
-
+    (const rosbag2_storage::StorageOptions &),
+    (override));
   std::vector<std::string> get_declared_read_only_plugins() const override {return {};}
   std::vector<std::string> get_declared_read_write_plugins() const override {return {};}
 };

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_storage/storage_factory_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
@@ -36,8 +37,8 @@ public:
     std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
       const rosbag2_storage::StorageOptions &));
 
-  std::vector<std::string> get_declared_read_only_plugins() const override { return {}; }
-  std::vector<std::string> get_declared_read_write_plugins() const override { return {}; }
+  std::vector<std::string> get_declared_read_only_plugins() const override {return {};}
+  std::vector<std::string> get_declared_read_write_plugins() const override {return {};}
 };
 
 #endif  // ROSBAG2_CPP__MOCK_STORAGE_FACTORY_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage_factory.hpp
@@ -28,18 +28,17 @@
 class MockStorageFactory : public rosbag2_storage::StorageFactoryInterface
 {
 public:
-  MOCK_METHOD(
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>,
+  MOCK_METHOD1(
     open_read_only,
-    (const rosbag2_storage::StorageOptions &),
-    (override));
-  MOCK_METHOD(
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>,
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface>(
+      const rosbag2_storage::StorageOptions &));
+  MOCK_METHOD1(
     open_read_write,
-    (const rosbag2_storage::StorageOptions &),
-    (override));
-  std::vector<std::string> get_declared_read_only_plugins() const override {return {};}
-  std::vector<std::string> get_declared_read_write_plugins() const override {return {};}
+    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface>(
+      const rosbag2_storage::StorageOptions &));
+
+  std::vector<std::string> get_declared_read_only_plugins() const {return {};}
+  std::vector<std::string> get_declared_read_write_plugins() const {return {};}
 };
 
 #endif  // ROSBAG2_CPP__MOCK_STORAGE_FACTORY_HPP_

--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -18,20 +18,27 @@ from rpyutils import add_dll_directories_from_env
 # to the search path.
 # See https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
 with add_dll_directories_from_env('PATH'):
-    from rosbag2_py._reader import \
-        SequentialCompressionReader, \
-        SequentialReader
-    from rosbag2_py._storage import \
-        ConverterOptions, \
-        StorageFilter, \
-        StorageOptions, \
-        TopicMetadata
-    from rosbag2_py._writer import \
-        SequentialCompressionWriter, \
-        SequentialWriter
+    from rosbag2_py._reader import (
+        SequentialCompressionReader,
+        SequentialReader,
+        get_registered_readers,
+    )
+    from rosbag2_py._storage import (
+        ConverterOptions,
+        StorageFilter,
+        StorageOptions,
+        TopicMetadata,
+    )
+    from rosbag2_py._writer import (
+        SequentialCompressionWriter,
+        SequentialWriter,
+        get_registered_writers,
+    )
 
 __all__ = [
     'ConverterOptions',
+    'get_registered_readers',
+    'get_registered_writers',
     'SequentialCompressionReader',
     'SequentialCompressionWriter',
     'SequentialReader',

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -78,9 +78,17 @@ public:
     reader_->reset_filter();
   }
 
+
 protected:
   std::unique_ptr<rosbag2_cpp::Reader> reader_;
 };
+
+std::vector<std::string> get_registered_readers()
+{
+  rosbag2_stroage::StorageFactory storage_factory;
+  return storage_factory.get_declared_read_plugins();
+}
+
 }  // namespace rosbag2_py
 
 PYBIND11_MODULE(_reader, m) {
@@ -116,4 +124,9 @@ PYBIND11_MODULE(_reader, m) {
   .def(
     "reset_filter",
     &rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>::reset_filter);
+
+  m.def(
+    "get_registered_readers",
+    &rosbag2_py::get_registered_readers,
+    "Returns list of discovered plugins that support rosbag2 playback.");
 }

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -83,10 +83,18 @@ protected:
   std::unique_ptr<rosbag2_cpp::Reader> reader_;
 };
 
-std::vector<std::string> get_registered_readers()
+std::unordered_set<std::string> get_registered_readers()
 {
-  rosbag2_stroage::StorageFactory storage_factory;
-  return storage_factory.get_declared_read_plugins();
+  rosbag2_storage::StorageFactory storage_factory;
+  std::unordered_set<std::string> all_readers;
+
+  auto read_only = storage_factory.get_declared_read_only_plugins();
+  std::copy(read_only.begin(), read_only.end(), std::inserter(all_readers, all_readers.end()));
+
+  auto read_write = storage_factory.get_declared_read_write_plugins();
+  std::copy(read_write.begin(), read_write.end(), std::inserter(all_readers, all_readers.end()));
+
+  return all_readers;
 }
 
 }  // namespace rosbag2_py

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -91,7 +91,7 @@ std::unordered_set<std::string> get_registered_readers()
   const auto read_only = storage_factory.get_declared_read_only_plugins();
   std::unordered_set<std::string> all_readers(read_only.begin(), read_only.end());
 
-  auto read_write = storage_factory.get_declared_read_write_plugins();
+  const auto read_write = storage_factory.get_declared_read_write_plugins();
   std::copy(read_write.begin(), read_write.end(), std::inserter(all_readers, all_readers.end()));
 
   return all_readers;

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -87,10 +87,9 @@ protected:
 std::unordered_set<std::string> get_registered_readers()
 {
   rosbag2_storage::StorageFactory storage_factory;
-  std::unordered_set<std::string> all_readers;
 
-  auto read_only = storage_factory.get_declared_read_only_plugins();
-  std::copy(read_only.begin(), read_only.end(), std::inserter(all_readers, all_readers.end()));
+  const auto read_only = storage_factory.get_declared_read_only_plugins();
+  std::unordered_set<std::string> all_readers(read_only.begin(), read_only.end());
 
   auto read_write = storage_factory.get_declared_read_write_plugins();
   std::copy(read_write.begin(), read_write.end(), std::inserter(all_readers, all_readers.end()));

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "rosbag2_compression/sequential_compression_reader.hpp"
@@ -77,7 +79,6 @@ public:
   {
     reader_->reset_filter();
   }
-
 
 protected:
   std::unique_ptr<rosbag2_cpp::Reader> reader_;

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -80,12 +80,8 @@ protected:
 std::unordered_set<std::string> get_registered_writers()
 {
   rosbag2_storage::StorageFactory storage_factory;
-  std::unordered_set<std::string> all_writers;
-
-  auto read_write = storage_factory.get_declared_read_write_plugins();
-  std::copy(read_write.begin(), read_write.end(), std::inserter(all_writers, all_writers.end()));
-
-  return all_writers;
+  const auto read_write = storage_factory.get_declared_read_write_plugins();
+  return std::unordered_set<std::string>(read_write.begin(), read_write.end());
 }
 
 }  // namespace rosbag2_py

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -75,6 +75,17 @@ protected:
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
 };
 
+std::unordered_set<std::string> get_registered_writers()
+{
+  rosbag2_storage::StorageFactory storage_factory;
+  std::unordered_set<std::string> all_writers;
+
+  auto read_write = storage_factory.get_declared_read_write_plugins();
+  std::copy(read_write.begin(), read_write.end(), std::inserter(all_writers, all_writers.end()));
+
+  return all_writers;
+}
+
 }  // namespace rosbag2_py
 
 PYBIND11_MODULE(_writer, m) {
@@ -99,4 +110,9 @@ PYBIND11_MODULE(_writer, m) {
   .def(
     "create_topic",
     &rosbag2_py::Writer<rosbag2_compression::SequentialCompressionWriter>::create_topic);
+
+  m.def(
+    "get_registered_writers",
+    &rosbag2_py::get_registered_writers,
+    "Returns list of discovered plugins that support rosbag2 recording");
 }

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 #include "rosbag2_compression/sequential_compression_writer.hpp"
 #include "rosbag2_cpp/converter_options.hpp"

--- a/rosbag2_py/test/test_sequential_reader.py
+++ b/rosbag2_py/test/test_sequential_reader.py
@@ -81,5 +81,5 @@ def test_sequential_reader():
 
 
 def test_plugin_list():
-    writer_plugins = rosbag2_py.get_registered_readers()
-    assert 'my_read_only_test_plugin' in writer_plugins
+    reader_plugins = rosbag2_py.get_registered_readers()
+    assert 'my_read_only_test_plugin' in reader_plugins

--- a/rosbag2_py/test/test_sequential_reader.py
+++ b/rosbag2_py/test/test_sequential_reader.py
@@ -78,3 +78,8 @@ def test_sequential_reader():
         if isinstance(msg, String):
             assert msg.data == f'Hello, world! {msg_counter}'
             msg_counter += 1
+
+
+def test_plugin_list():
+    writer_plugins = rosbag2_py.get_registered_readers()
+    assert 'my_read_only_test_plugin' in writer_plugins

--- a/rosbag2_py/test/test_sequential_writer.py
+++ b/rosbag2_py/test/test_sequential_writer.py
@@ -94,3 +94,8 @@ def test_sequential_writer(tmp_path):
         assert t == msg_counter * 100
 
         msg_counter += 1
+
+
+def test_plugin_list():
+    writer_plugins = rosbag2_py.get_registered_writers()
+    assert 'my_test_plugin' in writer_plugins

--- a/rosbag2_storage/include/rosbag2_storage/storage_factory.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_factory.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_storage/storage_factory_interface.hpp"
 #include "rosbag2_storage/visibility_control.hpp"

--- a/rosbag2_storage/include/rosbag2_storage/storage_factory.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_factory.hpp
@@ -54,6 +54,9 @@ public:
   std::shared_ptr<storage_interfaces::ReadWriteInterface>
   open_read_write(const StorageOptions & storage_options) override;
 
+  std::vector<std::string> get_declared_read_only_plugins() const override;
+  std::vector<std::string> get_declared_read_write_plugins() const override;
+
 private:
   std::unique_ptr<StorageFactoryImpl> impl_;
 };

--- a/rosbag2_storage/include/rosbag2_storage/storage_factory_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_factory_interface.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"

--- a/rosbag2_storage/include/rosbag2_storage/storage_factory_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_factory_interface.hpp
@@ -35,6 +35,9 @@ public:
 
   virtual std::shared_ptr<storage_interfaces::ReadWriteInterface>
   open_read_write(const StorageOptions & storage_options) = 0;
+
+  virtual std::vector<std::string> get_declared_read_only_plugins() const = 0;
+  virtual std::vector<std::string> get_declared_read_write_plugins() const = 0;
 };
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -138,6 +138,16 @@ public:
     return instance;
   }
 
+  std::vector<std::string> get_declared_read_only_plugins() const
+  {
+    return read_only_class_loader_->getDeclaredClasses();
+  }
+
+  std::vector<std::string> get_declared_read_write_plugins() const
+  {
+    return read_write_class_loader_->getDeclaredClasses();
+  }
+
 private:
   std::shared_ptr<pluginlib::ClassLoader<ReadWriteInterface>> read_write_class_loader_;
   std::shared_ptr<pluginlib::ClassLoader<ReadOnlyInterface>> read_only_class_loader_;

--- a/rosbag2_storage/src/rosbag2_storage/storage_factory.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/storage_factory.cpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"

--- a/rosbag2_storage/src/rosbag2_storage/storage_factory.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/storage_factory.cpp
@@ -47,4 +47,14 @@ std::shared_ptr<ReadWriteInterface> StorageFactory::open_read_write(
 {
   return impl_->open_read_write(storage_options);
 }
+
+std::vector<std::string> StorageFactory::get_declared_read_only_plugins() const
+{
+  return impl_->get_declared_read_only_plugins();
+}
+
+std::vector<std::string> StorageFactory::get_declared_read_write_plugins() const
+{
+  return impl_->get_declared_read_write_plugins();
+}
 }  // namespace rosbag2_storage

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
@@ -104,7 +104,8 @@ TEST_F(StorageFactoryTest, load_unavailable_plugin) {
 TEST_F(StorageFactoryTest, list_registered_plugins) {
   {
     auto read_only_plugins = factory.get_declared_read_only_plugins();
-    auto it = std::find(read_only_plugins.begin(), read_only_plugins.end(), test_read_only_plugin_id);
+    auto it = std::find(
+      read_only_plugins.begin(), read_only_plugins.end(), test_read_only_plugin_id);
     EXPECT_NE(it, read_only_plugins.end());
   }
   {

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
@@ -100,3 +100,16 @@ TEST_F(StorageFactoryTest, load_unavailable_plugin) {
     {bag_file_path, test_unavailable_plugin_id});
   EXPECT_EQ(nullptr, instance_ro);
 }
+
+TEST_F(StorageFactoryTest, list_registered_plugins) {
+  {
+    auto read_only_plugins = factory.get_declared_read_only_plugins();
+    auto it = std::find(read_only_plugins.begin(), read_only_plugins.end(), test_read_only_plugin_id);
+    EXPECT_NE(it, read_only_plugins.end());
+  }
+  {
+    auto read_write_plugins = factory.get_declared_read_write_plugins();
+    auto it = std::find(read_write_plugins.begin(), read_write_plugins.end(), test_plugin_id);
+    EXPECT_NE(it, read_write_plugins.end());
+  }
+}


### PR DESCRIPTION
For `ros2 bag record/play`, query the python API for which storage implementations are available.

Prefer `sqlite3` as the default, but only if it is found. Otherwise default to the first storage implementation found.

I plan to use this same pattern for converters/compressors.