### PR TITLE
Split Rosbag2Transport into Player and Recorder classes - first pass to enable further progress

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -89,15 +89,19 @@ namespace rosbag2_py
 class Player
 {
 public:
-  Player() = default;
-  virtual ~Player() = default;
+  Player()
+  {
+    rclcpp::init(0, nullptr);
+  }
+  virtual ~Player()
+  {
+    rclcpp::shutdown();
+  }
 
   void play(
     const rosbag2_storage::StorageOptions & storage_options,
     PlayOptions & play_options)
   {
-    auto writer = std::make_shared<rosbag2_cpp::Writer>(
-      std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
     std::shared_ptr<rosbag2_cpp::Reader> reader = nullptr;
     // Determine whether to build compression or regular reader
     {
@@ -116,18 +120,22 @@ public:
       }
     }
 
-    rosbag2_transport::Rosbag2Transport impl(reader, writer);
-    impl.init();
+    rosbag2_transport::Player impl(reader);
     impl.play(storage_options, play_options);
-    impl.shutdown();
   }
 };
 
 class Recorder
 {
 public:
-  Recorder() = default;
-  virtual ~Recorder() = default;
+  Recorder()
+  {
+    rclcpp::init(0, nullptr);
+  }
+  virtual ~Recorder()
+  {
+    rclcpp::shutdown();
+  }
 
   void record(
     const rosbag2_storage::StorageOptions & storage_options,
@@ -160,10 +168,8 @@ public:
         std::make_unique<rosbag2_cpp::writers::SequentialWriter>());
     }
 
-    rosbag2_transport::Rosbag2Transport impl(reader, writer);
-    impl.init();
+    rosbag2_transport::Recorder impl(writer);
     impl.record(storage_options, record_options);
-    impl.shutdown();
   }
 };
 

