### PR TITLE
Fix deprecated subscriber callback warnings

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -173,7 +173,7 @@ private:
       });
   }
 
-  void topic_callback(const test_msgs::msg::BasicTypes::SharedPtr /* msg */)
+  void topic_callback(const test_msgs::msg::BasicTypes::ConstSharedPtr /* msg */)
   {
     {
       std::lock_guard<std::mutex> lk(got_msg_mutex_);


### PR DESCRIPTION
ros2/rclcpp#1713 deprecates the `void shared_ptr<T>` subscription callback signatures, so this PR migrates away from said signatures.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>