### PR TITLE
Emit a warning rather than crash when a message is too big for sqlite

### DIFF
--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_exception.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_exception.hpp
@@ -33,7 +33,20 @@ class ROSBAG2_STORAGE_DEFAULT_PLUGINS_PUBLIC SqliteException : public std::runti
 {
 public:
   explicit SqliteException(const std::string & message)
-  : runtime_error(message) {}
+  : runtime_error(message), sqlite_return_code_(-1) {}
+
+  SqliteException(const std::string & message, int sqlite_return_code)
+  : runtime_error(message), sqlite_return_code_(sqlite_return_code) {}
+
+  /// Return the sqlite return code associated with the Exception, or -1 if none was given.
+  int
+  get_sqlite_return_code() const
+  {
+    return sqlite_return_code_;
+  }
+
+private:
+  int sqlite_return_code_;
 };
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -88,6 +88,12 @@ public:
 
   std::string get_storage_setting(const std::string & key);
 
+  /// Return the sqlite database wrapper.
+  /**
+   * \throws std::runtime_error if open() has not been called
+   */
+  SqliteWrapper & get_sqlite_database_wrapper();
+
 private:
   void initialize();
   void prepare_for_writing();

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -30,8 +30,6 @@
 namespace rosbag2_storage_plugins
 {
 
-using DBPtr = sqlite3 *;
-
 class ROSBAG2_STORAGE_DEFAULT_PLUGINS_PUBLIC SqliteWrapper
 {
 public:
@@ -49,12 +47,14 @@ public:
 
   operator bool();
 
+  sqlite3 * get_database();
+
 private:
   void apply_pragma_settings(
     std::unordered_map<std::string, std::string> & pragmas,
     rosbag2_storage::storage_interfaces::IOFlag io_flag);
 
-  DBPtr db_ptr;
+  sqlite3 * db_ptr;
 };
 
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_statement_wrapper.cpp
@@ -38,7 +38,7 @@ SqliteStatementWrapper::SqliteStatementWrapper(sqlite3 * database, const std::st
     errmsg << "Error when preparing SQL statement '" << query << "'. SQLite error: (" <<
       return_code << "): " << sqlite3_errstr(return_code);
 
-    throw SqliteException{errmsg.str()};
+    throw SqliteException{errmsg.str(), return_code};
   }
 
   statement_ = statement;
@@ -61,7 +61,7 @@ std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_rese
     errmsg << "Error when processing SQL statement. SQLite error (" <<
       return_code << "): " << sqlite3_errstr(return_code);
 
-    throw SqliteException{errmsg.str()};
+    throw SqliteException{errmsg.str(), return_code};
   }
 
   if (assert_return_value) {
@@ -73,7 +73,7 @@ std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_rese
       errmsg << "Statement returned empty value while result was expected: \'" <<
         sqlite3_sql(statement_) << "\'";
 
-      throw SqliteException{errmsg.str()};
+      throw SqliteException{errmsg.str(), return_code};
     }
   }
 
@@ -147,7 +147,7 @@ bool SqliteStatementWrapper::step()
     errmsg << "Error reading SQL query. SQLite error (" <<
       return_code << "): " << sqlite3_errstr(return_code);
 
-    throw SqliteException{errmsg.str()};
+    throw SqliteException{errmsg.str(), return_code};
   }
 }
 
@@ -188,7 +188,7 @@ void SqliteStatementWrapper::check_and_report_bind_error(int return_code)
       last_bound_parameter_index_ << ". SQLite error (" <<
       return_code << "): " << sqlite3_errstr(return_code);
 
