### PR TITLE
Fix rosbag2_py transport test for py capsule

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -40,9 +40,9 @@ namespace
 
 rclcpp::QoS qos_from_handle(const py::handle source)
 {
-  PyObject * obj = PyObject_CallMethod(source.ptr(), "get_c_qos_profile", "");
-  auto o = py::cast<py::object>(obj);
-  auto rmw_qos_profile = o.cast<rmw_qos_profile_t>();
+  PyObject * raw_obj = PyObject_CallMethod(source.ptr(), "get_c_qos_profile", "");
+  const auto py_obj = py::cast<py::object>(raw_obj);
+  const auto rmw_qos_profile = py_obj.cast<rmw_qos_profile_t>();
   const auto qos_init = rclcpp::QoSInitialization::from_rmw(rmw_qos_profile);
   return rclcpp::QoS{qos_init, rmw_qos_profile};
 }

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -40,11 +40,11 @@ namespace
 
 rclcpp::QoS qos_from_handle(const py::handle source)
 {
-  auto py_capsule = PyObject_CallMethod(source.ptr(), "get_c_qos_profile", "");
-  const auto rmw_qos_profile = reinterpret_cast<rmw_qos_profile_t *>(
-    PyCapsule_GetPointer(py_capsule, "rmw_qos_profile_t"));
-  const auto qos_init = rclcpp::QoSInitialization::from_rmw(*rmw_qos_profile);
-  return rclcpp::QoS{qos_init, *rmw_qos_profile};
+  PyObject * obj = PyObject_CallMethod(source.ptr(), "get_c_qos_profile", "");
+  auto o = py::cast<py::object>(obj);
+  auto rmw_qos_profile = o.cast<rmw_qos_profile_t>();
+  const auto qos_init = rclcpp::QoSInitialization::from_rmw(rmw_qos_profile);
+  return rclcpp::QoS{qos_init, rmw_qos_profile};
 }
 
 QoSMap qos_map_from_py_dict(const py::dict & dict)


### PR DESCRIPTION
Change introduced by ros2/rclpy#741 conflicted with parallel work in #702, the combination causing nightly test failure for `rosbag2_py`'s `_transport.cpp` tests. Fix to use the new `py::object` for `rmw_qos_profile_t` to fix the tests.

One instance https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/1559/testReport/junit/(root)/projectroot/test_transport_py/