--- a/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/rosbag2_transport.hpp
@@ -35,26 +35,44 @@ class Writer;
 namespace rosbag2_transport
 {
 
-class Rosbag2Node;
-
-class Rosbag2Transport
+class Player
 {
 public:
-  /// Default constructor
   ROSBAG2_TRANSPORT_PUBLIC
-  Rosbag2Transport();
-
-  /// Constructor for testing, allows to set the reader and writer to use
-  ROSBAG2_TRANSPORT_PUBLIC
-  Rosbag2Transport(
-    std::shared_ptr<rosbag2_cpp::Reader> reader,
-    std::shared_ptr<rosbag2_cpp::Writer> writer);
+  Player();
 
   ROSBAG2_TRANSPORT_PUBLIC
-  void init();
+  explicit Player(std::shared_ptr<rosbag2_cpp::Reader> reader);
 
   ROSBAG2_TRANSPORT_PUBLIC
-  void shutdown();
+  virtual ~Player();
+
+  /**
+   * Replay a bagfile.
+   *
+   * \param storage_options Option regarding the storage (e.g. bag file name)
+   * \param play_options Options regarding the playback (e.g. queue size)
+   */
+  ROSBAG2_TRANSPORT_PUBLIC
+  void play(
+    const rosbag2_storage::StorageOptions & storage_options,
+    const PlayOptions & play_options);
+
+protected:
+  std::shared_ptr<rosbag2_cpp::Reader> reader_;
+};
+
+class Recorder
+{
+public:
+  ROSBAG2_TRANSPORT_PUBLIC
+  Recorder();
+
+  ROSBAG2_TRANSPORT_PUBLIC
+  explicit Recorder(std::shared_ptr<rosbag2_cpp::Writer> writer);
+
+  ROSBAG2_TRANSPORT_PUBLIC
+  virtual ~Recorder();
 
   /**
    * Records topics to a bagfile. Subscription happens at startup time, hence the topics must
@@ -68,26 +86,8 @@ public:
     const rosbag2_storage::StorageOptions & storage_options,
     const RecordOptions & record_options);
 
-  /**
-   * Replay all topics in a bagfile.
-   *
-   * \param storage_options Option regarding the storage (e.g. bag file name)
-   * \param play_options Options regarding the playback (e.g. queue size)
-   */
-  ROSBAG2_TRANSPORT_PUBLIC
-  void play(
-    const rosbag2_storage::StorageOptions & storage_options,
-    const PlayOptions & play_options);
-
-private:
-  std::shared_ptr<rclcpp::Node> setup_node(
-    std::string node_prefix = "",
-    const std::vector<std::string> & topic_remapping_options = {});
-
-  std::shared_ptr<rosbag2_cpp::Reader> reader_;
+protected:
   std::shared_ptr<rosbag2_cpp::Writer> writer_;
-
-  std::shared_ptr<rclcpp::Node> transport_node_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -73,6 +73,8 @@ rclcpp::QoS publisher_qos_for_topic(
 
 namespace rosbag2_transport
 {
+namespace impl
+{
 
 const std::chrono::milliseconds
 Player::queue_read_wait_period_ = std::chrono::milliseconds(100);
@@ -240,4 +242,5 @@ void Player::prepare_clock(const PlayOptions & options, rcutils_time_point_value
   }
 }
 
+}  // namespace impl
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.hpp
@@ -40,9 +40,8 @@ class Reader;
 
 namespace rosbag2_transport
 {
-
-class GenericPublisher;
-class Rosbag2Node;
+namespace impl
+{
 
 class Player
 {
@@ -76,6 +75,7 @@ private:
   std::shared_ptr<rclcpp::TimerBase> clock_publish_timer_;
 };
 
+}  // namespace impl
 }  // namespace rosbag2_transport
 
 #endif  // ROSBAG2_TRANSPORT__PLAYER_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -46,6 +46,8 @@
 
 namespace rosbag2_transport
 {
+namespace impl
+{
 Recorder::Recorder(
   std::shared_ptr<rosbag2_cpp::Writer> writer,
   std::shared_ptr<rclcpp::Node> transport_node)
@@ -162,12 +164,12 @@ void Recorder::subscribe_topics(
 {
   for (const auto & topic_with_type : topics_and_types) {
     subscribe_topic(
-      {
-        topic_with_type.first,
-        topic_with_type.second,
-        serialization_format_,
-        serialized_offered_qos_profiles_for_topic(topic_with_type.first)
-      });
+        {
+          topic_with_type.first,
+          topic_with_type.second,
+          serialization_format_,
+          serialized_offered_qos_profiles_for_topic(topic_with_type.first)
+        });
   }
 }
 
@@ -298,5 +300,5 @@ void Recorder::warn_if_new_qos_for_subscribed_topic(const std::string & topic_na
     }
   }
 }
-
+}  // namespace impl
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.hpp
@@ -38,9 +38,8 @@ class Writer;
 
 namespace rosbag2_transport
 {
-
-class GenericSubscription;
-class Rosbag2Node;
+namespace impl
+{
 
 class Recorder
 {
@@ -106,6 +105,7 @@ private:
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides_;
 };
 
+}  // namespace impl
 }  // namespace rosbag2_transport
 
 #endif  // ROSBAG2_TRANSPORT__RECORDER_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
@@ -51,8 +51,8 @@ public:
     // the future object returned from std::async needs to be stored not to block the execution
     future_ = std::async(
       std::launch::async, [this, options]() {
-        rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_);
-        rosbag2_transport.record(storage_options_, options);
+        rosbag2_transport::Recorder recorder(writer_);
+        recorder.record(storage_options_, options);
       });
   }
 

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -45,15 +45,6 @@
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_test_common; // NOLINT
 
