### PR TITLE
Fix record test to reflect plugin query changes

### DIFF
--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -643,9 +643,9 @@ TEST_F(RecordFixture, record_fails_gracefully_if_plugin_for_given_encoding_does_
     execute_and_wait_until_completion("ros2 bag record -a -f some_rmw", temporary_dir_path_);
   auto error_output = internal::GetCapturedStderr();
 
-  EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
+  EXPECT_THAT(exit_code, Ne(EXIT_SUCCESS));
   EXPECT_THAT(
-    error_output, HasSubstr("Could not find converter for format some_rmw"));
+    error_output, HasSubstr("invalid choice: 'some_rmw'"));
 }
 
 TEST_F(RecordFixture, record_end_to_end_test_with_cache) {


### PR DESCRIPTION
`record_fails_gracefully_if_plugin_for_given_encoding_does_not_exist` was failing due to plugin query added in #827 