### PR TITLE
Use Reader's seek() method for seeking/jumping in Player

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -137,16 +137,15 @@ Player::Player(
   {
     std::lock_guard<std::mutex> lk(reader_mutex_);
     reader_ = std::move(reader);
+    // keep reader open until player is destroyed
     reader_->open(storage_options_, {"", rmw_get_serialization_format()});
-    const auto starting_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-      reader_->get_metadata().starting_time.time_since_epoch()).count();
-    clock_ = std::make_unique<rosbag2_cpp::TimeControllerClock>(starting_time);
+    auto metadata = reader_->get_metadata();
+    starting_time_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      metadata.starting_time.time_since_epoch()).count();
+    clock_ = std::make_unique<rosbag2_cpp::TimeControllerClock>(starting_time_);
     set_rate(play_options_.rate);
-
     topic_qos_profile_overrides_ = play_options_.topic_qos_profile_overrides;
     prepare_publishers();
-
-    reader_->close();
   }
   // service callbacks
   srv_pause_ = create_service<rosbag2_interfaces::srv::Pause>(
@@ -230,13 +229,6 @@ Player::~Player()
   }
 }
 
-rosbag2_cpp::Reader * Player::release_reader()
-{
-  std::lock_guard<std::mutex> lk(reader_mutex_);
-  reader_->close();
-  return reader_.release();
-}
-
 const std::chrono::milliseconds
 Player::queue_read_wait_period_ = std::chrono::milliseconds(100);
 
@@ -268,17 +260,12 @@ void Player::play()
         std::chrono::nanoseconds duration(delay.nanoseconds());
         std::this_thread::sleep_for(duration);
       }
-      rcutils_time_point_value_t starting_time = 0;
       {
         std::lock_guard<std::mutex> lk(reader_mutex_);
-        reader_->open(storage_options_, {"", rmw_get_serialization_format()});
-        starting_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-          reader_->get_metadata().starting_time.time_since_epoch()).count();
+        reader_->seek(starting_time_);
+        clock_->jump(starting_time_);
       }
-      clock_->jump(starting_time);
-
       storage_loading_future_ = std::async(std::launch::async, [this]() {load_storage_content();});
-
       wait_for_filled_queue();
       play_messages_from_queue();
       {
@@ -286,8 +273,6 @@ void Player::play()
         is_ready_to_play_from_queue_ = false;
         ready_to_play_from_queue_cv_.notify_all();
       }
-      std::lock_guard<std::mutex> lk(reader_mutex_);
-      reader_->close();
     } while (rclcpp::ok() && play_options_.loop);
   } catch (std::runtime_error & e) {
     RCLCPP_ERROR(get_logger(), "Failed to play: %s", e.what());
@@ -383,24 +368,7 @@ bool Player::play_next()
   return next_message_published;
 }
 
-void Player::restore_message_queue_from_storage(
-  rosbag2_storage::SerializedBagMessageSharedPtr origin_message)
-{
-  if (!origin_message) {return;}
-  reader_->close();
-  reader_->open(storage_options_, {"", rmw_get_serialization_format()});
-  rosbag2_storage::SerializedBagMessageSharedPtr current_message = reader_->read_next();
-  while (current_message->time_stamp != origin_message->time_stamp) {
-    current_message = reader_->read_next();
-  }
-  if (current_message->time_stamp != origin_message->time_stamp) {
-    throw std::runtime_error("Fail to restore message queue");
-  }
-  message_queue_.enqueue(current_message);
-  enqueue_up_to_boundary(play_options_.read_ahead_queue_size);  // refill queue
-}
-
-bool Player::seek(rcutils_time_point_value_t time_point)
+void Player::seek(rcutils_time_point_value_t time_point)
 {
   // Temporary stop playback in play_messages_from_queue() and block play_next()
   std::lock_guard<std::mutex> main_play_loop_lk(skip_message_in_main_play_loop_mutex_);
@@ -411,103 +379,24 @@ bool Player::seek(rcutils_time_point_value_t time_point)
     std::unique_lock<std::mutex> lk(ready_to_play_from_queue_mutex_);
     ready_to_play_from_queue_cv_.wait(lk, [this] {return is_ready_to_play_from_queue_;});
   }
-
   cancel_wait_for_next_message_ = true;
