### PR TITLE
Add API samples for writing to bags programmatically

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
         linter: ${{ matrix.linter }}
         distribution: rolling
         package-name: |
+            bag_recorder_nodes
             ros2bag
             rosbag2
             rosbag2_compression
@@ -50,6 +51,7 @@ jobs:
         linter: ${{ matrix.linter }}
         distribution: rolling
         package-name: |
+            bag_recorder_nodes
             rosbag2_compression
             rosbag2_compression_zstd
             rosbag2_cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -150,7 +150,7 @@ public:
    * Write a non-serialized message to a bagfile.
    * The topic will be created if it has not been created already.
    *
-   * \param message MessageT The serialized message to be written to the bagfile
+   * \param message MessageT The non-serialized message to be written to the bagfile
    * \param topic_name the string of the topic this messages belongs to
    * \param type_name the string of the type associated with this message
    * \param time The time stamp of the message

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/CMakeLists.txt
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/CMakeLists.txt
@@ -47,12 +47,6 @@ install(TARGETS
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/CMakeLists.txt
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.5)
+project(bag_recorder_nodes)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
+find_package(example_interfaces REQUIRED)
+
+add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
+ament_target_dependencies(simple_bag_recorder rclcpp rosbag2_cpp example_interfaces)
+
+install(TARGETS
+  simple_bag_recorder
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(data_generator_node src/data_generator_node.cpp)
+ament_target_dependencies(data_generator_node rclcpp rosbag2_cpp example_interfaces)
+
+install(TARGETS
+  data_generator_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(data_generator_executable src/data_generator_executable.cpp)
+ament_target_dependencies(data_generator_executable rclcpp rosbag2_cpp example_interfaces)
+
+install(TARGETS
+  data_generator_executable
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/package.xml
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>bag_recorder_nodes</name>
+  <version>0.0.0</version>
+  <description>C++ bag writing tutorial</description>
+  <maintainer email="gbiggs@killbots.net">geoff</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rosbag2_cpp</depend>
+  <depend>example_interfaces</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_executable.cpp
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_executable.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include <rclcpp/rclcpp.hpp>  // For rclcpp::Clock, rclcpp::Duration and rclcpp::Time
+#include <example_interfaces/msg/int32.hpp>
+
+#include <rosbag2_cpp/writer.hpp>
+#include <rosbag2_cpp/writers/sequential_writer.hpp>
+#include <rosbag2_storage/serialized_bag_message.hpp>
+
+using namespace std::chrono_literals;
+
+int main(int, char**)
+{
+  example_interfaces::msg::Int32 data;
+  data.data = 0;
+  std::unique_ptr<rosbag2_cpp::Writer> writer_ = std::make_unique<rosbag2_cpp::Writer>();
+
+  writer_->open("big_synthetic_bag");
+
+  writer_->create_topic(
+    {"synthetic",
+     "example_interfaces/msg/Int32",
+     rmw_get_serialization_format(),
+     ""});
+
+  rclcpp::Clock clock;
+  rclcpp::Time time_stamp = clock.now();
+  for (int32_t ii = 0; ii < 100; ++ii) {
+    writer_->write(data, "synthetic", time_stamp);
+    ++data.data;
+    time_stamp += rclcpp::Duration(1s);
+  }
+
+  return 0;
+}

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_executable.cpp
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_executable.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Open Source Robotics Foundation
+// Copyright 2021 Open Source Robotics Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,17 +13,18 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
 
-#include <rclcpp/rclcpp.hpp>  // For rclcpp::Clock, rclcpp::Duration and rclcpp::Time
-#include <example_interfaces/msg/int32.hpp>
+#include "example_interfaces/msg/int32.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-#include <rosbag2_cpp/writer.hpp>
-#include <rosbag2_cpp/writers/sequential_writer.hpp>
-#include <rosbag2_storage/serialized_bag_message.hpp>
+#include "rosbag2_cpp/writer.hpp"
+#include "rosbag2_cpp/writers/sequential_writer.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
 
 using namespace std::chrono_literals;
 
-int main(int, char**)
+int main(int, char **)
 {
   example_interfaces::msg::Int32 data;
   data.data = 0;
@@ -32,10 +33,12 @@ int main(int, char**)
   writer_->open("big_synthetic_bag");
 
   writer_->create_topic(
-    {"synthetic",
-     "example_interfaces/msg/Int32",
-     rmw_get_serialization_format(),
-     ""});
+  {
+    "synthetic",
+    "example_interfaces/msg/Int32",
+    rmw_get_serialization_format(),
+    ""
+  });
 
   rclcpp::Clock clock;
   rclcpp::Time time_stamp = clock.now();

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_node.cpp
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_node.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Open Source Robotics Foundation
+// Copyright 2021 Open Source Robotics Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 #include <chrono>
+#include <memory>
 
-#include <example_interfaces/msg/int32.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include "example_interfaces/msg/int32.hpp"
+#include "rclcpp/rclcpp.hpp"
 
-#include <rosbag2_cpp/writer.hpp>
+#include "rosbag2_cpp/writer.hpp"
 
 using namespace std::chrono_literals;
 
@@ -33,10 +34,12 @@ public:
     writer_->open("timed_synthetic_bag");
 
     writer_->create_topic(
-      {"synthetic",
-       "example_interfaces/msg/Int32",
-       rmw_get_serialization_format(),
-       ""});
+    {
+      "synthetic",
+      "example_interfaces/msg/Int32",
+      rmw_get_serialization_format(),
+      ""
+    });
 
     timer_ = create_wall_timer(1s, std::bind(&DataGenerator::timer_callback, this));
   }

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_node.cpp
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/src/data_generator_node.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2021 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include <example_interfaces/msg/int32.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <rosbag2_cpp/writer.hpp>
+
+using namespace std::chrono_literals;
+
+class DataGenerator : public rclcpp::Node
+{
+public:
+  DataGenerator()
+  : Node("data_generator")
+  {
+    data.data = 0;
+    writer_ = std::make_unique<rosbag2_cpp::Writer>();
+
+    writer_->open("timed_synthetic_bag");
+
+    writer_->create_topic(
+      {"synthetic",
+       "example_interfaces/msg/Int32",
+       rmw_get_serialization_format(),
+       ""});
+
+    timer_ = create_wall_timer(1s, std::bind(&DataGenerator::timer_callback, this));
+  }
+
+private:
+  void timer_callback()
+  {
+    writer_->write(data, "synthetic", now());
+
+    ++data.data;
+  }
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::unique_ptr<rosbag2_cpp::Writer> writer_;
+  example_interfaces::msg::Int32 data;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<DataGenerator>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/src/simple_bag_recorder.cpp
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/src/simple_bag_recorder.cpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2021 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+#include <example_interfaces/msg/string.hpp>
+
+#include <rosbag2_cpp/writer.hpp>
+
+using std::placeholders::_1;
+
+class SimpleBagRecorder : public rclcpp::Node
+{
+public:
+  SimpleBagRecorder()
+  : Node("simple_bag_recorder")
+  {
+    writer_ = std::make_unique<rosbag2_cpp::Writer>();
+
+    writer_->open("my_bag");
+
+    subscription_ = create_subscription<example_interfaces::msg::String>(
+      "chatter", 10, std::bind(&SimpleBagRecorder::topic_callback, this, _1));
+  }
+
+private:
+  void topic_callback(std::shared_ptr<rclcpp::SerializedMessage> msg) const
+  {
+    rclcpp::Time time_stamp = this->now();
+
+    writer_->write(*msg, "chatter", "example_interfaces/msg/String", time_stamp);
+  }
+
+  rclcpp::Subscription<rclcpp::SerializedMessage>::SharedPtr subscription_;
+  std::unique_ptr<rosbag2_cpp::Writer> writer_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<SimpleBagRecorder>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rosbag2_samples/api_samples/bag_recorder_nodes/src/simple_bag_recorder.cpp
+++ b/rosbag2_samples/api_samples/bag_recorder_nodes/src/simple_bag_recorder.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Open Source Robotics Foundation
+// Copyright 2021 Open Source Robotics Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rclcpp/rclcpp.hpp>
-#include <example_interfaces/msg/string.hpp>
+#include <memory>
 
-#include <rosbag2_cpp/writer.hpp>
+#include "example_interfaces/msg/string.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rosbag2_cpp/writer.hpp"
 
 using std::placeholders::_1;
 


### PR DESCRIPTION
This PR adds some sample code for writing to bag files programmatically. There are three samples: writing received data from a node, writing generated data from a node, and writing generated data from an executable. These samples correspond to the [documentation tutorial PR for writing to a bag](https://github.com/ros2/ros2_documentation/pull/1915).