### PR TITLE
alternative write api

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -110,6 +110,22 @@ public:
    */
   void write(std::shared_ptr<rosbag2_storage::SerializedBagMessage> message);
 
+  /**
+   * Write a message to a bagfile.
+   * Opposing a call to \sa write without topic metadata, the topic will be created.
+   *
+   * \param message to be written to the bagfile
+   * \param topic_name the string of the topic this messages belongs to
+   * \param type_name the string of the type associated with this message
+   * \param serialization_format the format in which this message is serialized
+   * \throws runtime_error if the Writer is not open.
+   */
+  void write(
+    std::shared_ptr<rosbag2_storage::SerializedBagMessage> message,
+    const std::string & topic_name,
+    const std::string & type_name,
+    const std::string & serialization_format = "cdr");
+
   writer_interfaces::BaseWriterInterface & get_implementation_handle() const
   {
     return *writer_impl_;

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -77,4 +77,24 @@ void Writer::write(std::shared_ptr<rosbag2_storage::SerializedBagMessage> messag
   writer_impl_->write(message);
 }
 
+void Writer::write(
+  std::shared_ptr<rosbag2_storage::SerializedBagMessage> message,
+  const std::string & topic_name,
+  const std::string & type_name,
+  const std::string & serialization_format)
+{
+  if (message->topic_name != topic_name) {
+    auto err = std::string("trying to write a message with mismatching topic information: ");
+    err += "(" + message->topic_name + ") vs (" + topic_name + ")";
+    throw std::runtime_error(err);
+  }
+
+  rosbag2_storage::TopicMetadata tm;
+  tm.name = topic_name;
+  tm.type = type_name;
+  tm.serialization_format = serialization_format;
+  create_topic(tm);
+  write(message);
+}
+
 }  // namespace rosbag2_cpp

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -67,8 +67,10 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
 
     writer.write(bag_message);
 
-
     // alternative way of writing a message
+    // if there's a topic mismatch, we throw
+    EXPECT_ANY_THROW(writer.write(bag_message, "/my/other/topic", "test_msgs/msg/BasicTypes"));
+
     bag_message->topic_name = "/my/other/topic";
     writer.write(bag_message, "/my/other/topic", "test_msgs/msg/BasicTypes");
 


### PR DESCRIPTION
I am adding an overlay to the rosbag2_cpp API which lets you directly add serialized messages with appropriate meta information without the explicit call to create topic beforehand.