### PR TITLE
[test] Run Action CI on Windows/OSX as well

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,49 @@ jobs:
       with:
         name: colcon-logs
         path: ros_ws/log
+
+  build_and_test_mac_win:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, windows-latest]
+    steps:
+    - name: Setup ROS
+      uses: ros-tooling/setup-ros@v0.1
+    - uses: ros-tooling/action-ros-ci@v0.2
+      with:
+        package-name: |
+          ros2bag
+          rosbag2
+          rosbag2_compression
+          rosbag2_compression_zstd
+          rosbag2_cpp
+          rosbag2_interfaces
+          rosbag2_py
+          rosbag2_storage
+          rosbag2_storage_default_plugins
+          rosbag2_test_common
+          rosbag2_tests
+          rosbag2_transport
+          shared_queues_vendor
+          sqlite3_vendor
+          zstd_vendor
+        target-ros2-distro: rolling
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+        colcon-defaults: |
+          {
+            "build": {
+              "cmake-args": [
+                "-DCMAKE_CXX_FLAGS=\"-Werror\""
+              ]
+            },
+            "test": {
+              "ctest-args": ["-LE", "xfail"],
+              "pytest-args": ["-m", "not xfail"]
+            }
+          }
+    - uses: actions/upload-artifact@v1
+      with:
+        name: colcon-logs
+        path: ros_ws/log


### PR DESCRIPTION
I'm not sure of a way to avoid copying the logic, because we can't use containers on Win/Mac, but we definitely want to on Linux - it's a lot faster.