### PR TITLE
Add start time play option

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -130,7 +130,7 @@ class PlayVerb(VerbExtension):
         play_options.delay = args.delay
         play_options.disable_keyboard_controls = args.disable_keyboard_controls
         play_options.start_paused = args.start_paused
-        play_options.starting_time = args.start_time
+        play_options.start_offset = args.start_time
 
         player = Player()
         player.play(storage_options, play_options)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -91,7 +91,7 @@ class PlayVerb(VerbExtension):
             '-p', '--start-paused', action='store_true', default=False,
             help='Start the playback player in a paused state.')
         parser.add_argument(
-            '--start-time', type=check_positive_float, default=0.0,
+            '--start-offset', type=check_positive_float, default=0.0,
             help='Start the playback player this many seconds into the bag file.')
 
     def main(self, *, args):  # noqa: D102
@@ -130,7 +130,7 @@ class PlayVerb(VerbExtension):
         play_options.delay = args.delay
         play_options.disable_keyboard_controls = args.disable_keyboard_controls
         play_options.start_paused = args.start_paused
-        play_options.start_offset = args.start_time
+        play_options.start_offset = args.start_offset
 
         player = Player()
         player.play(storage_options, play_options)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -90,6 +90,9 @@ class PlayVerb(VerbExtension):
         parser.add_argument(
             '-p', '--start-paused', action='store_true', default=False,
             help='Start the playback player in a paused state.')
+        parser.add_argument(
+            '--start-time', type=check_positive_float, default=0.0,
+            help='Start the playback player this many seconds into the bag file.')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -127,6 +130,7 @@ class PlayVerb(VerbExtension):
         play_options.delay = args.delay
         play_options.disable_keyboard_controls = args.disable_keyboard_controls
         play_options.start_paused = args.start_paused
+        play_options.starting_time = args.start_time
 
         player = Player()
         player.play(storage_options, play_options)

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -81,7 +81,7 @@ public:
 
   double getStartingTime() const
   {
-    return RCUTILS_NS_TO_S(static_cast<double>(starting_time));
+    return RCUTILS_NS_TO_S(static_cast<double>(this->starting_time));
   }
 
   void setTopicQoSProfileOverrides(const py::dict & overrides)

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -74,14 +74,14 @@ public:
     return RCUTILS_NS_TO_S(static_cast<double>(this->delay.nanoseconds()));
   }
 
-  void setStartingTime(double starting_time)
+  void setStartOffset(double start_offset)
   {
-    this->starting_time = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(starting_time));
+    this->start_offset = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(start_offset));
   }
 
-  double getStartingTime() const
+  double getStartOffset() const
   {
-    return RCUTILS_NS_TO_S(static_cast<double>(this->starting_time));
+    return RCUTILS_NS_TO_S(static_cast<double>(this->start_offset));
   }
 
   void setTopicQoSProfileOverrides(const py::dict & overrides)
@@ -244,9 +244,9 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("disable_keyboard_controls", &PlayOptions::disable_keyboard_controls)
   .def_readwrite("start_paused", &PlayOptions::start_paused)
   .def_property(
-    "starting_time",
-    &PlayOptions::getStartingTime,
-    &PlayOptions::setStartingTime)
+    "start_offset",
+    &PlayOptions::getStartOffset,
+    &PlayOptions::setStartOffset)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -74,6 +74,16 @@ public:
     return RCUTILS_NS_TO_S(static_cast<double>(this->delay.nanoseconds()));
   }
 
