### PR TITLE
Load compression and serialization choices via plugin query

### DIFF
--- a/ros2bag/ros2bag/verb/list.py
+++ b/ros2bag/ros2bag/verb/list.py
@@ -63,10 +63,12 @@ class ListVerb(VerbExtension):
                     # Compression and decompression plugins share the same resource index
                     # so they must be filtered using their base class
                     if args.plugin_type == 'compression' and \
-                            base_class_name.value != 'rosbag2_compression::BaseCompressorInterface':
+                            base_class_name.value != \
+                            'rosbag2_compression::BaseCompressorInterface':
                         continue
                     elif args.plugin_type == 'decompression' and \
-                            base_class_name.value != 'rosbag2_compression::BaseDecompressorInterface':
+                            base_class_name.value != \
+                            'rosbag2_compression::BaseDecompressorInterface':
                         continue
 
                     print('%s%s' % (('name: ' if args.verbose else ''), class_name.value))

--- a/ros2bag/ros2bag/verb/list.py
+++ b/ros2bag/ros2bag/verb/list.py
@@ -27,8 +27,9 @@ class ListVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         parser.add_argument(
-            'plugin_type', help='lists available plugins (storage plugins or converter plugins',
-            choices=['storage', 'converter'])
+            'plugin_type',
+            help='lists available plugins',
+            choices=['storage', 'converter', 'compression', 'decompression'])
         parser.add_argument(
             '--verbose', help='output verbose information about the available plugin',
             action='store_true')
@@ -37,6 +38,8 @@ class ListVerb(VerbExtension):
         # the following is the resource index which is created when installing a pluginlib xml file
         if args.plugin_type == 'storage':
             pluginlib_resource_index = 'rosbag2_storage__pluginlib__plugin'
+        elif args.plugin_type == 'compression' or args.plugin_type == 'decompression':
+            pluginlib_resource_index = 'rosbag2_compression__pluginlib__plugin'
         else:
             pluginlib_resource_index = 'rosbag2_cpp__pluginlib__plugin'
 
@@ -56,6 +59,15 @@ class ListVerb(VerbExtension):
                     type_name = class_item.attributes['type']
                     base_class_name = class_item.attributes['base_class_type']
                     description = class_item.getElementsByTagName('description')[0]
+
+                    # Compression and decompression plugins share the same resource index
+                    # so they must be filtered using their base class
+                    if args.plugin_type == 'compression' and \
+                            base_class_name.value != 'rosbag2_compression::BaseCompressorInterface':
+                        continue
+                    elif args.plugin_type == 'decompression' and \
+                            base_class_name.value != 'rosbag2_compression::BaseDecompressorInterface':
+                        continue
 
                     print('%s%s' % (('name: ' if args.verbose else ''), class_name.value))
                     if args.verbose:

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -21,9 +21,9 @@ from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_writers
 from rosbag2_py import get_registered_compressors
 from rosbag2_py import get_registered_serializers
+from rosbag2_py import get_registered_writers
 from rosbag2_py import Recorder
 from rosbag2_py import RecordOptions
 from rosbag2_py import StorageOptions

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -23,6 +23,7 @@ from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
 from rosbag2_py import get_registered_writers
 from rosbag2_py import get_registered_compressors
+from rosbag2_py import get_registered_serializers
 from rosbag2_py import Recorder
 from rosbag2_py import RecordOptions
 from rosbag2_py import StorageOptions
@@ -37,6 +38,7 @@ class RecordVerb(VerbExtension):
         default_writer = 'sqlite3' if 'sqlite3' in writer_choices else writer_choices[0]
 
         compression_format_choices = get_registered_compressors()
+        serialization_choices = get_registered_serializers()
 
         parser.add_argument(
             '-a', '--all', action='store_true',
@@ -59,7 +61,7 @@ class RecordVerb(VerbExtension):
             '-s', '--storage', default=default_writer, choices=writer_choices,
             help=f"storage identifier to be used, defaults to '{default_writer}'")
         parser.add_argument(
-            '-f', '--serialization-format', default='',
+            '-f', '--serialization-format', default='', choices=serialization_choices,
             help='rmw serialization format in which the messages are saved, defaults to the'
                  ' rmw currently in use')
         parser.add_argument(

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -22,6 +22,7 @@ from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
 from rosbag2_py import get_registered_writers
+from rosbag2_py import get_registered_compressors
 from rosbag2_py import Recorder
 from rosbag2_py import RecordOptions
 from rosbag2_py import StorageOptions
@@ -34,6 +35,8 @@ class RecordVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):  # noqa: D102
         writer_choices = get_registered_writers()
         default_writer = 'sqlite3' if 'sqlite3' in writer_choices else writer_choices[0]
