### PR TITLE
Recording with --all and --exclude fix

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -157,8 +157,8 @@ Recorder::get_requested_or_available_topics()
 
   std::regex topic_regex(record_options_.regex);
   std::regex exclude_regex(record_options_.exclude);
-  bool take = record_options_.all;
   for (const auto & kv : filtered_topics_and_types) {
+    bool take = record_options_.all;
     // regex_match returns false for 'empty' regex
     if (!record_options_.regex.empty()) {
       take = std::regex_match(kv.first, topic_regex);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -153,24 +153,12 @@ Recorder::get_requested_or_available_topics()
     return filtered_topics_and_types;
   }
 
-  std::unordered_map<std::string, std::string> filtered_by_regex;
-
-  std::regex topic_regex(record_options_.regex);
-  std::regex exclude_regex(record_options_.exclude);
-  for (const auto & kv : filtered_topics_and_types) {
-    bool take = record_options_.all;
-    // regex_match returns false for 'empty' regex
-    if (!record_options_.regex.empty()) {
-      take = std::regex_match(kv.first, topic_regex);
-    }
-    if (take) {
-      take = !std::regex_match(kv.first, exclude_regex);
-    }
-    if (take) {
-      filtered_by_regex.insert(kv);
-    }
-  }
-  return filtered_by_regex;
+  return topic_filter::filter_topics_using_regex(
+    filtered_topics_and_types,
+    record_options_.regex,
+    record_options_.exclude,
+    record_options_.all
+  );
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -95,7 +95,7 @@ filter_topics_using_regex(
   const std::unordered_map<std::string, std::string> & topics_and_types,
   const std::string & filter_regex_string,
   const std::string & exclude_regex_string,
-  const bool & all_flag
+  bool all_flag
 )
 {
   std::unordered_map<std::string, std::string> filtered_by_regex;

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <map>
+#include <regex>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -87,6 +88,35 @@ std::unordered_map<std::string, std::string> filter_topics_with_more_than_one_ty
     filtered_topics_and_types.insert({topic_and_type.first, topic_and_type.second[0]});
   }
   return filtered_topics_and_types;
+}
+
+std::unordered_map<std::string, std::string>
+filter_topics_using_regex(
+  const std::unordered_map<std::string, std::string> & topics_and_types,
+  const std::string & filter_regex_string,
+  const std::string & exclude_regex_string,
+  const bool & all_flag
+)
+{
+  std::unordered_map<std::string, std::string> filtered_by_regex;
+
+  std::regex filter_regex(filter_regex_string);
+  std::regex exclude_regex(exclude_regex_string);
+
+  for (const auto & kv : topics_and_types) {
+    bool take = all_flag;
+    // regex_match returns false for 'empty' regex
+    if (!all_flag && !filter_regex_string.empty()) {
+      take = std::regex_match(kv.first, filter_regex);
+    }
+    if (take) {
+      take = !std::regex_match(kv.first, exclude_regex);
+    }
+    if (take) {
+      filtered_by_regex.insert(kv);
+    }
+  }
+  return filtered_by_regex;
 }
 
 }  // namespace topic_filter

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
@@ -39,6 +39,15 @@ filter_topics_with_more_than_one_type(
   const std::map<std::string, std::vector<std::string>> & topics_and_types,
   bool include_hidden_topics = false);
 
+ROSBAG2_TRANSPORT_PUBLIC
+std::unordered_map<std::string, std::string>
+filter_topics_using_regex(
+  const std::unordered_map<std::string, std::string> & topics_and_types,
+  const std::string & filter_regex_string,
+  const std::string & exclude_regex_string,
+  const bool & all_flag
+);
+
 }  // namespace topic_filter
 }  // namespace rosbag2_transport
 

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
@@ -45,7 +45,7 @@ filter_topics_using_regex(
   const std::unordered_map<std::string, std::string> & topics_and_types,
   const std::string & filter_regex_string,
   const std::string & exclude_regex_string,
-  const bool & all_flag
+  bool all_flag
 );
 
 }  // namespace topic_filter

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -25,6 +25,19 @@
 
 using namespace ::testing;  // NOLINT
 
+class RegexFixture : public Test
+{
+protected:
+  std::unordered_map<std::string, std::string> topics_and_types_ = {
+    {"/planning", "planning_topic_type"},
+    {"/invalid_topic", "invalid_topic_type"},
+    {"/invalidated_topic", "invalidated_topic_type"},
+    {"/localization", "localization_topic_type"},
+    {"/invisible", "invisible_topic_type"},
+    {"/status", "status_topic_type"}
+  };
+};
+
 TEST(TestTopicFilter, filter_topics_with_more_than_one_type) {
   std::map<std::string, std::vector<std::string>> topic_with_type;
   topic_with_type.insert({"topic/a", {"type_a"}});
@@ -123,81 +136,73 @@ TEST(TestTopicFilter, filter_topics) {
   }
 }
 
-TEST(TestTopicFilter, filter_topics_using_regex)
+TEST_F(RegexFixture, regex_all_and_exclude)
 {
-  std::unordered_map<std::string, std::string> topics_and_types = {
-    {"/planning", "planning_topic_type"},
-    {"/invalid_topic", "invalid_topic_type"},
-    {"/invalidated_topic", "invalidated_topic_type"},
-    {"/localization", "localization_topic_type"},
-    {"/invisible", "invisible_topic_type"},
-    {"/status", "status_topic_type"}
-  };
+  std::string filter_regex_string = "";
+  std::string exclude_regex_string = "/inv.*";
+  bool all_flag = true;
 
-  {
-    std::string filter_regex_string = "";
-    std::string exclude_regex_string = "/inv.*";
-    bool all_flag = true;
+  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+    topics_and_types_,
+    filter_regex_string,
+    exclude_regex_string,
+    all_flag
+  );
 
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-      topics_and_types,
-      filter_regex_string,
-      exclude_regex_string,
-      all_flag
-    );
-
-    EXPECT_THAT(filtered_topics, SizeIs(3));
-    for (const auto & topic : {"/planning", "/localization", "/status"}) {
-      EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
-    }
+  EXPECT_THAT(filtered_topics, SizeIs(3));
+  for (const auto & topic : {"/planning", "/localization", "/status"}) {
+    EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
   }
