### PR TITLE
Fix/futurize foxy dependency fixes

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -75,6 +75,8 @@ if(BUILD_TESTING)
     test/rosbag2_compression/fake_compressor.cpp
     test/rosbag2_compression/fake_decompressor.cpp)
   target_link_libraries(fake_plugin ${PROJECT_NAME})
+  # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+  ament_target_dependencies(fake_plugin rosbag2_cpp rosbag2_storage)
   install(
     TARGETS fake_plugin
     ARCHIVE DESTINATION lib
@@ -86,22 +88,28 @@ if(BUILD_TESTING)
   ament_add_gmock(test_compression_factory
     test/rosbag2_compression/test_compression_factory.cpp)
   target_link_libraries(test_compression_factory ${PROJECT_NAME})
+  # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+  ament_target_dependencies(test_compression_factory rosbag2_cpp rosbag2_storage)
 
   ament_add_gmock(test_compression_options
     test/rosbag2_compression/test_compression_options.cpp)
   target_include_directories(test_compression_options PUBLIC include)
   target_link_libraries(test_compression_options ${PROJECT_NAME})
+  # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+  ament_target_dependencies(test_compression_options rosbag2_cpp rosbag2_storage)
 
   ament_add_gmock(test_sequential_compression_reader
     test/rosbag2_compression/test_sequential_compression_reader.cpp)
   target_include_directories(test_sequential_compression_reader PUBLIC include)
   target_link_libraries(test_sequential_compression_reader ${PROJECT_NAME})
+  # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
   ament_target_dependencies(test_sequential_compression_reader rosbag2_cpp rosbag2_storage)
 
   ament_add_gmock(test_sequential_compression_writer
     test/rosbag2_compression/test_sequential_compression_writer.cpp)
   target_include_directories(test_sequential_compression_writer PUBLIC include)
   target_link_libraries(test_sequential_compression_writer ${PROJECT_NAME})
+  # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
   ament_target_dependencies(test_sequential_compression_writer rosbag2_cpp rosbag2_storage)
 endif()
 

--- a/rosbag2_compression_zstd/CMakeLists.txt
+++ b/rosbag2_compression_zstd/CMakeLists.txt
@@ -38,7 +38,10 @@ target_include_directories(${PROJECT_NAME}
 ament_target_dependencies(${PROJECT_NAME}
   rcpputils
   rosbag2_compression
-  zstd)
+  zstd
+  # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+  rosbag2_cpp
+  rosbag2_storage)
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROSBAG2_COMPRESSION_ZSTD_BUILDING_DLL)
 pluginlib_export_plugin_description_file(rosbag2_compression plugin_description.xml)
 
@@ -69,9 +72,11 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_zstd_compressor
     test/rosbag2_compression_zstd/test_zstd_compressor.cpp)
-  target_include_directories(test_zstd_compressor PUBLIC include)
   target_link_libraries(test_zstd_compressor ${PROJECT_NAME})
-  ament_target_dependencies(test_zstd_compressor rclcpp rosbag2_test_common)
+
+  ament_target_dependencies(test_zstd_compressor rclcpp rosbag2_test_common
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    rosbag2_cpp rosbag2_storage zstd rosbag2_compression)
 endif()
 
 ament_package()

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -140,8 +140,9 @@ if(BUILD_TESTING)
   ament_add_gmock(test_converter_factory
     test/rosbag2_cpp/test_converter_factory.cpp)
   if(TARGET test_converter_factory)
-    target_include_directories(test_converter_factory PRIVATE include)
     target_link_libraries(test_converter_factory ${PROJECT_NAME})
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    ament_target_dependencies(test_converter_factory rosbag2_storage)
   endif()
 
   ament_add_gmock(test_typesupport_helpers
@@ -149,6 +150,8 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_typesupport_helpers)
     target_link_libraries(test_typesupport_helpers ${PROJECT_NAME})
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    ament_target_dependencies(test_typesupport_helpers rosbag2_storage rosbag2_test_common)
   endif()
 
   ament_add_gmock(test_info
@@ -156,27 +159,33 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_info)
     target_link_libraries(test_info ${PROJECT_NAME})
