### PR TITLE
Make sure the subscription exists before publishing messages

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
@@ -103,10 +103,11 @@ public:
   /// \param n_subscribers_to_match Number of subscribers publisher should have for match.
   /// \return true if find publisher by specified topic_name and publisher has specified number of
   ///   subscribers, otherwise false.
-  template<typename Timeout>
+  template<typename DurationRepT = int64_t, typename DurationT = std::milli>
   bool wait_for_matched(
     const char * topic_name,
-    Timeout timeout, size_t n_subscribers_to_match = 1)
+    std::chrono::duration<DurationRepT, DurationT> timeout = std::chrono::seconds(30),
+    size_t n_subscribers_to_match = 1)
   {
     rclcpp::PublisherBase::SharedPtr publisher = nullptr;
     for (const auto pub : publishers_) {

--- a/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
@@ -106,7 +106,7 @@ public:
   template<typename DurationRepT = int64_t, typename DurationT = std::milli>
   bool wait_for_matched(
     const char * topic_name,
-    std::chrono::duration<DurationRepT, DurationT> timeout = std::chrono::seconds(30),
+    std::chrono::duration<DurationRepT, DurationT> timeout = std::chrono::seconds(10),
     size_t n_subscribers_to_match = 1)
   {
     rclcpp::PublisherBase::SharedPtr publisher = nullptr;

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -83,7 +83,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name)) <<
     "Expected find rosbag subscription";
   wait_for_db();
 
@@ -138,7 +138,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched("/test_topic", 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched("/test_topic")) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -210,9 +210,9 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched("/test_topic0", 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched("/test_topic0")) <<
     "Expected find rosbag subscription";
-  ASSERT_TRUE(pub_manager.wait_for_matched("/test_topic1", 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched("/test_topic1")) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -264,7 +264,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name)) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -338,7 +338,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name)) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -402,7 +402,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name)) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -473,7 +473,7 @@ TEST_F(RecordFixture, record_end_to_end_with_duration_splitting_splits_bagfile) 
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name)) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -539,7 +539,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name)) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -653,7 +653,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_cache) {
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic_name)) <<
     "Expected find rosbag subscription";
 
   wait_for_db();
@@ -709,9 +709,9 @@ TEST_F(RecordFixture, rosbag2_record_and_play_multiple_topics_with_filter) {
       stop_execution(process_handle);
     });
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(first_topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(first_topic_name)) <<
     "Expected find rosbag subscription";
-  ASSERT_TRUE(pub_manager.wait_for_matched(second_topic_name, 30s, 1)) <<
+  ASSERT_TRUE(pub_manager.wait_for_matched(second_topic_name)) <<
     "Expected find rosbag subscription";
   wait_for_db();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -53,6 +53,9 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   start_async_spin(recorder);
 
+  ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str(), 30s, 1));
+
   pub_manager.run_publishers();
 
   auto & writer = recorder->get_writer_handle();
@@ -100,6 +103,8 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   recorder->record();
 
   start_async_spin(recorder);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str(), 30s, 1));
 
   pub_manager.run_publishers();
 
@@ -159,6 +164,8 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
 
   start_async_spin(recorder);
 
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str(), 30s, 1));
+
   pub_manager.run_publishers();
 
   auto & writer = recorder->get_writer_handle();
@@ -199,6 +206,8 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   recorder->record();
 
   start_async_spin(recorder);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str(), 30s, 1));
 
   auto & writer = recorder->get_writer_handle();
   MockSequentialWriter & mock_writer =

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -53,8 +53,8 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   start_async_spin(recorder);
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str(), 30s, 1));
-  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
+  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
   pub_manager.run_publishers();
 
@@ -104,7 +104,7 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
 
   start_async_spin(recorder);
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
   pub_manager.run_publishers();
 
@@ -164,7 +164,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
 
   start_async_spin(recorder);
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
   pub_manager.run_publishers();
 
@@ -207,7 +207,7 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
 
   start_async_spin(recorder);
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
   auto & writer = recorder->get_writer_handle();
   MockSequentialWriter & mock_writer =

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -54,8 +54,8 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   start_async_spin(recorder);
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str(), 30s, 1));
-  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
+  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
   pub_manager.run_publishers();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
@@ -28,6 +29,8 @@
 #include "rosbag2_transport/recorder.hpp"
 
 #include "record_integration_fixture.hpp"
+
+using namespace std::chrono_literals;  // NOLINT
 
 TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are_recorded)
 {
@@ -50,6 +53,9 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   recorder->record();
 
   start_async_spin(recorder);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str(), 30s, 1));
 
   pub_manager.run_publishers();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -75,7 +75,7 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
 
   start_async_spin(recorder);
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
 
   pub_manager.run_publishers();
 
@@ -148,8 +148,8 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_recording)
 
   start_async_spin(recorder);
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str(), 30s, 1));
-  ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
+  ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str()));
 
   pub_manager.run_publishers();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <chrono>
 #include <memory>
 #include <regex>
 #include <string>
@@ -31,6 +32,8 @@
 #include "test_msgs/message_fixtures.hpp"
 
 #include "record_integration_fixture.hpp"
+
+using namespace std::chrono_literals;  // NOLINT
 
 TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
 {
@@ -71,6 +74,8 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
   recorder->record();
 
   start_async_spin(recorder);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str(), 30s, 1));
 
   pub_manager.run_publishers();
 
@@ -142,6 +147,9 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_recording)
   recorder->record();
 
   start_async_spin(recorder);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str(), 30s, 1));
+  ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str(), 30s, 1));
 
   pub_manager.run_publishers();
 


### PR DESCRIPTION
Relevant to #732 and #766  

Improve the stability of test.  
Before publishing messages, make sure the subscription of rosbag is connected.  