### PR TITLE
use-ros-time

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -82,6 +82,10 @@ class PlayVerb(VerbExtension):
             help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
                  'Value must be positive. Defaults to not publishing.')
         parser.add_argument(
+            '--use-ros-time', type='store_true',
+            help='Use ROS Time by subscribing to /clock. '
+            'This will disable all player time controls. Incompatible with --clock.')
+        parser.add_argument(
             '-d', '--delay', type=positive_float, default=0.0,
             help='Sleep duration before play (each loop), in seconds. Negative durations invalid.')
         parser.add_argument(
@@ -131,6 +135,7 @@ class PlayVerb(VerbExtension):
         play_options.disable_keyboard_controls = args.disable_keyboard_controls
         play_options.start_paused = args.start_paused
         play_options.start_offset = args.start_offset
+        play_options.use_ros_time = args.use_ros_time
 
         player = Player()
         player.play(storage_options, play_options)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -82,7 +82,7 @@ class PlayVerb(VerbExtension):
             help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
                  'Value must be positive. Defaults to not publishing.')
         parser.add_argument(
-            '--use-ros-time', type='store_true',
+            '--use-ros-time', action='store_true',
             help='Use ROS Time by subscribing to /clock. '
             'This will disable all player time controls. Incompatible with --clock.')
         parser.add_argument(

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
   src/rosbag2_cpp/cache/message_cache.cpp
   src/rosbag2_cpp/cache/circular_message_cache.cpp
+  src/rosbag2_cpp/clocks/ros_time_clock.cpp
   src/rosbag2_cpp/clocks/time_controller_clock.cpp
   src/rosbag2_cpp/converter.cpp
   src/rosbag2_cpp/info.cpp

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -103,19 +103,15 @@ public:
   virtual bool is_paused() const = 0;
 
   /**
-   * \brief Change the current ROS time to an arbitrary time.
+   * \brief Change the internal offset used to calculate "now".
+   * Each clock implementation has an underlying source of truth for time, and maintains
+   * some offset to associate that with a bag time. 
    * \note This will wake any waiting `sleep_until` and trigger any registered JumpHandler
    * callbacks.
    * \param time_point Time point in ROS playback timeline.
    */
   ROSBAG2_CPP_PUBLIC
-  virtual void jump(rcutils_time_point_value_t time_point) = 0;
-
-  /**
-   * \sa jump
-   */
-  ROSBAG2_CPP_PUBLIC
-  virtual void jump(rclcpp::Time time) = 0;
+  virtual void override_offset(rclcpp::Time time) = 0;
 
   /// Add a callback to invoke if the jump threshold is exceeded.
   /// \sa rclcpp::Clock::create_jump_callback

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -105,13 +105,13 @@ public:
   /**
    * \brief Change the internal offset used to calculate "now".
    * Each clock implementation has an underlying source of truth for time, and maintains
-   * some offset to associate that with a bag time. 
+   * some offset to associate that with a bag time.
    * \note This will wake any waiting `sleep_until` and trigger any registered JumpHandler
    * callbacks.
-   * \param time_point Time point in ROS playback timeline.
+   * \param time_point Current time point in bag's reference frame, to match with internal now.
    */
   ROSBAG2_CPP_PUBLIC
-  virtual void override_offset(rclcpp::Time time) = 0;
+  virtual void override_offset(rcutils_time_point_value_t) = 0;
 
   /// Add a callback to invoke if the jump threshold is exceeded.
   /// \sa rclcpp::Clock::create_jump_callback

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
@@ -80,9 +80,9 @@ public:
     return false;
   }
 
-  /// Override the internal offset between ROS time and returned "now" time.
+  /// Override the internal offset between bag's timestamps and clock's ROS time.
   ROSBAG2_CPP_PUBLIC
-  void override_offset(rclcpp::Time /*ros_time*/) override {}
+  void override_offset(rcutils_time_point_value_t bag_time) override;
 
   /// Add a callback to invoke if the jump threshold is exceeded.
   /// \sa rclcpp::Clock::create_jump_callback
@@ -94,6 +94,7 @@ public:
 
 private:
   std::shared_ptr<rclcpp::Clock> clock_;
