### PR TITLE
Use the message_introspection header to get MessageMember.

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/types/introspection_message.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/types/introspection_message.hpp
@@ -20,14 +20,11 @@
 #include "rcutils/allocator.h"
 #include "rcutils/time.h"
 
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+
 #include "rosbag2_cpp/visibility_control.hpp"
 
 struct rosidl_message_type_support_t;
-
-namespace rosidl_typesupport_introspection_cpp
-{
-struct MessageMembers;
-}
 
 namespace rosbag2_cpp
 {


### PR DESCRIPTION
There is no reason to forward-declare it ourselves; just use
the header file that is provided.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>