### PR TITLE
Workaround for false positive findings by clang thread safety analysi…

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -138,9 +138,9 @@ public:
     {
       std::lock_guard<std::mutex> lock(state_mutex);
       snapshot(ros_time);
+      cv.notify_all();
     }
     process_callbacks_after_jump(time_jump);
-    cv.notify_all();
   }
 
   /**
@@ -211,9 +211,9 @@ private:
     }
   }
 
-  static void process_callback(
+  void process_callback(
     PlayerClock::JumpHandler::SharedPtr handler, const rcl_time_jump_t & time_jump,
-    bool before_jump) RCPPUTILS_TSA_REQUIRES(callback_list_mutex_)
+    bool before_jump) const RCPPUTILS_TSA_REQUIRES(callback_list_mutex_)
   {
     bool is_clock_change = time_jump.clock_change == RCL_ROS_TIME_ACTIVATED ||
       time_jump.clock_change == RCL_ROS_TIME_DEACTIVATED;


### PR DESCRIPTION
Workaround for false positive findings by clang thread safety analysis in time controller jump callbacks API.
Address #795 

Moved cv.notify_all() inside mutex lock scope, also made method process_callback() as non-static