### PR TITLE
Fixed inability to record hidden topics in foxy

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -108,7 +108,7 @@ Recorder::get_requested_or_available_topics(
 {
   return requested_topics.empty() ?
          node_->get_all_topics_with_types(include_hidden_topics) :
-         node_->get_topics_with_types(requested_topics);
+         node_->get_topics_with_types(requested_topics, include_hidden_topics);
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.cpp
@@ -136,7 +136,7 @@ std::string Rosbag2Node::expand_topic_name(const std::string & topic_name)
 }
 
 std::unordered_map<std::string, std::string> Rosbag2Node::get_topics_with_types(
-  const std::vector<std::string> & topic_names)
+  const std::vector<std::string> & topic_names, bool include_hidden_topics)
 {
   std::vector<std::string> sanitized_topic_names;
   for (const auto & topic_name : topic_names) {
@@ -159,7 +159,7 @@ std::unordered_map<std::string, std::string> Rosbag2Node::get_topics_with_types(
     }
   }
 
-  return filter_topics_with_more_than_one_type(filtered_topics_and_types);
+  return filter_topics_with_more_than_one_type(filtered_topics_and_types, include_hidden_topics);
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/rosbag2_node.hpp
@@ -54,7 +54,9 @@ public:
     std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
 
   std::unordered_map<std::string, std::string>
-  get_topics_with_types(const std::vector<std::string> & topic_names);
+  get_topics_with_types(
+    const std::vector<std::string> & topic_names,
+    bool include_hidden_topics = false);
 
   std::string
   expand_topic_name(const std::string & topic_name);

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -260,3 +260,20 @@ TEST_F(RosBag2NodeFixture, get_all_topics_with_types_returns_all_topics)
   EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/msg/Strings"));
   EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/msg/Strings"));
 }
+
+TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_specified_hidden_topics) {
+  std::string first_topic("/string_topic");
+  std::string second_topic("/other_topic");
+  std::string third_topic("/_hidden_topic");
+
+  create_publisher(first_topic);
+  create_publisher(second_topic);
+  create_publisher(third_topic);
+
+  sleep_to_allow_topics_discovery();
+  auto topics_and_types = node_->get_topics_with_types({first_topic, third_topic}, true);
+
+  ASSERT_THAT(topics_and_types, SizeIs(2));
+  EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/msg/Strings"));
+  EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/msg/Strings"));
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rosbag2_node.cpp
@@ -227,7 +227,7 @@ TEST_F(
 
 TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_only_specified_topics) {
   std::string first_topic("/string_topic");
-  std::string second_topic("/other_topic");
+  std::string second_topic("/_other_topic");
   std::string third_topic("/wrong_topic");
 
   create_publisher(first_topic);
@@ -235,7 +235,8 @@ TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_only_specified_topics) 
   create_publisher(third_topic);
 
   sleep_to_allow_topics_discovery();
-  auto topics_and_types = node_->get_topics_with_types({first_topic, second_topic});
+  // Tests for both regular and hidden topics
+  auto topics_and_types = node_->get_topics_with_types({first_topic, second_topic}, true);
 
   ASSERT_THAT(topics_and_types, SizeIs(2));
   EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/msg/Strings"));
@@ -258,22 +259,5 @@ TEST_F(RosBag2NodeFixture, get_all_topics_with_types_returns_all_topics)
   ASSERT_THAT(topics_and_types, SizeIs(Ge(3u)));
   EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/msg/Strings"));
   EXPECT_THAT(topics_and_types.find(second_topic)->second, StrEq("test_msgs/msg/Strings"));
-  EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/msg/Strings"));
-}
-
-TEST_F(RosBag2NodeFixture, get_topics_with_types_returns_specified_hidden_topics) {
-  std::string first_topic("/string_topic");
-  std::string second_topic("/other_topic");
-  std::string third_topic("/_hidden_topic");
-
-  create_publisher(first_topic);
-  create_publisher(second_topic);
-  create_publisher(third_topic);
-
-  sleep_to_allow_topics_discovery();
-  auto topics_and_types = node_->get_topics_with_types({first_topic, third_topic}, true);
-
-  ASSERT_THAT(topics_and_types, SizeIs(2));
-  EXPECT_THAT(topics_and_types.find(first_topic)->second, StrEq("test_msgs/msg/Strings"));
   EXPECT_THAT(topics_and_types.find(third_topic)->second, StrEq("test_msgs/msg/Strings"));
 }


### PR DESCRIPTION
Fixes #565
 
Ensure that the `--include-hidden-topics` flag is considered when collecting topics for recording.

This problem is already fixed on latest, and cannot be backported as it was part of a larger API-breaking change.