### PR TITLE
Naive clock jump implementation - allows for clock reuse and simplified Player setup

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -90,6 +90,12 @@ public:
    */
   ROSBAG2_CPP_PUBLIC
   virtual bool is_paused() const = 0;
+
+  /**
+   * Change the current ROS time to an arbitrary time.
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual void jump(rcutils_time_point_value_t) = 0;
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 
+#include "rclcpp/time.hpp"
 #include "rcutils/time.h"
 #include "rosbag2_cpp/visibility_control.hpp"
 
@@ -60,13 +61,21 @@ public:
   virtual bool sleep_until(rcutils_time_point_value_t until) = 0;
 
   /**
-   * Change the rate of the flow of time for the clock
+   * \sa sleep_until
    */
   ROSBAG2_CPP_PUBLIC
-  virtual void set_rate(double rate) = 0;
+  virtual bool sleep_until(rclcpp::Time time) = 0;
 
   /**
-   * Return the current playback rate.
+   * Change the rate of the flow of time for the clock.
+   * \param rate new rate of clock playback
+   * \bool false if rate is invalid for the clock implementation
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual bool set_rate(double rate) = 0;
+
+  /**
+   * \return the current playback rate.
    */
   ROSBAG2_CPP_PUBLIC
   virtual double get_rate() const = 0;
@@ -96,6 +105,12 @@ public:
    */
   ROSBAG2_CPP_PUBLIC
   virtual void jump(rcutils_time_point_value_t) = 0;
+
+  /**
+   * \sa jump
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual void jump(rclcpp::Time time) = 0;
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -102,6 +102,16 @@ public:
   ROSBAG2_CPP_PUBLIC
   bool is_paused() const override;
 
+  /**
+   * Change the current ROS time to an arbitrary time.
+   * This will wake any waiting `sleep_until`.
+   * Note: this initial implementation does not have any jump-callback handling,
+   * so it is not safe to use during playback, only for reconfiguration for clock reuse.
+   * \param ros_time: The new ROS time to use as the basis for "now()"
+   */
+  ROSBAG2_CPP_PUBLIC
+  void jump(rcutils_time_point_value_t ros_time) override;
+
 private:
   std::unique_ptr<TimeControllerClockImpl> impl_;
 };

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -36,18 +36,15 @@ public:
    *
    * \param starting_time: provides an initial offset for managing time
    *    This will likely be the timestamp of the first message in the bag
-   * \param rate: Rate of playback, a unit-free ratio. 1.0 is real-time
    * \param now_fn: Function used to get the current steady time
    *   defaults to std::chrono::steady_clock::now
    *   Used to control for unit testing, or for specialized needs
    * \param sleep_time_while_paused: Amount of time to sleep in `sleep_until` when the clock
    *   is paused. Allows the caller to spin at a defined rate while receiving `false`
-   * \throws std::runtime_error if rate is <= 0
    */
   ROSBAG2_CPP_PUBLIC
   TimeControllerClock(
     rcutils_time_point_value_t starting_time,
-    double rate = 1.0,
     NowFunction now_fn = std::chrono::steady_clock::now,
     std::chrono::milliseconds sleep_time_while_paused = std::chrono::milliseconds{100});
 
@@ -70,11 +67,19 @@ public:
   ROSBAG2_CPP_PUBLIC
   bool sleep_until(rcutils_time_point_value_t until) override;
 
+  ROSBAG2_CPP_PUBLIC
+  bool sleep_until(rclcpp::Time until) override;
+
   /**
-   * Change the rate of the flow of time for the clock
+   * Change the rate of the flow of time for the clock.
+   *
+   * \param rate tTe new rate of time
+   * \return false if rate <= 0, true otherwise.
+   *   It is not currently valid behavior to move time backwards.
+   *   To stop time, \sa pause.
    */
   ROSBAG2_CPP_PUBLIC
-  void set_rate(double rate) override;
+  bool set_rate(double rate) override;
 
   /**
    * Return the current playback rate.
@@ -105,12 +110,19 @@ public:
   /**
    * Change the current ROS time to an arbitrary time.
    * This will wake any waiting `sleep_until`.
-   * Note: this initial implementation does not have any jump-callback handling,
-   * so it is not safe to use during playback, only for reconfiguration for clock reuse.
+   * Note: this initial implementation does not have any jump-callback handling.
+   * The Player should not use this method while its queues are active ("during playback")
+   * as an arbitrary time jump can make those queues, and the state of the Reader/Storage, invalid
+   * The current Player implementation should only use this method in between calls to `play`,
+   * to reset the initial time of the clock.
+   *
    * \param ros_time: The new ROS time to use as the basis for "now()"
    */
   ROSBAG2_CPP_PUBLIC
   void jump(rcutils_time_point_value_t ros_time) override;
