### PR TITLE
Pause/resume PlayerClock

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -64,6 +64,26 @@ public:
    */
   ROSBAG2_CPP_PUBLIC
   virtual double get_rate() const = 0;
+
+  /**
+   * Stop the flow of time of the clock.
+   * If this changes the pause state, this will wake any waiting `sleep_until`
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual void pause() = 0;
+
+  /**
+   * Start the flow of time of the clock
+   * If this changes the pause state, this will wake any waiting `sleep_until`
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual void resume() = 0;
+
+  /**
+   * Return whether the clock is currently paused.
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual bool is_paused() const = 0;
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -40,6 +40,8 @@ public:
    * \param now_fn: Function used to get the current steady time
    *   defaults to std::chrono::steady_clock::now
    *   Used to control for unit testing, or for specialized needs
+   * \param sleep_time_while_paused: Amount of time to sleep in `sleep_until` when the clock
+   *   is paused. Allows the caller to spin at a defined rate while receiving `false`
    * \throws std::runtime_error if rate is <= 0
    */
   ROSBAG2_CPP_PUBLIC

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -46,7 +46,8 @@ public:
   TimeControllerClock(
     rcutils_time_point_value_t starting_time,
     double rate = 1.0,
-    NowFunction now_fn = std::chrono::steady_clock::now);
+    NowFunction now_fn = std::chrono::steady_clock::now,
+    std::chrono::milliseconds sleep_time_while_paused = std::chrono::milliseconds{100});
 
   ROSBAG2_CPP_PUBLIC
   virtual ~TimeControllerClock();
@@ -72,6 +73,26 @@ public:
    */
   ROSBAG2_CPP_PUBLIC
   double get_rate() const override;
+
+  /**
+   * Stop the flow of time of the clock.
+   * If this changes the pause state, this will wake any waiting `sleep_until`
+   */
+  ROSBAG2_CPP_PUBLIC
+  void pause() override;
+
+  /**
+   * Start the flow of time of the clock
+   * If this changes the pause state, this will wake any waiting `sleep_until`
+   */
+  ROSBAG2_CPP_PUBLIC
+  void resume() override;
+
+  /**
+   * Return whether the clock is currently paused.
+   */
+  ROSBAG2_CPP_PUBLIC
+  bool is_paused() const override;
 
 private:
   std::unique_ptr<TimeControllerClockImpl> impl_;

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -92,11 +92,17 @@ public:
     return steady_to_ros(now_fn());
   }
 
+  void snapshot(rcutils_time_point_value_t ros_time)
+  RCPPUTILS_TSA_REQUIRES(state_mutex)
+  {
+    reference.ros = ros_time;
+    reference.steady = now_fn();
+  }
+
   void snapshot()
   RCPPUTILS_TSA_REQUIRES(state_mutex)
   {
-    reference.ros = ros_now();
-    reference.steady = now_fn();
+    snapshot(ros_now());
   }
 
   const PlayerClock::NowFunction now_fn;


### PR DESCRIPTION
Part of #696

Add `set_paused` and `get_paused` functions to `PlayerClock` and expose to `Player`.