### PR TITLE
Declare missing dependency on 'git' in zstd_vendor

### DIFF
--- a/zstd_vendor/package.xml
+++ b/zstd_vendor/package.xml
@@ -14,6 +14,7 @@
   <url type="website">https://facebook.github.io/zstd/</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <depend>libzstd-dev</depend>
 


### PR DESCRIPTION
It looks like #846 took a dependency on git but didn't add the dependency on the `package.xml`. This has regressed the [RHEL build on build.ros2.org](https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__zstd_vendor__rhel_8_x86_64__binary/8/).

Because this package is in the critical path to `desktop`, the whole variant will be unavailable until this fix has been released.