### PR TITLE
Correct expectation for exit code in play_end_to_end test since after…

### DIFF
--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -115,7 +115,7 @@ TEST_F(PlayEndToEndTestFixture, play_fails_gracefully_if_needed_coverter_plugin_
     execute_and_wait_until_completion("ros2 bag play wrong_rmw_test", database_path_);
   auto error_output = internal::GetCapturedStderr();
 
-  EXPECT_THAT(exit_code, Eq(EXIT_SUCCESS));
+  EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
   EXPECT_THAT(
     error_output, HasSubstr("Could not find converter for format wrong_format"));
 }


### PR DESCRIPTION
We have failing `PlayEndToEndTestFixture, play_fails_gracefully_if_needed_coverter_plugin_does_not_exist` test on CI.

I have tried to make a brief analysis and come to conclusion that it should be expectation for `EXIT_FAILURE` at 
```cpp
EXPECT_THAT(exit_code, Eq(EXIT_SUCCESS));
```
https://github.com/ros2/rosbag2/blob/master/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp#L118.

1. In this test we are expecting to observe message "Could not find converter for format some_rmw" in the output.
2. This message only appears as text in throwing exception in https://github.com/ros2/rosbag2/blob/master/rosbag2_cpp/src/rosbag2_cpp/converter.cpp#L49-L56
3. I've tried to trace this exception up to the stack and seems we are not handling it anywhere. But if we are not handling this exception we should expect `EXIT_FAILURE` result in this case.

It seems first time we are creating format converter in [void SequentialReader::check_converter_serialization_format](https://github.com/ros2/rosbag2/blob/master/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp#L236)
which we are calling from [void SequentialReader::open(..)](https://github.com/ros2/rosbag2/blob/master/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp#L132) \
First time we are calling reader_->open(storage_options_, {"", rmw_get_serialization_format()}); in [constructor](https://github.com/ros2/rosbag2/blob/master/rosbag2_transport/src/rosbag2_transport/player.cpp#L110) of the player class which we invoke in [rosbag2_py::Player::play()](https://github.com/ros2/rosbag2/blob/master/rosbag2_py/src/rosbag2_py/_transport.cpp#L126) which is finally invokes from [`ros2bag verb play.py`](https://github.com/ros2/rosbag2/blob/master/ros2bag/ros2bag/verb/play.py#L120-L121) interface

None of them have try catch clause on the back trace.
The reason why we started to getting this test fail is because we made some redesign inside `Player` class and now we are calling in [constructor](https://github.com/ros2/rosbag2/blob/master/rosbag2_transport/src/rosbag2_transport/player.cpp#L110) `reader_->open(storage_options_, {"", rmw_get_serialization_format()});` \
Before redesign we were calling this reader_->open(..) in `Player::play(..)` method only where it was wrapped with try-catch statement.

I think it will be incorrect  to wrap call 
```cpp
reader_->open(storage_options_, {"", rmw_get_serialization_format()});
```
with try-catch statement in constructor. Therefore I am changing expectation in unit test. 