### PR TITLE
Expose the QoS object wrapper

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -376,6 +376,7 @@ void SequentialWriter::finalize_metadata()
     }
   }
 
+
   metadata_.topics_with_message_count.clear();
   metadata_.topics_with_message_count.reserve(topics_names_to_info_.size());
   metadata_.message_count = 0;

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -376,7 +376,6 @@ void SequentialWriter::finalize_metadata()
     }
   }
 
-
   metadata_.topics_with_message_count.clear();
   metadata_.topics_with_message_count.reserve(topics_names_to_info_.size());
   metadata_.message_count = 0;

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -93,9 +93,7 @@ function(create_tests_for_rmw_implementation)
   endif()
 
   rosbag2_transport_add_gmock(test_play
-    src/rosbag2_transport/qos.cpp
     test/rosbag2_transport/test_play.cpp
-    INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
     LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common
     ${SKIP_TEST})

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -140,6 +140,7 @@ function(create_tests_for_rmw_implementation)
   rosbag2_transport_add_gmock(test_qos
     test/rosbag2_transport/test_qos.cpp
     INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    LINK_LIBS rosbag2_transport
     AMENT_DEPS rosbag2_test_common yaml_cpp_vendor)
 
   rosbag2_transport_add_gmock(test_record

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -138,11 +138,8 @@ function(create_tests_for_rmw_implementation)
       AMENT_DEPS test_msgs rosbag2_test_common)
 
   rosbag2_transport_add_gmock(test_qos
-    src/rosbag2_transport/qos.cpp
     test/rosbag2_transport/test_qos.cpp
-    INCLUDE_DIRS
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
+    INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     AMENT_DEPS rosbag2_test_common yaml_cpp_vendor)
 
   rosbag2_transport_add_gmock(test_record

--- a/rosbag2_transport/include/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/qos.hpp
@@ -21,6 +21,8 @@
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/qos.hpp"
 
+#include "rosbag2_transport/visibility_control.hpp"
+
 #ifdef _WIN32
 // This is necessary because of a bug in yaml-cpp's cmake
 #define YAML_CPP_DLL
@@ -40,11 +42,15 @@ namespace rosbag2_transport
 class Rosbag2QoS : public rclcpp::QoS
 {
 public:
+  ROSBAG2_TRANSPORT_PUBLIC
   Rosbag2QoS()
   : rclcpp::QoS(rmw_qos_profile_default.depth) {}
+
+  ROSBAG2_TRANSPORT_PUBLIC
   explicit Rosbag2QoS(const rclcpp::QoS & value)
   : rclcpp::QoS(value) {}
 
+  ROSBAG2_TRANSPORT_PUBLIC
   Rosbag2QoS & default_history()
   {
     keep_last(rmw_qos_profile_default.depth);
@@ -59,6 +65,7 @@ public:
     * - Does not specify Lifespan, Deadline, or Liveliness to be maximally compatible, because
     * these policies do not affect message delivery.
     */
+  ROSBAG2_TRANSPORT_PUBLIC
   static Rosbag2QoS adapt_request_to_offers(
     const std::string & topic_name,
     const std::vector<rclcpp::TopicEndpointInfo> & endpoints);
@@ -71,6 +78,7 @@ public:
     * that exact value is returned.
     * Otherwise, fall back to the rosbag2 default and emit a warning.
     */
+  ROSBAG2_TRANSPORT_PUBLIC
   static Rosbag2QoS adapt_offer_to_recorded_offers(
     const std::string & topic_name,
     const std::vector<Rosbag2QoS> & profiles);

--- a/rosbag2_transport/include/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/qos.hpp
@@ -39,18 +39,15 @@
 namespace rosbag2_transport
 {
 /// Simple wrapper around rclcpp::QoS to provide a default constructor for YAML deserialization.
-class Rosbag2QoS : public rclcpp::QoS
+class ROSBAG2_TRANSPORT_PUBLIC Rosbag2QoS : public rclcpp::QoS
 {
 public:
-  ROSBAG2_TRANSPORT_PUBLIC
   Rosbag2QoS()
   : rclcpp::QoS(rmw_qos_profile_default.depth) {}
 
-  ROSBAG2_TRANSPORT_PUBLIC
   explicit Rosbag2QoS(const rclcpp::QoS & value)
   : rclcpp::QoS(value) {}
 
-  ROSBAG2_TRANSPORT_PUBLIC
   Rosbag2QoS & default_history()
   {
     keep_last(rmw_qos_profile_default.depth);
@@ -65,7 +62,6 @@ public:
     * - Does not specify Lifespan, Deadline, or Liveliness to be maximally compatible, because
     * these policies do not affect message delivery.
     */
-  ROSBAG2_TRANSPORT_PUBLIC
   static Rosbag2QoS adapt_request_to_offers(
     const std::string & topic_name,
     const std::vector<rclcpp::TopicEndpointInfo> & endpoints);
@@ -78,7 +74,6 @@ public:
     * that exact value is returned.
     * Otherwise, fall back to the rosbag2 default and emit a warning.
     */
-  ROSBAG2_TRANSPORT_PUBLIC
   static Rosbag2QoS adapt_offer_to_recorded_offers(
     const std::string & topic_name,
     const std::vector<Rosbag2QoS> & profiles);

--- a/rosbag2_transport/include/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/qos.hpp
@@ -83,14 +83,14 @@ public:
 namespace YAML
 {
 template<>
-struct convert<rmw_time_t>
+struct ROSBAG2_TRANSPORT_PUBLIC convert<rmw_time_t>
 {
   static Node encode(const rmw_time_t & time);
   static bool decode(const Node & node, rmw_time_t & time);
 };
 
 template<>
-struct convert<rosbag2_transport::Rosbag2QoS>
+struct ROSBAG2_TRANSPORT_PUBLIC convert<rosbag2_transport::Rosbag2QoS>
 {
   static Node encode(const rosbag2_transport::Rosbag2QoS & qos);
   static bool decode(const Node & node, rosbag2_transport::Rosbag2QoS & qos);

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -35,7 +35,7 @@
 
 #include "rosbag2_storage/storage_filter.hpp"
 
-#include "qos.hpp"
+#include "rosbag2_transport/qos.hpp"
 
 namespace
 {

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -17,7 +17,7 @@
 
 #include "rclcpp/logging.hpp"
 
-#include "qos.hpp"
+#include "rosbag2_transport/qos.hpp"
 
 namespace
 {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -31,7 +31,7 @@
 
 #include "rosbag2_interfaces/srv/snapshot.hpp"
 
-#include "qos.hpp"
+#include "rosbag2_transport/qos.hpp"
 #include "topic_filter.hpp"
 
 #ifdef _WIN32

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -32,7 +32,7 @@
 #include "test_msgs/msg/basic_types.hpp"
 #include "test_msgs/message_fixtures.hpp"
 
-#include "qos.hpp"
+#include "rosbag2_transport/qos.hpp"
 
 #include "rosbag2_play_test_fixture.hpp"
 #include "rosbag2_transport_test_fixture.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
@@ -19,7 +19,7 @@
 
 #include "rmw/types.h"
 
-#include "qos.hpp"
+#include "rosbag2_transport/qos.hpp"
 
 TEST(TestQoS, serialization)
 {

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -30,7 +30,7 @@
 #include "test_msgs/msg/arrays.hpp"
 #include "test_msgs/message_fixtures.hpp"
 
-#include "qos.hpp"
+#include "rosbag2_transport/qos.hpp"
 #include "record_integration_fixture.hpp"
 
 TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are_recorded)


### PR DESCRIPTION
This PR exposes the QoS wrapper in `rosbag_transport` for use by external users. This enables users of rosbag2 to create their own `recorder` objects that mimic the behaviour of the provided `Recorder` object with regards to QoS.