### PR TITLE
When playing a bag with --topics, don't create publishers for the ignored topics

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -197,11 +197,9 @@ void Player::prepare_publishers(const PlayOptions & options)
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
     // don't create publishers for topics that are not going to be used
-    if (!options.topics_to_filter.empty())
-    {
+    if (!options.topics_to_filter.empty()){
       const auto t = options.topics_to_filter;
-      if (std::find(t.begin(), t.end(), topic.name) == t.end())
-      {
+      if (std::find(t.begin(), t.end(), topic.name) == t.end()){
         continue;
       }
     }

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -196,7 +196,6 @@ void Player::prepare_publishers(const PlayOptions & options)
 
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
-    
     // don't create publishers for topics that are not going to be used
     if (!options.topics_to_filter.empty())
     {

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -196,6 +196,17 @@ void Player::prepare_publishers(const PlayOptions & options)
 
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
+    
+    // don't create publishers for topics that are not going to be used
+    if (!options.topics_to_filter.empty())
+    {
+      const auto t = options.topics_to_filter;
+      if (std::find(t.begin(), t.end(), topic.name) == t.end())
+      {
+        continue;
+      }
+    }
+
     auto topic_qos = publisher_qos_for_topic(topic, topic_qos_profile_overrides_);
     publishers_.insert(
       std::make_pair(

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -197,9 +197,9 @@ void Player::prepare_publishers(const PlayOptions & options)
   auto topics = reader_->get_all_topics_and_types();
   for (const auto & topic : topics) {
     // don't create publishers for topics that are not going to be used
-    if (!options.topics_to_filter.empty()){
+    if (!options.topics_to_filter.empty()) {
       const auto t = options.topics_to_filter;
-      if (std::find(t.begin(), t.end(), topic.name) == t.end()){
+      if (std::find(t.begin(), t.end(), topic.name) == t.end()) {
         continue;
       }
     }


### PR DESCRIPTION
Publisher are created for all topics in the bag even if the aren't used. This makes it harder to verify what is going to be published as they show up in ros2 topic list.