### PR TITLE
Auto-detect storage_id for Reader (if possible)

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -40,13 +40,12 @@ class PlayVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         reader_choices = get_registered_readers()
-        default_reader = 'sqlite3' if 'sqlite3' in reader_choices else reader_choices[0]
 
         parser.add_argument(
             'bag_file', type=check_path_exists, help='bag file to replay')
         parser.add_argument(
-            '-s', '--storage', default=default_reader, choices=reader_choices,
-            help=f"storage identifier to be used, defaults to '{default_reader}'")
+            '-s', '--storage', default='', choices=reader_choices,
+            help='Storage implementation of bag. By default tries to determine from metadata.')
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -103,6 +103,11 @@ void SequentialReader::open(
     current_file_iterator_ = file_paths_.begin();
     load_current_file();
   } else {
+    if (storage_options_.storage_id.empty()) {
+      throw std::runtime_error(
+              "No metadata found and no storage_id specified. "
+              "Can't open bag.");
+    }
     storage_ = storage_factory_->open_read_only(storage_options_);
     if (!storage_) {
       throw std::runtime_error{"No storage could be initialized. Abort"};

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -91,6 +91,9 @@ void SequentialReader::open(
   // This is necessary for non ROS2 bags (aka ROS1 legacy bags).
   if (metadata_io_->metadata_file_exists(storage_options.uri)) {
     metadata_ = metadata_io_->read_metadata(storage_options.uri);
+    if (storage_options_.storage_id.empty()) {
+      storage_options_.storage_id = metadata_.storage_identifier;
+    }
     if (metadata_.relative_file_paths.empty()) {
       ROSBAG2_CPP_LOG_WARN("No file paths were found in metadata.");
       return;


### PR DESCRIPTION
Part of #831

Most bags have a metadata file associated with them. If that's the case, then it's not strictly necessary to specify the storage format when playing back a bag, it can be determined. This is a quality of life improvement for non-default storage implementations (and for bag conversion input bags, in progress feature)