### PR TITLE
TopicFilter use regex_search instead of regex_match

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -46,19 +46,25 @@ class RecordVerb(VerbExtension):
             if f.endswith(converter_suffix)
         }
 
+        # Topic filter arguments
+        parser.add_argument(
+            'topics', nargs='*', default=None, help='List of topics to record.')
         parser.add_argument(
             '-a', '--all', action='store_true',
-            help='recording all topics, required if no topics '
-            'are listed explicitly or through a regex')
+            help='Record all topics. Required if no explicit topic list or regex filters.')
         parser.add_argument(
-            'topics', nargs='*', default=None, help='topics to be recorded')
+            '-e', '--regex', default='',
+            help='Record only topics containing provided regular expression. '
+            'Overrides --all, applies on top of topics list.')
         parser.add_argument(
-            '-e', '--regex', default='', help='recording only topics '
-            'matching provided regular expression')
+            '-x', '--exclude', default='',
+            help='Exclude topics containing provided regular expression. '
+            'Works on top of --all, --regex, or topics list.')
         parser.add_argument(
-            '-x', '--exclude', default='', help='exclude topics '
-            'matching provided regular expression. Works with -a and -e, '
-            'subtracting excluded topics')
+            '--include-hidden-topics', action='store_true',
+            help='Discover and record hidden topics as well. '
+            'These are topics used internally by ROS 2 implementation.')
+        # The rest. TODO(emersonknapp) organize these better by category
         parser.add_argument(
             '-o', '--output',
             help='destination of the bagfile to create, \
@@ -124,10 +130,6 @@ class RecordVerb(VerbExtension):
             '--snapshot-mode', action='store_true',
             help='Enable snapshot mode. Messages will not be written to the bagfile until '
                  'the "/rosbag2_recorder/snapshot" service is called.'
-        )
-        parser.add_argument(
-            '--include-hidden-topics', action='store_true',
-            help='record also hidden topics.'
         )
         parser.add_argument(
             '--ignore-leaf-topics', action='store_true',

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -135,7 +135,7 @@ bool TopicFilter::take_topic(
   }
 
   std::regex exclude_regex(record_options_.exclude);
-  if (std::regex_match(topic_name, exclude_regex)) {
+  if (std::regex_search(topic_name, exclude_regex)) {
     return false;
   }
 
@@ -143,7 +143,7 @@ bool TopicFilter::take_topic(
   if (
     !record_options_.all &&  // All takes precedence over regex
     !record_options_.regex.empty() &&  // empty regex matches nothing, but should be ignored
-    !std::regex_match(topic_name, include_regex))
+    !std::regex_search(topic_name, include_regex))
   {
     return false;
   }

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -135,7 +135,7 @@ bool TopicFilter::take_topic(
   }
 
   std::regex exclude_regex(record_options_.exclude);
-  if (std::regex_search(topic_name, exclude_regex)) {
+  if (!record_options_.exclude.empty() && std::regex_search(topic_name, exclude_regex)) {
     return false;
   }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -39,7 +39,7 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
 {
   auto test_string_messages = get_messages_strings();
   auto test_array_messages = get_messages_arrays();
-  std::string regex = "/aa";
+  std::string regex = "^/aa$";
 
   // matching topic
   std::string v1 = "/aa";

--- a/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
@@ -140,7 +140,7 @@ TEST_F(TestRewrite, test_filter_split) {
     storage_opts.storage_id = "sqlite3";
     rosbag2_transport::RecordOptions rec_opts;
     rec_opts.all = true;
-    rec_opts.exclude = ".*basic.*";
+    rec_opts.exclude = "basic";
     output_bags_.push_back({storage_opts, rec_opts});
   }
   {

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -183,7 +183,7 @@ TEST_F(RegexFixture, regex_filter_exclude)
 TEST_F(RegexFixture, regex_filter)
 {
   rosbag2_transport::RecordOptions record_options;
-  record_options.regex = "/inval.*";
+  record_options.regex = "^/inval";
   record_options.all = false;
   rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
   auto filtered_topics = filter.filter_topics(topics_and_types_);


### PR DESCRIPTION
So that include and exclude regexes don't require full specification.

User can specify `--regex foo` to include all topics containing "foo", instead of having to specify `--regex .*foo.*`. To match `/foo`, `/barbazfoo`. User can still specify in full using `$^` for beginning and end of string, when desired.