+
+  ROSBAG2_CPP_PUBLIC
+  void jump(rclcpp::Time ros_time) override;
 
 private:
   std::unique_ptr<TimeControllerClockImpl> impl_;

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -73,10 +73,10 @@ public:
   /**
    * Change the rate of the flow of time for the clock.
    *
-   * \param rate tTe new rate of time
+   * To stop time, \sa pause.
+   * It is not currently valid behavior to move time backwards.
+   * \param rate The new rate of time
    * \return false if rate <= 0, true otherwise.
-   *   It is not currently valid behavior to move time backwards.
-   *   To stop time, \sa pause.
    */
   ROSBAG2_CPP_PUBLIC
   bool set_rate(double rate) override;

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -62,12 +62,14 @@ public:
   {}
   virtual ~TimeControllerClockImpl() = default;
 
+  /// Return the total nanoseconds of an arbitrary duration type.
   template<typename T>
   rcutils_duration_value_t duration_nanos(const T & duration) const
   {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
   }
 
+  /// Convert an arbitrary SteadyTime to a ROSTime, based on the current reference snapshot.
   rcutils_time_point_value_t steady_to_ros(std::chrono::steady_clock::time_point steady_time) const
   RCPPUTILS_TSA_REQUIRES(state_mutex)
   {
@@ -75,6 +77,7 @@ public:
       rate * duration_nanos(steady_time - reference.steady));
   }
 
+  /// Convert an arbitrary ROSTime to a SteadyTime, based on the current reference snapshot.
   std::chrono::steady_clock::time_point ros_to_steady(rcutils_time_point_value_t ros_time) const
   RCPPUTILS_TSA_REQUIRES(state_mutex)
   {
@@ -83,6 +86,7 @@ public:
     return reference.steady + std::chrono::nanoseconds(diff_nanos);
   }
 
+  /// Return the current ROS time right now, based on current settings.
   rcutils_time_point_value_t ros_now() const
   RCPPUTILS_TSA_REQUIRES(state_mutex)
   {
@@ -92,6 +96,7 @@ public:
     return steady_to_ros(now_fn());
   }
 
+  /// Take a new reference snapshot, matching `ros_time` to the current steady time
   void snapshot(rcutils_time_point_value_t ros_time)
   RCPPUTILS_TSA_REQUIRES(state_mutex)
   {
@@ -99,6 +104,10 @@ public:
     reference.steady = now_fn();
   }
 
+  /**
+   * Take a new reference snaphot to match the current ROStime to the current SteadyTime
+   * This is needed when changing a setting such as pause or rate.
+   */
   void snapshot()
   RCPPUTILS_TSA_REQUIRES(state_mutex)
   {

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -206,4 +206,11 @@ bool TimeControllerClock::is_paused() const
   return impl_->paused;
 }
 
+void TimeControllerClock::jump(rcutils_time_point_value_t ros_time)
+{
+  std::lock_guard<std::mutex> lock(impl_->state_mutex);
+  impl_->snapshot(ros_time);
+  impl_->cv.notify_all();
+}
+
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -252,4 +252,9 @@ TEST_F(TimeControllerClockTest, jump)
   clock.jump(rclcpp::Time(100, 0));
   return_time += std::chrono::seconds(1);
   EXPECT_EQ(clock.now(), RCUTILS_S_TO_NS(101));
+
+  // Jump backward
+  clock.jump(rclcpp::Time(50, 0));
+  return_time += std::chrono::seconds(2);
+  EXPECT_EQ(clock.now(), RCUTILS_S_TO_NS(52));
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -125,6 +125,13 @@ TEST_F(TimeControllerClockTest, slow_rate)
   EXPECT_EQ(clock.now(), as_nanos(some_time) * playback_rate);
 }
 
