### PR TITLE
Enforce max/min spin rate on TimeControllerClock::sleep_until

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -52,9 +52,10 @@ public:
   /**
    * Try to sleep (non-busy) the current thread until the provided time is reached - according to this Clock
    *
-   * Return true if the time has been reached, false if it was not successfully reached after sleeping
-   * for the appropriate duration.
    * The user should not take action based on this sleep until it returns true.
+   *
+   * \param until: The ROS time to sleep until
+   * \return true if the `until` has been reached, false if timeout or awakened early.
    */
   ROSBAG2_CPP_PUBLIC
   virtual bool sleep_until(rcutils_time_point_value_t until) = 0;

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -36,6 +36,10 @@ public:
    *
    * \param starting_time: provides an initial offset for managing time
    *    This will likely be the timestamp of the first message in the bag
+   * \param sleep_timeout: maximum amount of time to sleep even if time is not reached
+   *    This helps dictate spin rate when clock is paused, as well as allowing periodic return
+   *    of control even if messages are far apart.
+   *    Value must be greater than 0.
    * \param rate: Rate of playback, a unit-free ratio. 1.0 is real-time
    * \param now_fn: Function used to get the current steady time
    *   defaults to std::chrono::steady_clock::now
@@ -45,6 +49,7 @@ public:
   ROSBAG2_CPP_PUBLIC
   TimeControllerClock(
     rcutils_time_point_value_t starting_time,
+    std::chrono::nanoseconds sleep_timeout,
     double rate = 1.0,
     NowFunction now_fn = std::chrono::steady_clock::now);
 
@@ -60,9 +65,10 @@ public:
   /**
    * Try to sleep (non-busy) the current thread until the provided time is reached - according to this Clock
    *
-   * Return true if the time has been reached, false if it was not successfully reached after sleeping
-   * for the appropriate duration.
    * The user should not take action based on this sleep until it returns true.
+   *
+   * \param until: The ROS time to sleep until
+   * \return true if the `until` has been reached, false if timeout or awakened early.
    */
   ROSBAG2_CPP_PUBLIC
   bool sleep_until(rcutils_time_point_value_t until) override;

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -217,7 +217,8 @@ void Player::prepare_publishers(const PlayOptions & options)
 void Player::prepare_clock(const PlayOptions & options, rcutils_time_point_value_t starting_time)
 {
   double rate = options.rate > 0.0 ? options.rate : 1.0;
-  clock_ = std::make_unique<rosbag2_cpp::TimeControllerClock>(starting_time, rate);
+  std::chrono::nanoseconds sleep_timeout{RCUTILS_S_TO_NS(1)};  // default 1Hz spin on paused
+  clock_ = std::make_unique<rosbag2_cpp::TimeControllerClock>(starting_time, sleep_timeout, rate);
 }
 
 }  // namespace rosbag2_transport


### PR DESCRIPTION
Control the rate of spinning in `while (!clock.sleep_until())` by giving a real-time sleep timeout.

* This will be useful for pause/resume, to dictate the spin rate while paused
* It will also be useful for clock publishing, so that the Player thread can give control back at the right frequency to publish `/clock`