### PR TITLE
[backport galactic] Add delay option (#789)

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -82,6 +82,9 @@ class PlayVerb(VerbExtension):
             '--clock', type=positive_float, nargs='?', const=40, default=0,
             help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
                  'Value must be positive. Defaults to not publishing.')
+        parser.add_argument(
+            '-d', '--delay', type=float, default=0.0,
+            help='Sleep SEC seconds before play. Valid range > 0.0')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -116,6 +119,7 @@ class PlayVerb(VerbExtension):
         play_options.loop = args.loop
         play_options.topic_remapping_options = topic_remapping
         play_options.clock_publish_frequency = args.clock
+        play_options.delay = args.delay
 
         player = Player()
         player.play(storage_options, play_options)

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -220,6 +220,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("loop", &PlayOptions::loop)
   .def_readwrite("topic_remapping_options", &PlayOptions::topic_remapping_options)
   .def_readwrite("clock_publish_frequency", &PlayOptions::clock_publish_frequency)
+  .def_readwrite("delay", &PlayOptions::delay)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -44,6 +44,9 @@ public:
   // Rate in Hz at which to publish to /clock.
   // 0 (or negative) means that no publisher will be created
   double clock_publish_frequency = 0.0;
+
+  // Sleep SEC seconds before play. Valid range > 0.0.
+  float delay = 0.0;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -213,8 +213,25 @@ bool Player::is_storage_completely_loaded() const
 void Player::play()
 {
   is_in_play_ = true;
+
+  float delay;
+  if (play_options_.delay >= 0.0) {
+    delay = play_options_.delay;
+  } else {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "Invalid delay value: %f. Delay is disabled.",
+      play_options_.delay);
+    delay = 0.0;
+  }
+
   try {
     do {
+      if (delay > 0.0) {
+        RCLCPP_INFO_STREAM(this->get_logger(), "Sleep " << delay << " sec");
+        std::chrono::duration<float> duration(delay);
+        std::this_thread::sleep_for(duration);
+      }
       reader_->open(storage_options_, {"", rmw_get_serialization_format()});
       const auto starting_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
         reader_->get_metadata().starting_time.time_since_epoch()).count();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -43,6 +43,8 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
   const size_t read_ahead_queue_size = 1000;
   const float rate = 1.0;
   const bool loop_playback = false;
+  double clock_publish_frequency = 0.0;
+  const float delay = 1.0;
 
   auto primitive_message1 = get_messages_basic_types()[0];
   primitive_message1->int32_value = test_value;
@@ -64,8 +66,9 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  rosbag2_transport::PlayOptions play_options =
-  {read_ahead_queue_size, "", rate, {}, {}, loop_playback, {}};
+  rosbag2_transport::PlayOptions play_options = {
+    read_ahead_queue_size, "", rate, {}, {}, loop_playback, {},
+    clock_publish_frequency, delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);
@@ -100,6 +103,8 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   const size_t read_ahead_queue_size = 1000;
   const float rate = 1.0;
   const bool loop_playback = true;
+  const double clock_publish_frequency = 0.0;
+  const float delay = 1.0;
 
   auto primitive_message1 = get_messages_basic_types()[0];
   primitive_message1->int32_value = test_value;
@@ -122,7 +127,7 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::PlayOptions play_options{read_ahead_queue_size, "", rate, {}, {},
-    loop_playback, {}};
+    loop_playback, {}, clock_publish_frequency, delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);


### PR DESCRIPTION
Backport #789 to Galactic.
In this PR I added --delay option like,
`ros2 bag play <rosbag2 file> -d 5`
If you have galactic rosbag2 installed, remove it before build to prevent wrong include. 
`sudo apt remove ros-galactic-rosbag2*`
