### PR TITLE
Add --start-paused option to `ros2 bag play`

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -88,6 +88,9 @@ class PlayVerb(VerbExtension):
         parser.add_argument(
             '--disable-keyboard-controls', action='store_true',
             help='disables keyboard controls for playback')
+        parser.add_argument(
+            '-p', '--start-paused', action='store_true', default=False,
+            help='Start the playback player paused.')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -124,6 +127,7 @@ class PlayVerb(VerbExtension):
         play_options.clock_publish_frequency = args.clock
         play_options.delay = args.delay
         play_options.disable_keyboard_controls = args.disable_keyboard_controls
+        play_options.paused = args.start_paused
 
         player = Player()
         player.play(storage_options, play_options)

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -41,12 +41,14 @@ public:
    *   Used to control for unit testing, or for specialized needs
    * \param sleep_time_while_paused: Amount of time to sleep in `sleep_until` when the clock
    *   is paused. Allows the caller to spin at a defined rate while receiving `false`
+   * \param paused: Start the clock paused
    */
   ROSBAG2_CPP_PUBLIC
   TimeControllerClock(
     rcutils_time_point_value_t starting_time,
     NowFunction now_fn = std::chrono::steady_clock::now,
-    std::chrono::milliseconds sleep_time_while_paused = std::chrono::milliseconds{100});
+    std::chrono::milliseconds sleep_time_while_paused = std::chrono::milliseconds{100},
+    bool paused = false);
 
   ROSBAG2_CPP_PUBLIC
   virtual ~TimeControllerClock();

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -57,9 +57,10 @@ public:
   };
 
   explicit TimeControllerClockImpl(
-    PlayerClock::NowFunction now_fn, std::chrono::milliseconds sleep_time_while_paused)
+    PlayerClock::NowFunction now_fn, std::chrono::milliseconds sleep_time_while_paused, bool paused)
   : now_fn(now_fn),
-    sleep_time_while_paused(sleep_time_while_paused)
+    sleep_time_while_paused(sleep_time_while_paused),
+    paused(paused)
   {}
   virtual ~TimeControllerClockImpl() = default;
 
@@ -237,8 +238,9 @@ private:
 TimeControllerClock::TimeControllerClock(
   rcutils_time_point_value_t starting_time,
   NowFunction now_fn,
-  std::chrono::milliseconds sleep_time_while_paused)
-: impl_(std::make_unique<TimeControllerClockImpl>(now_fn, sleep_time_while_paused))
+  std::chrono::milliseconds sleep_time_while_paused,
+  bool paused)
+: impl_(std::make_unique<TimeControllerClockImpl>(now_fn, sleep_time_while_paused, paused))
 {
   if (now_fn == nullptr) {
     throw std::invalid_argument("TimeControllerClock now_fn must be non-empty.");

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -247,6 +247,7 @@ PYBIND11_MODULE(_transport, m) {
     &PlayOptions::getDelay,
     &PlayOptions::setDelay)
   .def_readwrite("disable_keyboard_controls", &PlayOptions::disable_keyboard_controls)
+  .def_readwrite("paused", &PlayOptions::paused)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -50,6 +50,9 @@ public:
   // Sleep before play. Negative durations invalid. Will delay at the beginning of each loop.
   rclcpp::Duration delay = rclcpp::Duration(0, 0);
 
+  // Start paused.
+  bool paused = false;
+
   bool disable_keyboard_controls = false;
   // keybindings
   KeyboardHandler::KeyCode pause_resume_toggle_key = KeyboardHandler::KeyCode::SPACE;

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -142,7 +142,9 @@ Player::Player(
     auto metadata = reader_->get_metadata();
     starting_time_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
       metadata.starting_time.time_since_epoch()).count();
-    clock_ = std::make_unique<rosbag2_cpp::TimeControllerClock>(starting_time_);
+    clock_ = std::make_unique<rosbag2_cpp::TimeControllerClock>(
+      starting_time_, std::chrono::steady_clock::now,
+      std::chrono::milliseconds{100}, play_options_.paused);
     set_rate(play_options_.rate);
     topic_qos_profile_overrides_ = play_options_.topic_qos_profile_overrides;
     prepare_publishers();


### PR DESCRIPTION
I think this was proposed in https://github.com/ros2/rosbag2/pull/443.

That PR ended up being closed in favor of https://github.com/ros2/rosbag2/issues/696, but an option to start the player in a paused state hasn't been added AFAIS.