### PR TITLE
Build core sources in Action CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
           rosbag2_test_common
           rosbag2_tests
         target-ros2-distro: rolling
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
     - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs


### PR DESCRIPTION
The PR builder already builds against Rolling binaries for us, so the current setup is redundant information (and fails if Rolling packages have changed, but haven't been released). Have the Action CI reflect ci.ros2.org builds instead, by building the core from source.