### PR TITLE
Enable YAML encoding/decoding for RecordOptions and StorageOptions

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/result_utils.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/result_utils.cpp
@@ -22,23 +22,11 @@
 
 #include "rosbag2_storage/storage_options.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
+#include "rosbag2_storage/yaml.hpp"
 
 #include "rosbag2_performance_benchmarking/bag_config.hpp"
 #include "rosbag2_performance_benchmarking/publisher_group_config.hpp"
 #include "rosbag2_performance_benchmarking/config_utils.hpp"
-
-#ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
-// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-# pragma warning(push)
-# pragma warning(disable:4251)
-# pragma warning(disable:4275)
-#endif
-#include "yaml-cpp/yaml.h"
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 namespace result_utils
 {

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -110,6 +110,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_metadata_serialization ${PROJECT_NAME})
     ament_target_dependencies(test_metadata_serialization rosbag2_test_common)
   endif()
+
+  ament_add_gmock(test_storage_options
+    test/rosbag2_storage/test_storage_options.cpp)
+  target_include_directories(test_storage_options PRIVATE include)
+  target_link_libraries(test_storage_options ${PROJECT_NAME})
+  ament_target_dependencies(test_storage_options rosbag2_test_common)
 endif()
 
 ament_package()

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   src/rosbag2_storage/metadata_io.cpp
   src/rosbag2_storage/ros_helper.cpp
   src/rosbag2_storage/storage_factory.cpp
+  src/rosbag2_storage/storage_options.cpp
   src/rosbag2_storage/base_io_interface.cpp)
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
@@ -17,6 +17,9 @@
 
 #include <string>
 
+#include "rosbag2_storage/visibility_control.hpp"
+#include "rosbag2_storage/yaml.hpp"
+
 namespace rosbag2_storage
 {
 
@@ -53,5 +56,15 @@ public:
 };
 
 }  // namespace rosbag2_storage
+
+namespace YAML
+{
+template<>
+struct ROSBAG2_STORAGE_PUBLIC convert<rosbag2_storage::StorageOptions>
+{
+  static Node encode(const rosbag2_storage::StorageOptions & storage_options);
+  static bool decode(const Node & node, rosbag2_storage::StorageOptions & storage_options);
+};
+}  // namespace YAML
 
 #endif  // ROSBAG2_STORAGE__STORAGE_OPTIONS_HPP_

--- a/rosbag2_storage/include/rosbag2_storage/yaml.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/yaml.hpp
@@ -1,0 +1,46 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef ROSBAG2_STORAGE__YAML_HPP_
+#define ROSBAG2_STORAGE__YAML_HPP_
+
+#include <string>
+
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+# pragma warning(push)
+# pragma warning(disable:4251)
+# pragma warning(disable:4275)
+#endif
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
+
+namespace YAML
+{
+
+/// If "node" has a field named "field", then assign its value to "assign_to" destination.
+template<typename T>
+void optional_assign(const Node & node, std::string field, T & assign_to)
+{
+  if (node[field]) {
+    assign_to = node[field].as<T>();
+  }
+}
+
+}  // namespace YAML
+
+#endif  // ROSBAG2_STORAGE__YAML_HPP_

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -23,19 +23,7 @@
 #include "rcutils/filesystem.h"
 
 #include "rosbag2_storage/topic_metadata.hpp"
