### PR TITLE
Race condition in Player::peek_next_message_from_queue()

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -295,6 +295,11 @@ rosbag2_storage::SerializedBagMessageSharedPtr * Player::peek_next_message_from_
       message_ptr = message_queue_.peek();
     }
   }
+  // Workaround for race condition between peek and is_storage_completely_loaded()
+  // Don't sync with mutex for the sake of the performance
+  if (message_ptr == nullptr) {
+    message_ptr = message_queue_.peek();
+  }
   return message_ptr;
 }
 


### PR DESCRIPTION
There are possible race condition i.e. context switches between calling to
```cpp
rosbag2_storage::SerializedBagMessageSharedPtr * message_ptr = message_queue_.peek()
```
and
```cpp
if (message_ptr == nullptr && !is_storage_completely_loaded() && rclcpp::ok())
```
in [`Player::peek_next_message_from_queue()`](https://github.com/ros2/rosbag2/blob/master/rosbag2_transport/src/rosbag2_transport/player.cpp#L287-L288)
It could lead to the situation that last message from bag will not be played when message queue is starving.

While this is a very rare case in real life it could cause flakiness on CI.

To fix this issue it will be enough to recheck 
```cpp
if (message_ptr == nullptr) {
    message_ptr = message_queue_.peek();
  }
```
before returning from method.