-inline char separator()
-{
-#ifdef _WIN32
-  return '\\';
-#else
-  return '/';
-#endif
-}
-
 class Rosbag2TransportTestFixture : public Test
 {
 public:

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -75,8 +75,8 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  Rosbag2Transport rosbag2_transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  Player player(reader_);
+  player.play(storage_options_, play_options_);
 
   await_received_messages.get();
 
@@ -144,8 +144,8 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics_with_
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  Rosbag2Transport rosbag2_transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  Player player(reader_);
+  player.play(storage_options_, play_options_);
 
   await_received_messages.get();
 
@@ -214,8 +214,8 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
 
     auto await_received_messages = sub_->spin_subscriptions();
 
-    Rosbag2Transport rosbag2_transport(reader_, writer_);
-    rosbag2_transport.play(storage_options_, play_options_);
+    Player player(reader_);
+    player.play(storage_options_, play_options_);
 
     await_received_messages.get();
 
@@ -245,8 +245,8 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
 
     auto await_received_messages = sub_->spin_subscriptions();
 
-    Rosbag2Transport rosbag2_transport(reader_, writer_);
-    rosbag2_transport.play(storage_options_, play_options_);
+    Player player(reader_);
+    player.play(storage_options_, play_options_);
 
     await_received_messages.get();
 
@@ -276,8 +276,8 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
 
     auto await_received_messages = sub_->spin_subscriptions();
 
-    auto rosbag2_transport = Rosbag2Transport(reader_, writer_);
-    rosbag2_transport.play(storage_options_, play_options_);
+    auto player = Player(reader_);
+    player.play(storage_options_, play_options_);
 
     await_received_messages.get();
 
@@ -329,9 +329,9 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  Rosbag2Transport rosbag2_transport(reader_, writer_);
+  Player player(reader_);
   play_options_.topics_to_filter = {"topic2"};
-  rosbag2_transport.play(storage_options_, play_options_);
+  player.play(storage_options_, play_options_);
 
   await_received_messages.get();
 
@@ -355,9 +355,9 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
 
   await_received_messages = sub_->spin_subscriptions();
 
-  rosbag2_transport = Rosbag2Transport(reader_, writer_);
+  player = Player(reader_);
   play_options_.topics_to_filter = {"topic1"};
-  rosbag2_transport.play(storage_options_, play_options_);
+  player.play(storage_options_, play_options_);
 
   await_received_messages.get();
 
@@ -382,9 +382,9 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
 
   await_received_messages = sub_->spin_subscriptions();
 
-  rosbag2_transport = Rosbag2Transport(reader_, writer_);
+  player = Player(reader_);
   play_options_.topics_to_filter = {"topic1", "topic2"};
-  rosbag2_transport.play(storage_options_, play_options_);
+  player.play(storage_options_, play_options_);
 
   await_received_messages.get();
 
@@ -437,8 +437,8 @@ public:
   void play_and_wait(Duration timeout, bool expect_timeout = false)
   {
     auto await_received_messages = sub_->spin_subscriptions();
-    Rosbag2Transport transport{reader_, writer_};
-    transport.play(storage_options_, play_options_);
+    Player player{reader_};
+    player.play(storage_options_, play_options_);
     const auto result = await_received_messages.wait_for(timeout);
     // Must EXPECT, can't ASSERT because transport needs to be shutdown if timed out
     if (expect_timeout) {
@@ -446,8 +446,8 @@ public:
     } else {
       EXPECT_NE(result, std::future_status::timeout);
     }
-    // Have to rclcpp::shutdown here to make the spin_subscriptions async thread exit
-    transport.shutdown();
+    // Have to shutdown here to make the spin_subscriptions async thread exit
+    rclcpp::shutdown();
   }
 
   const std::string topic_name_{"/test_topic"};

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -64,10 +64,8 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  auto rosbag2_transport_ptr = std::make_shared<rosbag2_transport::Rosbag2Transport>(
-    reader_,
-    writer_);
-  std::thread loop_thread(&rosbag2_transport::Rosbag2Transport::play, rosbag2_transport_ptr,
+  auto player = std::make_shared<rosbag2_transport::Player>(reader_);
+  std::thread loop_thread(&rosbag2_transport::Player::play, player,
     storage_options_,
     rosbag2_transport::PlayOptions{read_ahead_queue_size, "", rate, {}, {}, loop_playback, {}});
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
@@ -65,8 +65,8 @@ public:
   void run_test()
   {
     auto await_received_messages = sub_->spin_subscriptions();
-    rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_);
-    rosbag2_transport.play(storage_options_, play_options_);
+    rosbag2_transport::Player player(reader_);
+    player.play(storage_options_, play_options_);
     await_received_messages.get();
 
     // Check that we got enough messages

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -60,8 +60,8 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_relative_timing_of_stored_m
   // we check that time elapsed during playing is at least the time difference between the two
   // messages
   auto start = std::chrono::steady_clock::now();
-  Rosbag2Transport rosbag2_transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  Player player(reader_);
+  player.play(storage_options_, play_options_);
   auto replay_time = std::chrono::steady_clock::now() - start;
 
   ASSERT_THAT(replay_time, Gt(message_time_difference));
@@ -95,8 +95,8 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_rate)
 
   play_options_.rate = 2.0;
   auto start = std::chrono::steady_clock::now();
-  Rosbag2Transport rosbag2_transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  Player player(reader_);
+  player.play(storage_options_, play_options_);
   auto replay_time = std::chrono::steady_clock::now() - start;
 
   ASSERT_THAT(replay_time, Gt(0.5 * message_time_difference));
@@ -109,8 +109,8 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_rate)
 
   play_options_.rate = 1.0;
   start = std::chrono::steady_clock::now();