+  rcutils_duration_value_t offset_{0};
 };
 }  // namespace rosbag2_cpp
 

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "rclcpp/clock.hpp"
+#include "rclcpp/node.hpp"
 
 #include "rosbag2_cpp/clocks/player_clock.hpp"
 
@@ -32,7 +33,7 @@ class RosTimeClock : public PlayerClock
 {
 public:
   ROSBAG2_CPP_PUBLIC
-  RosTimeClock();
+  RosTimeClock(rclcpp::Clock::SharedPtr clock);
 
   ROSBAG2_CPP_PUBLIC
   virtual ~RosTimeClock();
@@ -96,7 +97,7 @@ public:
     const rcl_jump_threshold_t & threshold) override;
 
 private:
-  std::unique_ptr<rclcpp::Clock> clock_;
+  std::shared_ptr<rclcpp::Clock> clock_;
 };
 }  // namespace rosbag2_cpp
 

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
@@ -1,0 +1,102 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_CPP__CLOCKS__ROS_TIME_CLOCK_HPP_
+#define ROSBAG2_CPP__CLOCKS__ROS_TIME_CLOCK_HPP_
+
+#include <chrono>
+#include <memory>
+
+#include "rclcpp/clock.hpp"
+
+#include "rosbag2_cpp/clocks/player_clock.hpp"
+
+namespace rosbag2_cpp
+{
+
+/// Implementation of PlayerClock that uses ROStime and cannot control time itself.
+/// All time control methods such as set_rate and seek will not do anything.
+/// If no /clock topic is publishing, time will not move forward.
+class RosTimeClock : public PlayerClock
+{
+public:
+  ROSBAG2_CPP_PUBLIC
+  RosTimeClock();
+
+  ROSBAG2_CPP_PUBLIC
+  virtual ~RosTimeClock();
+
+  /// Returns the latest /clock sample received
+  ROSBAG2_CPP_PUBLIC
+  rcutils_time_point_value_t now() const override;
+
+  /// Try to sleep (non-busy) the current thread until the provided time is reached according to /clock
+  /// \return true if time has been reached, false if it was not successfully reached
+  ROSBAG2_CPP_PUBLIC
+  bool sleep_until(rcutils_time_point_value_t until) override;
+
+  ROSBAG2_CPP_PUBLIC
+  bool sleep_until(rclcpp::Time until) override;
+
+  /// No-op
+  ROSBAG2_CPP_PUBLIC
+  bool set_rate(double /*rate*/) override
+  {
+    return false;
+  }
+
+  /// No-op
+  ROSBAG2_CPP_PUBLIC
+  double get_rate() const override
+  {
+    return 1.0;
+  }
+
+  /// No-op
+  ROSBAG2_CPP_PUBLIC
+  void pause() override {}
+
+  /// No-op
+  ROSBAG2_CPP_PUBLIC
+  void resume() override {}
+
+  /// No-op
+  ROSBAG2_CPP_PUBLIC
+  bool is_paused() const override
+  {
+    return false;
+  }
+
+  /// No-op
+  ROSBAG2_CPP_PUBLIC
+  void jump(rcutils_time_point_value_t /*ros_time*/) override {}
+
+  /// No-op
+  ROSBAG2_CPP_PUBLIC
+  void jump(rclcpp::Time /*ros_time*/) override {}
+
+  /// Add a callback to invoke if the jump threshold is exceeded.
+  /// \sa rclcpp::Clock::create_jump_callback
+  ROSBAG2_CPP_PUBLIC
+  rclcpp::JumpHandler::SharedPtr create_jump_callback(
+    rclcpp::JumpHandler::pre_callback_t pre_callback,
+    rclcpp::JumpHandler::post_callback_t post_callback,
+    const rcl_jump_threshold_t & threshold) override;
+
+private:
+  std::unique_ptr<rclcpp::Clock> clock_;
+};
+}  // namespace rosbag2_cpp
+
+#endif  // ROSBAG2_CPP__CLOCKS__ROS_TIME_CLOCK_HPP_

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
@@ -80,13 +80,9 @@ public:
     return false;
   }
 
-  /// No-op
+  /// Override the internal offset between ROS time and returned "now" time.
   ROSBAG2_CPP_PUBLIC
