### PR TITLE
Add play-next-n functionality

### DIFF
--- a/rosbag2_interfaces/srv/PlayNext.srv
+++ b/rosbag2_interfaces/srv/PlayNext.srv
@@ -1,3 +1,3 @@
-uint64 num_messages 1  # Defaults to one for backwards compatibility
+uint64 num_messages 1  # Defaults to one for backwards compatibility.
 ---
-bool success  # can only play-next while playback is paused
+uint64 played_messages # The number of messages that were actually played.

--- a/rosbag2_interfaces/srv/PlayNext.srv
+++ b/rosbag2_interfaces/srv/PlayNext.srv
@@ -1,2 +1,3 @@
+uint64 num_messages 1  # Defaults to one for backwards compatibility
 ---
 bool success  # can only play-next while playback is paused

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -121,13 +121,16 @@ public:
   virtual bool set_rate(double);
 
   /// \brief Playing next message from queue when in pause.
+  /// \param num_messages The number of messages to play from the queue. It is
+  /// nullopt by default which makes it just take one. When zero, it'll just
+  /// make the method return true.
   /// \details This is blocking call and it will wait until next available message will be
   /// published or rclcpp context shut down.
   /// \note If internal player queue is starving and storage has not been completely loaded,
   /// this method will wait until new element will be pushed to the queue.
   /// \return true if player in pause mode and successfully played next message, otherwise false.
   ROSBAG2_TRANSPORT_PUBLIC
-  virtual bool play_next();
+  virtual bool play_next(const std::optional<uint64_t> num_messages = std::nullopt);
 
   /// \brief Advance player to the message with closest timestamp >= time_point.
   /// \details This is blocking call and it will wait until current message will be published

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -120,17 +120,15 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   virtual bool set_rate(double);
 
-  /// \brief Playing next message from queue when in pause.
-  /// \param num_messages The number of messages to play from the queue. It is
-  /// nullopt by default which makes it just take one. When zero, it'll just
-  /// make the method return true.
+  /// \brief Playing next \p num_messages messages from queue when in pause.
+  /// \param num_messages The number of messages to play from the queue.
   /// \details This is blocking call and it will wait until next available message will be
   /// published or rclcpp context shut down.
   /// \note If internal player queue is starving and storage has not been completely loaded,
   /// this method will wait until new element will be pushed to the queue.
-  /// \return true if player in pause mode and successfully played next message, otherwise false.
+  /// \return The number of actually sent messages from the queue.
   ROSBAG2_TRANSPORT_PUBLIC
-  virtual bool play_next(const std::optional<uint64_t> num_messages = std::nullopt);
+  virtual uint64_t play_next(const uint64_t num_messages);
 
   /// \brief Advance player to the message with closest timestamp >= time_point.
   /// \details This is blocking call and it will wait until current message will be published

--- a/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
@@ -65,13 +65,11 @@ public:
     num_resumed++;
   }
 
-  bool play_next(const std::optional<uint64_t> /* num_messages */ = std::nullopt) override
+  uint64_t play_next(const uint64_t num_messages) override
   {
-    bool ret = Player::play_next();
-    if (ret) {
-      num_played_next++;
-    }
-    return ret;
+    const uint64_t played_messages = Player::play_next(num_messages);
+    num_played_next += played_messages;
+    return played_messages;
   }
 
   bool set_rate(double rate) override

--- a/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
@@ -65,7 +65,7 @@ public:
     num_resumed++;
   }
 
