### PR TITLE
Add QoS decoding translation for infinite durations to RMW_DURATION_INFINITE

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -34,7 +34,7 @@ namespace
  * With those values, if a bag is played back in a different implementation than it was recorded,
  * the publishers will fail to be created with an error indicating an invalid QoS value..
  */
-static const rmw_time_t RMW_CYCLONEDDS_FOXY_INFINITE = rmw_time_from_nsec(0x7FFFFFFFFFFFFFFFLL);
+static const rmw_time_t RMW_CYCLONEDDS_FOXY_INFINITE = rmw_time_from_nsec(0x7FFFFFFFFFFFFFFFll);
 static const rmw_time_t RMW_FASTRTPS_FOXY_INFINITE {0x7FFFFFFFll, 0xFFFFFFFFll};
 static const rmw_time_t RMW_CONNEXT_FOXY_INFINITE  {0x7FFFFFFFll, 0x7FFFFFFFll};
 }  // namespace


### PR DESCRIPTION
Fixes #656

QoS policy durations representing "Infinity" were returned as the verbatim internal constant values, before the RMW_DURATION_INFINITE changes. Old bags have these values recorded in their QoS metadata, causing problems playing back in the new implementation. This is especially a problem for bags recorded in Foxy (default rmw_fastrtps) - and played back in Galactic (default rmw_cyclonedds)

Values pulled from Tier-1 RMW implementations - any new implementations that respect RMW_DURATION_INFINITE will not need to be known here.