-  void jump(rcutils_time_point_value_t /*ros_time*/) override {}
-
-  /// No-op
-  ROSBAG2_CPP_PUBLIC
-  void jump(rclcpp::Time /*ros_time*/) override {}
+  void override_offset(rclcpp::Time /*ros_time*/) override {}
 
   /// Add a callback to invoke if the jump threshold is exceeded.
   /// \sa rclcpp::Clock::create_jump_callback

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/ros_time_clock.hpp
@@ -41,7 +41,8 @@ public:
   ROSBAG2_CPP_PUBLIC
   rcutils_time_point_value_t now() const override;
 
-  /// Try to sleep (non-busy) the current thread until the provided time is reached according to /clock
+  /// Try to sleep (non-busy) the current thread until the provided time is reached,
+  /// according to /clock
   /// \return true if time has been reached, false if it was not successfully reached
   ROSBAG2_CPP_PUBLIC
   bool sleep_until(rcutils_time_point_value_t until) override;

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -110,13 +110,13 @@ public:
   bool is_paused() const override;
 
   /**
-   * Change the current ROS time to an arbitrary time.
+   * Change the current time to an arbitrary time.
    * \note This will wake any waiting `sleep_until`, and may trigger jump callbacks.
    *
    * \param ros_time: The new bag time to use as the basis for "now()"
    */
   ROSBAG2_CPP_PUBLIC
-  void override_offset(rclcpp::Time ros_time) override;
+  void override_offset(rcutils_time_point_value_t bag_time) override;
 
   /// Since a jump can only occur via a `jump` call by the owner of this Clock,
   /// jump callbacks are not handled in this clock.

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -111,20 +111,12 @@ public:
 
   /**
    * Change the current ROS time to an arbitrary time.
-   * \note This will wake any waiting `sleep_until` and trigger any registered JumpHandler
-   * callbacks.
-   * \note The Player should not use this method while its queues are active ("during playback")
-   * as an arbitrary time jump can make those queues, and the state of the Reader/Storage, invalid
-   * The current Player implementation should only use this method in between calls to `play`,
-   * to reset the initial time of the clock.
+   * \note This will wake any waiting `sleep_until`, and may trigger jump callbacks.
    *
-   * \param ros_time: The new ROS time to use as the basis for "now()"
+   * \param ros_time: The new bag time to use as the basis for "now()"
    */
   ROSBAG2_CPP_PUBLIC
-  void jump(rcutils_time_point_value_t ros_time) override;
-
-  ROSBAG2_CPP_PUBLIC
-  void jump(rclcpp::Time ros_time) override;
+  void override_offset(rclcpp::Time ros_time) override;
 
   /// Since a jump can only occur via a `jump` call by the owner of this Clock,
   /// jump callbacks are not handled in this clock.

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/ros_time_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/ros_time_clock.cpp
@@ -1,0 +1,58 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "rcpputils/thread_safety_annotations.hpp"
+#include "rosbag2_cpp/clocks/ros_time_clock.hpp"
+#include "rosbag2_cpp/types.hpp"
+
+namespace rosbag2_cpp
+{
+
+RosTimeClock::RosTimeClock()
+: clock_(std::make_unique<rclcpp::Clock>(RCL_ROS_TIME))
+{}
+
+RosTimeClock::~RosTimeClock()
+{}
+
+rcutils_time_point_value_t RosTimeClock::now() const
+{
+  return clock_->now().nanoseconds();
+}
+
+bool RosTimeClock::sleep_until(rcutils_time_point_value_t until)
+{
+  return sleep_until(rclcpp::Time(until));
+}
+
+bool RosTimeClock::sleep_until(rclcpp::Time until)
+{
+  return clock_->sleep_until(until);
+}
+
+rclcpp::JumpHandler::SharedPtr RosTimeClock::create_jump_callback(
+  rclcpp::JumpHandler::pre_callback_t pre_callback,
+  rclcpp::JumpHandler::post_callback_t post_callback,
+  const rcl_jump_threshold_t & threshold)
+{
+  return clock_->create_jump_callback(pre_callback, post_callback, threshold);
+}
+
+}  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -125,7 +125,7 @@ public:
    * \note Will trigger any registered JumpHandler callbacks.
    * \param ros_time Time point in ROS playback timeline.
    */
