### PR TITLE
Add rosbag2_py::Player::play to replace rosbag2_transport_python version

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -22,9 +22,9 @@ from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
 from rosbag2_py import get_registered_readers
+from rosbag2_py import Player
 from rosbag2_py import PlayOptions
 from rosbag2_py import StorageOptions
-from rosbag2_py import Transport
 import yaml
 
 
@@ -106,5 +106,5 @@ class PlayVerb(VerbExtension):
             topic_remapping_options=topic_remapping,
         )
 
-        transport = Transport()
-        transport.play(storage_options, play_options)
+        player = Player()
+        player.play(storage_options, play_options)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -22,6 +22,9 @@ from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
 from rosbag2_py import get_registered_readers
+from rosbag2_py import PlayOptions
+from rosbag2_py import StorageOptions
+from rosbag2_py import Transport
 import yaml
 
 
@@ -46,7 +49,7 @@ class PlayVerb(VerbExtension):
             '-r', '--rate', type=check_positive_float, default=1.0,
             help='rate at which to play back messages. Valid range > 0.0.')
         parser.add_argument(
-            '--topics', type=str, default='', nargs='+',
+            '--topics', type=str, default=[], nargs='+',
             help='topics to replay, separated by space. If none specified, all topics will be '
                  'replayed.')
         parser.add_argument(
@@ -83,20 +86,25 @@ class PlayVerb(VerbExtension):
         if args.storage_config_file:
             storage_config_file = args.storage_config_file.name
 
-        # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
-        #               combined with constrained environments (as imposed by colcon test)
-        #               may result in DLL loading failures when attempting to import a C
-        #               extension. Therefore, do not import rosbag2_transport at the module
-        #               level but on demand, right before first use.
-        from rosbag2_transport import rosbag2_transport_py
-        rosbag2_transport_py.play(
+        topic_remapping = ['--ros-args']
+        for remap_rule in args.remap:
+            topic_remapping.append('--remap')
+            topic_remapping.append(remap_rule)
+
+        storage_options = StorageOptions(
             uri=args.bag_file,
             storage_id=args.storage,
-            node_prefix=NODE_NAME_PREFIX,
+            storage_config_uri=storage_config_file,
+        )
+        play_options = PlayOptions(
             read_ahead_queue_size=args.read_ahead_queue_size,
+            node_prefix=NODE_NAME_PREFIX,
             rate=args.rate,
-            topics=args.topics,
-            qos_profile_overrides=qos_profile_overrides,
+            topics_to_filter=args.topics,
+            topic_qos_profile_overrides=qos_profile_overrides,
             loop=args.loop,
-            topic_remapping=args.remap,
-            storage_config_file=storage_config_file)
+            topic_remapping_options=topic_remapping,
+        )
+
+        transport = Transport()
+        transport.play(storage_options, play_options)

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rosbag2_compression REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_storage REQUIRED)
+find_package(rosbag2_transport REQUIRED)
 
 # Find python before pybind11
 find_package(python_cmake_module REQUIRED)
@@ -106,6 +107,17 @@ ament_target_dependencies(_info PUBLIC
 )
 clean_windows_flags(_info)
 
+pybind11_add_module(_transport SHARED
+  src/rosbag2_py/_transport.cpp
+)
+ament_target_dependencies(_transport PUBLIC
+  "rosbag2_compression"
+  "rosbag2_cpp"
+  "rosbag2_storage"
+  "rosbag2_transport"
+)
+clean_windows_flags(_transport)
+
 # Install cython modules as sub-modules of the project
 install(
   TARGETS
@@ -113,6 +125,7 @@ install(
     _storage
     _writer
     _info
+    _transport
   DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}"
 )
 

--- a/rosbag2_py/package.xml
+++ b/rosbag2_py/package.xml
@@ -21,6 +21,7 @@
   <depend>rosbag2_compression</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>
+  <depend>rosbag2_transport</depend>
 
   <exec_depend>rpyutils</exec_depend>
 

--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -39,6 +39,10 @@ with add_dll_directories_from_env('PATH'):
     from rosbag2_py._info import (
         Info,
     )
