### PR TITLE
👩‍🌾 test_play_services: fail gracefully on future error

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -99,7 +99,9 @@ public:
   {
     auto future = cli->async_send_request(request);
     EXPECT_EQ(future.wait_for(service_call_timeout_), std::future_status::ready);
-    auto result = future.get();
+    EXPECT_TRUE(future.valid());
+    auto result = std::make_shared<typename Srv::Response>();
+    EXPECT_NO_THROW({result = future.get();});
     EXPECT_TRUE(result);
     return result;
   }


### PR DESCRIPTION
`test_play_services` failed during the latest [Linux nightly build](https://ci.ros2.org/job/nightly_linux_release/1961/testReport/(root)/projectroot/test_play_services__rmw_cyclonedds_cpp/) with:

```
[ RUN      ] PlaySrvsTest.play_next
terminate called after throwing an instance of 'std::future_error'
  what():  std::future_error: No associated state
-- run_test.py: return code -6
```

The test had never failed before the latest nightly, see the test history:

https://ci.ros2.org/job/nightly_linux_release/lastSuccessfulBuild/testReport/(root)/projectroot/test_play_services__rmw_cyclonedds_cpp/history/

I'm not sure what caused the error, I can't reproduce it locally, so I think it's probably a rare flake.

But just in case it fails again in the future, this PR adds some extra checks that should make the test fail in a more informative way.

---

https://github.com/osrf/buildfarmer/issues/207