-  void jump(rcutils_time_point_value_t ros_time)
+  void override_offset(rcutils_time_point_value_t ros_time)
   {
     std::lock_guard<std::mutex> lock(state_mutex);
     snapshot(ros_time);
@@ -241,14 +241,9 @@ bool TimeControllerClock::is_paused() const
   return impl_->paused;
 }
 
-void TimeControllerClock::jump(rcutils_time_point_value_t ros_time)
+void TimeControllerClock::override_offset(rclcpp::Time ros_time)
 {
-  impl_->jump(ros_time);
-}
-
-void TimeControllerClock::jump(rclcpp::Time ros_time)
-{
-  jump(ros_time.nanoseconds());
+  impl_->override_offset(ros_time.nanoseconds());
 }
 
 rclcpp::JumpHandler::SharedPtr TimeControllerClock::create_jump_callback(

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -241,9 +241,9 @@ bool TimeControllerClock::is_paused() const
   return impl_->paused;
 }
 
-void TimeControllerClock::override_offset(rclcpp::Time ros_time)
+void TimeControllerClock::override_offset(rcutils_time_point_value_t bag_time)
 {
-  impl_->override_offset(ros_time.nanoseconds());
+  impl_->override_offset(bag_time);
 }
 
 rclcpp::JumpHandler::SharedPtr TimeControllerClock::create_jump_callback(

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -243,19 +243,19 @@ TEST_F(TimeControllerClockTest, jump)
   rcutils_time_point_value_t expected_ros_time = RCUTILS_S_TO_NS(10);
   rosbag2_cpp::TimeControllerClock clock(ros_start_time, now_fn);
 
-  clock.jump(expected_ros_time);
+  clock.override_offset(expected_ros_time);
   EXPECT_EQ(clock.now(), expected_ros_time);
 
   return_time += std::chrono::seconds(10);
   expected_ros_time += RCUTILS_S_TO_NS(10);
   EXPECT_EQ(clock.now(), expected_ros_time);
 
-  clock.jump(rclcpp::Time(100, 0));
+  clock.override_offset(rclcpp::Time(100, 0));
   return_time += std::chrono::seconds(1);
   EXPECT_EQ(clock.now(), RCUTILS_S_TO_NS(101));
 
   // Jump backward
-  clock.jump(rclcpp::Time(50, 0));
+  clock.override_offset(rclcpp::Time(50, 0));
   return_time += std::chrono::seconds(2);
   EXPECT_EQ(clock.now(), RCUTILS_S_TO_NS(52));
 }
@@ -271,7 +271,7 @@ TEST_F(TimeControllerClockTest, jump_forward_with_playback_rate)
   testing_clock.set_rate(playback_rate);
 
   const rcutils_time_point_value_t ros_time_point_for_jump = ros_start_time + RCUTILS_S_TO_NS(3);
-  testing_clock.jump(ros_time_point_for_jump);
+  testing_clock.override_offset(ros_time_point_for_jump);
 
   // Emulate wall clock ticks
   const SteadyTimePoint current_wall_time = wall_time_begin + SteadyTimeDurationSecT(5);
@@ -297,7 +297,7 @@ TEST_F(TimeControllerClockTest, jump_backward_with_playback_rate)
   testing_clock.set_rate(playback_rate);
 
   const rcutils_time_point_value_t ros_time_point_for_jump = ros_start_time - RCUTILS_S_TO_NS(3);
-  testing_clock.jump(ros_time_point_for_jump);
+  testing_clock.override_offset(ros_time_point_for_jump);
 
   // Emulate wall clock ticks
   const SteadyTimePoint current_wall_time = wall_time_begin + SteadyTimeDurationSecT(5);

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -247,6 +247,7 @@ PYBIND11_MODULE(_transport, m) {
     "start_offset",
     &PlayOptions::getStartOffset,
     &PlayOptions::setStartOffset)
+  .def_readwrite("use_ros_time", &PlayOptions::use_ros_time)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -21,6 +21,9 @@
 #include <vector>
 
 #include "keyboard_handler/keyboard_handler.hpp"
+
+#include "rcl/time.h"
+
 #include "rclcpp/duration.hpp"
 #include "rclcpp/qos.hpp"
 
@@ -46,6 +49,10 @@ public:
   // Rate in Hz at which to publish to /clock.
   // 0 (or negative) means that no publisher will be created
   double clock_publish_frequency = 0.0;
