### PR TITLE
Provide MetadataIO interface to convert metadata to a string in memory, alongside file IO versions

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/metadata_io.hpp
@@ -39,6 +39,12 @@ public:
   ROSBAG2_STORAGE_PUBLIC
   virtual bool metadata_file_exists(const std::string & uri);
 
+  ROSBAG2_STORAGE_PUBLIC
+  virtual std::string serialize_metadata(const BagMetadata & metadata);
+
+  ROSBAG2_STORAGE_PUBLIC
+  virtual BagMetadata deserialize_metadata(const std::string & serialized_metadata);
+
 private:
   std::string get_metadata_file_name(const std::string & uri);
 };

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -284,4 +284,18 @@ bool MetadataIo::metadata_file_exists(const std::string & uri)
   return rcpputils::fs::exists(rcpputils::fs::path(get_metadata_file_name(uri)));
 }
 
+std::string MetadataIo::serialize_metadata(const BagMetadata & metadata)
+{
+  auto node = YAML::convert<BagMetadata>().encode(metadata);
+  std::stringstream out;
+  out << node;
+  return out.str();
+}
+
+BagMetadata MetadataIo::deserialize_metadata(const std::string & serialized_metadata)
+{
+  YAML::Node yaml = YAML::Load(serialized_metadata);
+  return yaml.as<BagMetadata>();
+}
+
 }  // namespace rosbag2_storage


### PR DESCRIPTION
This way storage plugins or other utilities can serialize into a string without having to go to a file.