### PR TITLE
Started working on jump service feature

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -51,6 +51,7 @@ find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
+find_package(rosbag2_interfaces REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/cache/cache_consumer.cpp
@@ -84,6 +85,7 @@ ament_target_dependencies(${PROJECT_NAME}
   rosidl_runtime_cpp
   rosidl_typesupport_cpp
   rosidl_typesupport_introspection_cpp
+  rosbag2_interfaces
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "rosbag2_cpp/clocks/player_clock.hpp"
+#include "rosbag2_interfaces/srv/Seek.hpp"
 
 namespace rosbag2_cpp
 {
@@ -146,6 +147,7 @@ public:
 
 private:
   std::unique_ptr<TimeControllerClockImpl> impl_;
+  rclcpp::Service<rosbag2_interfaces::srv::Seek>::SharedPtr srv_jump_;
 };
 
 

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -246,6 +246,16 @@ TimeControllerClock::TimeControllerClock(
   std::lock_guard<std::mutex> lock(impl_->state_mutex);
   impl_->reference.ros = starting_time;
   impl_->reference.steady = impl_->now_fn();
+
+    srv_jump_ = create_service<rosbag2_interfaces::srv::SetRate>(
+            "~/set_rate",
+            [this](
+                    const std::shared_ptr<rmw_request_id_t>/* request_header */,
+                    const std::shared_ptr<rosbag2_interfaces::srv::Seek::Request> request,
+                    const std::shared_ptr<rosbag2_interfaces::srv::Seek::Response> response)
+            {
+                response->success = jump(request->ros_time);
+            });
 }
 
 TimeControllerClock::~TimeControllerClock()


### PR DESCRIPTION
I would like to implement Expose jump services on the Player from #696. I checked how it was done for the set_rate service #767, but the whole package is quite complex and I'm not sure how rosbag2_cpp interacts with rosbag2_transport. I'm not sure if one can be seen as the backend and the other as the frontend and if I should expose the jump service in rosbag2_transport, like the others or if it should reside in rosbag2_cpp like I did now. I currently can't get it to build, but before investing more time, I would be thankful for some advice, if this is the correct package to add the service.