+  // if using ros time, then depending on external time controller
+  // and disabling all player time controls including keyboard controls and ros service controls
+  // Incompatible with positive clock_publish_frequency
+  bool use_ros_time = false;
 
   // Sleep before play. Negative durations invalid. Will delay at the beginning of each loop.
   rclcpp::Duration delay = rclcpp::Duration(0, 0);

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -169,6 +169,7 @@ private:
     const std::function<void()> & cb,
     const std::string & op_name);
   void add_keyboard_callbacks();
+  void add_jump_callbacks();
 
   void create_control_services();
 
@@ -177,13 +178,16 @@ private:
   moodycamel::ReaderWriterQueue<rosbag2_storage::SerializedBagMessageSharedPtr> message_queue_;
   mutable std::future<void> storage_loading_future_;
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides_;
-  std::unique_ptr<rosbag2_cpp::PlayerClock> clock_;
-  std::shared_ptr<rclcpp::TimerBase> clock_publish_timer_;
   std::mutex skip_message_in_main_play_loop_mutex_;
   bool skip_message_in_main_play_loop_ RCPPUTILS_TSA_GUARDED_BY
     (skip_message_in_main_play_loop_mutex_) = false;
 
   rcutils_time_point_value_t starting_time_;
+
+  // timing
+  std::unique_ptr<rosbag2_cpp::PlayerClock> clock_;
+  std::shared_ptr<rclcpp::TimerBase> clock_publish_timer_;
+  rclcpp::JumpHandler::SharedPtr clock_jump_handler_;
 
   // control services
   rclcpp::Service<rosbag2_interfaces::srv::Pause>::SharedPtr srv_pause_;

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -39,6 +39,8 @@
 
 #include "rosbag2_transport/qos.hpp"
 
