### PR TITLE
Rewrite TopicFilter for single-call reusability

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -178,11 +178,6 @@ function(create_tests_for_rmw_implementation)
     LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common)
 
-  rosbag2_transport_add_gmock(test_topic_filter
-    test/rosbag2_transport/test_topic_filter.cpp
-    INCLUDE_DIRS
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
-    LINK_LIBS rosbag2_transport)
 endfunction()
 
 if(BUILD_TESTING)
@@ -200,6 +195,11 @@ if(BUILD_TESTING)
   target_include_directories(test_record_options PRIVATE include)
   target_link_libraries(test_record_options ${PROJECT_NAME})
 
+  ament_add_gmock(test_topic_filter
+    test/rosbag2_transport/test_topic_filter.cpp)
+  target_include_directories(test_topic_filter PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>)
+  target_link_libraries(test_topic_filter rosbag2_transport)
 endif()
 
 ament_package()

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -90,6 +90,10 @@ Recorder::Recorder(
   RCLCPP_INFO_STREAM(
     get_logger(),
     "Press " << key_str << " for pausing/resuming");
+
+  for (auto & topic : record_options_.topics) {
+    topic = rclcpp::expand_topic_or_service_name(topic, get_name(), get_namespace(), false);
+  }
 }
 
 Recorder::~Recorder()
