### PR TITLE
Remove temporary directory platform-specific logic from test fixture

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -19,14 +19,7 @@
 
 #include <string>
 
-#ifdef _WIN32
-# include <direct.h>
-# include <Windows.h>
-#else
-# include <unistd.h>
-# include <sys/types.h>
-# include <dirent.h>
-#endif
+#include "rcpputils/filesystem_helper.hpp"
 
 using namespace ::testing;  // NOLINT
 
@@ -38,64 +31,15 @@ class TemporaryDirectoryFixture : public Test
 public:
   TemporaryDirectoryFixture()
   {
-    char template_char[] = "tmp_test_dir.XXXXXX";
-#ifdef _WIN32
-    char temp_path[255];
-    GetTempPathA(255, temp_path);
-    _mktemp_s(template_char, strnlen(template_char, 20) + 1);
-    temporary_dir_path_ = std::string(temp_path) + std::string(template_char);
-    _mkdir(temporary_dir_path_.c_str());
-#else
-    char * dir_name = mkdtemp(template_char);
-    temporary_dir_path_ = dir_name;
-#endif
+    auto tmpdir = rcpputils::fs::temp_directory_path();
+    temporary_dir_path_ = rcpputils::fs::create_temp_directory(
+      rcpputils::fs::temp_directory_path(),
+      "tmp_test_dir").string();
   }
 
   ~TemporaryDirectoryFixture() override
   {
-    remove_directory_recursively(temporary_dir_path_);
-  }
-
-  void remove_directory_recursively(const std::string & directory_path)
-  {
-#ifdef _WIN32
-    // We need a string of type PCZZTSTR, which is a double null terminated char ptr
-    size_t length = strlen(directory_path.c_str());
-    TCHAR * temp_dir = new TCHAR[length + 2];
-    memcpy(temp_dir, temporary_dir_path_.c_str(), length);
-    temp_dir[length] = 0;
-    temp_dir[length + 1] = 0;  // double null terminated
-
-    SHFILEOPSTRUCT file_options;
-    file_options.hwnd = nullptr;
-    file_options.wFunc = FO_DELETE;  // delete (recursively)
-    file_options.pFrom = temp_dir;
-    file_options.pTo = nullptr;
-    file_options.fFlags = FOF_NOCONFIRMATION | FOF_SILENT;  // do not prompt user
-    file_options.fAnyOperationsAborted = FALSE;
-    file_options.lpszProgressTitle = nullptr;
-    file_options.hNameMappings = nullptr;
-
-    SHFileOperation(&file_options);
-    delete[] temp_dir;
-#else
-    DIR * dir = opendir(directory_path.c_str());
-    if (!dir) {
-      return;
-    }
-    struct dirent * directory_entry;
-    while ((directory_entry = readdir(dir)) != nullptr) {
-      // Make sure to not call ".." or "." entries in directory (might delete everything)
-      if (strcmp(directory_entry->d_name, ".") != 0 && strcmp(directory_entry->d_name, "..") != 0) {
-        if (directory_entry->d_type == DT_DIR) {
-          remove_directory_recursively(directory_path + "/" + directory_entry->d_name);
-        }
-        remove((directory_path + "/" + directory_entry->d_name).c_str());
-      }
-    }
-    closedir(dir);
-    remove(temporary_dir_path_.c_str());
-#endif
+    rcpputils::fs::remove_all(rcpputils::fs::path(temporary_dir_path_));
   }
 
   std::string temporary_dir_path_;

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -31,10 +31,7 @@ class TemporaryDirectoryFixture : public Test
 public:
   TemporaryDirectoryFixture()
   {
-    auto tmpdir = rcpputils::fs::temp_directory_path();
-    temporary_dir_path_ = rcpputils::fs::create_temp_directory(
-      rcpputils::fs::temp_directory_path(),
-      "tmp_test_dir").string();
+    temporary_dir_path_ = rcpputils::fs::create_temp_directory("tmp_test_dir_").string();
   }
 
   ~TemporaryDirectoryFixture() override

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -52,9 +52,7 @@ public:
     // Clean up potentially leftover bag files.
     // There may be leftovers if the system reallocates a temp directory
     // used by a previous test execution and the test did not have a clean exit.
-    if (root_bag_path_.exists()) {
-      remove_directory_recursively(root_bag_path_.string());
-    }
+    rcpputils::fs::remove_all(root_bag_path_);
   }
 
   static void SetUpTestCase()
@@ -64,7 +62,7 @@ public:
 
   void TearDown() override
   {
-    remove_directory_recursively(root_bag_path_.string());
+    rcpputils::fs::remove_all(root_bag_path_);
   }
 
   static void TearDownTestCase()


### PR DESCRIPTION
Depends on ros2/rcpputils#126

The `remove_all` functionality already existed - adding the temp dir creation logic to rcpputils to support removing all the platform-specific code.