+  void setStartingTime(double starting_time)
+  {
+    this->starting_time = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(starting_time));
+  }
+
+  double getStartingTime() const
+  {
+    return RCUTILS_NS_TO_S(static_cast<double>(starting_time));
+  }
+
   void setTopicQoSProfileOverrides(const py::dict & overrides)
   {
     py_dict = overrides;
@@ -233,6 +243,10 @@ PYBIND11_MODULE(_transport, m) {
     &PlayOptions::setDelay)
   .def_readwrite("disable_keyboard_controls", &PlayOptions::disable_keyboard_controls)
   .def_readwrite("start_paused", &PlayOptions::start_paused)
+  .def_property(
+    "starting_time",
+    &PlayOptions::getStartingTime,
+    &PlayOptions::setStartingTime)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -16,7 +16,6 @@
 #define ROSBAG2_TRANSPORT__PLAY_OPTIONS_HPP_
 
 #include <cstddef>
-#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -55,7 +54,7 @@ public:
   bool start_paused = false;
 
   // Time to start playback as an offset from the beginning of the bag.
-  rcutils_time_point_value_t start_offset = INT64_C(0);
+  rcutils_time_point_value_t start_offset = 0;
 
   bool disable_keyboard_controls = false;
   // keybindings

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -54,8 +54,8 @@ public:
   // Start paused.
   bool start_paused = false;
 
-  // Start time from which the player should play the bag.
-  rcutils_time_point_value_t starting_time = INT64_C(0);
+  // Time to start playback as an offset from the beginning of the bag.
+  rcutils_time_point_value_t start_offset = INT64_C(0);
 
   bool disable_keyboard_controls = false;
   // keybindings

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_TRANSPORT__PLAY_OPTIONS_HPP_
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -52,6 +53,9 @@ public:
 
   // Start paused.
   bool start_paused = false;
+
+  // Start time from which the player should play the bag.
+  rcutils_time_point_value_t starting_time = INT64_C(0);
 
   bool disable_keyboard_controls = false;
   // keybindings

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -144,7 +144,7 @@ Player::Player(
       metadata.starting_time.time_since_epoch()).count();
     // If a non-default (positive) starting time offset is provided in PlayOptions,
     // then add the offset to the starting time obtained from reader metadata
-    if (play_options_.start_offset < INT64_C(0)) {
+    if (play_options_.start_offset < 0) {
       RCLCPP_WARN_STREAM(
         get_logger(),
         "Invalid start offset value: " <<

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -191,6 +191,12 @@ void Player::play()
       "Invalid delay value: " << play_options_.delay.nanoseconds() << ". Delay is disabled.");
   }
 
+  // If a non-default (positive) starting time was
+  // provided, override the starting time from metadata
+  if (play_options_.starting_time > INT64_C(0)) {
+    starting_time_ = play_options_.starting_time;
+  }
+
   try {
     do {
       if (delay > rclcpp::Duration(0, 0)) {

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -191,8 +191,8 @@ void Player::play()
       "Invalid delay value: " << play_options_.delay.nanoseconds() << ". Delay is disabled.");
   }
 
-  // If a non-default (positive) starting time was
-  // provided, override the starting time from metadata
+  // If a non-default (positive) starting time is provided in PlayOptions,
+  // override the starting time obtained from reader metadata
   if (play_options_.starting_time > INT64_C(0)) {
     starting_time_ = play_options_.starting_time;
   }

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -142,6 +142,17 @@ Player::Player(
     auto metadata = reader_->get_metadata();
     starting_time_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
       metadata.starting_time.time_since_epoch()).count();
+    // If a non-default (positive) starting time offset is provided in PlayOptions,
+    // then add the offset to the starting time obtained from reader metadata
+    if (play_options_.start_offset < INT64_C(0)) {
+      RCLCPP_WARN_STREAM(
+        get_logger(),
+        "Invalid start offset value: " <<
+          RCUTILS_NS_TO_S(static_cast<double>(play_options_.start_offset)) <<
+          ". Negative start offset ignored.");
+    } else {
+      starting_time_ += play_options_.start_offset;
+    }
     clock_ = std::make_unique<rosbag2_cpp::TimeControllerClock>(
       starting_time_, std::chrono::steady_clock::now,
       std::chrono::milliseconds{100}, play_options_.start_paused);
@@ -189,12 +200,6 @@ void Player::play()
     RCLCPP_WARN_STREAM(
       get_logger(),
       "Invalid delay value: " << play_options_.delay.nanoseconds() << ". Delay is disabled.");
-  }
-
-  // If a non-default (positive) starting time is provided in PlayOptions,
-  // override the starting time obtained from reader metadata
-  if (play_options_.starting_time > INT64_C(0)) {
-    starting_time_ = play_options_.starting_time;
   }
 
   try {

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -15,7 +15,6 @@
 #include <gmock/gmock.h>
 
 #include <chrono>
-#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -194,7 +193,7 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_delay)
 
 TEST_F(PlayerTestFixture, play_respects_start_offset)
 {
-  rclcpp::Duration start_delay(0, static_cast<uint32_t>(5e8));  // 5e8 ns == 0.5 s
+  rclcpp::Duration start_delay(0, static_cast<uint32_t>(RCUTILS_S_TO_NS(0.5)));
   rclcpp::Duration delay_margin(1, 0);
 
   // Start 0.5 seconds into the bag
@@ -218,7 +217,7 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_start_offset)
   rclcpp::Duration delay_margin(1, 0);
 
   // Player should ignore an invalid (negative) start offset
-  play_options_.start_offset = INT64_C(-5);
+  play_options_.start_offset = -5;
   auto lower_expected_duration = message_time_difference;
   auto upper_expected_duration = message_time_difference + delay_margin;
   auto player = std::make_shared<rosbag2_transport::Player>(

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -194,13 +194,13 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_delay)
 
 TEST_F(PlayerTestFixture, play_respects_starting_time)
 {
-  rclcpp::Duration start_delay(5, 0);
+  rclcpp::Duration start_delay(0, 5e8);  // 5e8 ns == 0.5 s
   rclcpp::Duration delay_margin(1, 0);
 
   // Start 5 seconds into the bag
-  play_options_.starting_time = INT64_C(5);
-  auto lower_expected_duration = message_time_difference + start_delay;
-  auto upper_expected_duration = message_time_difference + start_delay + delay_margin;
+  play_options_.starting_time = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(0.5));
+  auto lower_expected_duration = message_time_difference - start_delay;
+  auto upper_expected_duration = message_time_difference - start_delay + delay_margin;
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(reader), storage_options_, play_options_);
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -194,7 +194,7 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_delay)
 
 TEST_F(PlayerTestFixture, play_respects_starting_time)
 {
-  rclcpp::Duration start_delay(0, 5e8);  // 5e8 ns == 0.5 s
+  rclcpp::Duration start_delay(0, static_cast<uint32_t>(5e8));  // 5e8 ns == 0.5 s
   rclcpp::Duration delay_margin(1, 0);
 
   // Start 5 seconds into the bag

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -197,8 +197,9 @@ TEST_F(PlayerTestFixture, play_respects_starting_time)
   rclcpp::Duration start_delay(0, static_cast<uint32_t>(5e8));  // 5e8 ns == 0.5 s
   rclcpp::Duration delay_margin(1, 0);
 
-  // Start 5 seconds into the bag
+  // Start 0.5 seconds into the bag
   play_options_.starting_time = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(0.5));
+  // Subtract the delay since we've seeked further into the bag
   auto lower_expected_duration = message_time_difference - start_delay;
   auto upper_expected_duration = message_time_difference - start_delay + delay_margin;
   auto player = std::make_shared<rosbag2_transport::Player>(

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -192,14 +192,14 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_delay)
   EXPECT_THAT(replay_time, Lt(upper_expected_duration));
 }
 
