### PR TITLE
[Galactic backport] Copy recorder QoS profile to local variable so that temporary value isn't cleared (#803)

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -292,7 +292,8 @@ void Recorder::warn_if_new_qos_for_subscribed_topic(const std::string & topic_na
     // Already warned about this topic
     return;
   }
-  const auto & used_profile = existing_subscription->second->get_actual_qos().get_rmw_qos_profile();
+  const auto actual_qos = existing_subscription->second->get_actual_qos();
+  const auto & used_profile = actual_qos.get_rmw_qos_profile();
   auto publishers_info = this->get_publishers_info_by_topic(topic_name);
   for (const auto & info : publishers_info) {
     auto new_profile = info.qos_profile().get_rmw_qos_profile();


### PR DESCRIPTION
Backport #803 to Galactic