+
+        compression_format_choices = get_registered_compressors()
 
         parser.add_argument(
             '-a', '--all', action='store_true',
@@ -96,7 +99,7 @@ class RecordVerb(VerbExtension):
             help="Determine whether to compress by file or message. Default is 'none'."
         )
         parser.add_argument(
-            '--compression-format', type=str, default='', choices=['zstd'],
+            '--compression-format', type=str, default='', choices=compression_format_choices,
             help='Specify the compression format/algorithm. Default is none.'
         )
         parser.add_argument(

--- a/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_factory.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "base_compressor_interface.hpp"
 #include "base_decompressor_interface.hpp"
@@ -65,6 +66,13 @@ public:
    */
   virtual std::shared_ptr<rosbag2_compression::BaseDecompressorInterface>
   create_decompressor(const std::string & compression_format);
+
+  /**
+   * Determine which compression plugins are available.
+   *
+   * \return A vector of all available compression plugins.
+   */
+  virtual std::vector<std::string> get_declared_compressor_plugins() const;
 
 private:
   std::unique_ptr<CompressionFactoryImpl> impl_;

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_compression/compression_factory.hpp"
 
@@ -37,6 +38,11 @@ std::shared_ptr<rosbag2_compression::BaseDecompressorInterface>
 CompressionFactory::create_decompressor(const std::string & compression_format)
 {
   return impl_->create_decompressor(compression_format);
+}
+
+std::vector<std::string> CompressionFactory::get_declared_compressor_plugins() const
+{
+  return impl_->get_declared_compressor_plugins();
 }
 
 }  // namespace rosbag2_compression

--- a/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/compression_factory_impl.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "pluginlib/class_loader.hpp"
 
@@ -127,6 +128,12 @@ public:
         "Could not load/open plugin for compression format '" << compression_format << "'");
     }
     return instance;
+  }
+
+  /// See CompressionFactory::get_declared_compressor_plugins for documentation.
+  std::vector<std::string> get_declared_compressor_plugins() const
+  {
+    return compressor_class_loader_->getDeclaredClasses();
   }
 
 private:

--- a/rosbag2_compression/test/rosbag2_compression/mock_converter_factory.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_converter_factory.hpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_cpp/serialization_format_converter_factory_interface.hpp"
 
@@ -34,6 +35,10 @@ public:
     load_deserializer,
     std::unique_ptr<rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer>(
       const std::string &));
+
+  MOCK_CONST_METHOD0(
+    get_declared_serialization_plugins,
+    std::vector<std::string>());
 };
 
 #endif  // ROSBAG2_COMPRESSION__MOCK_CONVERTER_FACTORY_HPP_

--- a/rosbag2_compression/test/rosbag2_compression/test_compression_factory.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_compression_factory.cpp
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <algorithm>
+#include <vector>
 
 #include "rosbag2_compression/compression_factory.hpp"
 
