### PR TITLE
Redesign in cache consumer and circular message cache to get rid from busy loop

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/cache/cache_consumer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/cache_consumer.hpp
@@ -74,8 +74,8 @@ public:
   /// \brief start inner consumer thread if it hasn't been started yet
   void start();
 
-  /// shut down the consumer thread
-  void close();
+  /// \brief shut down the consumer thread
+  void stop();
 
 private:
   std::shared_ptr<MessageCacheInterface> message_cache_;
@@ -86,8 +86,6 @@ private:
 
   /// Consumer thread shutdown sync
   std::atomic_bool is_stop_issued_ {false};
-  std::mutex consumer_mutex_;
-
   std::thread consumer_thread_;
 };
 

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache.hpp
@@ -80,12 +80,13 @@ public:
   /// In this greedy implementation, swap buffers before providing the buffer.
   std::shared_ptr<CacheBufferInterface> get_consumer_buffer() override;
 
-  /// Notify that get_consumer_buffer has been fully used. Unlock.
+  /// \brief Signals that tne consumer is done consuming, unlocking the buffer so it may be swapped.
   void release_consumer_buffer() override;
 
   /// \brief Blocks current thread and going to wait on condition variable until notify_data_ready
   /// will be called.
   void wait_for_data() override;
+
   /**
   * Consumer API: wait until primary buffer is ready and swap it with consumer buffer.
   * The caller thread (consumer thread) will sleep on a conditional variable

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache.hpp
@@ -71,18 +71,21 @@ class ROSBAG2_CPP_PUBLIC MessageCache
 public:
   explicit MessageCache(size_t max_buffer_size);
 
-  ~MessageCache();
+  ~MessageCache() override;
 
   /// Puts msg into primary buffer. With full cache, msg is ignored and counted as lost
   void push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
 
   /// Gets a consumer buffer.
   /// In this greedy implementation, swap buffers before providing the buffer.
-  std::shared_ptr<CacheBufferInterface> consumer_buffer() override;
+  std::shared_ptr<CacheBufferInterface> get_consumer_buffer() override;
 
-  /// Notify that consumer_buffer has been fully used. Unlock.
+  /// Notify that get_consumer_buffer has been fully used. Unlock.
   void release_consumer_buffer() override;
 
+  /// \brief Blocks current thread and going to wait on condition variable until notify_data_ready
+  /// will be called.
+  void wait_for_data() override;
   /**
   * Consumer API: wait until primary buffer is ready and swap it with consumer buffer.
   * The caller thread (consumer thread) will sleep on a conditional variable
@@ -101,23 +104,22 @@ public:
   /// Summarize dropped/remaining messages
   void log_dropped() override;
 
+  /// Producer API: notify consumer to wake-up (primary buffer has data)
+  void notify_data_ready() override;
+
 protected:
   /// Dropped messages per topic. Used for printing in alphabetic order
   std::unordered_map<std::string, uint32_t> messages_dropped_per_topic_;
 
 private:
-  /// Producer API: notify consumer to wake-up (primary buffer has data)
-  void notify_buffer_consumer();
-
   /// Double buffers
   std::shared_ptr<MessageCacheBuffer> producer_buffer_;
   std::mutex producer_buffer_mutex_;
   std::shared_ptr<MessageCacheBuffer> consumer_buffer_;
-  std::recursive_mutex consumer_buffer_mutex_;
-
+  std::mutex consumer_buffer_mutex_;
 
   /// Double buffers sync (following cpp core guidelines for condition variables)
-  bool primary_buffer_can_be_swapped_ {false};
+  bool data_ready_ {false};
   std::condition_variable cache_condition_var_;
 
   /// Cache is no longer accepting messages and is in the process of flushing

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_interface.hpp
@@ -43,18 +43,21 @@ public:
   /// Push a bag message into the producer buffer.
   virtual void push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) = 0;
 
-  /// Get a pointer to the buffer that can be used for consuming the cached messages.
-  /// This call locks access to the buffer, `swap_buffers` and `consumer_buffer` will block until
-  /// `release_consumer_buffer` is called to unlock access to the buffer.
+  /// \brief Get a pointer to the buffer that can be used for consuming the cached messages.
+  /// This call locks access to the buffer, `swap_buffers` and `get_consumer_buffer` will block
+  /// until `release_consumer_buffer` is called to unlock access to the buffer.
   /// Consumer should call `release_consumer_buffer` when they are done consuming the messages.
   /// \return a pointer to the consumer buffer interface.
-  virtual std::shared_ptr<CacheBufferInterface> consumer_buffer() = 0;
+  virtual std::shared_ptr<CacheBufferInterface> get_consumer_buffer() = 0;
 
   /// Signals that tne consumer is done consuming, unlocking the buffer so it may be swapped.
   virtual void release_consumer_buffer() = 0;
 
+  /// \brief Blocks current thread and going to wait until notify_data_ready will be called.
+  virtual void wait_for_data() {}
+
   /// Swap producer and consumer buffers.
-  /// Note: this will block if `consumer_buffer` has been called but `release_consumer_buffer`
+  /// Note: this will block if `get_consumer_buffer` has been called but `release_consumer_buffer`
   /// has not been called yet to signal end of consuming.
   virtual void swap_buffers() = 0;
 
@@ -66,6 +69,9 @@ public:
 
   /// Print a log message with details of any dropped messages.
   virtual void log_dropped() {}
+
+  /// \brief Producer API: notify wait_for_data() to wake up and unblock consumer thread.
+  virtual void notify_data_ready() {}
 };
 
 }  // namespace cache

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -122,7 +122,7 @@ protected:
   std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io_;
   std::unique_ptr<Converter> converter_;
 
-  bool use_cache_;
+  bool use_cache_ {false};
   std::shared_ptr<rosbag2_cpp::cache::MessageCacheInterface> message_cache_;
   std::unique_ptr<rosbag2_cpp::cache::CacheConsumer> cache_consumer_;
 
@@ -132,10 +132,6 @@ protected:
     const std::string & base_folder, uint64_t storage_count);
 
   rosbag2_storage::StorageOptions storage_options_;
-
-  // Used in bagfile splitting;
-  // specifies the best-effort maximum duration of a bagfile in seconds.
-  std::chrono::seconds max_bagfile_duration;
 
   // Used to track topic -> message count. If cache is present, it is updated by CacheConsumer
   std::unordered_map<std::string, rosbag2_storage::TopicInformation> topics_names_to_info_;

--- a/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
@@ -80,9 +80,12 @@ TEST_F(CircularMessageCacheTest, circular_message_cache_overwrites_old) {
     circular_message_cache->push(msg);
   }
   // Swap cache
+  circular_message_cache->notify_data_ready();
   circular_message_cache->swap_buffers();
 
-  auto consumer_buffer = circular_message_cache->consumer_buffer();
+  auto consumer_buffer = circular_message_cache->get_consumer_buffer();
+  EXPECT_THAT(consumer_buffer->size(), Ne(0u));
+
   auto message_vector = consumer_buffer->data();
   std::string first_message = deserialize_message(message_vector.front()->serialized_data);
   circular_message_cache->release_consumer_buffer();
@@ -114,16 +117,19 @@ TEST_F(CircularMessageCacheTest, circular_message_cache_ensure_empty) {
     circular_message_cache->push(msg);
   }
   // Swap filled cache to secondary
+  circular_message_cache->notify_data_ready();
   circular_message_cache->swap_buffers();
-  EXPECT_THAT(circular_message_cache->consumer_buffer()->size(), Ne(0u));
+  EXPECT_THAT(circular_message_cache->get_consumer_buffer()->size(), Ne(0u));
   circular_message_cache->release_consumer_buffer();
 
   // Swap back to primary (expected to empty buffer)
+  circular_message_cache->notify_data_ready();
   circular_message_cache->swap_buffers();
 
   // Swap back to secondary without adding messages
+  circular_message_cache->notify_data_ready();
   circular_message_cache->swap_buffers();
   // Cache should have been emptied
-  EXPECT_THAT(circular_message_cache->consumer_buffer()->size(), Eq(0u));
+  EXPECT_THAT(circular_message_cache->get_consumer_buffer()->size(), Eq(0u));
   circular_message_cache->release_consumer_buffer();
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
@@ -102,6 +102,6 @@ TEST_F(MessageCacheTest, message_cache_writes_full_producer_buffer) {
   using namespace std::chrono_literals;
   std::this_thread::sleep_for(20ms);
 
-  mock_cache_consumer->close();
+  mock_cache_consumer->stop();
   EXPECT_EQ(consumed_message_count, message_count - should_be_dropped_count);
 }


### PR DESCRIPTION
Add `wait_for_data()` method to the message cache interface which will
block current thread and wait on condition variable until
`notify_data_ready()` will be called from producer thread.
Now logic will be more transparent in cache consumer IMO. i.e.
```cpp
    message_cache_->wait_for_data();
    message_cache_->swap_buffers();
    auto consumer_buffer = message_cache_->get_consumer_buffer();
    consume_callback_(consumer_buffer->data());
    consumer_buffer->clear();
    message_cache_->release_consumer_buffer();
```
Also with this PR I think we will finally fix an issue  related to the high probability to drop messages during the bag split.  
Now there are no chance to drop messages unless there are no space in the cache any more. i.e. We can safely put new messages in primary buffer, while at the same time flushing messages to the storage from the secondary buffer.

- Closes #940
- Closes #640