### PR TITLE
Change index.ros.org -> docs.ros.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,5 +278,5 @@ This also allows to record data in a native format to optimize for speed, but to
 
 By default, rosbag2 can convert from and to CDR as it's the default serialization format for ROS 2.
 
-[qos-override-tutorial]: https://index.ros.org/doc/ros2/Tutorials/Ros2bag/Overriding-QoS-Policies-For-Recording-And-Playback/
-[about-qos-settings]: https://index.ros.org/doc/ros2/Concepts/About-Quality-of-Service-Settings/
+[qos-override-tutorial]: https://docs.ros.org/en/rolling/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.html
+[about-qos-settings]: https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>