### PR TITLE
WIP: Fix logic for regular expressions in topic_filter

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.hpp
@@ -39,10 +39,11 @@ class ROSBAG2_TRANSPORT_PUBLIC TopicFilter
 {
 public:
   explicit TopicFilter(
-    RecordOptions record_options,
+    const RecordOptions & record_options,
     rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph = nullptr,
     bool allow_unknown_types = false);
-  virtual ~TopicFilter();
+
+  virtual ~TopicFilter() = default;
 
   /// Filter all topic_names_and_types via take_topic method, return the resulting filtered set
   /// Filtering order is:

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -49,15 +49,15 @@ TEST(TestTopicFilter, filter_hidden_topics) {
     {"_/topic/c", {"type_c"}},
   };
 
+  rosbag2_transport::RecordOptions record_options;
+  record_options.all = true;
   {
-    rosbag2_transport::RecordOptions record_options;
     record_options.include_hidden_topics = true;
     rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
     auto filtered_topics = filter.filter_topics(topics_and_types);
     ASSERT_EQ(topics_and_types.size(), filtered_topics.size());
   }
   {
-    rosbag2_transport::RecordOptions record_options;
     record_options.include_hidden_topics = false;
     rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
     auto filtered_topics = filter.filter_topics(topics_and_types);
@@ -73,7 +73,9 @@ TEST(TestTopicFilter, filter_topics_with_more_than_one_type) {
     {"topic/d", {"type_d", "type_d", "type_d2"}},
   };
 
-  rosbag2_transport::TopicFilter filter{rosbag2_transport::RecordOptions{}, nullptr, true};
+  rosbag2_transport::RecordOptions record_options;
+  record_options.all = true;
+  rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
   auto filtered_topics = filter.filter_topics(topics_and_types);
   EXPECT_THAT(filtered_topics, SizeIs(2));
   for (const auto & topic :
@@ -90,7 +92,9 @@ TEST(TestTopicFilter, filter_topics_with_known_type_invalid) {
     {"topic/c", {"type_c"}}
   };
 
-  rosbag2_transport::TopicFilter filter{rosbag2_transport::RecordOptions{}, nullptr};
+  rosbag2_transport::RecordOptions record_options;
+  record_options.all = true;
+  rosbag2_transport::TopicFilter filter{record_options, nullptr};
   auto filtered_topics = filter.filter_topics(topics_and_types);
   ASSERT_EQ(0u, filtered_topics.size());
 }
@@ -101,7 +105,9 @@ TEST(TestTopicFilter, filter_topics_with_known_type_valid) {
     {"topic/b", {"test_msgs/BasicTypes"}},
     {"topic/c", {"test_msgs/BasicTypes"}}
   };
-  rosbag2_transport::TopicFilter filter{rosbag2_transport::RecordOptions{}, nullptr};
+  rosbag2_transport::RecordOptions record_options;
+  record_options.all = true;
+  rosbag2_transport::TopicFilter filter{record_options, nullptr};
   auto filtered_topics = filter.filter_topics(topics_and_types);
   ASSERT_EQ(3u, filtered_topics.size());
 }


### PR DESCRIPTION
Fixing logic for filtering messages in topic_filter to respect `record_options.all`, `regex` and `topic list`.

Current logic for filtering messages in `TopicFilter` doesn't respect `record_options.all` in case if  defined topic list at the same time. 
If topic name not in `topic list` but match with `regex` it's still will be filtered out. i.e. `regex` doesn't work if topic list not empty and topic name not in `topic list`.
Also if `record_options.all` equal `false` and `topic_name` doesn't match with other filters `TopicFilter` will not filter out such topics.

Expected behavior :
1. `record_options.alll` takes precedence over `regex` and `topic list`
1. `topic list` shouldn't have precedence over `regex`. They should be addition to each other.
1. `TopicFilter::take_topic(..)` should return false, if `record_options.alll == false`  and topic name doesn't match with any other filter conditions.