-
-#ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
-// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-# pragma warning(push)
-# pragma warning(disable:4251)
-# pragma warning(disable:4275)
-#endif
-#include "yaml-cpp/yaml.h"
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
+#include "rosbag2_storage/yaml.hpp"
 
 namespace YAML
 {

--- a/rosbag2_storage/src/rosbag2_storage/storage_options.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/storage_options.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "rosbag2_storage/storage_options.hpp"
+
+namespace YAML
+{
+
+Node convert<rosbag2_storage::StorageOptions>::encode(
+  const rosbag2_storage::StorageOptions & storage_options)
+{
+  Node node;
+  node["uri"] = storage_options.uri;
+  node["storage_id"] = storage_options.storage_id;
+  node["max_bagfile_size"] = storage_options.max_bagfile_size;
+  node["max_bagfile_duration"] = storage_options.max_bagfile_duration;
+  node["max_cache_size"] = storage_options.max_cache_size;
+  node["storage_preset_profile"] = storage_options.storage_preset_profile;
+  node["storage_config_uri"] = storage_options.storage_config_uri;
+  node["snapshot_mode"] = storage_options.snapshot_mode;
+  return node;
+}
+
+bool convert<rosbag2_storage::StorageOptions>::decode(
+  const Node & node, rosbag2_storage::StorageOptions & storage_options)
+{
+  storage_options.uri = node["uri"].as<std::string>();
+  optional_assign<std::string>(node, "storage_id", storage_options.storage_id);
+  optional_assign<uint64_t>(node, "max_bagfile_size", storage_options.max_bagfile_size);
+  optional_assign<uint64_t>(node, "max_bagfile_duration", storage_options.max_bagfile_duration);
+  optional_assign<uint64_t>(node, "max_cache_size", storage_options.max_cache_size);
+  optional_assign<std::string>(
+    node, "storage_preset_profile", storage_options.storage_preset_profile);
+  optional_assign<std::string>(node, "storage_config_uri", storage_options.storage_config_uri);
+  optional_assign<bool>(node, "snapshot_mode", storage_options.snapshot_mode);
+  return true;
+}
+
+}  // namespace YAML

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_options.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_options.cpp
@@ -1,0 +1,49 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "rosbag2_storage/storage_options.hpp"
+
+using namespace ::testing;  // NOLINT
+
+TEST(storage_options, test_yaml_serialization)
+{
+  rosbag2_storage::StorageOptions original;
+  original.uri = "some_uri";
+  original.storage_id = "storage";
+  original.max_bagfile_size = 5;
+  original.max_bagfile_duration = 120;
+  original.max_cache_size = 1024;
+  original.storage_preset_profile = "profile";
+  original.storage_config_uri = "config_uri";
+  original.snapshot_mode = true;
+
+  auto node = YAML::convert<rosbag2_storage::StorageOptions>().encode(original);
+
+  std::stringstream serializer;
+  serializer << node;
+
+  auto reconstructed_node = YAML::Load(serializer.str());
+  auto reconstructed = reconstructed_node.as<rosbag2_storage::StorageOptions>();
+
+  ASSERT_EQ(original.uri, reconstructed.uri);
+  ASSERT_EQ(original.storage_id, reconstructed.storage_id);
+  ASSERT_EQ(original.max_bagfile_size, reconstructed.max_bagfile_size);
+  ASSERT_EQ(original.max_bagfile_duration, reconstructed.max_bagfile_duration);
+  ASSERT_EQ(original.max_cache_size, reconstructed.max_cache_size);
+  ASSERT_EQ(original.storage_preset_profile, reconstructed.storage_preset_profile);
+  ASSERT_EQ(original.storage_config_uri, reconstructed.storage_config_uri);
+  ASSERT_EQ(original.snapshot_mode, reconstructed.snapshot_mode);
+}

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -31,22 +31,10 @@
 
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/yaml.hpp"
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_exception.hpp"
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_pragmas.hpp"
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.hpp"
-
-#ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
-// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-# pragma warning(push)
-# pragma warning(disable:4251)
-# pragma warning(disable:4275)
-#endif
-#include "yaml-cpp/yaml.h"
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 #include "../logging.hpp"
 

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_transport/player.cpp
   src/rosbag2_transport/qos.cpp
   src/rosbag2_transport/recorder.cpp
+  src/rosbag2_transport/record_options.cpp
   src/rosbag2_transport/topic_filter.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -193,6 +193,12 @@ if(BUILD_TESTING)
   include(cmake/rosbag2_transport_add_gmock.cmake)
   ament_lint_auto_find_test_dependencies()
   call_for_each_rmw_implementation(create_tests_for_rmw_implementation)
+
+  ament_add_gmock(test_record_options
+    test/rosbag2_transport/test_record_options.cpp)
+  target_include_directories(test_record_options PRIVATE include)
+  target_link_libraries(test_record_options ${PROJECT_NAME})
+
 endif()
 
 ament_package()

--- a/rosbag2_transport/include/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/qos.hpp
@@ -22,19 +22,7 @@
 #include "rclcpp/qos.hpp"
 
 #include "rosbag2_transport/visibility_control.hpp"
-
-#ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
-// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-# pragma warning(push)
-# pragma warning(disable:4251)
-# pragma warning(disable:4275)
-#endif
-#include "yaml-cpp/yaml.h"
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
+#include "rosbag2_storage/yaml.hpp"
 
 namespace rosbag2_transport
 {

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -21,17 +21,19 @@
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rosbag2_storage/yaml.hpp"
+#include "rosbag2_transport/visibility_control.hpp"
 
 namespace rosbag2_transport
 {
 struct RecordOptions
 {
 public:
-  bool all;
-  bool is_discovery_disabled;
+  bool all = false;
+  bool is_discovery_disabled = false;
   std::vector<std::string> topics;
   std::string rmw_serialization_format;
-  std::chrono::milliseconds topic_polling_interval;
+  std::chrono::milliseconds topic_polling_interval{100};
   std::string regex = "";
   std::string exclude = "";
   std::string node_prefix = "";
@@ -44,5 +46,15 @@ public:
 };
 
 }  // namespace rosbag2_transport
+
+namespace YAML
+{
+template<>
+struct ROSBAG2_TRANSPORT_PUBLIC convert<rosbag2_transport::RecordOptions>
+{
+  static Node encode(const rosbag2_transport::RecordOptions & storage_options);
+  static bool decode(const Node & node, rosbag2_transport::RecordOptions & storage_options);
+};
+}  // namespace YAML
 
 #endif  // ROSBAG2_TRANSPORT__RECORD_OPTIONS_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -1,0 +1,93 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "rosbag2_transport/qos.hpp"
+#include "rosbag2_transport/record_options.hpp"
+
+namespace YAML
+{
+
+template<>
+struct convert<std::chrono::milliseconds>
+{
+  static Node encode(const std::chrono::milliseconds & millis)
+  {
+    Node node{millis.count()};
+    return node;
+  }
+
+  static bool decode(const Node & node, std::chrono::milliseconds & millis)
+  {
+    millis = std::chrono::milliseconds{node.as<int>()};
+    return true;
+  }
+};
+
+Node convert<rosbag2_transport::RecordOptions>::encode(
+  const rosbag2_transport::RecordOptions & record_options)
+{
+  Node node;
+  node["all"] = record_options.all;
+  node["is_discovery_disabled"] = record_options.is_discovery_disabled;
+  node["topics"] = record_options.topics;
+  node["rmw_serialization_format"] = record_options.rmw_serialization_format;
+  node["topic_polling_interval"] = record_options.topic_polling_interval;
+  node["regex"] = record_options.regex;
+  node["exclude"] = record_options.exclude;
+  node["node_prefix"] = record_options.node_prefix;
+  node["compression_mode"] = record_options.compression_mode;
+  node["compression_format"] = record_options.compression_format;
+  node["compression_queue_size"] = record_options.compression_queue_size;
+  node["compression_threads"] = record_options.compression_threads;
+  std::map<std::string, rosbag2_transport::Rosbag2QoS> qos_overrides(
+    record_options.topic_qos_profile_overrides.begin(),
+    record_options.topic_qos_profile_overrides.end());
+  node["topic_qos_profile_overrides"] = qos_overrides;
+  node["include_hidden_topics"] = record_options.include_hidden_topics;
+  return node;
+}
+
+bool convert<rosbag2_transport::RecordOptions>::decode(
+  const Node & node, rosbag2_transport::RecordOptions & record_options)
+{
+  optional_assign<bool>(node, "all", record_options.all);
+  optional_assign<bool>(node, "is_discovery_disabled", record_options.is_discovery_disabled);
+  optional_assign<std::vector<std::string>>(node, "topics", record_options.topics);
+  optional_assign<std::string>(
+    node, "rmw_serialization_format", record_options.rmw_serialization_format);
+  optional_assign<std::chrono::milliseconds>(
+    node, "topic_polling_interval", record_options.topic_polling_interval);
+  optional_assign<std::string>(node, "regex", record_options.regex);
+  optional_assign<std::string>(node, "exclude", record_options.exclude);
+  optional_assign<std::string>(node, "node_prefix", record_options.node_prefix);
+  optional_assign<std::string>(node, "compression_mode", record_options.compression_mode);
+  optional_assign<std::string>(node, "compression_format", record_options.compression_format);
+  optional_assign<uint64_t>(node, "compression_queue_size", record_options.compression_queue_size);
+  optional_assign<uint64_t>(node, "compression_threads", record_options.compression_threads);
+
+  // yaml-cpp doesn't implement unordered_map
+  std::map<std::string, rosbag2_transport::Rosbag2QoS> qos_overrides;
+  optional_assign<std::map<std::string, rosbag2_transport::Rosbag2QoS>>(
+    node, "topic_qos_profile_overrides", qos_overrides);
+  record_options.topic_qos_profile_overrides.insert(qos_overrides.begin(), qos_overrides.end());
+
+  optional_assign<bool>(node, "include_hidden_topics", record_options.include_hidden_topics);
+  return true;
+}
+
+}  // namespace YAML

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -31,21 +31,10 @@
 
 #include "rosbag2_interfaces/srv/snapshot.hpp"
 
+#include "rosbag2_storage/yaml.hpp"
 #include "rosbag2_transport/qos.hpp"
-#include "topic_filter.hpp"
 
-#ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
-// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-# pragma warning(push)
-# pragma warning(disable:4251)
-# pragma warning(disable:4275)
-#endif
-#include "yaml-cpp/yaml.h"
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
+#include "topic_filter.hpp"
 
 namespace rosbag2_transport
 {

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "rosbag2_transport/record_options.hpp"
+
+using namespace ::testing;  // NOLINT
+
+TEST(record_options, test_yaml_serialization)
+{
+  rosbag2_transport::RecordOptions original;
+  original.all = true;
+  original.is_discovery_disabled = true;
+  original.topics = {"topic", "other_topic"};
+  original.rmw_serialization_format = "cdr";
+  original.topic_polling_interval = std::chrono::milliseconds{200};
+  original.regex = "[xyz]/topic";
+  original.exclude = "*";
+  original.node_prefix = "prefix";
+  original.compression_mode = "stream";
+  original.compression_format = "h264";
+  original.compression_queue_size = 2;
+  original.compression_threads = 123;
+  original.topic_qos_profile_overrides.emplace("topic", rclcpp::QoS(10).transient_local());
+  original.include_hidden_topics = true;
+
+  auto node = YAML::convert<rosbag2_transport::RecordOptions>().encode(original);
+
+  std::stringstream serializer;
+  serializer << node;
+  auto reconstructed_node = YAML::Load(serializer.str());
+  auto reconstructed = reconstructed_node.as<rosbag2_transport::RecordOptions>();
+
+  #define CHECK(field) ASSERT_EQ(original.field, reconstructed.field)
+  CHECK(all);
+  CHECK(is_discovery_disabled);
+  CHECK(topics);
+  CHECK(rmw_serialization_format);
+  #undef CMP
+}


### PR DESCRIPTION
Related to #831 

Initial: Create a common yaml.hpp header so that we stop copy-pasting the same block of windows workarounds.

Add YAML codec for RecordOptions and StorageOptions structs, this will be used for input for bag converter.