### PR TITLE
Update Foxy distro branch CI to use latest setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,36 +1,31 @@
 name: Test rosbag2
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
-      - master
-  schedule:
-    # Run every hour. This helps detect flakiness,
-    # and broken external dependencies.
-    - cron:  '0 * * * *'
+      - foxy
 
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
-    # TODO(setup-ros-docker#7): calling chown is necessary for now
-    - run: sudo chown -R rosbuild:rosbuild "$HOME" .
-    - uses: ros-tooling/action-ros-ci@0.0.16
+    - uses: ros-tooling/action-ros-ci@v0.2
       with:
-        package-name: |
-          ros2bag
-          rosbag2_compression
-          rosbag2_converter_default_plugins
-          rosbag2_cpp
-          rosbag2_storage
-          rosbag2_storage_default_plugins
-          rosbag2_transport
-          shared_queues_vendor
-          sqlite3_vendor
-          rosbag2_test_common
-          rosbag2_tests
+        target-ros2-distro: foxy
+        colcon-defaults: |
+          {
+            "build": {
+              "cmake-args": [
+                "-DCMAKE_CXX_FLAGS=\"-Werror\""
+              ]
+            },
+            "test": {
+              "ctest-args": ["-LE", "xfail"],
+              "pytest-args": ["-m", "not xfail"]
+            }
+          }
     - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs


### PR DESCRIPTION
Changes:
* Run tests on pull requests
* Remove `cron`, which won't run on a non-default branch anyways
* Use a base-setup image instead of one with ros installed
* Use latest action-ros-ci, with "build-all" default, instead of specifying all packages by name
* Add `xfail` test arguments