+}
 
-  {
-    std::string filter_regex_string = "/invalid.*";
-    std::string exclude_regex_string = ".invalidated.*";
-    bool all_flag = false;
+TEST_F(RegexFixture, regex_filter_exclude)
+{
+  std::string filter_regex_string = "/invalid.*";
+  std::string exclude_regex_string = ".invalidated.*";
+  bool all_flag = false;
 
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-      topics_and_types,
-      filter_regex_string,
-      exclude_regex_string,
-      all_flag
-    );
+  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+    topics_and_types_,
+    filter_regex_string,
+    exclude_regex_string,
+    all_flag
+  );
 
-    EXPECT_THAT(filtered_topics, SizeIs(1));
-    EXPECT_TRUE(filtered_topics.find("/invalid_topic") != filtered_topics.end());
+  EXPECT_THAT(filtered_topics, SizeIs(1));
+  EXPECT_TRUE(filtered_topics.find("/invalid_topic") != filtered_topics.end());
+}
+
+TEST_F(RegexFixture, regex_filter)
+{
+  std::string filter_regex_string = "/inval.*";
+  std::string exclude_regex_string = "";
+  bool all_flag = false;
+
+  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+    topics_and_types_,
+    filter_regex_string,
+    exclude_regex_string,
+    all_flag
+  );
+
+  EXPECT_THAT(filtered_topics, SizeIs(2));
+  for (const auto & topic : {"/invalid_topic", "/invalidated_topic"}) {
+    EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
   }
+}
 
-  {
-    std::string filter_regex_string = "/inval.*";
-    std::string exclude_regex_string = "";
-    bool all_flag = false;
+TEST_F(RegexFixture, regex_all_and_filter)
+{
+  std::string filter_regex_string = "/status";
+  std::string exclude_regex_string = "";
+  bool all_flag = true;
 
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-      topics_and_types,
-      filter_regex_string,
-      exclude_regex_string,
-      all_flag
-    );
+  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+    topics_and_types_,
+    filter_regex_string,
+    exclude_regex_string,
+    all_flag
+  );
 
-    EXPECT_THAT(filtered_topics, SizeIs(2));
-    for (const auto & topic : {"/invalid_topic", "/invalidated_topic"}) {
-      EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
-    }
-  }
-
-  {
-    std::string filter_regex_string = "/status";
-    std::string exclude_regex_string = "";
-    bool all_flag = true;
-
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-      topics_and_types,
-      filter_regex_string,
-      exclude_regex_string,
-      all_flag
-    );
-
-    EXPECT_THAT(filtered_topics, SizeIs(6));
-  }
+  EXPECT_THAT(filtered_topics, SizeIs(6));
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -122,3 +122,82 @@ TEST(TestTopicFilter, filter_topics) {
     }
   }
 }
+
+TEST(TestTopicFilter, filter_topics_using_regex)
+{
+  std::unordered_map<std::string, std::string> topics_and_types = {
+    {"/planning", "planning_topic_type"},
+    {"/invalid_topic", "invalid_topic_type"},
+    {"/invalidated_topic", "invalidated_topic_type"},
+    {"/localization", "localization_topic_type"},
+    {"/invisible", "invisible_topic_type"},
+    {"/status", "status_topic_type"}
+  };
+
+  {
+    std::string filter_regex_string = "";
+    std::string exclude_regex_string = "/inv.*";
+    bool all_flag = true;
+
+    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+      topics_and_types,
+      filter_regex_string,
+      exclude_regex_string,
+      all_flag
+    );
+
+    EXPECT_THAT(filtered_topics, SizeIs(3));
+    for (const auto & topic : {"/planning", "/localization", "/status"}) {
+      EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
+    }
+  }
+
+  {
+    std::string filter_regex_string = "/invalid.*";
+    std::string exclude_regex_string = ".invalidated.*";
+    bool all_flag = false;
+
+    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+      topics_and_types,
+      filter_regex_string,
+      exclude_regex_string,
+      all_flag
+    );
+
+    EXPECT_THAT(filtered_topics, SizeIs(1));
+    EXPECT_TRUE(filtered_topics.find("/invalid_topic") != filtered_topics.end());
+  }
+
+  {
+    std::string filter_regex_string = "/inval.*";
+    std::string exclude_regex_string = "";
+    bool all_flag = false;
+
+    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+      topics_and_types,
+      filter_regex_string,
+      exclude_regex_string,
+      all_flag
+    );
+
+    EXPECT_THAT(filtered_topics, SizeIs(2));
+    for (const auto & topic : {"/invalid_topic", "/invalidated_topic"}) {
+      EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
+    }
+  }
+
+  {
+    std::string filter_regex_string = "/status";
+    std::string exclude_regex_string = "";
+    bool all_flag = true;
+
+    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
+      topics_and_types,
+      filter_regex_string,
+      exclude_regex_string,
+      all_flag
+    );
+
+    EXPECT_THAT(filtered_topics, SizeIs(6));
+  }
+}


### PR DESCRIPTION
During regex/exclude filtering `take` flag works incorrectly. This results in dropping all messages after first `take` is set to `false`.

This PR fixes this by resetting `take` flag before each topic check.