@@ -47,4 +48,21 @@ TEST_F(CompressionFactoryTest, throws_on_bad_compressor_format) {
 TEST_F(CompressionFactoryTest, throws_on_bad_decompressor_format) {
   const auto compression_format = "bar";
   ASSERT_EQ(factory.create_decompressor(compression_format), nullptr);
+}
+
+TEST_F(CompressionFactoryTest, load_compression_plugins_test) {
+  const auto compression_format = "fake_comp";
+  auto compressor = factory.create_compressor(compression_format);
+  ASSERT_TRUE(compressor != nullptr);
+  std::vector<std::string> compressor_list = factory.get_declared_compressor_plugins();
+  bool found_compressor = false;
+
+  // Ensure the compressor plugin can be found
+  for (auto it = compressor_list.begin(); it != compressor_list.end(); it++) {
+    if (*it == compression_format) {
+      found_compressor = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(found_compressor);
 }

--- a/rosbag2_compression/test/rosbag2_compression/test_compression_factory.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_compression_factory.cpp
@@ -52,8 +52,6 @@ TEST_F(CompressionFactoryTest, throws_on_bad_decompressor_format) {
 
 TEST_F(CompressionFactoryTest, load_compression_plugins_test) {
   const auto compression_format = "fake_comp";
-  auto compressor = factory.create_compressor(compression_format);
-  ASSERT_TRUE(compressor != nullptr);
   std::vector<std::string> compressor_list = factory.get_declared_compressor_plugins();
   bool found_compressor = false;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/serialization_format_converter_factory.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/serialization_format_converter_factory.hpp
@@ -49,7 +49,7 @@ public:
   std::unique_ptr<converter_interfaces::SerializationFormatSerializer>
   load_serializer(const std::string & format) override;
 
-  virtual std::vector<std::string> get_declared_serialization_plugins() const override;
+  std::vector<std::string> get_declared_serialization_plugins() const override;
 
 private:
   std::unique_ptr<SerializationFormatConverterFactoryImpl> impl_;

--- a/rosbag2_cpp/include/rosbag2_cpp/serialization_format_converter_factory.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/serialization_format_converter_factory.hpp
@@ -49,6 +49,8 @@ public:
   std::unique_ptr<converter_interfaces::SerializationFormatSerializer>
   load_serializer(const std::string & format) override;
 
+  virtual std::vector<std::string> get_declared_serialization_plugins() const override;
+
 private:
   std::unique_ptr<SerializationFormatConverterFactoryImpl> impl_;
 };

--- a/rosbag2_cpp/include/rosbag2_cpp/serialization_format_converter_factory_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/serialization_format_converter_factory_interface.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_cpp/converter_interfaces/serialization_format_converter.hpp"
 #include "rosbag2_cpp/visibility_control.hpp"
@@ -34,6 +35,8 @@ public:
 
   virtual std::unique_ptr<converter_interfaces::SerializationFormatSerializer>
   load_serializer(const std::string & format) = 0;
+
+  virtual std::vector<std::string> get_declared_serialization_plugins() const = 0;
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/serialization_format_converter_factory.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/serialization_format_converter_factory.cpp
@@ -41,4 +41,10 @@ SerializationFormatConverterFactory::load_serializer(const std::string & format)
   return impl_->load_serializer(format);
 }
 
+std::vector<std::string>
+SerializationFormatConverterFactory::get_declared_serialization_plugins() const
+{
+  return impl_->get_declared_serialization_plugins();
+}
+
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/serialization_format_converter_factory_impl.hpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/serialization_format_converter_factory_impl.hpp
@@ -73,6 +73,11 @@ public:
     return load_interface(format, serializer_class_loader_);
   }
 
+  std::vector<std::string> get_declared_serialization_plugins() const
+  {
+    return serializer_class_loader_->getDeclaredClasses();
+  }
+
 private:
   // Return true if a plugin is found with this ID
   bool is_plugin_registered(

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_converter_factory.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_converter_factory.hpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rosbag2_cpp/serialization_format_converter_factory_interface.hpp"
 
@@ -34,6 +35,10 @@ public:
     load_deserializer,
     std::unique_ptr<rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer>(
       const std::string &));
+
+  MOCK_CONST_METHOD0(
+    get_declared_serialization_plugins,
+    std::vector<std::string>());
 };
 
 #endif  // ROSBAG2_CPP__MOCK_CONVERTER_FACTORY_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/test_converter_factory.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_converter_factory.cpp
@@ -51,3 +51,16 @@ TEST_F(ConverterFactoryTest, load_deserializer_cannot_load_serializer_plugin) {
   auto converter = factory.load_deserializer("s");
   EXPECT_THAT(converter, IsNull());
 }
+
+TEST_F(ConverterFactoryTest, load_serialization_plugins_test) {
+  auto serialization_plugins = factory.get_declared_serialization_plugins();
+  bool found = false;
+
+  for (auto it = serialization_plugins.begin(); it != serialization_plugins.end(); it++) {
+    if (*it == "s_converter") {
+      found = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(found);
+}

--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -35,6 +35,7 @@ with add_dll_directories_from_env('PATH'):
         SequentialCompressionWriter,
         SequentialWriter,
         get_registered_writers,
+        get_registered_compressors,
     )
     from rosbag2_py._info import (
         Info,
@@ -53,6 +54,7 @@ __all__ = [
     'ConverterOptions',
     'get_registered_readers',
     'get_registered_writers',
+    'get_registered_compressors',
     'Reindexer',
     'SequentialCompressionReader',
     'SequentialCompressionWriter',

--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -36,6 +36,7 @@ with add_dll_directories_from_env('PATH'):
         SequentialWriter,
         get_registered_writers,
         get_registered_compressors,
+        get_registered_serializers,
     )
     from rosbag2_py._info import (
         Info,
@@ -55,6 +56,7 @@ __all__ = [
     'get_registered_readers',
     'get_registered_writers',
     'get_registered_compressors',
+    'get_registered_serializers',
     'Reindexer',
     'SequentialCompressionReader',
     'SequentialCompressionWriter',

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -22,6 +22,7 @@
 #include "rosbag2_cpp/converter_options.hpp"
 #include "rosbag2_cpp/writer.hpp"
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
+#include "rosbag2_cpp/serialization_format_converter_factory.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/storage_filter.hpp"
 #include "rosbag2_storage/storage_options.hpp"
@@ -92,6 +93,13 @@ std::unordered_set<std::string> get_registered_compressors()
   return std::unordered_set<std::string>(compressor_plugins.begin(), compressor_plugins.end());
 }
 
+std::unordered_set<std::string> get_registered_serializers()
+{
+  rosbag2_cpp::SerializationFormatConverterFactory serialization_factory;
+  const auto serialization_plugins = serialization_factory.get_declared_serialization_plugins();
+  return std::unordered_set<std::string>(serialization_plugins.begin(), serialization_plugins.end());
+}
+
 }  // namespace rosbag2_py
 
 PYBIND11_MODULE(_writer, m) {
@@ -126,4 +134,9 @@ PYBIND11_MODULE(_writer, m) {
     "get_registered_compressors",
     &rosbag2_py::get_registered_compressors,
     "Returns list of compression plugins available for rosbag2 recording");
+
+  m.def(
+    "get_registered_serializers",
+    &rosbag2_py::get_registered_serializers,
+    "Returns list of serialization format plugins available for rosbag2 recording");
 }

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -97,7 +97,9 @@ std::unordered_set<std::string> get_registered_serializers()
 {
   rosbag2_cpp::SerializationFormatConverterFactory serialization_factory;
   const auto serialization_plugins = serialization_factory.get_declared_serialization_plugins();
-  return std::unordered_set<std::string>(serialization_plugins.begin(), serialization_plugins.end());
+  return std::unordered_set<std::string>(
+    serialization_plugins.begin(),
+    serialization_plugins.end());
 }
 
 }  // namespace rosbag2_py

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_set>
 
+#include "rosbag2_compression/compression_factory.hpp"
 #include "rosbag2_compression/sequential_compression_writer.hpp"
 #include "rosbag2_cpp/converter_options.hpp"
 #include "rosbag2_cpp/writer.hpp"
@@ -84,6 +85,13 @@ std::unordered_set<std::string> get_registered_writers()
   return std::unordered_set<std::string>(read_write.begin(), read_write.end());
 }
 
+std::unordered_set<std::string> get_registered_compressors()
+{
+  rosbag2_compression::CompressionFactory compression_factory;
+  const auto compressor_plugins = compression_factory.get_declared_compressor_plugins();
+  return std::unordered_set<std::string>(compressor_plugins.begin(), compressor_plugins.end());
+}
+
 }  // namespace rosbag2_py
 
 PYBIND11_MODULE(_writer, m) {
@@ -113,4 +121,9 @@ PYBIND11_MODULE(_writer, m) {
     "get_registered_writers",
     &rosbag2_py::get_registered_writers,
     "Returns list of discovered plugins that support rosbag2 recording");
+
+  m.def(
+    "get_registered_compressors",
+    &rosbag2_py::get_registered_compressors,
+    "Returns list of compression plugins available for rosbag2 recording");
 }