+    from rosbag2_py._transport import (
+        PlayOptions,
+        Transport,
+    )
 
 __all__ = [
     'ConverterOptions',
@@ -54,4 +58,6 @@ __all__ = [
     'TopicInformation',
     'BagMetadata',
     'Info',
+    'PlayOptions',
+    'Transport',
 ]

--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -40,8 +40,8 @@ with add_dll_directories_from_env('PATH'):
         Info,
     )
     from rosbag2_py._transport import (
+        Player,
         PlayOptions,
-        Transport,
     )
 
 __all__ = [
@@ -58,6 +58,6 @@ __all__ = [
     'TopicInformation',
     'BagMetadata',
     'Info',
+    'Player',
     'PlayOptions',
-    'Transport',
 ]

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -42,12 +42,13 @@ PYBIND11_MODULE(_storage, m) {
 
   pybind11::class_<rosbag2_storage::StorageOptions>(m, "StorageOptions")
   .def(
-    pybind11::init<std::string, std::string, uint64_t, uint64_t, uint64_t>(),
+    pybind11::init<std::string, std::string, uint64_t, uint64_t, uint64_t, std::string>(),
     pybind11::arg("uri"),
     pybind11::arg("storage_id"),
     pybind11::arg("max_bagfile_size") = 0,
     pybind11::arg("max_bagfile_duration") = 0,
-    pybind11::arg("max_cache_size") = 0)
+    pybind11::arg("max_cache_size") = 0,
+    pybind11::arg("storage_config_uri") = "")
   .def_readwrite("uri", &rosbag2_storage::StorageOptions::uri)
   .def_readwrite("storage_id", &rosbag2_storage::StorageOptions::storage_id)
   .def_readwrite(
@@ -58,7 +59,10 @@ PYBIND11_MODULE(_storage, m) {
     &rosbag2_storage::StorageOptions::max_bagfile_duration)
   .def_readwrite(
     "max_cache_size",
-    &rosbag2_storage::StorageOptions::max_cache_size);
+    &rosbag2_storage::StorageOptions::max_cache_size)
+  .def_readwrite(
+    "storage_config_uri",
+    &rosbag2_storage::StorageOptions::storage_config_uri);
 
   pybind11::class_<rosbag2_storage::StorageFilter>(m, "StorageFilter")
   .def(

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -47,7 +47,6 @@ public:
     const rosbag2_storage::StorageOptions & storage_options,
     const rosbag2_transport::PlayOptions & play_options)
   {
-    printf("Entered rosbag2_py::Transport::play\n");
     auto writer = std::make_shared<rosbag2_cpp::Writer>(
       std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
     std::shared_ptr<rosbag2_cpp::Reader> reader = nullptr;
@@ -63,18 +62,14 @@ public:
         }
       }
       if (reader == nullptr) {
-        printf("Creating regular player\n");
         reader = std::make_shared<rosbag2_cpp::Reader>(
           std::make_unique<rosbag2_cpp::readers::SequentialReader>());
       }
     }
 
-    printf("Creating Rosbag2Transport\n");
     Rosbag2Transport impl(reader, writer);
     impl.init();
-    printf("Calling play\n");
     impl.play(storage_options, play_options);
