### PR TITLE
Disable SIGTERM test on Windows in Foxy due to shutdown behavior in tests on that platform.

### DIFF
--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -164,6 +164,8 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   EXPECT_THAT(wrong_topic_messages, IsEmpty());
 }
 
+// Disable this test on Windows in Foxy. See TODO note on following metadata test for details.
+#ifndef _WIN32
 TEST_F(RecordFixture, record_end_to_end_exits_gracefully_on_sigterm) {
   const std::string topic_name = "/test_sigterm";
   auto message = get_messages_strings()[0];
@@ -177,6 +179,7 @@ TEST_F(RecordFixture, record_end_to_end_exits_gracefully_on_sigterm) {
   stop_execution(process_handle, SIGTERM);
   wait_for_metadata();
 }
+#endif
 
 // TODO(zmichaels11): Fix and enable this test on Windows.
 // This tests depends on the ability to read the metadata file.


### PR DESCRIPTION
Followup to #809 - disables this test for Foxy on Windows, because the `xfail` label hadn't yet been applied there and the Windows shutdown in tests doesn't work properly in Foxy.