-  bool message_found = false;
-  rosbag2_storage::SerializedBagMessageSharedPtr * message_ptr = peek_next_message_from_queue();
-  rosbag2_storage::SerializedBagMessageSharedPtr message_before_seek;
-  if (message_ptr != nullptr) {
-    message_before_seek = *message_ptr;
+  // if given seek value is earlier than the beginning of the bag, then clamp
+  // it to the beginning of the bag
+  if (time_point < starting_time_) {
+    time_point = starting_time_;
   }
-
-  {  // Update message queue and adjust reader pointer
+  {
     std::lock_guard<std::mutex> lk(reader_mutex_);
-    // Read next current_message
-    rosbag2_storage::SerializedBagMessageSharedPtr current_message;
-    if (!message_queue_.try_dequeue(current_message)) {
-      if (!reader_->has_next()) {
-        reader_->close();
-        reader_->open(storage_options_, {"", rmw_get_serialization_format()});
-        if (!reader_->has_next()) {
-          return false;  // The bag is empty
-        }
-        // else means that we were at the end of the bag when we were started and will try to
-        // search from the beginning
-        assert(is_storage_completely_loaded());
-        storage_loading_future_ =
-          std::async(std::launch::async, [this]() {load_storage_content();});
-      }
-      current_message = reader_->read_next();
-    }
-
-    const bool jump_forward = (time_point >= current_message->time_stamp);
-
-    if (jump_forward) {
-      if (current_message->time_stamp >= time_point) {
-        message_found = true;
-      }
-      // Pop up current_message queue trying to find current_message with needed timestamp
-      while (!message_found && message_queue_.try_dequeue(current_message)) {
-        if (current_message->time_stamp >= time_point) {
-          message_found = true;
-        }
-      }
-      while (!message_found && reader_->has_next()) {
-        current_message = reader_->read_next();
-        if (current_message->time_stamp >= time_point) {
-          message_found = true;
-        }
-      }
-      if (message_found) {
-        // Enqueue current_message and rest of the queue to the queue again to preserve order of
-        // messages
-        if (message_queue_.peek() != nullptr) {  // if message_queue_ not empty
-          decltype(message_queue_) temp_message_queue;
-          temp_message_queue.enqueue(current_message);
-          // Copy residual messages from message_queue_ to the temp_message_queue
-          while (message_queue_.try_dequeue(current_message)) {
-            temp_message_queue.enqueue(current_message);
-          }
-          // Copy all messages back to the message_queue_
-          while (temp_message_queue.try_dequeue(current_message)) {
-            message_queue_.enqueue(current_message);
-          }
-          enqueue_up_to_boundary(play_options_.read_ahead_queue_size);  // refill queue
-        } else {
-          message_queue_.enqueue(current_message);
-          enqueue_up_to_boundary(play_options_.read_ahead_queue_size);  // refill queue
-        }
-      } else {
-        restore_message_queue_from_storage(message_before_seek);
-      }
-    } else {  // jump_backward
-      // Purge queue
-      while (message_queue_.pop()) {}
-      // Reopen bag
-      reader_->close();
-      reader_->open(storage_options_, {"", rmw_get_serialization_format()});
-
-      // Try to find current_message in bag with timestamp >= time_point
-      while (!message_found && reader_->has_next()) {
-        current_message = reader_->read_next();
-        if (current_message->time_stamp >= time_point) {
-          message_found = true;
-        }
-      }
-      if (message_found) {
-        message_queue_.enqueue(current_message);
-        enqueue_up_to_boundary(play_options_.read_ahead_queue_size);  // refill queue
-      } else {
-        restore_message_queue_from_storage(message_before_seek);
-      }
-    }
-  }
-
-  if (message_found) {
+    // Purge current messages in queue.
+    while (message_queue_.pop()) {}
+    reader_->seek(time_point);
     clock_->jump(time_point);
-    return true;
-  } else {
-    return false;
+    // Restart queuing thread if it has finished running (previously reached end of bag),
+    // otherwise, queueing should continue automatically after releasing mutex
+    if (is_storage_completely_loaded() && rclcpp::ok()) {
+      storage_loading_future_ =
+        std::async(std::launch::async, [this]() {load_storage_content();});
+    }
   }
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -353,6 +353,7 @@ bool Player::play_next()
     std::unique_lock<std::mutex> lk(ready_to_play_from_queue_mutex_);
     ready_to_play_from_queue_cv_.wait(lk, [this] {return is_ready_to_play_from_queue_;});
   }
+
   rosbag2_storage::SerializedBagMessageSharedPtr * message_ptr = peek_next_message_from_queue();
 
   bool next_message_published = false;
@@ -475,6 +476,11 @@ void Player::play_messages_from_queue()
     }
     message_queue_.pop();
     message_ptr = peek_next_message_from_queue();
