### PR TITLE
Remove rmw_fastrtps_cpp find_package in rosbag2_tests

### DIFF
--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -30,7 +30,6 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  find_package(rmw_fastrtps_cpp QUIET)
   find_package(rclcpp REQUIRED)
   find_package(rcpputils REQUIRED)
   find_package(rosbag2_compression REQUIRED)


### PR DESCRIPTION
I think this line isn't needed anymore (after https://github.com/ros2/rosbag2/pull/670).