### PR TITLE
Fix bad_function_call by replacing rclcpp::spin_some with SingleThreadedExecutor

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -79,8 +79,9 @@ public:
   {
     return async(
       std::launch::async, [this]() {
-        while (continue_spinning(expected_topics_with_size_)) {
-          rclcpp::spin_some(subscriber_node_);
+        rclcpp::executors::SingleThreadedExecutor exec;
+        while (rclcpp::ok() && continue_spinning(expected_topics_with_size_)) {
+          exec.spin_node_some(subscriber_node_);
         }
       });
   }

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -446,6 +446,7 @@ public:
     } else {
       EXPECT_NE(result, std::future_status::timeout);
     }
+    // Have to rclcpp::shutdown here to make the spin_subscriptions async thread exit
     transport.shutdown();
   }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -50,6 +50,7 @@ public:
     publisher_node_ = std::make_shared<rclcpp::Node>(
       "publisher_node",
       rclcpp::NodeOptions().start_parameter_event_publisher(false));
+    executor_.add_node(node_);
   }
 
   static void SetUpTestCase()
@@ -84,7 +85,7 @@ public:
       });
 
     while (counter < expected_messages_number) {
-      rclcpp::spin_some(node_);
+      executor_.spin_some();
     }
     return messages;
   }
@@ -111,13 +112,14 @@ public:
       if ((clock::now() - start) > timeout) {
         return false;
       }
-      rclcpp::spin_some(node_);
+      executor_.spin_some();
     }
     return true;
   }
 
   MemoryManagement memory_management_;
   std::shared_ptr<rosbag2_transport::Rosbag2Node> node_;
+  rclcpp::executors::SingleThreadedExecutor executor_;
   rclcpp::Node::SharedPtr publisher_node_;
   std::vector<std::shared_ptr<rclcpp::PublisherBase>> publishers_;
 };


### PR DESCRIPTION
Extension of https://github.com/ros2/rosbag2/pull/576 - same fix applied in more places. I have been seeing occasional test flakiness due to this cause. See details from #576 following

> Every time we called spin_some, a new executor was constructed. This would happen potentially a few thousand times per test. Given that the global context was not shutdown during this time, it would accumulate on_shutdown_callbacks_, one from each executor that was created. When this list was very large we would occasionally get std::bad_function_call for one of the callbacks in the shutdown.

> With this change, the global Context has only 2 items in on_shutdown_callbacks_, and I am not able to reproduce bad_function_call any more.