### PR TITLE
Recording CPU load decrease through spin_some()

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_transport.cpp
@@ -98,7 +98,11 @@ void Recorder::record(
     exec.add_node(recorder);
     auto spin_thread = std::thread(
       [&exec]() {
-        exec.spin();
+        const auto time_step = std::chrono::milliseconds(1);
+        while (rclcpp::ok()) {
+          exec.spin_some();
+          std::this_thread::sleep_for(time_step);
+        }
       });
     auto exit = rcpputils::scope_exit(
       [&exec, &spin_thread]() {


### PR DESCRIPTION
The rationale behind this PR is explained here: https://github.com/ros2/rosbag2/issues/737 and here:  https://github.com/ros2/rclcpp/issues/1637.

In short, it is cutting CPU load from `ros2 bag record` from 110% to 55% in a certain use-case on a certain platform without apparent drawbacks. Notably, the use-case is quite a representative automotive one and the platform is also unexceptional. I believe this extrapolates well into reducing CPU use overall when the number of executables (e. g. subscriptions) to process each second is high. There might be some additional testing needed to build even more confidence in the broader conclusion.

Update: I have no confidence in the generalized claim anymore, see comment below.


