### PR TITLE
Remove YAML_CPP_DLL define

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/yaml.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/yaml.hpp
@@ -17,8 +17,6 @@
 #include <string>
 
 #ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
 // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
 # pragma warning(push)
 # pragma warning(disable:4251)


### PR DESCRIPTION
Since https://github.com/ros2/yaml_cpp_vendor/issues/10 is fixed, the explicit `YAML_CPP_DLL` define is no longer needed and needs to be removed to prevent the macro redefinition warnings.

This should be backported to foxy and galactic.