-    ament_target_dependencies(test_info rosbag2_test_common)
+    ament_target_dependencies(test_info rosbag2_test_common
+      # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+      rosbag2_storage)
   endif()
 
   ament_add_gmock(test_sequential_reader
     test/rosbag2_cpp/test_sequential_reader.cpp)
   if(TARGET test_sequential_reader)
-    ament_target_dependencies(test_sequential_reader rosbag2_storage)
     target_link_libraries(test_sequential_reader ${PROJECT_NAME})
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    ament_target_dependencies(test_sequential_reader rosbag2_storage)
   endif()
 
   ament_add_gmock(test_storage_without_metadata_file
     test/rosbag2_cpp/test_storage_without_metadata_file.cpp)
   if(TARGET test_storage_without_metadata_file)
-    ament_target_dependencies(test_storage_without_metadata_file rosbag2_storage)
     target_link_libraries(test_storage_without_metadata_file ${PROJECT_NAME})
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    ament_target_dependencies(test_storage_without_metadata_file rosbag2_storage)
   endif()
 
   ament_add_gmock(test_message_cache
     test/rosbag2_cpp/test_message_cache.cpp)
   if(TARGET test_message_cache)
     target_link_libraries(test_message_cache ${PROJECT_NAME})
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    ament_target_dependencies(test_message_cache rosbag2_storage)
   endif()
 
   # If compiling with gcc, run this test with sanitizers enabled
@@ -207,15 +216,17 @@ if(BUILD_TESTING)
   ament_add_gmock(test_sequential_writer
     test/rosbag2_cpp/test_sequential_writer.cpp)
   if(TARGET test_sequential_writer)
-    ament_target_dependencies(test_sequential_writer rosbag2_storage)
     target_link_libraries(test_sequential_writer ${PROJECT_NAME})
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    ament_target_dependencies(test_sequential_writer rosbag2_storage)
   endif()
 
   ament_add_gmock(test_multifile_reader
     test/rosbag2_cpp/test_multifile_reader.cpp)
   if(TARGET test_multifile_reader)
-    ament_target_dependencies(test_multifile_reader rosbag2_storage)
     target_link_libraries(test_multifile_reader ${PROJECT_NAME})
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    ament_target_dependencies(test_multifile_reader rosbag2_storage)
   endif()
 endif()
 

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -40,19 +40,23 @@ if(BUILD_TESTING)
   find_package(rosbag2_test_common REQUIRED)
   find_package(std_msgs REQUIRED)
   find_package(test_msgs REQUIRED)
+  find_package(zstd_vendor REQUIRED)
 
   ament_add_gmock(test_rosbag2_record_end_to_end
     test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_rosbag2_record_end_to_end)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
     ament_target_dependencies(test_rosbag2_record_end_to_end
       rclcpp
+      rosbag2_cpp
       rosbag2_compression
       rosbag2_compression_zstd
       rosbag2_storage
       rosbag2_storage_default_plugins
       rosbag2_test_common
-      test_msgs)
+      test_msgs
+      zstd_vendor)
     ament_add_test_label(test_rosbag2_record_end_to_end xfail)
   endif()
 
@@ -60,6 +64,7 @@ if(BUILD_TESTING)
     test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_rosbag2_play_end_to_end)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
     ament_target_dependencies(test_rosbag2_play_end_to_end
       rclcpp
       rosbag2_storage
@@ -73,6 +78,7 @@ if(BUILD_TESTING)
     test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_rosbag2_info_end_to_end)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
     ament_target_dependencies(test_rosbag2_info_end_to_end
       rosbag2_storage
       rosbag2_test_common)
