### PR TITLE
Add stopRecording into rosbag2_py

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -153,13 +153,13 @@ public:
 class Recorder
 {
 private:
-  rclcpp::executors::SingleThreadedExecutor * exec_;
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
 
 public:
   Recorder()
   {
     rclcpp::init(0, nullptr);
-    exec_ = new rclcpp::executors::SingleThreadedExecutor;
+    exec_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
     std::signal(
       SIGTERM, [](int /* signal */) {
         rclcpp::shutdown();
@@ -168,7 +168,6 @@ public:
 
   virtual ~Recorder()
   {
-    delete exec_;
     rclcpp::shutdown();
   }
 

--- a/rosbag2_py/test/common.py
+++ b/rosbag2_py/test/common.py
@@ -15,8 +15,8 @@
 import time
 from typing import Callable
 
-from rclpy.duration import Duration
 from rclpy.clock import Clock, ClockType
+from rclpy.duration import Duration
 import rosbag2_py
 
 

--- a/rosbag2_py/test/common.py
+++ b/rosbag2_py/test/common.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+from typing import Callable
+
+from rclpy.duration import Duration
+from rclpy.clock import Clock, ClockType
 import rosbag2_py
 
 
@@ -23,3 +28,17 @@ def get_rosbag_options(path, serialization_format='cdr'):
         output_serialization_format=serialization_format)
 
     return storage_options, converter_options
+
+
+def wait_for(
+    condition: Callable[[], bool],
+    timeout: Duration,
+    sleep_time: float = 0.1,
+):
+    clock = Clock(clock_type=ClockType.STEADY_TIME)
+    start = clock.now()
+    while not condition():
+        if clock.now() - start > timeout:
+            return False
+        time.sleep(sleep_time)
+        return True

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -82,8 +82,6 @@ def test_record_cancel(tmp_path):
         pub.publish(msg)
 
     recorder.cancel()
-    msg.data = 'Spining one last time'
-    pub.publish(msg)
 
     time_counter = 0
     while (not os.path.exists(Path(bag_path) / 'metadata.yaml') or

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -17,10 +17,9 @@ from pathlib import Path
 import os
 import sys
 import threading
-import time
 
 
-from common import get_rosbag_options
+from common import get_rosbag_options, wait_for
 import rclpy
 from rclpy.qos import QoSProfile
 from std_msgs.msg import String
@@ -83,13 +82,7 @@ def test_record_cancel(tmp_path):
 
     recorder.cancel()
 
-    time_counter = 0
-    while (not os.path.exists(Path(bag_path) / 'metadata.yaml') or
-           not os.path.exists(Path(bag_path) / 'test_record_cancel_0.db3')):
-        time.sleep(0.1)
-        time_counter += 1
-        if time_counter >= 10:
-            break
-
-    assert (Path(bag_path) / 'metadata.yaml').exists()
-    assert (Path(bag_path) / 'test_record_cancel_0.db3').exists()
+    metadata_path = Path(bag_path) / 'metadata.yaml'
+    db3_path = Path(bag_path) / 'test_record_cancel_0.db3'
+    assert wait_for(lambda: metadata_path.is_file() and db3_path.is_file(),
+                    timeout=rclpy.duration.Duration(seconds=3))

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+from pathlib import Path
 import os
 import sys
+import threading
+import time
 
+
+from common import get_rosbag_options
+import rclpy
 from rclpy.qos import QoSProfile
+from std_msgs.msg import String
+import rosbag2_py
 
 if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
     # This is needed on Linux when compiling with clang/libc++.
@@ -23,8 +32,6 @@ if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
     #
     # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
     sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
-
-import rosbag2_py  # noqa
 
 
 def test_options_qos_conversion():
@@ -40,3 +47,51 @@ def test_options_qos_conversion():
     record_options = rosbag2_py.RecordOptions()
     record_options.topic_qos_profile_overrides = simple_overrides
     assert record_options.topic_qos_profile_overrides == simple_overrides
+
+
+def test_record_cancel(tmp_path):
+    bag_path = str(tmp_path / 'test_record_cancel')
+    storage_options, converter_options = get_rosbag_options(bag_path)
+
+    recorder = rosbag2_py.Recorder()
+
+    record_options = rosbag2_py.RecordOptions()
+    record_options.all = True
+    record_options.is_discovery_disabled = False
+    record_options.rmw_serialization_format = ""
+    record_options.topic_polling_interval = datetime.timedelta(milliseconds=100)
+
+    rclpy.init()
+    record_thread = threading.Thread(
+        target=recorder.record,
+        args=(storage_options, record_options),
+        daemon=True)
+    record_thread.start()
+
+    node = rclpy.create_node('test_record_cancel')
+    executor = rclpy.executors.SingleThreadedExecutor()
+    executor.add_node(node)
+    pub = node.create_publisher(String, 'chatter', 10)
+
+    i = 0
+    msg = String()
+
+    while rclpy.ok() and i < 10:
+        msg.data = 'Hello World: {0}'.format(i)
+        i += 1
+        pub.publish(msg)
+
+    recorder.cancel()
+    msg.data = 'Spining one last time'
+    pub.publish(msg)
+
+    time_counter = 0
+    while (not os.path.exists(Path(bag_path) / 'metadata.yaml') or
+           not os.path.exists(Path(bag_path) / 'test_record_cancel_0.db3')):
+        time.sleep(0.1)
+        time_counter += 1
+        if time_counter >= 10:
+            break
+
+    assert (Path(bag_path) / 'metadata.yaml').exists()
+    assert (Path(bag_path) / 'test_record_cancel_0.db3').exists()

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import datetime
-from pathlib import Path
 import os
+from pathlib import Path
 import sys
 import threading
 
@@ -22,8 +22,8 @@ import threading
 from common import get_rosbag_options, wait_for
 import rclpy
 from rclpy.qos import QoSProfile
-from std_msgs.msg import String
 import rosbag2_py
+from std_msgs.msg import String
 
 if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
     # This is needed on Linux when compiling with clang/libc++.
@@ -57,7 +57,6 @@ def test_record_cancel(tmp_path):
     record_options = rosbag2_py.RecordOptions()
     record_options.all = True
     record_options.is_discovery_disabled = False
-    record_options.rmw_serialization_format = ""
     record_options.topic_polling_interval = datetime.timedelta(milliseconds=100)
 
     rclpy.init()


### PR DESCRIPTION
This PR implements a command to stop recording a rosbag without the need of using ctrl+c

In my development, I was trying to find a way to stop recording the rosbag using the python API without the need of closing the terminal. I've tried to kill the process using the PID I received from the python Recorder() the value differs from the PID used inside the rosdbag2_transport wrapper. In this case, I've created a method that when it is called it sends a SIGTERM to terminate the process without the need of closing my application.