### PR TITLE
Update `PlayOptions::delay` to `rclcpp::Duration` to get nanosecond resolution

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -83,8 +83,8 @@ class PlayVerb(VerbExtension):
             help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
                  'Value must be positive. Defaults to not publishing.')
         parser.add_argument(
-            '-d', '--delay', type=float, default=0.0,
-            help='Sleep SEC seconds before play. Valid range > 0.0')
+            '-d', '--delay', type=positive_float, default=0.0,
+            help='Sleep duration before play (each loop), in seconds. Negative durations invalid.')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -67,14 +67,15 @@ template<class T>
 struct OptionsWrapper : public T
 {
 public:
-  void setDelay(float delay)
+  void setDelay(double delay)
   {
-    this->delay = rclcpp::Duration::from_nanoseconds(RCUTILS_S_TO_NS(delay));
+    this->delay = rclcpp::Duration::from_nanoseconds(
+      static_cast<rcl_duration_value_t>(RCUTILS_S_TO_NS(delay)));
   }
 
-  float getDelay() const
+  double getDelay() const
   {
-    return RCUTILS_NS_TO_S(this->delay.nanoseconds());
+    return RCUTILS_NS_TO_S(static_cast<double>(this->delay.nanoseconds()));
   }
 
   void setTopicQoSProfileOverrides(const py::dict & overrides)

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -67,14 +67,23 @@ template<class T>
 struct OptionsWrapper : public T
 {
 public:
-  void setTopicQoSProfileOverrides(
-    const py::dict & overrides)
+  void setDelay(float delay)
+  {
+    this->delay = rclcpp::Duration::from_nanoseconds(RCUTILS_S_TO_NS(delay));
+  }
+
+  float getDelay() const
+  {
+    return RCUTILS_NS_TO_S(this->delay.nanoseconds());
+  }
+
+  void setTopicQoSProfileOverrides(const py::dict & overrides)
   {
     py_dict = overrides;
     this->topic_qos_profile_overrides = qos_map_from_py_dict(overrides);
   }
 
-  const py::dict & getTopicQoSProfileOverrides()
+  const py::dict & getTopicQoSProfileOverrides() const
   {
     return py_dict;
   }
@@ -225,7 +234,10 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("loop", &PlayOptions::loop)
   .def_readwrite("topic_remapping_options", &PlayOptions::topic_remapping_options)
   .def_readwrite("clock_publish_frequency", &PlayOptions::clock_publish_frequency)
-  .def_readwrite("delay", &PlayOptions::delay)
+  .def_property(
+    "delay",
+    &PlayOptions::getDelay,
+    &PlayOptions::setDelay)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "rclcpp/duration.hpp"
 #include "rclcpp/qos.hpp"
 
 namespace rosbag2_transport
@@ -45,8 +46,8 @@ public:
   // 0 (or negative) means that no publisher will be created
   double clock_publish_frequency = 0.0;
 
-  // Sleep SEC seconds before play. Valid range > 0.0.
-  float delay = 0.0;
+  // Sleep before play. Negative durations invalid. Will delay at the beginning of each loop.
+  rclcpp::Duration delay = rclcpp::Duration(0, 0);
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -216,14 +216,14 @@ void Player::play()
   if (play_options_.delay >= rclcpp::Duration(0, 0)) {
     delay = play_options_.delay;
   } else {
-    RCLCPP_WARN(
+    RCLCPP_WARN_STREAM(
       this->get_logger(),
-      "Invalid delay value: %d. Delay is disabled.", play_options_.delay.nanoseconds());
+      "Invalid delay value: " << play_options_.delay.nanoseconds() << ". Delay is disabled.");
   }
 
   try {
     do {
-      if (delay > rclcpp::Duration(0)) {
+      if (delay > rclcpp::Duration(0, 0)) {
         RCLCPP_INFO_STREAM(this->get_logger(), "Sleep " << delay.nanoseconds() << " ns");
         std::chrono::nanoseconds duration(delay.nanoseconds());
         std::this_thread::sleep_for(duration);

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -212,20 +212,20 @@ bool Player::is_storage_completely_loaded() const
 
 void Player::play()
 {
-  float delay;
-  if (play_options_.delay >= 0.0) {
+  rclcpp::Duration delay(0, 0);
+  if (play_options_.delay >= rclcpp::Duration(0, 0)) {
     delay = play_options_.delay;
   } else {
     RCLCPP_WARN(
-      this->get_logger(), "Invalid delay value: %f. Delay is disabled.", play_options_.delay);
-    delay = 0.0;
+      this->get_logger(),
+      "Invalid delay value: %d. Delay is disabled.", play_options_.delay.nanoseconds());
   }
 
   try {
     do {
-      if (delay > 0.0) {
-        RCLCPP_INFO_STREAM(this->get_logger(), "Sleep " << delay << " sec");
-        std::chrono::duration<float> duration(delay);
+      if (delay > rclcpp::Duration(0)) {
+        RCLCPP_INFO_STREAM(this->get_logger(), "Sleep " << delay.nanoseconds() << " ns");
+        std::chrono::nanoseconds duration(delay.nanoseconds());
         std::this_thread::sleep_for(duration);
       }
       reader_->open(storage_options_, {"", rmw_get_serialization_format()});

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -44,7 +44,7 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
   const float rate = 1.0;
   const bool loop_playback = false;
   double clock_publish_frequency = 0.0;
-  const float delay = 1.0;
+  const rclcpp::Duration delay(1, 0);
 
   auto primitive_message1 = get_messages_basic_types()[0];
   primitive_message1->int32_value = test_value;
@@ -104,7 +104,7 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   const float rate = 1.0;
   const bool loop_playback = true;
   const double clock_publish_frequency = 0.0;
-  const float delay = 1.0;
+  const rclcpp::Duration delay(1, 0);
 
   auto primitive_message1 = get_messages_basic_types()[0];
   primitive_message1->int32_value = test_value;

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -212,12 +212,10 @@ TEST_F(PlayerTestFixture, playing_respects_delay)
     play_options_.delay = 5.0;
     auto lower_expected_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
       message_time_difference +
-      std::chrono::duration<float>(play_options_.delay)
-    ).count();
+      std::chrono::duration<float>(play_options_.delay)).count();
     auto upper_expected_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
       message_time_difference +
-      std::chrono::duration<float>(play_options_.delay + delay_margin)
-    ).count();
+      std::chrono::duration<float>(play_options_.delay + delay_margin)).count();
 
     auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
     prepared_mock_reader->prepare(messages, topics_and_types);


### PR DESCRIPTION
Fixes failing delay test on Windows (see https://ci.ros2.org/view/nightly/job/nightly_win_deb/2077/#showFailuresLink for example) - which was finishing a few milliseconds early. This is likely due to the resolution of `float` not carrying the expectations clearly.

Additionally, this is a more clear API given that `rclcpp::Duration` is strongly typed, rather than having to clarify the units in the `PlayOptions` declaration.