-    throw SqliteException{errmsg.str()};
+    throw SqliteException{errmsg.str(), return_code};
   }
 }
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -258,11 +258,11 @@ void SqliteStorage::write_locked(
         SQLITE_LIMIT_LENGTH,
         -1);
       ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_WARN_STREAM(
-        "Message on topic '" << message->topic_name << "' of size '"
-        << message->serialized_data->buffer_length
-        << "' bytes failed to write because it exceeds the maximum size sqlite can store ('"
-        << sqlite_limit << "' bytes): "
-        << exc.what());
+        "Message on topic '" << message->topic_name << "' of size '" <<
+          message->serialized_data->buffer_length <<
+          "' bytes failed to write because it exceeds the maximum size sqlite can store ('" <<
+          sqlite_limit << "' bytes): " <<
+          exc.what());
       return;
     } else {
       // Rethrow.

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -252,10 +252,16 @@ void SqliteStorage::write_locked(
     write_statement_->bind(message->time_stamp, topic_entry->second, message->serialized_data);
   } catch (const SqliteException & exc) {
     if (SQLITE_TOOBIG == exc.get_sqlite_return_code()) {
+      // Get the sqlite string/blob limit.
+      size_t sqlite_limit = sqlite3_limit(
+        this->get_sqlite_database_wrapper().get_database(),
+        SQLITE_LIMIT_LENGTH,
+        -1);
       ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_WARN_STREAM(
         "Message on topic '" << message->topic_name << "' of size '"
         << message->serialized_data->buffer_length
-        << "' bytes failed to write because it exceeds the maximum size sqlite can store: "
+        << "' bytes failed to write because it exceeds the maximum size sqlite can store ('"
+        << sqlite_limit << "' bytes): "
         << exc.what());
       return;
     } else {

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -498,6 +498,14 @@ std::string SqliteStorage::get_storage_setting(const std::string & key)
   return database_->query_pragma_value(key);
 }
 
+SqliteWrapper & SqliteStorage::get_sqlite_database_wrapper()
+{
+  if (nullptr == database_) {
+    throw std::runtime_error("database not open");
+  }
+  return *database_;
+}
+
 }  // namespace rosbag2_storage_plugins
 
 #include "pluginlib/class_list_macros.hpp"  // NOLINT

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -253,7 +253,7 @@ void SqliteStorage::write_locked(
   } catch (const SqliteException & exc) {
     if (SQLITE_TOOBIG == exc.get_sqlite_return_code()) {
       // Get the sqlite string/blob limit.
-      size_t sqlite_limit = sqlite3_limit(
+      const size_t sqlite_limit = sqlite3_limit(
         this->get_sqlite_database_wrapper().get_database(),
         SQLITE_LIMIT_LENGTH,
         -1);

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -133,4 +133,9 @@ SqliteWrapper::operator bool()
   return db_ptr != nullptr;
 }
 
+sqlite3 * SqliteWrapper::get_database()
+{
+  return db_ptr;
+}
+
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -51,7 +51,7 @@ public:
 
   std::shared_ptr<rcutils_uint8_array_t> make_serialized_message(const std::string & message)
   {
-    int message_size = get_buffer_capacity(message);
+    size_t message_size = get_buffer_capacity(message);
     assert(message_size > 0);
 
     auto msg = new rcutils_uint8_array_t;
@@ -74,7 +74,7 @@ public:
       });
 
     serialized_data->buffer_length = message_size;
-    int written_size = write_data_to_serialized_string_message(
+    size_t written_size = write_data_to_serialized_string_message(
       serialized_data->buffer, serialized_data->buffer_capacity, message);
 
     (void) written_size;
@@ -167,12 +167,12 @@ protected:
     return {0x00, 0x01, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00};
   }
 
-  int get_buffer_capacity(const std::string & message)
+  size_t get_buffer_capacity(const std::string & message)
   {
     return get_preamble().size() + message.size();
   }
 
-  int write_data_to_serialized_string_message(
+  size_t write_data_to_serialized_string_message(
     uint8_t * buffer, size_t buffer_capacity, const std::string & message)
   {
     size_t remaining_buffer = buffer_capacity;

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -178,45 +178,32 @@ protected:
   int write_data_to_serialized_string_message(
     uint8_t * buffer, size_t buffer_capacity, const std::string & message)
   {
-    // snprintf doesn't handle very large messages, so use memcpy when the
-    // message is large.
-    if (message.size() <= 4096) {
-      // This function also writes the final null charachter, which is absent in the CDR format.
-      // Here this behaviour is ok, because we only test test writing and reading from/to sqlite.
-      return rcutils_snprintf(
-        reinterpret_cast<char *>(buffer),
-        buffer_capacity,
-        "%c%c%c%c%c%c%c%c%s",
-        0x00, 0x01, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00,
-        message.c_str());
-    } else {
-      size_t remaining_buffer = buffer_capacity;
-      size_t amount_written = 0;
-      if (remaining_buffer == 0) {
-        return amount_written;
-      }
-
-      size_t amount_to_write = remaining_buffer;
-      std::string preamble = get_preamble();
-      if (preamble.size() < amount_to_write) {
-        amount_to_write = preamble.size();
-      }
-      std::memcpy(buffer, preamble.data(), amount_to_write);
-      amount_written += amount_to_write;
-      remaining_buffer -= amount_written;
-      if (remaining_buffer == 0) {
-        return amount_written;
-      }
-
-      amount_to_write = remaining_buffer;
-      if (message.size() < amount_to_write) {
-        amount_to_write = message.size();
-      }
-      std::memcpy(buffer + amount_written, message.data(), amount_to_write);
-      amount_written += amount_to_write;
-
+    size_t remaining_buffer = buffer_capacity;
+    size_t amount_written = 0;
+    if (remaining_buffer == 0) {
       return amount_written;
     }
+
+    size_t amount_to_write = remaining_buffer;
+    std::string preamble = get_preamble();
+    if (preamble.size() < amount_to_write) {
+      amount_to_write = preamble.size();
+    }
+    std::memcpy(buffer, preamble.data(), amount_to_write);
+    amount_written += amount_to_write;
+    remaining_buffer -= amount_written;
+    if (remaining_buffer == 0) {
+      return amount_written;
+    }
+
+    amount_to_write = remaining_buffer;
+    if (message.size() < amount_to_write) {
+      amount_to_write = message.size();
+    }
+    std::memcpy(buffer + amount_written, message.data(), amount_to_write);
+    amount_written += amount_to_write;
+
+    return amount_written;
   }
 
   rcutils_allocator_t allocator_;

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -73,10 +73,9 @@ public:
       });
 
     serialized_data->buffer_length = message_size;
-    size_t written_size = write_data_to_serialized_string_message(
+    write_data_to_serialized_string_message(
       serialized_data->buffer, serialized_data->buffer_capacity, message);
 
-    (void) written_size;
     return serialized_data;
   }
 
@@ -179,6 +178,8 @@ protected:
     if (remaining_buffer == 0) {
       return amount_written;
     }
+
+    assert(buffer_capacity >= preamble.size() + message.size());
 
     size_t amount_to_write = remaining_buffer;
     std::string preamble = get_preamble();

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -52,7 +52,6 @@ public:
   std::shared_ptr<rcutils_uint8_array_t> make_serialized_message(const std::string & message)
   {
     size_t message_size = get_buffer_capacity(message);
-    assert(message_size > 0);
 
     auto msg = new rcutils_uint8_array_t;
     *msg = rcutils_get_zero_initialized_uint8_array();

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -179,10 +179,10 @@ protected:
       return amount_written;
     }
 
+    std::string preamble = get_preamble();
     assert(buffer_capacity >= preamble.size() + message.size());
 
     size_t amount_to_write = remaining_buffer;
-    std::string preamble = get_preamble();
     if (preamble.size() < amount_to_write) {
       amount_to_write = preamble.size();
     }

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -388,7 +388,8 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
 
   // This should produce a warning, but not an exception.
   std::string msg(sqlite_limit + 1, '\0');
-  EXPECT_NO_THROW({
+  EXPECT_NO_THROW(
+  {
     this->write_messages_to_sqlite(
     {
       {msg, 0, "/too_big_message", "some_type", "some_rmw"}

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -391,7 +391,7 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
   // Artificially lower the limit, make sure it's smaller than the original.
   size_t artificial_limit = 1000;  // 1KB
   artificial_limit = std::min(artificial_limit, sqlite_limit);
-  assert(artificial_limit <= std::numeric_limits<int>::max());
+  assert(artificial_limit <= static_cast<size_t>(std::numeric_limits<int>::max()));
   sqlite3_limit(
     writable_storage->get_sqlite_database_wrapper().get_database(),
     SQLITE_LIMIT_LENGTH,

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -386,8 +387,9 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
     SQLITE_LIMIT_LENGTH,
     -1);
 
-  // Make an arbitrarily new artificial limit that is much smaller, but also never 0 or 1.
-  size_t artificial_limit = ((sqlite_limit % 1000) + 1) * 42;
+  // Artificially lower the limit, make sure it's smaller than the original.
+  size_t artificial_limit = 1000;  // 1KB
+  artificial_limit = std::min(artificial_limit, sqlite_limit);
   sqlite3_limit(
     writable_storage->get_sqlite_database_wrapper().get_database(),
     SQLITE_LIMIT_LENGTH,

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -388,8 +388,10 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
 
   // This should produce a warning, but not an exception.
   std::string msg(sqlite_limit + 1, '\0');
-  this->write_messages_to_sqlite(
-  {
-    {msg, 0, "/too_big_message", "some_type", "some_rmw"}
-  }, writable_storage);
+  EXPECT_NO_THROW({
+    this->write_messages_to_sqlite(
+    {
+      {msg, 0, "/too_big_message", "some_type", "some_rmw"}
+    }, writable_storage);
+  });
 }

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -386,8 +386,15 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
     SQLITE_LIMIT_LENGTH,
     -1);
 
+  // Make an arbitrarily new artificial limit that is much smaller, but also never 0 or 1.
+  size_t artificial_limit = ((sqlite_limit % 1000) + 1) * 42;
+  sqlite3_limit(
+    writable_storage->get_sqlite_database_wrapper().get_database(),
+    SQLITE_LIMIT_LENGTH,
+    artificial_limit);
+
   // This should produce a warning, but not an exception.
-  std::string msg(sqlite_limit + 1, '\0');
+  std::string msg(artificial_limit + 1, '\0');
   EXPECT_NO_THROW(
   {
     this->write_messages_to_sqlite(

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -390,10 +391,11 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
   // Artificially lower the limit, make sure it's smaller than the original.
   size_t artificial_limit = 1000;  // 1KB
   artificial_limit = std::min(artificial_limit, sqlite_limit);
+  assert(artificial_limit <= std::numeric_limits<int>::max());
   sqlite3_limit(
     writable_storage->get_sqlite_database_wrapper().get_database(),
     SQLITE_LIMIT_LENGTH,
-    artificial_limit);
+    static_cast<int>(artificial_limit));
 
   // This should produce a warning, but not an exception.
   std::string msg(artificial_limit + 1, '\0');


### PR DESCRIPTION
Related to issue https://github.com/ros2/rosbag2/issues/915

This pull request changes the behavior of the sqlite storage plugin to emit a warning rather than throw an exception when a message is written that is too large for sqlite.