+#include "logging.hpp"
+
 namespace
 {
 /**
@@ -85,6 +87,22 @@ rclcpp::QoS publisher_qos_for_topic(
   const auto offered_qos_profiles = profiles_yaml.as<std::vector<Rosbag2QoS>>();
   return Rosbag2QoS::adapt_offer_to_recorded_offers(topic.name, offered_qos_profiles);
 }
+
+rclcpp::Time wait_for_first_nonzero_time(const rclcpp::Clock::SharedPtr clock)
+{
+  ROSBAG2_TRANSPORT_LOG_INFO("Waiting for first sim_time sample before starting playback.");
+  while (rclcpp::ok()) {
+    auto now = clock->now();
+    if (now == rclcpp::Time(0)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    } else {
+      return now;
+    }
+  }
+  ROSBAG2_TRANSPORT_LOG_WARN("No active /clock time found before RCLCPP shutdown.");
+  return rclcpp::Time(0);
+}
+
 }  // namespace
 
 namespace rosbag2_transport
@@ -116,8 +134,7 @@ Player::Player(
   const std::string & node_name,
   const rclcpp::NodeOptions & node_options)
 : Player(std::move(reader),
-    // only call KeyboardHandler when using default keyboard handler implementation
-    std::shared_ptr<KeyboardHandler>(new KeyboardHandler()),
+    play_options.use_ros_time ? nullptr : std::make_shared<KeyboardHandler>(),
     storage_options, play_options,
     node_name, node_options)
 {}
@@ -217,6 +234,14 @@ void Player::play()
 
   try {
     do {
+      // TODO(emersonknapp) we need some "wait for first simulated time" function here
+      // give good messaging and match up first received time with the bag start time
+      // if (play_options_.use_ros_time) {
+      //   auto start_sim_time = wait_for_first_nonzero_time(get_clock());
+      //   ROSBAG2_TRANSPORT_LOG_INFO("Sim time detected. Bag ");
+          // clock_->override_offset(start_sim_time);
+      // }
+
       if (delay > rclcpp::Duration(0, 0)) {
         RCLCPP_INFO_STREAM(get_logger(), "Sleep " << delay.nanoseconds() << " ns");
         std::chrono::nanoseconds duration(delay.nanoseconds());
@@ -225,7 +250,7 @@ void Player::play()
       {
         std::lock_guard<std::mutex> lk(reader_mutex_);
         reader_->seek(starting_time_);
-        clock_->jump(starting_time_);
+        clock_->override_offset(rclcpp::Time(starting_time_));
       }
       storage_loading_future_ = std::async(std::launch::async, [this]() {load_storage_content();});
       wait_for_filled_queue();
@@ -247,13 +272,17 @@ void Player::play()
 void Player::pause()
 {
   clock_->pause();
-  RCLCPP_INFO_STREAM(get_logger(), "Pausing play.");
+  if (!play_options_.use_ros_time) {
+    RCLCPP_INFO_STREAM(get_logger(), "Pausing play.");
+  }
 }
 
 void Player::resume()
 {
   clock_->resume();
-  RCLCPP_INFO_STREAM(get_logger(), "Resuming play.");
+  if (!play_options_.use_ros_time) {
+    RCLCPP_INFO_STREAM(get_logger(), "Resuming play.");
+  }
 }
 
 void Player::toggle_paused()
@@ -274,10 +303,12 @@ double Player::get_rate() const
 bool Player::set_rate(double rate)
 {
   bool ok = clock_->set_rate(rate);
-  if (ok) {
-    RCLCPP_INFO_STREAM(get_logger(), "Set rate to " << rate);
-  } else {
-    RCLCPP_WARN_STREAM(get_logger(), "Failed to set rate to invalid value " << rate);
+  if (!play_options_.use_ros_time) {
+    if (ok) {
+      RCLCPP_INFO_STREAM(get_logger(), "Set rate to " << rate);
+    } else {
+      RCLCPP_WARN_STREAM(get_logger(), "Failed to set rate to invalid value " << rate);
+    }
   }
   return ok;
 }
@@ -329,7 +360,7 @@ bool Player::play_next()
     {
       rosbag2_storage::SerializedBagMessageSharedPtr message = *message_ptr;
       next_message_published = publish_message(message);
-      clock_->jump(message->time_stamp);
+      clock_->override_offset(rclcpp::Time(message->time_stamp));
     }
     message_queue_.pop();
     message_ptr = peek_next_message_from_queue();
@@ -359,7 +390,7 @@ void Player::seek(rcutils_time_point_value_t time_point)
     // Purge current messages in queue.
     while (message_queue_.pop()) {}
     reader_->seek(time_point);
-    clock_->jump(time_point);
+    clock_->override_offset(rclcpp::Time(time_point));
     // Restart queuing thread if it has finished running (previously reached end of bag),
     // otherwise, queueing should continue automatically after releasing mutex
     if (is_storage_completely_loaded() && rclcpp::ok()) {

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -40,10 +40,6 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
   const size_t num_messages = 3;
   const int64_t time_stamp_in_milliseconds = 700;
   const size_t expected_number_of_messages = num_messages * 2;
-  const size_t read_ahead_queue_size = 1000;
-  const float rate = 1.0;
-  const bool loop_playback = false;
-  double clock_publish_frequency = 0.0;
   const rclcpp::Duration delay(1, 0);
 
   auto primitive_message1 = get_messages_basic_types()[0];
@@ -66,9 +62,9 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  rosbag2_transport::PlayOptions play_options = {
-    read_ahead_queue_size, "", rate, {}, {}, loop_playback, {},
-    clock_publish_frequency, delay};
+  rosbag2_transport::PlayOptions play_options;
+  play_options.delay = delay;
+
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);
@@ -100,10 +96,6 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   const size_t num_messages = 3;
   const int64_t time_stamp_in_milliseconds = 700;
   const size_t expected_number_of_messages = num_messages * 3;
-  const size_t read_ahead_queue_size = 1000;
-  const float rate = 1.0;
-  const bool loop_playback = true;
-  const double clock_publish_frequency = 0.0;
   const rclcpp::Duration delay(1, 0);
 
   auto primitive_message1 = get_messages_basic_types()[0];
@@ -126,8 +118,9 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
 
   auto await_received_messages = sub_->spin_subscriptions();
 
-  rosbag2_transport::PlayOptions play_options{read_ahead_queue_size, "", rate, {}, {},
-    loop_playback, {}, clock_publish_frequency, delay};
+  rosbag2_transport::PlayOptions play_options;
+  play_options.loop = true;
+  play_options.delay = delay;
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);


### PR DESCRIPTION
Closes #694

Implements "use-ros-time" option for playback. This will listen to `/clock` to control playback time, disabling all other timing controls.