### PR TITLE
Move Player::play setup logic mostly into constructor

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -49,11 +49,26 @@ namespace rosbag2_transport
 class Player : public rclcpp::Node
 {
 public:
+  /**
+   * rclcpp::Node constructor.
+   * Not yet implemented.
+   */
   ROSBAG2_TRANSPORT_PUBLIC
   explicit Player(
     const std::string & node_name = "rosbag2_player",
     const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
 
+  /**
+   * Constructor.
+   *
+   * Prepares playback publishers and sets up the internal clock.
+   * Does not start reading messages from the reader.
+   *
+   * \param storage_options: Configuration for the storage
+   * \param play_options: Configuration for the playback behavior
+   * \param node_name: Name of the underlying Node
+   * \param node_options: Configuration opitons for the underlying Node.
+   */
   ROSBAG2_TRANSPORT_PUBLIC
   Player(
     std::unique_ptr<rosbag2_cpp::Reader> reader,
@@ -65,20 +80,56 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   virtual ~Player();
 
+  /**
+   * Play the bag from beginning to end, blocking.
+   * \return void: when playback is complete, or has been interrupted by rclcpp shutdown.
+   */
   ROSBAG2_TRANSPORT_PUBLIC
   void play();
 
+  /**
+   * Give back ownership of the reader that was acquired at construction.
+   * The player may not play again after this release, it is invalid and must be destroyed.
+   */
   ROSBAG2_TRANSPORT_PUBLIC
   rosbag2_cpp::Reader * release_reader();
 
 private:
+  /**
+   * Load new messages constantly into the play queue - when there is room.
+   * Intended to be run in a background thread.
+   * Returns when it reaches the end of the underlying storage.
+   */
   void load_storage_content();
+  /**
+   * Return true if load_storage_content has finished,
+   * meaning all messages have been read from storage and enqueued.
+   */
   bool is_storage_completely_loaded() const;
+  /**
+   * Read messages into the queue until the message count is reached in the queue.
+   * \param boundary: number of messages that should be in the full queue
+   */
   void enqueue_up_to_boundary(uint64_t boundary);
+  /// Block until the message queue is full.
   void wait_for_filled_queue() const;
+  /// Play messages until the end of the storage is reached.
   void play_messages_from_queue();
+  /**
+   * Play messages until the current queue is empty.
+   * If this returns before the end of playback, it means the queue is not filling fast enough.
+   */
   void play_messages_until_queue_empty();
+  /**
+   * Set up all the publishers for the playback.
+   * Precondition: reader_ must be open.
+   */
   void prepare_publishers();
+  /**
+   * Construct the internal clock and reset starting time to match the bag.
+   * Call before restarting playback.
+   * Precondition: reader_ must be open.
+   */
   void prepare_clock();
   static constexpr double read_ahead_lower_bound_percentage_ = 0.9;
   static const std::chrono::milliseconds queue_read_wait_period_;

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -79,7 +79,7 @@ private:
   void play_messages_from_queue();
   void play_messages_until_queue_empty();
   void prepare_publishers();
-  void prepare_clock(rcutils_time_point_value_t starting_time);
+  void prepare_clock();
   static constexpr double read_ahead_lower_bound_percentage_ = 0.9;
   static const std::chrono::milliseconds queue_read_wait_period_;
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -271,11 +271,8 @@ void Player::prepare_publishers()
   }
 }
 
-/**
- * Set up the correct clock and pointer.
- * Prerequisite: reader_ must be open
- */
-void Player::prepare_clock() {
+void Player::prepare_clock()
+{
   double rate = play_options_.rate > 0.0 ? play_options_.rate : 1.0;
   const auto starting_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
     reader_->get_metadata().starting_time.time_since_epoch()).count();


### PR DESCRIPTION
Not sure if this is the exact pattern we want, but it moves publisher and clock setup into the constructor. And, makes the clock live on the stack so it can't be NULL.

Put here for consideration.