+TEST_F(TimeControllerClockTest, invalid_rate)
+{
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
+  EXPECT_FALSE(clock.set_rate(-5));
+  EXPECT_FALSE(clock.set_rate(0));
+}
+
 TEST_F(TimeControllerClockTest, is_paused)
 {
   rosbag2_cpp::TimeControllerClock clock(ros_start_time);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -47,86 +47,87 @@ TEST_F(TimeControllerClockTest, must_provide_now_fn)
 {
   NowFunction empty_now;
   EXPECT_THROW(
-    rosbag2_cpp::TimeControllerClock(ros_start_time, 1.0, empty_now),
+    rosbag2_cpp::TimeControllerClock(ros_start_time, empty_now),
     std::invalid_argument);
 }
 
 TEST_F(TimeControllerClockTest, steadytime_precision)
 {
-  const double playback_rate = 1.0;
-  rosbag2_cpp::TimeControllerClock pclock(ros_start_time, playback_rate, now_fn);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
 
   const SteadyTimePoint begin_time(std::chrono::seconds(0));
   return_time = begin_time;
-  EXPECT_EQ(pclock.now(), as_nanos(begin_time));
+  EXPECT_EQ(clock.now(), as_nanos(begin_time));
 
   const SteadyTimePoint ten_seconds(std::chrono::seconds(10));
   return_time = ten_seconds;
-  EXPECT_EQ(pclock.now(), as_nanos(ten_seconds));
+  EXPECT_EQ(clock.now(), as_nanos(ten_seconds));
 
   // NOTE: this would have already lost precision at 100 seconds if we were multiplying by float
   const SteadyTimePoint hundred_seconds(std::chrono::seconds(100));
   return_time = hundred_seconds;
-  EXPECT_EQ(pclock.now(), as_nanos(hundred_seconds));
+  EXPECT_EQ(clock.now(), as_nanos(hundred_seconds));
 
   const int64_t near_limit_nanos = 1LL << 61;
   const auto near_limit_time = SteadyTimePoint(std::chrono::nanoseconds(near_limit_nanos));
   return_time = near_limit_time;
-  EXPECT_EQ(pclock.now(), near_limit_nanos);
+  EXPECT_EQ(clock.now(), near_limit_nanos);
 
   // Expect to lose exact equality at this point due to precision limit of double*int mult
   const int64_t over_limit_nanos = (1LL << 61) + 1LL;
   const auto over_limit_time = SteadyTimePoint(std::chrono::nanoseconds(over_limit_nanos));
   return_time = over_limit_time;
-  EXPECT_NE(pclock.now(), over_limit_nanos);
-  EXPECT_LT(std::abs(pclock.now() - over_limit_nanos), 10LL);
+  EXPECT_NE(clock.now(), over_limit_nanos);
+  EXPECT_LT(std::abs(clock.now() - over_limit_nanos), 10LL);
 }
 
 TEST_F(TimeControllerClockTest, nonzero_start_time)
 {
   ros_start_time = 1234567890LL;
-  const double playback_rate = 1.0;
-  rosbag2_cpp::TimeControllerClock pclock(ros_start_time, playback_rate, now_fn);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
+  clock.set_rate(1.0);
 
   const SteadyTimePoint begin_time(std::chrono::seconds(0));
   return_time = begin_time;
-  EXPECT_EQ(pclock.now(), ros_start_time);
+  EXPECT_EQ(clock.now(), ros_start_time);
 
   return_time = SteadyTimePoint(std::chrono::seconds(1));
-  EXPECT_EQ(pclock.now(), ros_start_time + as_nanos(return_time));
+  EXPECT_EQ(clock.now(), ros_start_time + as_nanos(return_time));
 }
 
 TEST_F(TimeControllerClockTest, fast_rate)
 {
   const double playback_rate = 2.5;
-  rosbag2_cpp::TimeControllerClock pclock(ros_start_time, playback_rate, now_fn);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
+  clock.set_rate(playback_rate);
 
   const SteadyTimePoint begin_time(std::chrono::seconds(0));
   return_time = begin_time;
-  EXPECT_EQ(pclock.now(), as_nanos(begin_time));
+  EXPECT_EQ(clock.now(), as_nanos(begin_time));
 
   const SteadyTimePoint some_time(std::chrono::seconds(3));
   return_time = some_time;
-  EXPECT_EQ(pclock.now(), as_nanos(some_time) * playback_rate);
+  EXPECT_EQ(clock.now(), as_nanos(some_time) * playback_rate);
 }
 
 TEST_F(TimeControllerClockTest, slow_rate)
 {
   const double playback_rate = 0.4;
-  rosbag2_cpp::TimeControllerClock pclock(ros_start_time, playback_rate, now_fn);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
+  clock.set_rate(playback_rate);
 
   const SteadyTimePoint begin_time(std::chrono::seconds(0));
   return_time = begin_time;
-  EXPECT_EQ(pclock.now(), as_nanos(begin_time));
+  EXPECT_EQ(clock.now(), as_nanos(begin_time));
 
   const SteadyTimePoint some_time(std::chrono::seconds(12));
   return_time = some_time;
-  EXPECT_EQ(pclock.now(), as_nanos(some_time) * playback_rate);
+  EXPECT_EQ(clock.now(), as_nanos(some_time) * playback_rate);
 }
 
 TEST_F(TimeControllerClockTest, is_paused)
 {
-  rosbag2_cpp::TimeControllerClock clock(ros_start_time, 1.0);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time);
   EXPECT_FALSE(clock.is_paused());
   clock.pause();
   EXPECT_TRUE(clock.is_paused());
@@ -136,7 +137,7 @@ TEST_F(TimeControllerClockTest, is_paused)
 
 TEST_F(TimeControllerClockTest, unpaused_sleep_returns_true)
 {
-  rosbag2_cpp::TimeControllerClock clock(ros_start_time, 1.0);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time);
   clock.resume();
   EXPECT_TRUE(clock.sleep_until(clock.now() + 100));
 
@@ -147,14 +148,14 @@ TEST_F(TimeControllerClockTest, unpaused_sleep_returns_true)
 
 TEST_F(TimeControllerClockTest, paused_sleep_returns_false_quickly)
 {
-  rosbag2_cpp::TimeControllerClock clock(ros_start_time, 1.0);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time);
   clock.pause();
   EXPECT_FALSE(clock.sleep_until(clock.now() + RCUTILS_S_TO_NS(10)));
 }
 
 TEST_F(TimeControllerClockTest, paused_now_always_same)
 {
-  rosbag2_cpp::TimeControllerClock clock(ros_start_time, 1.0);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time);
   clock.pause();
   auto now_start = clock.now();
   EXPECT_EQ(now_start, clock.now());