-  rosbag2_transport = Rosbag2Transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  player = Player(reader_);
+  player.play(storage_options_, play_options_);
   replay_time = std::chrono::steady_clock::now() - start;
 
   ASSERT_THAT(replay_time, Gt(message_time_difference));
@@ -122,8 +122,8 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_rate)
 
   play_options_.rate = 0.5;
   start = std::chrono::steady_clock::now();
-  rosbag2_transport = Rosbag2Transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  player = Player(reader_);
+  player.play(storage_options_, play_options_);
   replay_time = std::chrono::steady_clock::now() - start;
 
   ASSERT_THAT(replay_time, Gt(2 * message_time_difference));
@@ -135,8 +135,8 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_rate)
 
   play_options_.rate = 0.0;
   start = std::chrono::steady_clock::now();
-  rosbag2_transport = Rosbag2Transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  player = Player(reader_);
+  player.play(storage_options_, play_options_);
   replay_time = std::chrono::steady_clock::now() - start;
 
   ASSERT_THAT(replay_time, Gt(message_time_difference));
@@ -148,8 +148,8 @@ TEST_F(Rosbag2TransportTestFixture, playing_respects_rate)
 
   play_options_.rate = -1.23f;
   start = std::chrono::steady_clock::now();
-  rosbag2_transport = Rosbag2Transport(reader_, writer_);
-  rosbag2_transport.play(storage_options_, play_options_);
+  player = Player(reader_);
+  player.play(storage_options_, play_options_);
   replay_time = std::chrono::steady_clock::now() - start;
 
   ASSERT_THAT(replay_time, Gt(message_time_difference));

--- a/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
@@ -63,9 +63,9 @@ TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
     remapped_topic, 1u);
   auto await_received_messages = sub_->spin_subscriptions();
 
-  rosbag2_transport::Rosbag2Transport rosbag2_transport(reader_, writer_);
+  rosbag2_transport::Player player(reader_);
 
-  rosbag2_transport.play(storage_options_, play_options_);
+  player.play(storage_options_, play_options_);
 
   await_received_messages.get();
 


### PR DESCRIPTION
Alternative, or precursor to https://github.com/ros2/rosbag2/pull/716

Only splits the Rosbag2Transport class into separate Recorder and Player classes. Does not create new headers, or change them into subclass of `rclcpp::Node`

Potential follow-ons after this PR:
* Make `Player` and `Recorder` subclasses of `rclcpp::Node`
* Move `Player` node-spinning out into the invoking context
* Get rid of `Rosbag2TransportTestFixture` class, which no longer provides very much add-on value