### PR TITLE
Add parentheses suggested by Clang on OSX to fix build warning

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
@@ -149,7 +149,7 @@ void perform_rewrite(
   next_messages.resize(input_bags.size(), nullptr);
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> next_msg;
-  while (next_msg = get_next(input_bags, next_messages)) {
+  while ((next_msg = get_next(input_bags, next_messages))) {
     auto topic_writers = topic_outputs.find(next_msg->topic_name);
     if (topic_writers != topic_outputs.end()) {
       for (auto writer : topic_writers->second) {


### PR DESCRIPTION
See https://github.com/ros2/rosbag2/pull/920#discussion_r761980242 - #920 introduced a Clang build warning