### PR TITLE
Allow a loaned message to be published

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/generic_publisher.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/generic_publisher.hpp
@@ -35,6 +35,14 @@ public:
   virtual ~GenericPublisher() = default;
 
   void publish(std::shared_ptr<rmw_serialized_message_t> message);
+  void publish_loaned_message(void * ros_message);
+  void * borrow_loaned_message();
+  void deserialize_message(
+    const rmw_serialized_message_t * serialized_message,
+    void * deserialized_msg);
+
+private:
+  const rosidl_message_type_support_t & type_support_;
 };
 
 }  // namespace rosbag2_transport


### PR DESCRIPTION
Closes https://github.com/ros2/rosbag2/issues/652

I was not able to successfully build master (against ROS 2 Foxy) with the following commands:

```bash
$ docker pull osrf/ros:foxy-desktop
$ docker run --name=foxy -it osrf/ros:foxy-desktop bash
$ source /opt/ros/foxy/setup.bash
$  mkdir -p ~/rosbag_ws/src && cd ~/rosbag_ws/src
$ git clone https://github.com/ros2/rosbag2.git
$ cd ..
$ colcon build
--- stderr: rosbag2_storage                                                                         
/rosbag2/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp: In member function ‘virtual rosbag2_storage::BagMetadata rosbag2_storage::MetadataIo::read_metadata(const string&)’:
/rosbag2/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp:236:53: error: could not convert ‘& metadata.rosbag2_storage::BagMetadata::bag_size’ from ‘uint64_t*’ {aka ‘long unsigned int*’} to ‘rcutils_allocator_t’
  236 |       rcutils_calculate_directory_size(uri.c_str(), &metadata.bag_size, allocator))
      |                                                     ^~~~~~~~~~~~~~~~~~
      |                                                     |
      |                                                     uint64_t* {aka long unsigned int*}
```