### PR TITLE
[galactic] allow for implementation of composable recorder via inheritance

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -78,6 +78,12 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   const rosbag2_cpp::Writer & get_writer_handle();
 
+protected:
+  std::shared_ptr<rosbag2_cpp::Writer> writer_;
+  rosbag2_storage::StorageOptions storage_options_;
+  rosbag2_transport::RecordOptions record_options_;
+  std::atomic<bool> stop_discovery_;
+
 private:
   void topics_discovery();
 
@@ -111,10 +117,6 @@ private:
 
   void warn_if_new_qos_for_subscribed_topic(const std::string & topic_name);
 
-  std::shared_ptr<rosbag2_cpp::Writer> writer_;
-  rosbag2_storage::StorageOptions storage_options_;
-  rosbag2_transport::RecordOptions record_options_;
-  std::atomic<bool> stop_discovery_;
   std::future<void> discovery_future_;
   std::unordered_map<std::string, std::shared_ptr<rclcpp::GenericSubscription>> subscriptions_;
   std::unordered_set<std::string> topics_warned_about_incompatibility_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -55,7 +55,6 @@ Recorder::Recorder(
   // TODO(karsten1987): Use this constructor later with parameter parsing.
   // The reader, storage_options as well as record_options can be loaded via parameter.
   // That way, the recorder can be used as a simple component in a component manager.
-  throw rclcpp::exceptions::UnimplementedError();
 }
 
 Recorder::Recorder(


### PR DESCRIPTION
This PR is meant to be a stop gap measure until a full implementation of a composable Node is complete.

It will allow developers to write their own recorder node under galactic by inheriting from rosbag2_transport::Recorder and const-casting the references returned by the accessors. To make this work the constructor was changed to no longer throw an exception, but instead log a warning.

The motivation for this PR is the need to record high bandwidth and frequency data that interprocess communication was not able to handle.

