### PR TITLE
Updated benchmark package to use writer close() instead of old reset()

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
@@ -136,7 +136,7 @@ void WriterBenchmark::start_benchmark()
   for (auto & prod_thread : producer_threads_) {
     prod_thread.join();
   }
-  writer_->reset();
+  writer_->close();
 
   result_utils::write_benchmark_results(configurations_, bag_config_, results_file_);
 }


### PR DESCRIPTION
A minor fix which restores benchmarking package build.

`rosbag2_performance_benchmarking` stopped building since #760. The reason for this going under the radar might be that CI checks no longer build this package with required flag `BUILD_ROSBAG2_BENCHMARKS`. We need to address that by either removing the flag and making package build by default, or making sure the flag stays in auto checks.
