### PR TITLE
[Foxy-future] Avoid passing exception KeyboardInterrupt to the upper layer (backport #788)

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -180,29 +180,31 @@ class RecordVerb(VerbExtension):
         #               extension. Therefore, do not import rosbag2_transport at the module
         #               level but on demand, right before first use.
         from rosbag2_transport import rosbag2_transport_py
-
-        rosbag2_transport_py.record(
-            uri=uri,
-            storage_id=args.storage,
-            serialization_format=args.serialization_format,
-            node_prefix=NODE_NAME_PREFIX,
-            compression_mode=args.compression_mode,
-            compression_format=args.compression_format,
-            compression_queue_size=args.compression_queue_size,
-            compression_threads=args.compression_threads,
-            all=args.all,
-            no_discovery=args.no_discovery,
-            polling_interval=args.polling_interval,
-            max_bagfile_size=args.max_bag_size,
-            max_bagfile_duration=args.max_bag_duration,
-            max_cache_size=args.max_cache_size,
-            topics=args.topics,
-            regex=args.regex,
-            exclude=args.exclude,
-            include_hidden_topics=args.include_hidden_topics,
-            qos_profile_overrides=qos_profile_overrides,
-            storage_preset_profile=args.storage_preset_profile,
-            storage_config_file=storage_config_file)
+        try:
+            rosbag2_transport_py.record(
+                uri=uri,
+                storage_id=args.storage,
+                serialization_format=args.serialization_format,
+                node_prefix=NODE_NAME_PREFIX,
+                compression_mode=args.compression_mode,
+                compression_format=args.compression_format,
+                compression_queue_size=args.compression_queue_size,
+                compression_threads=args.compression_threads,
+                all=args.all,
+                no_discovery=args.no_discovery,
+                polling_interval=args.polling_interval,
+                max_bagfile_size=args.max_bag_size,
+                max_bagfile_duration=args.max_bag_duration,
+                max_cache_size=args.max_cache_size,
+                topics=args.topics,
+                regex=args.regex,
+                exclude=args.exclude,
+                include_hidden_topics=args.include_hidden_topics,
+                qos_profile_overrides=qos_profile_overrides,
+                storage_preset_profile=args.storage_preset_profile,
+                storage_config_file=storage_config_file)
+        except KeyboardInterrupt:
+            pass
 
         if os.path.isdir(uri) and not os.listdir(uri):
             os.rmdir(uri)

--- a/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
@@ -66,7 +66,7 @@ void stop_execution(const ProcessHandle & handle, int signum = SIGINT)
   waitpid(handle, &child_return_code, 0);
   // this call will make sure that the process does execute without issues before it is killed by
   // the user in the test or, in case it runs until completion, that it has correctly executed.
-  EXPECT_THAT(WEXITSTATUS(child_return_code), Not(Eq(EXIT_FAILURE)));
+  EXPECT_THAT(WEXITSTATUS(child_return_code), EXIT_SUCCESS);
 }
 
 #endif  // ROSBAG2_TEST_COMMON__PROCESS_EXECUTION_HELPERS_UNIX_HPP_


### PR DESCRIPTION
* Avoid passing exception KeyboardInterrupt to the upper layer

Signed-off-by: Barry Xu <barry.xu@sony.com>