### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(${PROJECT_NAME}
   pluginlib
   rcpputils
@@ -47,7 +47,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE ROSBAG2_COMPRESSION_BUILDING_
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -56,9 +56,13 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
+
 ament_export_dependencies(pluginlib rcpputils rcutils rosbag2_cpp rosbag2_storage)
 
 if(BUILD_TESTING)
@@ -86,18 +90,15 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_compression_options
     test/rosbag2_compression/test_compression_options.cpp)
-  target_include_directories(test_compression_options PUBLIC include)
   target_link_libraries(test_compression_options ${PROJECT_NAME})
 
   ament_add_gmock(test_sequential_compression_reader
     test/rosbag2_compression/test_sequential_compression_reader.cpp)
-  target_include_directories(test_sequential_compression_reader PUBLIC include)
   target_link_libraries(test_sequential_compression_reader ${PROJECT_NAME})
   ament_target_dependencies(test_sequential_compression_reader rosbag2_cpp rosbag2_storage)
 
   ament_add_gmock(test_sequential_compression_writer
     test/rosbag2_compression/test_sequential_compression_writer.cpp)
-  target_include_directories(test_sequential_compression_writer PUBLIC include)
   target_link_libraries(test_sequential_compression_writer ${PROJECT_NAME})
   ament_target_dependencies(test_sequential_compression_writer rosbag2_cpp rosbag2_storage)
 endif()

--- a/rosbag2_compression_zstd/CMakeLists.txt
+++ b/rosbag2_compression_zstd/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(${PROJECT_NAME}
   rcpputils
   rosbag2_compression
@@ -44,7 +44,7 @@ pluginlib_export_plugin_description_file(rosbag2_compression plugin_description.
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -53,9 +53,13 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
+
 # order matters here, first vendor, then zstd
 ament_export_dependencies(rcpputils rosbag2_compression zstd_vendor zstd)
 
@@ -69,7 +73,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_zstd_compressor
     test/rosbag2_compression_zstd/test_zstd_compressor.cpp)
-  target_include_directories(test_zstd_compressor PUBLIC include)
   target_link_libraries(test_zstd_compressor ${PROJECT_NAME})
   ament_target_dependencies(test_zstd_compressor rclcpp rosbag2_test_common)
 endif()

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -91,7 +91,7 @@ ament_target_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -100,7 +100,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_CPP_BUILDING_DLL")
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -109,9 +109,13 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
+
 ament_export_dependencies(
   pluginlib
   rclcpp
@@ -147,7 +151,6 @@ if(BUILD_TESTING)
   ament_add_gmock(test_converter_factory
     test/rosbag2_cpp/test_converter_factory.cpp)
   if(TARGET test_converter_factory)
-    target_include_directories(test_converter_factory PRIVATE include)
     target_link_libraries(test_converter_factory ${PROJECT_NAME})
   endif()
 
@@ -206,8 +209,7 @@ if(BUILD_TESTING)
     endif()
     target_include_directories(test_ros2_message
       PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<INSTALL_INTERFACE:include>)
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
     ament_target_dependencies(test_ros2_message
       ament_index_cpp
       rcpputils

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -60,19 +60,16 @@ if(BUILD_ROSBAG2_BENCHMARKS)
   target_include_directories(writer_benchmark
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
   )
 
   target_include_directories(benchmark_publishers
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
   )
 
   target_include_directories(results_writer
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
   )
 
   install(TARGETS writer_benchmark benchmark_publishers results_writer

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 ament_target_dependencies(
   ${PROJECT_NAME}
@@ -52,7 +52,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_STORAGE_BUILDING_DLL
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -61,9 +61,13 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
+
 ament_export_dependencies(pluginlib yaml_cpp_vendor)
 
 if(BUILD_TESTING)
@@ -89,28 +93,24 @@ if(BUILD_TESTING)
   ament_add_gmock(test_storage_factory
     test/rosbag2_storage/test_storage_factory.cpp)
   if(TARGET test_storage_factory)
-    target_include_directories(test_storage_factory PRIVATE include)
     target_link_libraries(test_storage_factory ${PROJECT_NAME})
   endif()
 
   ament_add_gmock(test_ros_helper
     test/rosbag2_storage/test_ros_helper.cpp)
   if(TARGET test_ros_helper)
-    target_include_directories(test_ros_helper PRIVATE include)
     target_link_libraries(test_ros_helper ${PROJECT_NAME})
   endif()
 
   ament_add_gmock(test_metadata_serialization
     test/rosbag2_storage/test_metadata_serialization.cpp)
   if(TARGET test_metadata_serialization)
-    target_include_directories(test_metadata_serialization PRIVATE include)
     target_link_libraries(test_metadata_serialization ${PROJECT_NAME})
     ament_target_dependencies(test_metadata_serialization rosbag2_test_common)
   endif()
 
   ament_add_gmock(test_storage_options
     test/rosbag2_storage/test_storage_options.cpp)
-  target_include_directories(test_storage_options PRIVATE include)
   target_link_libraries(test_storage_options ${PROJECT_NAME})
   ament_target_dependencies(test_storage_options rosbag2_test_common)
 endif()

--- a/rosbag2_storage_default_plugins/CMakeLists.txt
+++ b/rosbag2_storage_default_plugins/CMakeLists.txt
@@ -45,7 +45,7 @@ ament_target_dependencies(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -57,7 +57,7 @@ pluginlib_export_plugin_description_file(rosbag2_storage plugin_description.xml)
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -65,8 +65,10 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
 ament_export_dependencies(rosbag2_storage rcpputils rcutils sqlite3_vendor SQLite3)
 
 if(BUILD_TESTING)

--- a/rosbag2_test_common/CMakeLists.txt
+++ b/rosbag2_test_common/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(rcutils REQUIRED)
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(${PROJECT_NAME} INTERFACE rclcpp rcutils)
 
 install(
@@ -35,7 +35,7 @@ install(
   EXPORT export_${PROJECT_NAME})
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -44,6 +44,10 @@ endif()
 
 ament_export_dependencies(rclcpp rcutils)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
+
 ament_package()

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_transport/topic_filter.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 ament_target_dependencies(${PROJECT_NAME}
   keyboard_handler
   rcl
@@ -66,7 +66,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_TRANSPORT_BUILDING_L
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 install(
   TARGETS ${PROJECT_NAME}
@@ -76,9 +76,13 @@ install(
   RUNTIME DESTINATION bin
 )
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
+
 ament_export_dependencies(
   keyboard_handler
   rosbag2_cpp
@@ -200,7 +204,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_record_options
     test/rosbag2_transport/test_record_options.cpp)
-  target_include_directories(test_record_options PRIVATE include)
   target_link_libraries(test_record_options ${PROJECT_NAME})
 
   ament_add_gmock(test_topic_filter
@@ -211,7 +214,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_rewrite
     test/rosbag2_transport/test_rewrite.cpp)
-  target_include_directories(test_rewrite PRIVATE include)
   target_link_libraries(test_rewrite ${PROJECT_NAME})
   ament_target_dependencies(test_rewrite keyboard_handler rcpputils rosbag2_cpp test_msgs)
 endif()


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1150 - this installs headers to a unique directory in a merged workspace to avoid include directory search order issues when overriding packages.