### PR TITLE
Update to pybind11 2.7.1

### DIFF
--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -29,18 +29,13 @@ find_package(PythonExtra REQUIRED)
 find_package(Python3 REQUIRED Interpreter Development)
 if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   # Set the python debug interpreter.
-  # pybind11 will setup the build for debug now.
+  # We need to set *both* PYTHON_EXECUTABLE (for use in this CMake file),
+  # as well as Python3_EXECUTABLE (which is what pybind11 uses).
   set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
 endif()
 
 find_package(pybind11 REQUIRED)
-
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # pybind11 logic for setting up a debug build when both a debug and release
-  # python interpreter are present in the system seems to be pretty much broken.
-  # This works around the issue.
-  set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
-endif()
 
 ament_python_install_package(${PROJECT_NAME})
 

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(rosbag2_transport REQUIRED)
 # Find python before pybind11
 find_package(python_cmake_module REQUIRED)
 find_package(PythonExtra REQUIRED)
+find_package(Python3 REQUIRED Interpreter Development)
 if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   # Set the python debug interpreter.
   # pybind11 will setup the build for debug now.
@@ -41,31 +42,6 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
 endif()
 
-function(clean_windows_flags target)
-  # Hack to avoid pybind11 issue.
-  #
-  # TODO(ivanpauno):
-  # This can be deleted when we update `pybind11_vendor` to a version including
-  # https://github.com/pybind/pybind11/pull/2590.
-  #
-  # They are enabling /LTCG on Windows to reduce binary size,
-  # but that doesn't play well with MSVC incremental linking (default for Debug/RelWithDebInfo).
-  #
-  # See:
-  # - https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=vs-2019
-  # - https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=vs-2019
-
-  if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
-    get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
-    list(REMOVE_ITEM target_link_libraries "$<$<NOT:$<CONFIG:Debug>>:-LTCG>")
-    set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${target_link_libraries}")
-
-    get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
-    list(REMOVE_ITEM target_compile_options "$<$<NOT:$<CONFIG:Debug>>:/GL>")
-    set_target_properties(${target} PROPERTIES COMPILE_OPTIONS "${target_compile_options}")
-  endif()
-endfunction()
-
 ament_python_install_package(${PROJECT_NAME})
 
 pybind11_add_module(_reader SHARED
@@ -76,7 +52,6 @@ ament_target_dependencies(_reader PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
-clean_windows_flags(_reader)
 
 pybind11_add_module(_storage SHARED
   src/rosbag2_py/_storage.cpp
@@ -86,7 +61,6 @@ ament_target_dependencies(_storage PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
-clean_windows_flags(_storage)
 
 pybind11_add_module(_writer SHARED
   src/rosbag2_py/_writer.cpp
@@ -96,7 +70,6 @@ ament_target_dependencies(_writer PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
-clean_windows_flags(_writer)
 
 pybind11_add_module(_info SHARED
   src/rosbag2_py/_info.cpp
@@ -105,7 +78,6 @@ ament_target_dependencies(_info PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
-clean_windows_flags(_info)
 
 pybind11_add_module(_transport SHARED
   src/rosbag2_py/_transport.cpp
@@ -116,7 +88,6 @@ ament_target_dependencies(_transport PUBLIC
   "rosbag2_storage"
   "rosbag2_transport"
 )
-clean_windows_flags(_transport)
 
 pybind11_add_module(_reindexer SHARED
   src/rosbag2_py/_reindexer.cpp
@@ -125,7 +96,6 @@ ament_target_dependencies(_reindexer PUBLIC
   "rosbag2_cpp"
   "rosbag2_storage"
 )
-clean_windows_flags(_reindexer)
 
 # Install cython modules as sub-modules of the project
 install(

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -15,6 +15,15 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Figure out Python3 debug/release before anything else can find_package it
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
+
+  # Force FindPython3 to use the debug interpreter where ROS 2 expects it
+  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
@@ -24,17 +33,9 @@ find_package(rosbag2_storage REQUIRED)
 find_package(rosbag2_transport REQUIRED)
 
 # Find python before pybind11
-find_package(python_cmake_module REQUIRED)
-find_package(PythonExtra REQUIRED)
-find_package(Python3 REQUIRED Interpreter Development)
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # Set the python debug interpreter.
-  # We need to set *both* PYTHON_EXECUTABLE (for use in this CMake file),
-  # as well as Python3_EXECUTABLE (which is what pybind11 uses).
-  set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-  set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-endif()
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
+find_package(pybind11_vendor REQUIRED)
 find_package(pybind11 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
@@ -109,10 +110,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_pytest REQUIRED)
 
-  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  if(WIN32 AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-  endif()
   set(append_env_vars "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}")
   set(set_env_vars "ROSBAG2_PY_TEST_RESOURCES_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test/resources")
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -123,36 +120,30 @@ if(BUILD_TESTING)
 
   # message(FATAL_ERROR "HELP I AM THE PATH ${CMAKE_CURRENT_SOURCE_DIR}")
   ament_add_pytest_test(test_sequential_reader_py "test/test_sequential_reader.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )
   ament_add_pytest_test(test_sequential_reader_multiple_files_py "test/test_sequential_reader_multiple_files.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )
   ament_add_pytest_test(test_sequential_writer_py
     "test/test_sequential_writer.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )
   ament_add_pytest_test(test_transport_py
     "test/test_transport.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )
   ament_add_pytest_test(test_reindexer_py
     "test/test_reindexer.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )
   ament_add_pytest_test(test_convert_py
     "test/test_convert.py"
-    PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )


### PR DESCRIPTION
We can remove most of the hacks we were carrying around, but we also need to add in one more overload of the Python executable so pybind11 properly detects things on Windows Debug.

Depends on ros2/pybind11_vendor#10 (CI is over in that PR)