### PR TITLE
Fix pause snapshot behavior and add regression test

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -163,7 +163,7 @@ void TimeControllerClock::pause()
   if (impl_->paused) {
     return;
   }
-  // Note: needs to not be paused when taking snapshot, otherwise it will use last ros ref
+  // Take snaphot before changing state
   impl_->snapshot();
   impl_->paused = true;
   impl_->cv.notify_all();
@@ -175,9 +175,9 @@ void TimeControllerClock::resume()
   if (!impl_->paused) {
     return;
   }
-  // Note: needs to not be paused when taking snapshot, otherwise it will use last ros ref
-  impl_->paused = false;
+  // Take snaphot before changing state
   impl_->snapshot();
+  impl_->paused = false;
   impl_->cv.notify_all();
 }
 


### PR DESCRIPTION
The test fails without the change - the snapshot behavior was just not correct. It would update `ros_now` on `resume` - so a paused clock would go, e.g. `1, 2, 3, 4, 4, 4, 4, 8, 9, 10` instead of `1, 2, 3, 4, 4, 4, 4, 5, 6, 7`