-TEST_F(PlayerTestFixture, play_respects_starting_time)
+TEST_F(PlayerTestFixture, play_respects_start_offset)
 {
   rclcpp::Duration start_delay(0, static_cast<uint32_t>(5e8));  // 5e8 ns == 0.5 s
   rclcpp::Duration delay_margin(1, 0);
 
   // Start 0.5 seconds into the bag
-  play_options_.starting_time = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(0.5));
-  // Subtract the delay since we've seeked further into the bag
+  play_options_.start_offset = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(0.5));
+  // Subtract the delay since we've sought further into the bag
   auto lower_expected_duration = message_time_difference - start_delay;
   auto upper_expected_duration = message_time_difference - start_delay + delay_margin;
   auto player = std::make_shared<rosbag2_transport::Player>(
@@ -213,13 +213,12 @@ TEST_F(PlayerTestFixture, play_respects_starting_time)
   EXPECT_THAT(replay_time, Lt(upper_expected_duration));
 }
 
-TEST_F(PlayerTestFixture, play_ignores_invalid_starting_time)
+TEST_F(PlayerTestFixture, play_ignores_invalid_start_offset)
 {
   rclcpp::Duration delay_margin(1, 0);
 
-  // Invalid value should result in playing from
-  // metadata starting time - which is 0 seconds here
-  play_options_.starting_time = INT64_C(-5);
+  // Player should ignore an invalid (negative) start offset
+  play_options_.start_offset = INT64_C(-5);
   auto lower_expected_duration = message_time_difference;
   auto upper_expected_duration = message_time_difference + delay_margin;
   auto player = std::make_shared<rosbag2_transport::Player>(

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -206,10 +206,10 @@ TEST_F(PlayerTestFixture, play_respects_start_offset)
 
   auto start = clock.now();
   player->play();
-  auto replay_time = clock.now() - start;
+  auto replay_duration = clock.now() - start;
 
-  EXPECT_THAT(replay_time, Gt(lower_expected_duration));
-  EXPECT_THAT(replay_time, Lt(upper_expected_duration));
+  EXPECT_THAT(replay_duration, Gt(lower_expected_duration));
+  EXPECT_THAT(replay_duration, Lt(upper_expected_duration));
 }
 
 TEST_F(PlayerTestFixture, play_ignores_invalid_start_offset)
@@ -225,8 +225,8 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_start_offset)
 
   auto start = clock.now();
   player->play();
