### PR TITLE
Add logging macros for rosbag2_transport

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/logging.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/logging.hpp
@@ -1,0 +1,61 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_TRANSPORT__LOGGING_HPP_
+#define ROSBAG2_TRANSPORT__LOGGING_HPP_
+
+#include <sstream>
+#include <string>
+
+#include "rcutils/logging_macros.h"
+
+#define ROSBAG2_TRANSPORT_PACKAGE_NAME "ROSBAG2_TRANSPORT"
+
+#define ROSBAG2_TRANSPORT_LOG_INFO(...) \
+  RCUTILS_LOG_INFO_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
+
+#define ROSBAG2_TRANSPORT_LOG_INFO_STREAM(args) do { \
+    std::stringstream __ss; \
+    __ss << args; \
+    RCUTILS_LOG_INFO_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+} while (0)
+
+#define ROSBAG2_TRANSPORT_LOG_ERROR(...) \
+  RCUTILS_LOG_ERROR_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
+
+#define ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(args) do { \
+    std::stringstream __ss; \
+    __ss << args; \
+    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+} while (0)
+
+#define ROSBAG2_TRANSPORT_LOG_WARN(...) \
+  RCUTILS_LOG_WARN_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
+
+#define ROSBAG2_TRANSPORT_LOG_WARN_STREAM(args) do { \
+    std::stringstream __ss; \
+    __ss << args; \
+    RCUTILS_LOG_WARN_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+} while (0)
+
+#define ROSBAG2_TRANSPORT_LOG_DEBUG(...) \
+  RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
+
+#define ROSBAG2_TRANSPORT_LOG_DEBUG_STREAM(args) do { \
+    std::stringstream __ss; \
+    __ss << args; \
+    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+} while (0)
+
+#endif  // ROSBAG2_TRANSPORT__LOGGING_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.cpp
@@ -15,9 +15,9 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/logging.hpp"
 
 #include "rosbag2_transport/qos.hpp"
+#include "logging.hpp"
 
 namespace
 {
@@ -122,8 +122,6 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
     }
   }
 
-  auto logger = rclcpp::get_logger("rosbag2_transport");
-
   // We set policies in order as defined in rmw_qos_profile_t
   Rosbag2QoS request_qos{};
   // Policy: history, depth
@@ -134,8 +132,7 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
     request_qos.reliable();
   } else {
     if (reliability_reliable_endpoints_count > 0) {
-      RCLCPP_WARN_STREAM(
-        logger,
+      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
         "Some, but not all, publishers on topic \"" << topic_name << "\" "
           "are offering RMW_QOS_POLICY_RELIABILITY_RELIABLE. "
           "Falling back to RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT "
@@ -151,8 +148,7 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
     request_qos.transient_local();
   } else {
     if (durability_transient_local_endpoints_count > 0) {
-      RCLCPP_WARN_STREAM(
-        logger,
+      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
         "Some, but not all, publishers on topic \"" << topic_name << "\" "
           "are offering RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL. "
           "Falling back to RMW_QOS_POLICY_DURABILITY_VOLATILE "
@@ -222,8 +218,7 @@ Rosbag2QoS Rosbag2QoS::adapt_offer_to_recorded_offers(
     return result.default_history();
   }
 
-  RCLCPP_WARN_STREAM(
-    rclcpp::get_logger("rosbag2_transport"),
+  ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
     "Not all original publishers on topic " << topic_name << " offered the same QoS profiles. "
       "Rosbag2 cannot yet choose an adapted profile to offer for this mixed case. "
       "Falling back to the rosbag2_transport default publisher offer.");

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -20,11 +20,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "rclcpp/logging.hpp"
-
 #include "rcpputils/split.hpp"
 
-#include "./topic_filter.hpp"
+#include "logging.hpp"
+#include "topic_filter.hpp"
 
 namespace rosbag2_transport
 {
@@ -59,12 +58,9 @@ std::unordered_map<std::string, std::string> filter_topics_with_more_than_one_ty
 {
   std::unordered_map<std::string, std::string> filtered_topics_and_types;
 
-  auto logger = rclcpp::get_logger("rosbag2_transport");
-
   for (const auto & topic_and_type : topics_and_types) {
     if (topic_and_type.second.size() > 1) {
-      RCLCPP_ERROR_STREAM(
-        logger,
+      ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
         "Topic '" << topic_and_type.first <<
           "' has several types associated. Only topics with one type are supported");
       continue;
@@ -79,8 +75,7 @@ std::unordered_map<std::string, std::string> filter_topics_with_more_than_one_ty
           return token[0] == '_';
         });
       if (is_hidden != tokens.end()) {
-        RCLCPP_WARN_ONCE(
-          logger,
+        ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
           "Hidden topics are not recorded. Enable them with --include-hidden-topics");
         continue;
       }
@@ -136,8 +131,7 @@ filter_topics_with_known_type(
         topic_and_type.second);
       if (got == topic_unknown_types.end()) {
         topic_unknown_types.emplace(topic_and_type.second);
-        RCLCPP_WARN_STREAM(
-          rclcpp::get_logger("rosbag2_transport"),
+        ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
           "Topic '" << topic_and_type.first <<
             "' has unknown type '" << topic_and_type.second <<
             "' associated. Only topics with known type are supported. Reason: '" << e.what());


### PR DESCRIPTION
Related to #831 

The others packages have these. I will be adding more features soon that will need it as well.

The original reason this didn't exist was because everything happened within a Node. However, the "convert" feature will happen mostly within rosbag2_transport, but will not happen inside a Node.