### PR TITLE
Try to make PR builder pass

### DIFF
--- a/rosbag2_tests/package.xml
+++ b/rosbag2_tests/package.xml
@@ -18,6 +18,11 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rcpputils</test_depend>
+  <!--
+  TODO(emersonknapp): remove this once we aren't pulling in fastrtps as a dependency.
+  For now, since fastrtps is installed, cyclone is not automatically installed for PR builds
+  -->
+  <test_depend>rmw_cyclonedds_cpp</test_depend>
   <test_depend>ros2bag</test_depend>
   <test_depend>rosbag2_compression</test_depend>
   <test_depend>rosbag2_compression_zstd</test_depend>


### PR DESCRIPTION
The PR builder hasn't been working since the default rmw implementation changed on the buildfarm.https://build.ros2.org/job/Rpr__rosbag2__ubuntu_focal_amd64/

Hypothesis: internally to the core, the default RMW implementation is set to `rmw_cyclonedds_cpp`. However, since rosbag2 installs `rmw_fastrtps_cpp` explicitly as a dependency, installing `rmw` doesn't force Cyclone to get installed, because the "at least one RMW implementation" requirement is met. Even though `rmw_fastrtps_cpp` is the only installed RMW implementation, the default value is still set to `rmw_cyclonedds_cpp`, it's not dynamically checked.

By adding this dependency explicitly, the PR builder should install the default and be able to pass tests when `RMW_IMPLEMENTATION` is not specified.

This won't be necessary when we remove the converter dependency on `rmw_fastrtps_cpp` (and maybe we should just do that instead of this - I am testing the above hypothesis via this PR)