@@ -83,16 +89,19 @@ if(BUILD_TESTING)
     test/rosbag2_tests/test_converter.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_converter)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
     ament_target_dependencies(test_converter
       rosbag2_cpp
       rosbag2_test_common
-      test_msgs)
+      test_msgs
+      rosbag2_storage)
   endif()
 
   ament_add_gmock(test_rosbag2_cpp_api
     test/rosbag2_tests/test_rosbag2_cpp_api.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_rosbag2_cpp_api)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
     ament_target_dependencies(test_rosbag2_cpp_api
       rclcpp
       rosbag2_cpp

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -68,6 +68,7 @@ ament_target_dependencies(rosbag2_transport_py
   rosbag2_cpp
   rosbag2_storage
   rmw
+  shared_queues_vendor
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -94,17 +95,20 @@ function(create_tests_for_rmw_implementation)
   rosbag2_transport_add_gmock(test_record_all
     test/rosbag2_transport/test_record_all.cpp
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor)
 
   rosbag2_transport_add_gmock(test_record_all_no_discovery
     test/rosbag2_transport/test_record_all_no_discovery.cpp
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor)
 
   rosbag2_transport_add_gmock(test_play_timing
     test/rosbag2_transport/test_play_timing.cpp
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor)
 
   rosbag2_transport_add_gmock(test_rosbag2_node
     src/rosbag2_transport/generic_publisher.cpp
@@ -118,6 +122,7 @@ function(create_tests_for_rmw_implementation)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
       $<INSTALL_INTERFACE:include>
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
     AMENT_DEPS
       ament_index_cpp
       rclcpp
@@ -125,7 +130,9 @@ function(create_tests_for_rmw_implementation)
       rosbag2_storage
       rosbag2_test_common
       test_msgs
-      yaml_cpp_vendor)
+      yaml_cpp_vendor
+      rosbag2_compression
+      shared_queues_vendor)
 
   rosbag2_transport_add_gmock(test_qos
     src/rosbag2_transport/qos.cpp
@@ -133,6 +140,7 @@ function(create_tests_for_rmw_implementation)
     INCLUDE_DIRS
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
     AMENT_DEPS
       rclcpp
       rosbag2_test_common
@@ -147,7 +155,8 @@ function(create_tests_for_rmw_implementation)
 
   rosbag2_transport_add_gmock(test_record
     test/rosbag2_transport/test_record.cpp
-    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor
     INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
     LINK_LIBS rosbag2_transport
     ${SKIP_TEST})
@@ -155,7 +164,8 @@ function(create_tests_for_rmw_implementation)
   rosbag2_transport_add_gmock(test_record_regex
     test/rosbag2_transport/test_record_regex.cpp
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS test_msgs rosbag2_test_common
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor rosbag2_cpp rosbag2_storage
     ${SKIP_TEST})
 
   rosbag2_transport_add_gmock(test_play
@@ -163,20 +173,23 @@ function(create_tests_for_rmw_implementation)
     test/rosbag2_transport/test_play.cpp
     INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor
     ${SKIP_TEST})
 
   rosbag2_transport_add_gmock(test_play_loop
     test/rosbag2_transport/test_play_loop.cpp
     ${SKIP_TEST}
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor)
 
   rosbag2_transport_add_gmock(test_play_topic_remap
     test/rosbag2_transport/test_play_topic_remap.cpp
     ${SKIP_TEST}
     LINK_LIBS rosbag2_transport
-    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common)
+    # Needs to be removed/revised after https://github.com/ros2/ros2/issues/1150 gets fixed
+    AMENT_DEPS rosbag2_cpp rosbag2_storage test_msgs rosbag2_test_common rosbag2_compression shared_queues_vendor)
 endfunction()
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Fix #698 

Needs to be refactored after https://github.com/ros2/ros2/issues/1150

How to check if everything goes "OK":
* Build via `colcon build --ament-cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_ROSBAG2_BENCHMARKS=ON --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_ROSBAG2_BENCHMARKS=ON`
* Open `build/compile_commands.json`
* Test against regex `-((I)|(isystem))\s*/opt(?!((/ros/foxy/src/gmock)|(/ros/foxy/src/gtest))).*-((I)|(isystem))\s*/home`, where `/home` - first part of absolute path to local workspace