-  bool play_next() override
+  bool play_next(const std::optional<uint64_t> /* num_messages */ = std::nullopt) override
   {
     bool ret = Player::play_next();
     if (ret) {

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -115,17 +115,14 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_back_in_time) {
   auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
 
   EXPECT_TRUE(player->is_paused());
-  EXPECT_TRUE(player->play_next());
-  EXPECT_TRUE(player->play_next());
+  EXPECT_EQ(2u, player->play_next(2u));
 
   // Jump in timestamp equal to the timestamp in first message - 1 nanosecond
   player->seek(start_time_ms_ * 1000000 - 1);
-  EXPECT_TRUE(player->play_next());
-  EXPECT_TRUE(player->play_next());
+  EXPECT_EQ(2u, player->play_next(2u));
   // Jump in timestamp equal to the timestamp in first message
   player->seek(start_time_ms_ * 1000000);
-  EXPECT_TRUE(player->play_next());
-  EXPECT_TRUE(player->play_next());
+  EXPECT_EQ(2u, player->play_next(2u));
   player->resume();
   player_future.get();
   await_received_messages.get();
@@ -162,13 +159,13 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_with_timestamp_later_than_in_last_messag
   auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
 
   EXPECT_TRUE(player->is_paused());
-  EXPECT_TRUE(player->play_next());
+  EXPECT_EQ(1u, player->play_next(1u));
 
   // Jump in timestamp equal to the timestamp in last message + 1 nanosecond
   player->seek((start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1);
 
   // shouldn't be able to keep playing since we're at end of bag
-  EXPECT_FALSE(player->play_next());
+  EXPECT_EQ(0u, player->play_next(1u));
   player->resume();
   player_future.get();
   await_received_messages.get();
@@ -196,11 +193,11 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_forward) {
   auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
 
   EXPECT_TRUE(player->is_paused());
-  EXPECT_TRUE(player->play_next());
+  EXPECT_EQ(1u, player->play_next(1u));
 
   // Jump on third message (1200 ms)
   player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
-  EXPECT_TRUE(player->play_next());
+  EXPECT_EQ(1u, player->play_next(1u));
   player->resume();
   player_future.get();
   await_received_messages.get();
@@ -235,14 +232,12 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_back_in_time_from_the_end_of_the_bag) {
 
   EXPECT_TRUE(player->is_paused());
   // Play all messages  from bag
-  for (size_t i = 0; i < num_msgs_in_bag_; i++) {
-    EXPECT_TRUE(player->play_next());
-  }
-  EXPECT_FALSE(player->play_next());  // Make sure there are no messages to play
+  EXPECT_EQ(num_msgs_in_bag_, player->play_next(num_msgs_in_bag_));
+  EXPECT_EQ(0u, player->play_next(1u));  // Make sure there are no messages to play
 
   // Jump on third message (1200 ms)
   player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
-  EXPECT_TRUE(player->play_next());
+  EXPECT_EQ(1u, player->play_next(1u));
   player->resume();
   player_future.get();
   await_received_messages.get();
@@ -281,14 +276,12 @@ TEST_F(RosBag2PlaySeekTestFixture, seek_forward_from_the_end_of_the_bag) {
 
   EXPECT_TRUE(player->is_paused());
   // Play all messages  from bag
-  for (size_t i = 0; i < num_msgs_in_bag_; i++) {
-    EXPECT_TRUE(player->play_next());
-  }
-  EXPECT_FALSE(player->play_next());  // Make sure there are no messages to play
+  EXPECT_EQ(num_msgs_in_bag_, player->play_next(num_msgs_in_bag_));
+  EXPECT_EQ(0u, player->play_next(1u));  // Make sure there are no messages to play
 
   // Jump in timestamp equal to the timestamp in last message + 1 nanosecond
   player->seek((start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1);
-  EXPECT_FALSE(player->play_next());
+  EXPECT_EQ(0u, player->play_next(1u));
   player->resume();
   player_future.get();
   await_received_messages.get();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -327,7 +327,7 @@ TEST_F(PlaySrvsTest, play_next) {
       message_counter_ = 0;
     }
     play_next_response = successful_call<PlayNext>(cli_play_next_);
-    ASSERT_TRUE(play_next_response->success);
+    ASSERT_EQ(1u, play_next_response->played_messages);
     expect_messages(true, false);
   }
 
@@ -337,13 +337,13 @@ TEST_F(PlaySrvsTest, play_next) {
     message_counter_ = 0;
   }
   play_next_response = successful_call<PlayNext>(cli_play_next_);
-  ASSERT_FALSE(play_next_response->success);
+  ASSERT_EQ(0u, play_next_response->played_messages);
   expect_messages(false, false);
 
   // Check that play_next will return false when player not in pause mode.
   start_playback();
   ASSERT_FALSE(player_->is_paused());
   play_next_response = successful_call<PlayNext>(cli_play_next_);
-  ASSERT_FALSE(play_next_response->success);
+  ASSERT_EQ(0u, play_next_response->played_messages);
   expect_messages(true);
 }


### PR DESCRIPTION
This PR extends the play-next-message service/function with the ability to play the next N messages instead of just one message.

This work was co-authored by @agalbachicar.