### PR TITLE
Missing std_msgs depend in simple_bag_recorder sample

### DIFF
--- a/rosbag2_samples/api_samples/bag_recorder_nodes/CMakeLists.txt
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/CMakeLists.txt
@@ -14,12 +14,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
-find_package(example_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 
 add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
 ament_target_dependencies(simple_bag_recorder
+  std_msgs
   rclcpp
   rosbag2_cpp)
 

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/package.xml
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/package.xml
@@ -9,9 +9,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>example_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>
-  <depend>example_interfaces</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
https://github.com/ros2/rosbag2/pull/800 added the simple_bag_recorder file, which [uses `std_msgs`](https://github.com/ros2/rosbag2/pull/800/files#diff-944bba4d88aecb5c0e6da7da34a658cb39b5d9cd8a9124f144b13db55cd55f4dR17) but does not declare it in package.xml making CI to cry: [Fci__nightly-release_ubuntu_focal_amd64](https://build.ros2.org/view/Fci/job/Fci__nightly-release_ubuntu_focal_amd64/309/) and [Fci__nightly-fastrtps_ubuntu_focal_amd64](https://build.ros2.org/view/Fci/job/Fci__nightly-fastrtps_ubuntu_focal_amd64/318/).

I'm also alpha-order the depends in the PR.