-  auto replay_time = clock.now() - start;
+  auto replay_duration = clock.now() - start;
 
-  EXPECT_THAT(replay_time, Gt(lower_expected_duration));
-  EXPECT_THAT(replay_time, Lt(upper_expected_duration));
+  EXPECT_THAT(replay_duration, Gt(lower_expected_duration));
+  EXPECT_THAT(replay_duration, Lt(upper_expected_duration));
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -198,11 +198,11 @@ TEST_F(PlayerTestFixture, play_respects_starting_time)
   rclcpp::Duration delay_margin(1, 0);
 
   // Start 5 seconds into the bag
-  play_option_.starting_time = INT64_C(5);
+  play_options_.starting_time = INT64_C(5);
   auto lower_expected_duration = message_time_difference + start_delay;
   auto upper_expected_duration = message_time_difference + start_delay + delay_margin;
   auto player = std::make_shared<rosbag2_transport::Player>(
-    std::move(reader), storage_options_, play_options);
+    std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
   player->play();


### PR DESCRIPTION
This PR adds a `--start-time` (optional) argument to the `ros2 bag play` verb. The desired use is as follows:

```python
ros2 bag play --start-time [positive-float-denoting-start-time-in-seconds]
```

In doing so, the `start_offset` field is added to `rosbag2_transport::PlayOptions` class and its corresponding PyBind11 wrapper.

`rosbag2_transport::Player` respects this option by adding `start_offset` - during construction - to the `starting_time` obtained from its readers metadata, but only does so if the start time is a valid non-negative value. Else, `Player` outputs to the warning stream about the invalid offset.

Partially addresses https://github.com/ros2/rosbag2/issues/929 and gets closer to parity with `rosbag play` from ROS 1.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>