+  }
+  // while we're in pause state, make sure we don't return
+  // if we happen to be at the end of queue
+  while (is_paused()) {
+    clock_->sleep_until(clock_->now());
   }
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -82,6 +82,7 @@ public:
   void seek(const rcutils_time_point_value_t & timestamp) override
   {
     seek_time_ = timestamp;
+    num_read_ = 0;
   }
 
   void prepare(

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -120,11 +120,11 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_back_in_time) {
   EXPECT_TRUE(player->play_next());
 
   // Jump in timestamp equal to the timestamp in first message - 1 nanosecond
-  EXPECT_TRUE(player->seek(start_time_ms_ * 1000000 - 1));
+  player->seek(start_time_ms_ * 1000000 - 1);
   EXPECT_TRUE(player->play_next());
   EXPECT_TRUE(player->play_next());
   // Jump in timestamp equal to the timestamp in first message
-  EXPECT_TRUE(player->seek(start_time_ms_ * 1000000));
+  player->seek(start_time_ms_ * 1000000);
   EXPECT_TRUE(player->play_next());
   EXPECT_TRUE(player->play_next());
   player->resume();
@@ -145,7 +145,7 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_back_in_time) {
 }
 
 TEST_F(RosBag2PlaySeekTestFixture, seek_with_timestamp_later_than_in_last_message) {
-  const size_t expected_number_of_messages = num_msgs_in_bag_;
+  const size_t expected_number_of_messages = 0;
   auto player = std::make_shared<MockPlayer>(std::move(reader_), storage_options_, play_options_);
 
   sub_ = std::make_shared<SubscriptionManager>();
@@ -166,23 +166,16 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_with_timestamp_later_than_in_last_messag
   EXPECT_TRUE(player->play_next());
 
   // Jump in timestamp equal to the timestamp in last message + 1 nanosecond
-  EXPECT_FALSE(
-    player->seek(
-      (start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1)
-  );
+  player->seek((start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1);
 
-  EXPECT_TRUE(player->play_next());
-  EXPECT_TRUE(player->play_next());
+  // shouldn't be able to keep playing since we're at end of bag
+  EXPECT_FALSE(player->play_next());
   player->resume();
   player_future.get();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
   ASSERT_THAT(replayed_topic1, SizeIs(expected_number_of_messages));
-
-  for (size_t i = 0; i < replayed_topic1.size(); i++) {
-    EXPECT_EQ(replayed_topic1[i]->int32_value, static_cast<int32_t>(i + 1)) << "i=" << i;
-  }
 }
 
 TEST_F(RosBag2PlaySeekTestFixture, seek_forward) {
@@ -207,7 +200,7 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_forward) {
   EXPECT_TRUE(player->play_next());
 
   // Jump on third message (1200 ms)
-  EXPECT_TRUE(player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000));
+  player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
   EXPECT_TRUE(player->play_next());
   player->resume();
   player_future.get();
@@ -249,7 +242,7 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_back_in_time_from_the_end_of_the_bag) {
   EXPECT_FALSE(player->play_next());  // Make sure there are no messages to play
 
   // Jump on third message (1200 ms)
-  EXPECT_TRUE(player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000));
+  player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
   EXPECT_TRUE(player->play_next());
   player->resume();
   player_future.get();
@@ -295,10 +288,7 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_forward_from_the_end_of_the_bag) {
   EXPECT_FALSE(player->play_next());  // Make sure there are no messages to play
 
   // Jump in timestamp equal to the timestamp in last message + 1 nanosecond
-  EXPECT_FALSE(
-    player->seek(
-      (start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1)
-  );
+  player->seek((start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1);
   EXPECT_FALSE(player->play_next());
   player->resume();
   player_future.get();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -254,6 +254,12 @@ TEST_F(PlaySrvsTest, pause_resume)
     ASSERT_TRUE(is_paused());
   }
   expect_messages(false);
+
+  // resume to make sure we exit
+  for (size_t i = 0; i < 3; i++) {
+    successful_call<Resume>(cli_resume_);
+    ASSERT_FALSE(is_paused());
+  }
 }
 
 TEST_F(PlaySrvsTest, toggle_paused)


### PR DESCRIPTION
Closes #824 

The current `Player->seek()` was implemented before storage and by extension the reader exposed `seek` interface (#824). This PR updates the implementation to use the Reader's `seek()` method, which reduces the implementation complexity.

Other details:
- Reader's `seek()` method does not require closing and reopening. Thus it's preferable to just keep the reader open from the constructor, and close it in the destructor. Other methods can just assume an open reader and set `seek()` as needed.
- Removed the `release_reader()` method as the player is basically useless after releasing the reader anyway. This removes one more way the reader can get closed before play ends.
- Player `seek()` method no longer special cases seeking to a timestamp after the end of the bag. Previously, if no messages are found after the seek time, the Player will reset to the original time stamp before the seek method was called. Now, seek will always be performed, and seeking to a later timestamp will either end bag play or loop according to player options. This makes seek behavior to be consistent with the behavior of playing until the end of the bag. There is also no reason to return `true`/`false` depending on the success of seek, as the seek will always be successful.