--- a/rosbag2_py/test/test_sequential_writer.py
+++ b/rosbag2_py/test/test_sequential_writer.py
@@ -109,3 +109,13 @@ def test_compression_plugin_list():
     """
     compression_formats = rosbag2_py.get_registered_compressors()
     assert 'zstd' in compression_formats
+
+
+def test_serialization_plugin_list():
+    """
+    Testing retrieval of available serialization format plugins.
+
+    :return:
+    """
+    serialization_formats = rosbag2_py.get_registered_serializers()
+    assert 's_converter' in serialization_formats

--- a/rosbag2_py/test/test_sequential_writer.py
+++ b/rosbag2_py/test/test_sequential_writer.py
@@ -108,7 +108,7 @@ def test_compression_plugin_list():
     :return:
     """
     compression_formats = rosbag2_py.get_registered_compressors()
-    assert 'zstd' in compression_formats
+    assert 'fake_comp' in compression_formats
 
 
 def test_serialization_plugin_list():

--- a/rosbag2_py/test/test_sequential_writer.py
+++ b/rosbag2_py/test/test_sequential_writer.py
@@ -99,3 +99,13 @@ def test_sequential_writer(tmp_path):
 def test_plugin_list():
     writer_plugins = rosbag2_py.get_registered_writers()
     assert 'my_test_plugin' in writer_plugins
+
+
+def test_compression_plugin_list():
+    """
+    Testing retrieval of available compression format plugins.
+
+    :return:
+    """
+    compression_formats = rosbag2_py.get_registered_compressors()
+    assert 'zstd' in compression_formats


### PR DESCRIPTION
Resolves #769 

Query installed plugins to dynamically set compression and serialization format choices in the `ros2 bag record -h` help menu.

Also added "compression" and "decompression" choices to `ros2 bag list` for listing available compression and decompression plugins.