-    printf("Done playing\n");
     impl.shutdown();
   }
 };

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -1,0 +1,115 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_compression/compression_options.hpp"
+#include "rosbag2_compression/sequential_compression_reader.hpp"
+#include "rosbag2_compression/sequential_compression_writer.hpp"
+#include "rosbag2_cpp/reader.hpp"
+#include "rosbag2_cpp/readers/sequential_reader.hpp"
+#include "rosbag2_cpp/writer.hpp"
+#include "rosbag2_cpp/writers/sequential_writer.hpp"
+#include "rosbag2_storage/storage_options.hpp"
+#include "rosbag2_transport/play_options.hpp"
+#include "rosbag2_transport/rosbag2_transport.hpp"
+
+#include "./pybind11.hpp"
+
+using PlayOptions = rosbag2_transport::PlayOptions;
+using Rosbag2Transport = rosbag2_transport::Rosbag2Transport;
+
+namespace rosbag2_py
+{
+
+class Transport
+{
+public:
+  Transport() {}
+
+  virtual ~Transport() = default;
+
+  void play(
+    const rosbag2_storage::StorageOptions & storage_options,
+    const rosbag2_transport::PlayOptions & play_options)
+  {
+    printf("Entered rosbag2_py::Transport::play\n");
+    auto writer = std::make_shared<rosbag2_cpp::Writer>(
+      std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
+    std::shared_ptr<rosbag2_cpp::Reader> reader = nullptr;
+    // Determine whether to build compression or regular reader
+    {
+      rosbag2_storage::MetadataIo metadata_io{};
+      rosbag2_storage::BagMetadata metadata{};
+      if (metadata_io.metadata_file_exists(storage_options.uri)) {
+        metadata = metadata_io.read_metadata(storage_options.uri);
+        if (!metadata.compression_format.empty()) {
+          reader = std::make_shared<rosbag2_cpp::Reader>(
+            std::make_unique<rosbag2_compression::SequentialCompressionReader>());
+        }
+      }
+      if (reader == nullptr) {
+        printf("Creating regular player\n");
+        reader = std::make_shared<rosbag2_cpp::Reader>(
+          std::make_unique<rosbag2_cpp::readers::SequentialReader>());
+      }
+    }
+
+    printf("Creating Rosbag2Transport\n");
+    Rosbag2Transport impl(reader, writer);
+    impl.init();
+    printf("Calling play\n");
+    impl.play(storage_options, play_options);
+    printf("Done playing\n");
+    impl.shutdown();
+  }
+};
+
+}  // namespace rosbag2_py
+
+PYBIND11_MODULE(_transport, m) {
+  m.doc() = "Python wrapper of the rosbag2_transport API";
+
+  pybind11::class_<PlayOptions>(m, "PlayOptions")
+  .def(
+    pybind11::init<
+      size_t,
+      std::string,
+      float,
+      std::vector<std::string>,
+      std::unordered_map<std::string, rclcpp::QoS>,
+      bool,
+      std::vector<std::string>
+    >(),
+    pybind11::arg("read_ahead_queue_size"),
+    pybind11::arg("node_prefix") = "",
+    pybind11::arg("rate") = 1.0,
+    pybind11::arg("topics_to_filter") = std::vector<std::string>{},
+    pybind11::arg("topic_qos_profile_overrides") = std::unordered_map<std::string, rclcpp::QoS>{},
+    pybind11::arg("loop") = false,
+    pybind11::arg("topic_remapping_options") = std::vector<std::string>{}
+  )
+  .def_readwrite("read_ahead_queue_size", &PlayOptions::read_ahead_queue_size)
+  .def_readwrite("node_prefix", &PlayOptions::node_prefix)
+  .def_readwrite("rate", &PlayOptions::rate)
+  .def_readwrite("topics_to_filter", &PlayOptions::topics_to_filter)
+  .def_readwrite("topic_qos_profile_overrides", &PlayOptions::topic_qos_profile_overrides)
+  .def_readwrite("loop", &PlayOptions::loop)
+  .def_readwrite("topic_remapping_options", &PlayOptions::topic_remapping_options)
+  ;
+
+  pybind11::class_<rosbag2_py::Transport>(m , "Transport")
+  .def(pybind11::init())
+  .def("play", &rosbag2_py::Transport::play)
+  ;
+
+}

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -36,12 +36,11 @@ using Rosbag2Transport = rosbag2_transport::Rosbag2Transport;
 namespace rosbag2_py
 {
 
-class Transport
+class Player
 {
 public:
-  Transport() {}
-
-  virtual ~Transport() = default;
+  Player() = default;
+  virtual ~Player() = default;
 
   void play(
     const rosbag2_storage::StorageOptions & storage_options,
@@ -107,8 +106,8 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("topic_remapping_options", &PlayOptions::topic_remapping_options)
   ;
 
-  pybind11::class_<rosbag2_py::Transport>(m, "Transport")
+  pybind11::class_<rosbag2_py::Player>(m, "Player")
   .def(pybind11::init())
-  .def("play", &rosbag2_py::Transport::play)
+  .def("play", &rosbag2_py::Player::play)
   ;
 }

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "rosbag2_compression/compression_options.hpp"
 #include "rosbag2_compression/sequential_compression_reader.hpp"
 #include "rosbag2_compression/sequential_compression_writer.hpp"
@@ -107,9 +112,8 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("topic_remapping_options", &PlayOptions::topic_remapping_options)
   ;
 
-  pybind11::class_<rosbag2_py::Transport>(m , "Transport")
+  pybind11::class_<rosbag2_py::Transport>(m, "Transport")
   .def(pybind11::init())
   .def("play", &rosbag2_py::Transport::play)
   ;
-
 }


### PR DESCRIPTION
"record" is an easy followup if we like this pattern.

As I'm preparing to add more playback arguments, I don't want to manage the `PyArg_ParseTupleAndKeywords` monster anymore