### PR TITLE
Make unpublished topics unrecorded by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ output_bags
   compression_queue_size: 1
   compression_threads: 0
   include_hidden_topics: false
+  include_unpublished_topics: false
 ```
 
 Example merge:

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -61,6 +61,11 @@ class RecordVerb(VerbExtension):
             help='Exclude topics containing provided regular expression. '
             'Works on top of --all, --regex, or topics list.')
         parser.add_argument(
+            '--include-unpublished-topics', action='store_true',
+            help='Discover and record topics which have no publisher. '
+            'Subscriptions on such topics will be made with default QoS unless otherwise '
+            'specified in a QoS overrides file.')
+        parser.add_argument(
             '--include-hidden-topics', action='store_true',
             help='Discover and record hidden topics as well. '
             'These are topics used internally by ROS 2 implementation.')
@@ -228,6 +233,7 @@ class RecordVerb(VerbExtension):
         record_options.compression_threads = args.compression_threads
         record_options.topic_qos_profile_overrides = qos_profile_overrides
         record_options.include_hidden_topics = args.include_hidden_topics
+        record_options.include_unpublished_topics = args.include_unpublished_topics
         record_options.start_paused = args.start_paused
         record_options.ignore_leaf_topics = args.ignore_leaf_topics
 

--- a/ros2bag/test/test_record.py
+++ b/ros2bag/test/test_record.py
@@ -57,10 +57,6 @@ class TestRecord(unittest.TestCase):
             "Subscribed to topic '/rosout'",
             process=record_all_process
         )
-        proc_output.assertWaitFor(
-            "Subscribed to topic '/parameter_events'",
-            process=record_all_process
-        )
 
 
 @launch_testing.post_shutdown_test()

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -269,6 +269,7 @@ PYBIND11_MODULE(_transport, m) {
     &RecordOptions::getTopicQoSProfileOverrides,
     &RecordOptions::setTopicQoSProfileOverrides)
   .def_readwrite("include_hidden_topics", &RecordOptions::include_hidden_topics)
+  .def_readwrite("include_unpublished_topics", &RecordOptions::include_unpublished_topics)
   .def_readwrite("start_paused", &RecordOptions::start_paused)
   .def_readwrite("ignore_leaf_topics", &RecordOptions::ignore_leaf_topics)
   ;

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -173,6 +173,11 @@ function(create_tests_for_rmw_implementation)
     LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common)
 
+  rosbag2_transport_add_gmock(test_record_all_include_unpublished_topics
+    test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
   rosbag2_transport_add_gmock(test_record_all_no_discovery
     test/rosbag2_transport/test_record_all_no_discovery.cpp
     LINK_LIBS rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -44,6 +44,7 @@ public:
   uint64_t compression_threads = 0;
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides{};
   bool include_hidden_topics = false;
+  bool include_unpublished_topics = false;
   bool ignore_leaf_topics = false;
   bool start_paused = false;
 };

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -110,8 +110,8 @@ public:
   inline constexpr static const auto kPauseResumeToggleKey = KeyboardHandler::KeyCode::SPACE;
 
 protected:
-  std::unordered_map<std::string, std::string>
-  get_requested_or_available_topics();
+  ROSBAG2_TRANSPORT_EXPORT
+  std::unordered_map<std::string, std::string> get_requested_or_available_topics();
 
 private:
   void topics_discovery();

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -109,11 +109,12 @@ public:
 
   inline constexpr static const auto kPauseResumeToggleKey = KeyboardHandler::KeyCode::SPACE;
 
-private:
-  void topics_discovery();
-
+protected:
   std::unordered_map<std::string, std::string>
   get_requested_or_available_topics();
+
+private:
+  void topics_discovery();
 
   std::unordered_map<std::string, std::string>
   get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics);

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -59,6 +59,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
     record_options.topic_qos_profile_overrides.end());
   node["topic_qos_profile_overrides"] = qos_overrides;
   node["include_hidden_topics"] = record_options.include_hidden_topics;
+  node["include_unpublished_topics"] = record_options.include_unpublished_topics;
   return node;
 }
 
@@ -87,6 +88,9 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   record_options.topic_qos_profile_overrides.insert(qos_overrides.begin(), qos_overrides.end());
 
   optional_assign<bool>(node, "include_hidden_topics", record_options.include_hidden_topics);
+  optional_assign<bool>(
+    node, "include_unpublished_topics",
+    record_options.include_unpublished_topics);
   return true;
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -71,6 +71,14 @@ bool topic_in_list(const std::string & topic_name, const std::vector<std::string
 }
 
 bool
+topic_is_unpublished(
+  const std::string & topic_name, rclcpp::node_interfaces::NodeGraphInterface & node_graph)
+{
+  auto publishers_info = node_graph.get_publishers_info_by_topic(topic_name);
+  return publishers_info.size() == 0;
+}
+
+bool
 is_leaf_topic(
   const std::string & topic_name, rclcpp::node_interfaces::NodeGraphInterface & node_graph)
 {
@@ -121,6 +129,12 @@ bool TopicFilter::take_topic(
   if (!record_options_.include_hidden_topics && topic_is_hidden(topic_name)) {
     ROSBAG2_TRANSPORT_LOG_WARN_STREAM(
       "Hidden topics are not recorded. Enable them with --include-hidden-topics");
+    return false;
+  }
+
+  if (!record_options_.include_unpublished_topics && node_graph_ &&
+    topic_is_unpublished(topic_name, *node_graph_))
+  {
     return false;
   }
 

--- a/rosbag2_transport/test/rosbag2_transport/mock_recorder.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_recorder.hpp
@@ -1,0 +1,70 @@
+// Copyright 2022, Apex.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_TRANSPORT__MOCK_RECORDER_HPP_
+#define ROSBAG2_TRANSPORT__MOCK_RECORDER_HPP_
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <ratio>
+
+#include "rosbag2_transport/recorder.hpp"
+
+class MockRecorder : public rosbag2_transport::Recorder
+{
+public:
+  MockRecorder(
+    std::shared_ptr<rosbag2_cpp::Writer> writer,
+    const rosbag2_storage::StorageOptions & storage_options,
+    const rosbag2_transport::RecordOptions & record_options)
+  : Recorder(writer, storage_options, record_options)
+  {}
+
+  template<typename DurationRepT = int64_t, typename DurationT = std::milli>
+  bool wait_for_topic_to_be_discovered(
+    const std::string & topic_name_to_wait_for,
+    std::chrono::duration<DurationRepT, DurationT> timeout = std::chrono::seconds(10))
+  {
+    bool discovered = false;
+    using clock = std::chrono::steady_clock;
+    auto start = clock::now();
+    do {
+      auto topic_names_and_types = this->get_topic_names_and_types();
+      for (const auto &[topic_name, topic_types] : topic_names_and_types) {
+        if (topic_name_to_wait_for == topic_name) {
+          discovered = true;
+          break;
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    } while (!discovered && (clock::now() - start) < timeout);
+    return discovered;
+  }
+
+  bool topic_available_for_recording(const std::string & topic_name)
+  {
+    bool available_for_recording = false;
+    auto topics_to_subscribe = this->get_requested_or_available_topics();
+    for (const auto & topic_and_type : topics_to_subscribe) {
+      if (topic_and_type.first == topic_name) {
+        available_for_recording = true;
+        break;
+      }
+    }
+    return available_for_recording;
+  }
+};
+
+#endif  // ROSBAG2_TRANSPORT__MOCK_RECORDER_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
@@ -1,0 +1,201 @@
+// Copyright 2022 Seegrid Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+#include "rosbag2_test_common/publication_manager.hpp"
+#include "rosbag2_test_common/wait_for.hpp"
+
+#include "rosbag2_transport/recorder.hpp"
+
+#include "record_integration_fixture.hpp"
+
+using namespace std::chrono_literals;  // NOLINT
+
+TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignores_unpublished)
+{
+  std::string string_topic = "/string_topic";
+  auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
+  auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
+    string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
+
+  rosbag2_transport::RecordOptions record_options = {true, false, {}, "rmw_format", 100ms};
+  record_options.include_unpublished_topics = false;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  size_t expected_messages = 0;
+  rosbag2_test_common::wait_until_shutdown(
+    std::chrono::seconds(2),
+    [&mock_writer, &expected_messages]() {
+      return mock_writer.get_messages().size() > expected_messages;
+    });
+  (void) expected_messages;  // we can't say anything here, there might be some rosout
+
+  auto recorded_topics = mock_writer.get_topics();
+  EXPECT_EQ(0u, recorded_topics.count(string_topic));
+}
+
+TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_true_includes_unpublished)
+{
+  std::string string_topic = "/string_topic";
+  auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
+  auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
+    string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
+
+  rosbag2_transport::RecordOptions record_options = {true, false, {}, "rmw_format", 100ms};
+  record_options.include_unpublished_topics = true;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  size_t expected_messages = 0;
+  rosbag2_test_common::wait_until_shutdown(
+    std::chrono::seconds(2),
+    [&mock_writer, &expected_messages]() {
+      return mock_writer.get_messages().size() > expected_messages;
+    });
+  (void) expected_messages;  // we can't say anything here, there might be some rosout
+
+  auto recorded_topics = mock_writer.get_topics();
+  EXPECT_EQ(1u, recorded_topics.count(string_topic));
+}
+
+TEST_F(
+  RecordIntegrationTestFixture,
+  record_all_include_unpublished_false_includes_later_published_default_qos)
+{
+  std::string string_topic = "/string_topic";
+  auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
+  auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
+    string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
+
+  rosbag2_transport::RecordOptions record_options = {true, false, {}, "rmw_format", 100ms};
+  record_options.include_unpublished_topics = false;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+
+  // Start up a publisher on our topic *after* the recording has started
+  auto string_message = get_messages_strings()[0];
+  string_message->string_value = "Hello World";
+  rosbag2_test_common::PublicationManager pub_manager;
+
+  // Publish 40 messages at a 50ms interval for a steady 2 seconds worth of data
+  pub_manager.setup_publisher(
+    string_topic, string_message, 40, rclcpp::QoS{rclcpp::KeepAll()}, 50ms);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
+
+  pub_manager.run_publishers();
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  size_t expected_messages = 0;
+  auto ret = rosbag2_test_common::wait_until_shutdown(
+    std::chrono::seconds(2),
+    [&mock_writer, &expected_messages]() {
+      return mock_writer.get_messages().size() > expected_messages;
+    });
+  auto recorded_messages = mock_writer.get_messages();
+  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
+
+  auto recorded_topics = mock_writer.get_topics();
+  EXPECT_EQ(1u, recorded_topics.count(string_topic));
+
+  // We expect to drop some messages due to the discovery process, but there
+  // should be at least one message received in the duration of this test.
+  auto string_messages = filter_messages<test_msgs::msg::Strings>(
+    recorded_messages, string_topic);
+  ASSERT_THAT(string_messages, SizeIs(Ge(1u)));
+  EXPECT_THAT(string_messages[0]->string_value, Eq("Hello World"));
+}
+
+TEST_F(
+  RecordIntegrationTestFixture,
+  record_all_include_unpublished_false_includes_later_published_sensor_data_qos)
+{
+  std::string string_topic = "/string_topic";
+  auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
+  auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
+    string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
+
+  rosbag2_transport::RecordOptions record_options = {true, false, {}, "rmw_format", 100ms};
+  record_options.include_unpublished_topics = false;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+
+  // Start up a publisher on our topic *after* the recording has started
+  auto string_message = get_messages_strings()[0];
+  string_message->string_value = "Hello World";
+  rosbag2_test_common::PublicationManager pub_manager;
+
+  // Publish 40 messages at a 50ms interval for a steady 2 seconds worth of data
+  pub_manager.setup_publisher(string_topic, string_message, 40, rclcpp::SensorDataQoS(), 50ms);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
+
+  pub_manager.run_publishers();
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  size_t expected_messages = 0;
+  auto ret = rosbag2_test_common::wait_until_shutdown(
+    std::chrono::seconds(2),
+    [&mock_writer, &expected_messages]() {
+      return mock_writer.get_messages().size() > expected_messages;
+    });
+  auto recorded_messages = mock_writer.get_messages();
+  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
+
+  auto recorded_topics = mock_writer.get_topics();
+  EXPECT_EQ(1u, recorded_topics.count(string_topic));
+
+  // We expect to drop some messages due to the discovery process, but there
+  // should be at least one message received in the duration of this test.
+  auto string_messages = filter_messages<test_msgs::msg::Strings>(
+    recorded_messages, string_topic);
+  ASSERT_THAT(string_messages, SizeIs(Ge(1u)));
+  EXPECT_THAT(string_messages[0]->string_value, Eq("Hello World"));
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
@@ -33,7 +33,7 @@ using namespace std::chrono_literals;  // NOLINT
 
 TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignores_unpublished)
 {
-  std::string string_topic = "/string_topic";
+  const std::string string_topic = "/string_topic";
   auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
   auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
     string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
@@ -50,13 +50,12 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignore
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  size_t expected_messages = 0;
   rosbag2_test_common::wait_until_shutdown(
     std::chrono::seconds(2),
-    [&mock_writer, &expected_messages]() {
-      return mock_writer.get_messages().size() > expected_messages;
+    [&mock_writer]() {
+      // Return false so we wait the full two seconds
+      return false;
     });
-  (void) expected_messages;  // we can't say anything here, there might be some rosout
 
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(0u, recorded_topics.count(string_topic));
@@ -64,7 +63,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignore
 
 TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_true_includes_unpublished)
 {
-  std::string string_topic = "/string_topic";
+  const std::string string_topic = "/string_topic";
   auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
   auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
     string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
@@ -81,13 +80,12 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_true_include
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  size_t expected_messages = 0;
   rosbag2_test_common::wait_until_shutdown(
     std::chrono::seconds(2),
-    [&mock_writer, &expected_messages]() {
-      return mock_writer.get_messages().size() > expected_messages;
+    [&mock_writer]() {
+      // Return false so we wait the full two seconds
+      return false;
     });
-  (void) expected_messages;  // we can't say anything here, there might be some rosout
 
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(1u, recorded_topics.count(string_topic));
@@ -97,7 +95,7 @@ TEST_F(
   RecordIntegrationTestFixture,
   record_all_include_unpublished_false_includes_later_published_default_qos)
 {
-  std::string string_topic = "/string_topic";
+  const std::string string_topic = "/string_topic";
   auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
   auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
     string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
@@ -127,15 +125,13 @@ TEST_F(
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  size_t expected_messages = 0;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
+  rosbag2_test_common::wait_until_shutdown(
     std::chrono::seconds(2),
-    [&mock_writer, &expected_messages]() {
-      return mock_writer.get_messages().size() > expected_messages;
+    [&mock_writer]() {
+      // Return false so we wait the full two seconds
+      return false;
     });
   auto recorded_messages = mock_writer.get_messages();
-  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
-
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(1u, recorded_topics.count(string_topic));
 
@@ -151,7 +147,7 @@ TEST_F(
   RecordIntegrationTestFixture,
   record_all_include_unpublished_false_includes_later_published_sensor_data_qos)
 {
-  std::string string_topic = "/string_topic";
+  const std::string string_topic = "/string_topic";
   auto node = std::make_shared<rclcpp::Node>("test_string_msg_listener_node");
   auto string_msgs_sub = node->create_subscription<test_msgs::msg::Strings>(
     string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
@@ -180,20 +176,19 @@ TEST_F(
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  size_t expected_messages = 0;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
+  rosbag2_test_common::wait_until_shutdown(
     std::chrono::seconds(2),
-    [&mock_writer, &expected_messages]() {
-      return mock_writer.get_messages().size() > expected_messages;
+    [&mock_writer]() {
+      // Return false so we wait the full two seconds
+      return false;
     });
-  auto recorded_messages = mock_writer.get_messages();
-  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
 
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(1u, recorded_topics.count(string_topic));
 
   // We expect to drop some messages due to the discovery process, but there
   // should be at least one message received in the duration of this test.
+  auto recorded_messages = mock_writer.get_messages();
   auto string_messages = filter_messages<test_msgs::msg::Strings>(
     recorded_messages, string_topic);
   ASSERT_THAT(string_messages, SizeIs(Ge(1u)));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
@@ -23,7 +23,6 @@
 #include "test_msgs/message_fixtures.hpp"
 
 #include "rosbag2_test_common/publication_manager.hpp"
-#include "rosbag2_test_common/wait_for.hpp"
 
 #include "rosbag2_transport/recorder.hpp"
 
@@ -50,12 +49,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignore
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(2),
-    [&mock_writer]() {
-      // Return false so we wait the full two seconds
-      return false;
-    });
+  rclcpp::sleep_for(std::chrono::seconds(2));
 
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(0u, recorded_topics.count(string_topic));
@@ -80,12 +74,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_true_include
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(2),
-    [&mock_writer]() {
-      // Return false so we wait the full two seconds
-      return false;
-    });
+  rclcpp::sleep_for(std::chrono::seconds(2));
 
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(1u, recorded_topics.count(string_topic));
@@ -125,12 +114,8 @@ TEST_F(
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(2),
-    [&mock_writer]() {
-      // Return false so we wait the full two seconds
-      return false;
-    });
+  rclcpp::sleep_for(std::chrono::seconds(2));
+
   auto recorded_messages = mock_writer.get_messages();
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(1u, recorded_topics.count(string_topic));
@@ -176,12 +161,7 @@ TEST_F(
   MockSequentialWriter & mock_writer =
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(2),
-    [&mock_writer]() {
-      // Return false so we wait the full two seconds
-      return false;
-    });
+  rclcpp::sleep_for(std::chrono::seconds(2));
 
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_EQ(1u, recorded_topics.count(string_topic));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -35,6 +35,7 @@ TEST(record_options, test_yaml_serialization)
   original.compression_threads = 123;
   original.topic_qos_profile_overrides.emplace("topic", rclcpp::QoS(10).transient_local());
   original.include_hidden_topics = true;
+  original.include_unpublished_topics = true;
 
   auto node = YAML::convert<rosbag2_transport::RecordOptions>().encode(original);
 


### PR DESCRIPTION
Topics with no publishers do not offer any QoS profiles. This causes the
recorder to subscribe with a default QoS, which is often disadvantageous.

This change makes subscribing to unpublished topics optional, off by
default. Once a publisher is discovered for a topic, discovery picks it
up and adds it to the bag.

This addresses #967