### PR TITLE
Enforce non-null now_fn in TimeControllerClock

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -122,6 +122,9 @@ TimeControllerClock::TimeControllerClock(
   std::chrono::milliseconds sleep_time_while_paused)
 : impl_(std::make_unique<TimeControllerClockImpl>(now_fn, sleep_time_while_paused))
 {
+  if (now_fn == nullptr) {
+    throw std::invalid_argument("TimeControllerClock now_fn must be non-empty.");
+  }
   std::lock_guard<std::mutex> lock(impl_->state_mutex);
   impl_->reference.ros = starting_time;
   impl_->reference.steady = impl_->now_fn();

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -43,6 +43,14 @@ public:
   rcutils_time_point_value_t ros_start_time = 0;
 };
 
+TEST_F(TimeControllerClockTest, must_provide_now_fn)
+{
+  NowFunction empty_now;
+  EXPECT_THROW(
+    rosbag2_cpp::TimeControllerClock(ros_start_time, 1.0, empty_now),
+    std::invalid_argument);
+}
+
 TEST_F(TimeControllerClockTest, steadytime_precision)
 {
   const double playback_rate = 1.0;


### PR DESCRIPTION
Instead of raising `std::bad_function` on first use, raise `std::invalid_argument` in the constructor