@@ -167,7 +168,7 @@ TEST_F(TimeControllerClockTest, paused_now_always_same)
 
 TEST_F(TimeControllerClockTest, interrupted_sleep_returns_false_immediately)
 {
-  rosbag2_cpp::TimeControllerClock clock(ros_start_time, 1.0);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time);
   std::atomic_bool thread_sleep_result{true};
   auto sleep_long_thread = std::thread(
     [&clock, &thread_sleep_result]() {
@@ -181,7 +182,7 @@ TEST_F(TimeControllerClockTest, interrupted_sleep_returns_false_immediately)
 
 TEST_F(TimeControllerClockTest, resumes_at_correct_ros_time)
 {
-  rosbag2_cpp::TimeControllerClock clock(ros_start_time, 1.0, now_fn);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
 
   // Time passes while paused, no ROS time passes
   clock.pause();
@@ -203,7 +204,7 @@ TEST_F(TimeControllerClockTest, resumes_at_correct_ros_time)
 
 TEST_F(TimeControllerClockTest, change_rate)
 {
-  rosbag2_cpp::TimeControllerClock clock(ros_start_time, 1.0, now_fn);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
   rcutils_time_point_value_t expected_ros_time = 0;
 
   // 1 second passes for both
@@ -227,4 +228,21 @@ TEST_F(TimeControllerClockTest, change_rate)
   return_time += std::chrono::seconds(2);
   expected_ros_time += RCUTILS_S_TO_NS(1);
   EXPECT_EQ(clock.now(), expected_ros_time);
+}
+
+TEST_F(TimeControllerClockTest, jump)
+{
+  rcutils_time_point_value_t expected_ros_time = RCUTILS_S_TO_NS(10);
+  rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
+
+  clock.jump(expected_ros_time);
+  EXPECT_EQ(clock.now(), expected_ros_time);
+
+  return_time += std::chrono::seconds(10);
+  expected_ros_time += RCUTILS_S_TO_NS(10);
+  EXPECT_EQ(clock.now(), expected_ros_time);
+
+  clock.jump(rclcpp::Time(100, 0));
+  return_time += std::chrono::seconds(1);
+  EXPECT_EQ(clock.now(), RCUTILS_S_TO_NS(101));
 }

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -120,7 +120,6 @@ private:
   void play_messages_from_queue();
   void play_messages_until_queue_empty();
   void prepare_publishers();
-  void prepare_clock(rcutils_time_point_value_t starting_time);
   static constexpr double read_ahead_lower_bound_percentage_ = 0.9;
   static const std::chrono::milliseconds queue_read_wait_period_;
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -84,6 +84,16 @@ Player::Player(const std::string & node_name, const rclcpp::NodeOptions & node_o
 }
 
 Player::Player(
+  const rosbag2_storage::StorageOptions & storage_options,
+  const rosbag2_transport::PlayOptions & play_options,
+  const std::string & node_name,
+  const rclcpp::NodeOptions & node_options)
+: Player(std::make_unique<rosbag2_cpp::Reader>(),
+    storage_options, play_options,
+    node_name, node_options)
+{}
+
+Player::Player(
   std::unique_ptr<rosbag2_cpp::Reader> reader,
   const rosbag2_storage::StorageOptions & storage_options,
   const rosbag2_transport::PlayOptions & play_options,


### PR DESCRIPTION
Clock can be created in the constructor so it is never null, and have all its state simply maintained while looping or repeated calls to `play`.

This is an intentionally simple implementation that accomplishes this single goal, and is definitely not safe for use _during_ playback. There is significantly more complexity involved in handling jumping during playback - but that is out of the scope of this change.