### PR TITLE
Add support for rmw_connextdds

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -149,19 +149,11 @@ function(create_tests_for_rmw_implementation)
       rosbag2_test_common
       yaml_cpp_vendor)
 
-  # disable the following tests for connext
-  # due to slower discovery of nodes
-  set(SKIP_TEST "")
-  if(${rmw_implementation} MATCHES "(.*)connext(.*)")
-    set(SKIP_TEST "SKIP_TEST")
-  endif()
-
   rosbag2_transport_add_gmock(test_record
     test/rosbag2_transport/test_record.cpp
     AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common
     INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
-    LINK_LIBS rosbag2_transport
-    ${SKIP_TEST})
+    LINK_LIBS rosbag2_transport)
 
   rosbag2_transport_add_gmock(test_record_regex
     test/rosbag2_transport/test_record_regex.cpp

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -149,11 +149,19 @@ function(create_tests_for_rmw_implementation)
       rosbag2_test_common
       yaml_cpp_vendor)
 
+  # disable the following tests for connext
+  # due to slower discovery of nodes
+  set(SKIP_TEST "")
+  if(${rmw_implementation} MATCHES "rmw_connext(.*)_cpp")
+    set(SKIP_TEST "SKIP_TEST")
+  endif()
+
   rosbag2_transport_add_gmock(test_record
     test/rosbag2_transport/test_record.cpp
     AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common
     INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
-    LINK_LIBS rosbag2_transport)
+    LINK_LIBS rosbag2_transport
+    ${SKIP_TEST})
 
   rosbag2_transport_add_gmock(test_record_regex
     test/rosbag2_transport/test_record_regex.cpp


### PR DESCRIPTION
This PR removes all references to `rmw_connext_cpp`, so that it may be replaced by `rmw_connextdds`.

The PR re-enables a test which was previously disabled for Connext.

See [rticommunity/rmw_connextdds #9](https://github.com/rticommunity/rmw_connextdds/issues/9) for a list of related PRs, and an overview of all the changes required to replace [ros2/rmw_connext](https://github.com/ros2/rmw_connext) (`rmw_connext_cpp`) with [rticommunity/rmw_connextdds](https://github.com/rticommunity/rmw_connextdds) in the ROS2 source tree.