### PR TITLE
Use git hash for zstd vendor

### DIFF
--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -32,7 +32,7 @@ macro(build_zstd)
   # We need to configure the CMake command to build from there instead.
   ExternalProject_Add(zstd-${zstd_version}
     GIT_REPOSITORY https://github.com/facebook/zstd.git
-    GIT_TAG v${zstd_version}
+    GIT_TAG 10f0e6993f9d2f682da6d04aa2385b7d53cbb4ee  # v${zstd_version}
     GIT_CONFIG advice.detachedHead=false
     # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
     # See https://github.com/ament/uncrustify_vendor/pull/22 for details


### PR DESCRIPTION
CMake ExternalProject_add recommends using a specific git hash with
GIT_TAG because branches and tags can be updated to point to different
references.

https://cmake.org/cmake/help/latest/module/ExternalProject.html

This switches zstd_vendor to a git hash.
sqlite3_vendor and shared_queues_vendor don't need to be changed because
they use URL and URL_MD5 instead.

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>