@@ -193,35 +197,8 @@ std::unordered_map<std::string, std::string>
 Recorder::get_requested_or_available_topics()
 {
   auto all_topics_and_types = this->get_topic_names_and_types();
-  auto filtered_topics_and_types = topic_filter::filter_topics_with_more_than_one_type(
-    all_topics_and_types, record_options_.include_hidden_topics);
-
-  filtered_topics_and_types = topic_filter::filter_topics_with_known_type(
-    filtered_topics_and_types, topic_unknown_types_);
-
-  if (!record_options_.topics.empty()) {
-    // expand specified topics
-    std::vector<std::string> expanded_topics;
-    expanded_topics.reserve(record_options_.topics.size());
-    for (const auto & topic : record_options_.topics) {
-      expanded_topics.push_back(
-        rclcpp::expand_topic_or_service_name(
-          topic, this->get_name(), this->get_namespace(), false));
-    }
-    filtered_topics_and_types = topic_filter::filter_topics(
-      expanded_topics, filtered_topics_and_types);
-  }
-
-  if (record_options_.regex.empty() && record_options_.exclude.empty()) {
-    return filtered_topics_and_types;
-  }
-
-  return topic_filter::filter_topics_using_regex(
-    filtered_topics_and_types,
-    record_options_.regex,
-    record_options_.exclude,
-    record_options_.all
-  );
+  TopicFilter topic_filter{record_options_};
+  return topic_filter.filter_topics(all_topics_and_types);
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -79,6 +79,9 @@ TopicFilter::TopicFilter(RecordOptions record_options, bool allow_unknown_types)
   allow_unknown_types_(allow_unknown_types)
 {}
 
+TopicFilter::~TopicFilter()
+{}
+
 std::unordered_map<std::string, std::string> TopicFilter::filter_topics(
   const std::map<std::string, std::vector<std::string>> & topic_names_and_types)
 {

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -18,130 +18,134 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include <unordered_set>
+#include <utility>
 
 #include "rcpputils/split.hpp"
+#include "rosbag2_cpp/typesupport_helpers.hpp"
 
 #include "logging.hpp"
 #include "topic_filter.hpp"
 
+namespace
+{
+bool has_single_type(
+  const std::string & topic_name, const std::vector<std::string> & topic_types)
+{
+  if (topic_types.empty()) {
+    ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+      "Topic " << topic_name << " has no associated types. "
+        "This case shouldn't occur.");
+    return false;
+  }
+  auto it = topic_types.begin();
+  const std::string & reference_type = *it;
+  for (; it != topic_types.end(); it++) {
+    if (reference_type != *it) {
+      ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
+        "Topic '" << topic_name <<
+          "' has more than one type associated. Only topics with one type are supported");
+      return false;
+    }
+  }
+  return true;
+}
+
+
+bool topic_is_hidden(const std::string & topic_name)
+{
+  // According to rclpy's implementation, the indicator for a hidden topic is a leading '_'
+  // https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/topic_or_service_is_hidden.py#L15
+  auto tokens = rcpputils::split(topic_name, '/', true);  // skip empty
+  auto hidden_it = std::find_if(
+    tokens.begin(), tokens.end(), [](const auto & token) -> bool {
+      return token[0] == '_';
+    });
+  return hidden_it != tokens.end();
+}
+
+bool topic_in_list(const std::string & topic_name, const std::vector<std::string> & topics)
+{
+  auto it = std::find(topics.begin(), topics.end(), topic_name);
+  return it != topics.end();
+}
+
+}  // namespace
+
 namespace rosbag2_transport
 {
-namespace topic_filter
+
+TopicFilter::TopicFilter(RecordOptions record_options, bool allow_unknown_types)
+: record_options_(record_options),
+  allow_unknown_types_(allow_unknown_types)
+{}
+
+std::unordered_map<std::string, std::string> TopicFilter::filter_topics(
+  const std::map<std::string, std::vector<std::string>> & topic_names_and_types)
 {
-
-std::unordered_map<std::string, std::string> filter_topics(
-  const std::vector<std::string> & selected_topic_names,
-  const std::unordered_map<std::string, std::string> & all_topic_names_and_types)
-{
-  std::unordered_map<std::string, std::string> filtered_topics_and_types;
-
-  auto topic_name_matches = [&selected_topic_names](const auto & topic_and_type) -> bool
-    {
-      return std::find(
-        selected_topic_names.begin(),
-        selected_topic_names.end(), topic_and_type.first) != selected_topic_names.end();
-    };
-
-  for (const auto & topic_and_type : all_topic_names_and_types) {
-    if (topic_name_matches(topic_and_type)) {
-      filtered_topics_and_types.insert(topic_and_type);
+  std::unordered_map<std::string, std::string> filtered_topics;
+  for (const auto & [topic_name, topic_types] : topic_names_and_types) {
+    if (take_topic(topic_name, topic_types)) {
+      filtered_topics.insert(std::make_pair(topic_name, topic_types[0]));
     }
   }
-
-  return filtered_topics_and_types;
+  return filtered_topics;
 }
 
-std::unordered_map<std::string, std::string> filter_topics_with_more_than_one_type(
-  const std::map<std::string, std::vector<std::string>> & topics_and_types,
-  bool include_hidden_topics)
+bool TopicFilter::take_topic(
+  const std::string & topic_name, const std::vector<std::string> & topic_types)
 {
-  std::unordered_map<std::string, std::string> filtered_topics_and_types;
-
-  for (const auto & topic_and_type : topics_and_types) {
-    if (topic_and_type.second.size() > 1) {
-      ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(
-        "Topic '" << topic_and_type.first <<
-          "' has several types associated. Only topics with one type are supported");
-      continue;
-    }
-
-    // According to rclpy's implementation, the indicator for a hidden topic is a leading '_'
-    // https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/topic_or_service_is_hidden.py#L15
-    if (!include_hidden_topics) {
-      auto tokens = rcpputils::split(topic_and_type.first, '/', true);  // skip empty
-      auto is_hidden = std::find_if(
-        tokens.begin(), tokens.end(), [](const auto & token) -> bool {
-          return token[0] == '_';
-        });
-      if (is_hidden != tokens.end()) {
-        ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
-          "Hidden topics are not recorded. Enable them with --include-hidden-topics");
-        continue;
-      }
-    }
-
-    filtered_topics_and_types.insert({topic_and_type.first, topic_and_type.second[0]});
+  if (!has_single_type(topic_name, topic_types)) {
+    return false;
   }
-  return filtered_topics_and_types;
+
+  const std::string & topic_type = topic_types[0];
+  if (!allow_unknown_types_ && !type_is_known(topic_name, topic_type)) {
+    return false;
+  }
+
+  if (!record_options_.include_hidden_topics && topic_is_hidden(topic_name)) {
+    ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+      "Hidden topics are not recorded. Enable them with --include-hidden-topics");
+    return false;
+  }
+
+  if (!record_options_.topics.empty() && !topic_in_list(topic_name, record_options_.topics)) {
+    return false;
+  }
+
+  std::regex exclude_regex(record_options_.exclude);
+  if (std::regex_match(topic_name, exclude_regex)) {
+    return false;
+  }
+
+  std::regex include_regex(record_options_.regex);
+  if (
+    !record_options_.all &&  // All takes precedence over regex
+    !record_options_.regex.empty() &&  // empty regex matches nothing, but should be ignored
+    !std::regex_match(topic_name, include_regex))
+  {
+    return false;
+  }
+
+  return true;
 }
 
-std::unordered_map<std::string, std::string>
-filter_topics_using_regex(
-  const std::unordered_map<std::string, std::string> & topics_and_types,
-  const std::string & filter_regex_string,
-  const std::string & exclude_regex_string,
-  bool all_flag
-)
+bool TopicFilter::type_is_known(const std::string & topic_name, const std::string & topic_type)
 {
-  std::unordered_map<std::string, std::string> filtered_by_regex;
-
-  std::regex filter_regex(filter_regex_string);
-  std::regex exclude_regex(exclude_regex_string);
-
-  for (const auto & kv : topics_and_types) {
-    bool take = all_flag;
-    // regex_match returns false for 'empty' regex
-    if (!all_flag && !filter_regex_string.empty()) {
-      take = std::regex_match(kv.first, filter_regex);
+  try {
+    auto package_name = std::get<0>(rosbag2_cpp::extract_type_identifier(topic_type));
+    rosbag2_cpp::get_typesupport_library_path(package_name, "rosidl_typesupport_cpp");
+  } catch (std::runtime_error & e) {
+    if (already_warned_unknown_types_.find(topic_type) == already_warned_unknown_types_.end()) {
+      already_warned_unknown_types_.emplace(topic_type);
+      ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
+        "Topic '" << topic_name <<
+          "' has unknown type '" << topic_type <<
+          "' . Only topics with known type are supported. Reason: '" << e.what());
     }
-    if (take) {
-      take = !std::regex_match(kv.first, exclude_regex);
-    }
-    if (take) {
-      filtered_by_regex.insert(kv);
-    }
+    return false;
   }
-  return filtered_by_regex;
+  return true;
 }
 
-std::unordered_map<std::string, std::string>
-filter_topics_with_known_type(
-  const std::unordered_map<std::string, std::string> & topics_and_types,
-  std::unordered_set<std::string> & topic_unknown_types)
-{
-  std::unordered_map<std::string, std::string> filtered_topics_and_types;
-
-  for (const auto & topic_and_type : topics_and_types) {
-    try {
-      auto package_name = std::get<0>(rosbag2_cpp::extract_type_identifier(topic_and_type.second));
-      rosbag2_cpp::get_typesupport_library_path(package_name, "rosidl_typesupport_cpp");
-    } catch (std::runtime_error & e) {
-      std::unordered_set<std::string>::const_iterator got = topic_unknown_types.find(
-        topic_and_type.second);
-      if (got == topic_unknown_types.end()) {
-        topic_unknown_types.emplace(topic_and_type.second);
-        ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
-          "Topic '" << topic_and_type.first <<
-            "' has unknown type '" << topic_and_type.second <<
-            "' associated. Only topics with known type are supported. Reason: '" << e.what());
-      }
-      continue;
-    }
-    filtered_topics_and_types.insert(topic_and_type);
-  }
-  return filtered_topics_and_types;
-}
-
-}  // namespace topic_filter
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
@@ -21,42 +21,34 @@
 #include <unordered_set>
 #include <vector>
 
-#include "rosbag2_cpp/typesupport_helpers.hpp"
+#include "rosbag2_transport/record_options.hpp"
 #include "rosbag2_transport/visibility_control.hpp"
 
 namespace rosbag2_transport
 {
-namespace topic_filter
+
+class ROSBAG2_TRANSPORT_PUBLIC TopicFilter
 {
+public:
+  explicit TopicFilter(RecordOptions record_options, bool allow_unknown_types = false);
 
-ROSBAG2_TRANSPORT_PUBLIC
-std::unordered_map<std::string, std::string>
-filter_topics(
-  const std::vector<std::string> & selected_topic_names,
-  const std::unordered_map<std::string, std::string> & all_topic_names_and_types);
+  /// Filter all topic_names_and_types via take_topic method, return the resulting filtered set
+  /// Filtering order is:
+  /// - remove topics with more than one type or unknown type (unable to load typesupport)
+  /// - RecordOptions::all xor RecordOptions::topics (topics takes precedence if both provided)
+  /// - apply include/exclude regex if specified
+  std::unordered_map<std::string, std::string> filter_topics(
+    const std::map<std::string, std::vector<std::string>> & topic_names_and_types);
 
-ROSBAG2_TRANSPORT_PUBLIC
-std::unordered_map<std::string, std::string>
-filter_topics_with_more_than_one_type(
-  const std::map<std::string, std::vector<std::string>> & topics_and_types,
-  bool include_hidden_topics = false);
+private:
+  /// Return true if the topic passes all filter criteria
+  bool take_topic(const std::string & topic_name, const std::vector<std::string> & topic_types);
+  bool type_is_known(const std::string & topic_name, const std::string & topic_type);
 
-ROSBAG2_TRANSPORT_PUBLIC
-std::unordered_map<std::string, std::string>
-filter_topics_using_regex(
-  const std::unordered_map<std::string, std::string> & topics_and_types,
-  const std::string & filter_regex_string,
-  const std::string & exclude_regex_string,
-  bool all_flag
-);
-
-ROSBAG2_TRANSPORT_PUBLIC
-std::unordered_map<std::string, std::string>
-filter_topics_with_known_type(
-  const std::unordered_map<std::string, std::string> & topics_and_types,
-  std::unordered_set<std::string> & topic_unknown_types);
-
-}  // namespace topic_filter
+  RecordOptions record_options_;
+  bool allow_unknown_types_ = false;
+  std::unordered_set<std::string> already_warned_unknown_types_;
+};
 }  // namespace rosbag2_transport
 
 #endif  // ROSBAG2_TRANSPORT__TOPIC_FILTER_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
@@ -35,9 +35,10 @@ public:
 
   /// Filter all topic_names_and_types via take_topic method, return the resulting filtered set
   /// Filtering order is:
-  /// - remove topics with more than one type or unknown type (unable to load typesupport)
-  /// - RecordOptions::all xor RecordOptions::topics (topics takes precedence if both provided)
-  /// - apply include/exclude regex if specified
+  /// - remove topics with multiple types, unknown type, and hidden topics
+  /// - topics list
+  /// - exclude regex
+  /// - include regex OR "all"
   std::unordered_map<std::string, std::string> filter_topics(
     const std::map<std::string, std::vector<std::string>> & topic_names_and_types);
 

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
@@ -24,6 +24,14 @@
 #include "rosbag2_transport/record_options.hpp"
 #include "rosbag2_transport/visibility_control.hpp"
 
+// This is necessary because of using stl types here. It is completely safe, because
+// a) the member is not accessible from the outside
+// b) there are no inline functions.
+#ifdef _WIN32
+# pragma warning(push)
+# pragma warning(disable:4251)
+#endif
+
 namespace rosbag2_transport
 {
 
@@ -31,7 +39,7 @@ class ROSBAG2_TRANSPORT_PUBLIC TopicFilter
 {
 public:
   explicit TopicFilter(RecordOptions record_options, bool allow_unknown_types = false);
-  virtual ~TopicFilter() {}
+  virtual ~TopicFilter();
 
   /// Filter all topic_names_and_types via take_topic method, return the resulting filtered set
   /// Filtering order is:

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
@@ -31,6 +31,7 @@ class ROSBAG2_TRANSPORT_PUBLIC TopicFilter
 {
 public:
   explicit TopicFilter(RecordOptions record_options, bool allow_unknown_types = false);
+  virtual ~TopicFilter() {}
 
   /// Filter all topic_names_and_types via take_topic method, return the resulting filtered set
   /// Filtering order is:

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -29,114 +29,104 @@ using namespace ::testing;  // NOLINT
 class RegexFixture : public Test
 {
 protected:
-  std::unordered_map<std::string, std::string> topics_and_types_ = {
-    {"/planning", "planning_topic_type"},
-    {"/invalid_topic", "invalid_topic_type"},
-    {"/invalidated_topic", "invalidated_topic_type"},
-    {"/localization", "localization_topic_type"},
-    {"/invisible", "invisible_topic_type"},
-    {"/status", "status_topic_type"}
+  std::map<std::string, std::vector<std::string>> topics_and_types_ = {
+    {"/planning", {"planning_topic_type"}},
+    {"/invalid_topic", {"invalid_topic_type"}},
+    {"/invalidated_topic", {"invalidated_topic_type"}},
+    {"/localization", {"localization_topic_type"}},
+    {"/invisible", {"invisible_topic_type"}},
+    {"/status", {"status_topic_type"}}
   };
 };
 
+TEST(TestTopicFilter, filter_hidden_topics) {
+  std::map<std::string, std::vector<std::string>> topics_and_types {
+    {"topic/a", {"type_a"}},
+    {"topic/b", {"type_b"}},
+    {"topic/c", {"type_c"}},
+    {"_/topic/a", {"type_a"}},
+    {"_/topic/b", {"type_b"}},
+    {"_/topic/c", {"type_c"}},
+  };
+
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.include_hidden_topics = true;
+    rosbag2_transport::TopicFilter filter{record_options, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    ASSERT_EQ(topics_and_types.size(), filtered_topics.size());
+  }
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.include_hidden_topics = false;
+    rosbag2_transport::TopicFilter filter{record_options, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    ASSERT_EQ(topics_and_types.size() - 3, filtered_topics.size());
+  }
+}
+
 TEST(TestTopicFilter, filter_topics_with_more_than_one_type) {
-  std::map<std::string, std::vector<std::string>> topic_with_type;
-  topic_with_type.insert({"topic/a", {"type_a"}});
-  topic_with_type.insert({"topic/b", {"type_b"}});
-  topic_with_type.insert({"topic/c", {"type_c"}});
-  {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_more_than_one_type(
-      topic_with_type, true /* include hidden topics */);
-    ASSERT_EQ(topic_with_type.size(), filtered_topics.size());
-  }
-  {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_more_than_one_type(
-      topic_with_type, false /* include hidden topics */);
-    ASSERT_EQ(topic_with_type.size(), filtered_topics.size());
-  }
+  std::map<std::string, std::vector<std::string>> topics_and_types {
+    {"topic/a", {"type_a", "type_a", "type_a"}},
+    {"topic/b", {"type_b"}},
+    {"topic/c", {"type_c", "type_c2"}},
+    {"topic/d", {"type_d", "type_d", "type_d2"}},
+  };
 
-  topic_with_type.insert({"_/topic/a", {"type_a"}});
-  topic_with_type.insert({"_/topic/b", {"type_b"}});
-  topic_with_type.insert({"_/topic/c", {"type_c"}});
+  rosbag2_transport::TopicFilter filter{rosbag2_transport::RecordOptions{}, true};
+  auto filtered_topics = filter.filter_topics(topics_and_types);
+  EXPECT_THAT(filtered_topics, SizeIs(2));
+  for (const auto & topic :
+    {"topic/a", "topic/b"})
   {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_more_than_one_type(
-      topic_with_type, true /* include hidden topics */);
-    ASSERT_EQ(topic_with_type.size(), filtered_topics.size());
-  }
-  {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_more_than_one_type(
-      topic_with_type, false);
-    ASSERT_EQ(topic_with_type.size() - 3, filtered_topics.size());
-  }
-
-  topic_with_type.insert({"_/topic/aaa", {"type_a", "type_a", "type_a"}});
-  topic_with_type.insert({"_/topic/bbb", {"type_b", "type_b", "type_b"}});
-  topic_with_type.insert({"_/topic/ccc", {"type_c", "type_c", "type_c"}});
-  {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_more_than_one_type(
-      topic_with_type, true /* include hidden topics */);
-    ASSERT_EQ(topic_with_type.size() - 3, filtered_topics.size());
-    for (const auto & topic :
-      {"topic/a", "topic/b", "topic/c", "_/topic/a", "_/topic/b", "_/topic/c"})
-    {
-      EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
-    }
-  }
-  {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_more_than_one_type(
-      topic_with_type, false);
-    ASSERT_EQ(topic_with_type.size() - 2 * 3, filtered_topics.size());
-    for (const auto & topic : {"topic/a", "topic/b", "topic/c"}) {
-      EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
-    }
+    EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
   }
 }
 
 TEST(TestTopicFilter, filter_topics_with_known_type_invalid) {
-  std::unordered_map<std::string, std::string> topic_with_type;
-  std::unordered_set<std::string> topic_unknown_types;
-  topic_with_type.insert({"topic/a", "type_a"});
-  topic_with_type.insert({"topic/b", "type_b"});
-  topic_with_type.insert({"topic/c", "type_c"});
-  {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_known_type(
-      topic_with_type, topic_unknown_types);
-    ASSERT_EQ(0u, filtered_topics.size());
-  }
+  std::map<std::string, std::vector<std::string>> topics_and_types {
+    {"topic/a", {"type_a"}},
+    {"topic/b", {"type_b"}},
+    {"topic/c", {"type_c"}}
+  };
+
+  rosbag2_transport::TopicFilter filter{rosbag2_transport::RecordOptions{}};
+  auto filtered_topics = filter.filter_topics(topics_and_types);
+  ASSERT_EQ(0u, filtered_topics.size());
 }
 
 TEST(TestTopicFilter, filter_topics_with_known_type_valid) {
-  std::unordered_map<std::string, std::string> topic_with_type;
-  std::unordered_set<std::string> topic_unknown_types;
-  topic_with_type.insert({"topic/a", "test_msgs/BasicTypes"});
-  topic_with_type.insert({"topic/b", "test_msgs/BasicTypes"});
-  topic_with_type.insert({"topic/c", "test_msgs/BasicTypes"});
-  {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_with_known_type(
-      topic_with_type, topic_unknown_types);
-    ASSERT_EQ(3u, filtered_topics.size());
-  }
+  std::map<std::string, std::vector<std::string>> topics_and_types {
+    {"topic/a", {"test_msgs/BasicTypes"}},
+    {"topic/b", {"test_msgs/BasicTypes"}},
+    {"topic/c", {"test_msgs/BasicTypes"}}
+  };
+  rosbag2_transport::TopicFilter filter{rosbag2_transport::RecordOptions{}};
+  auto filtered_topics = filter.filter_topics(topics_and_types);
+  ASSERT_EQ(3u, filtered_topics.size());
 }
 
 TEST(TestTopicFilter, filter_topics) {
-  std::unordered_map<std::string, std::string> topic_with_type;
-  topic_with_type.insert({"topic/a", "type_a"});
-  topic_with_type.insert({"topic/b", "type_b"});
-  topic_with_type.insert({"topic/c", "type_c"});
+  std::map<std::string, std::vector<std::string>> topics_and_types {
+    {"topic/a", {"type_a"}},
+    {"topic/b", {"type_b"}},
+    {"topic/c", {"type_c"}}
+  };
 
   {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics(
-      {"topic/a"},
-      topic_with_type);
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"topic/a"};
+    rosbag2_transport::TopicFilter filter{record_options, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
     ASSERT_EQ(1u, filtered_topics.size());
     ASSERT_EQ("topic/a", filtered_topics.begin()->first);
   }
 
   {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics(
-      {"topic/a", "topic/b",
-        "topic/c"},
-      topic_with_type);
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"topic/a", "topic/b", "topic/c"};
+    rosbag2_transport::TopicFilter filter{record_options, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
     ASSERT_EQ(3u, filtered_topics.size());
     for (const auto & topic : {"topic/a", "topic/b", "topic/c"}) {
       EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
@@ -144,18 +134,18 @@ TEST(TestTopicFilter, filter_topics) {
   }
 
   {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics(
-      {"topic/d", "topic/e",
-        "topic/f"},
-      topic_with_type);
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"topic/d", "topic/e", "topic/f"};
+    rosbag2_transport::TopicFilter filter{record_options, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
     ASSERT_EQ(0u, filtered_topics.size());
   }
 
   {
-    auto filtered_topics = rosbag2_transport::topic_filter::filter_topics(
-      {"topic/a", "topic/b",
-        "topic/d"},
-      topic_with_type);
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"topic/a", "topic/b", "topic/d"};
+    rosbag2_transport::TopicFilter filter{record_options, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
     ASSERT_EQ(2u, filtered_topics.size());
     for (const auto & topic : {"topic/a", "topic/b"}) {
       EXPECT_TRUE(filtered_topics.find(topic) != filtered_topics.end());
@@ -165,16 +155,11 @@ TEST(TestTopicFilter, filter_topics) {
 
 TEST_F(RegexFixture, regex_all_and_exclude)
 {
-  std::string filter_regex_string = "";
-  std::string exclude_regex_string = "/inv.*";
-  bool all_flag = true;
-
-  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-    topics_and_types_,
-    filter_regex_string,
-    exclude_regex_string,
-    all_flag
-  );
+  rosbag2_transport::RecordOptions record_options;
+  record_options.exclude = "/inv.*";
+  record_options.all = true;
+  rosbag2_transport::TopicFilter filter{record_options, true};
+  auto filtered_topics = filter.filter_topics(topics_and_types_);
 
   EXPECT_THAT(filtered_topics, SizeIs(3));
   for (const auto & topic : {"/planning", "/localization", "/status"}) {
@@ -184,16 +169,12 @@ TEST_F(RegexFixture, regex_all_and_exclude)
 
 TEST_F(RegexFixture, regex_filter_exclude)
 {
-  std::string filter_regex_string = "/invalid.*";
-  std::string exclude_regex_string = ".invalidated.*";
-  bool all_flag = false;
-
-  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-    topics_and_types_,
-    filter_regex_string,
-    exclude_regex_string,
-    all_flag
-  );
+  rosbag2_transport::RecordOptions record_options;
+  record_options.regex = "/invalid.*";
+  record_options.exclude = ".invalidated.*";
+  record_options.all = false;
+  rosbag2_transport::TopicFilter filter{record_options, true};
+  auto filtered_topics = filter.filter_topics(topics_and_types_);
 
   EXPECT_THAT(filtered_topics, SizeIs(1));
   EXPECT_TRUE(filtered_topics.find("/invalid_topic") != filtered_topics.end());
@@ -201,16 +182,11 @@ TEST_F(RegexFixture, regex_filter_exclude)
 
 TEST_F(RegexFixture, regex_filter)
 {
-  std::string filter_regex_string = "/inval.*";
-  std::string exclude_regex_string = "";
-  bool all_flag = false;
-
-  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-    topics_and_types_,
-    filter_regex_string,
-    exclude_regex_string,
-    all_flag
-  );
+  rosbag2_transport::RecordOptions record_options;
+  record_options.regex = "/inval.*";
+  record_options.all = false;
+  rosbag2_transport::TopicFilter filter{record_options, true};
+  auto filtered_topics = filter.filter_topics(topics_and_types_);
 
   EXPECT_THAT(filtered_topics, SizeIs(2));
   for (const auto & topic : {"/invalid_topic", "/invalidated_topic"}) {
@@ -220,16 +196,10 @@ TEST_F(RegexFixture, regex_filter)
 
 TEST_F(RegexFixture, regex_all_and_filter)
 {
-  std::string filter_regex_string = "/status";
-  std::string exclude_regex_string = "";
-  bool all_flag = true;
-
-  auto filtered_topics = rosbag2_transport::topic_filter::filter_topics_using_regex(
-    topics_and_types_,
-    filter_regex_string,
-    exclude_regex_string,
-    all_flag
-  );
-
+  rosbag2_transport::RecordOptions record_options;
+  record_options.regex = "/status";
+  record_options.all = true;
+  rosbag2_transport::TopicFilter filter{record_options, true};
+  auto filtered_topics = filter.filter_topics(topics_and_types_);
   EXPECT_THAT(filtered_topics, SizeIs(6));
 }


### PR DESCRIPTION
Part of #831
Going to use this filter for Converter functionality to choose which Writers receive which topics from Readers. The single-call structure makes it clear that both the Recorder and the Converter use the same logic.

The current implementation was hard to understand the order of operations for the topic filter.

This new implementation fully checks each topic all the way through all filters, allowing it to be easily used for a single topic, or iterate over a container. This is a mild optimization in that only a single container copy is done, rather than repeatedly copying into a new container for each filter step. 

More importantly, it makes the pipeline of functions easier to follow and extend by clearly showing the linear order of filters for a topic.