### PR TITLE
support to publish as loaned message

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -105,6 +105,11 @@ class PlayVerb(VerbExtension):
                  "Note that this option is valid only if the publisher\'s QOS profile is "
                  'RELIABLE.',
             metavar='TIMEOUT')
+        parser.add_argument(
+            '--enable-loan-message', action='store_true', default=False,
+            help='Enable to publish as loaned message if loaned message can be used. '
+                 'It can help to reduce the number of data copies, so there is a greater benefit '
+                 'for sending big data.')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -144,6 +149,7 @@ class PlayVerb(VerbExtension):
         play_options.start_paused = args.start_paused
         play_options.start_offset = args.start_offset
         play_options.wait_acked_timeout = args.wait_for_all_acked
+        play_options.enable_loan_message = args.enable_loan_message
 
         player = Player()
         player.play(storage_options, play_options)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -106,10 +106,11 @@ class PlayVerb(VerbExtension):
                  'RELIABLE.',
             metavar='TIMEOUT')
         parser.add_argument(
-            '--enable-loan-message', action='store_true', default=False,
-            help='Enable to publish as loaned message if loaned message can be used. '
-                 'It can help to reduce the number of data copies, so there is a greater benefit '
-                 'for sending big data.')
+            '--disable-loan-message', action='store_true', default=False,
+            help='Disable to publish as loaned message. '
+                 'By default, if loaned message can be used, messages are published as loaned '
+                 'message. It can help to reduce the number of data copies, so there is a greater '
+                 'benefit for sending big data.')
 
     def main(self, *, args):  # noqa: D102
         qos_profile_overrides = {}  # Specify a valid default
@@ -149,7 +150,7 @@ class PlayVerb(VerbExtension):
         play_options.start_paused = args.start_paused
         play_options.start_offset = args.start_offset
         play_options.wait_acked_timeout = args.wait_for_all_acked
-        play_options.enable_loan_message = args.enable_loan_message
+        play_options.disable_loan_message = args.disable_loan_message
 
         player = Player()
         player.play(storage_options, play_options)

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -248,7 +248,7 @@ PYBIND11_MODULE(_transport, m) {
     &PlayOptions::getStartOffset,
     &PlayOptions::setStartOffset)
   .def_readwrite("wait_acked_timeout", &PlayOptions::wait_acked_timeout)
-  .def_readwrite("enable_loan_message", &PlayOptions::enable_loan_message)
+  .def_readwrite("disable_loan_message", &PlayOptions::disable_loan_message)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -248,6 +248,7 @@ PYBIND11_MODULE(_transport, m) {
     &PlayOptions::getStartOffset,
     &PlayOptions::setStartOffset)
   .def_readwrite("wait_acked_timeout", &PlayOptions::wait_acked_timeout)
+  .def_readwrite("enable_loan_message", &PlayOptions::enable_loan_message)
   ;
 
   py::class_<RecordOptions>(m, "RecordOptions")

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -66,6 +66,9 @@ public:
   // Timeout for waiting for all published messages to be acknowledged.
   // Negative value means that published messages do not need to be acknowledged.
   int64_t wait_acked_timeout = -1;
+
+  // Enable to publish as loaned message
+  bool enable_loan_message = false;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -67,8 +67,8 @@ public:
   // Negative value means that published messages do not need to be acknowledged.
   int64_t wait_acked_timeout = -1;
 
-  // Enable to publish as loaned message
-  bool enable_loan_message = false;
+  // Disable to publish as loaned message
+  bool disable_loan_message = false;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -61,11 +61,11 @@ namespace rosbag2_transport
 class DataPublisher final
 {
 public:
-  explicit DataPublisher(std::shared_ptr<rclcpp::GenericPublisher> pub)
+  explicit DataPublisher(std::shared_ptr<rclcpp::GenericPublisher> pub, bool enable_loan_message)
   : publisher_(std::move(pub))
   {
     using std::placeholders::_1;
-    if (publisher_->can_loan_messages()) {
+    if (enable_loan_message && publisher_->can_loan_messages()) {
       publish_func_ = std::bind(&rclcpp::GenericPublisher::publish_as_loaned_msg, publisher_, _1);
     } else {
       publish_func_ = std::bind(&rclcpp::GenericPublisher::publish, publisher_, _1);

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -58,37 +58,6 @@ class Reader;
 
 namespace rosbag2_transport
 {
-class DataPublisher final
-{
-public:
-  explicit DataPublisher(std::shared_ptr<rclcpp::GenericPublisher> pub, bool disable_loan_message)
-  : publisher_(std::move(pub))
-  {
-    using std::placeholders::_1;
-    if (disable_loan_message || !publisher_->can_loan_messages()) {
-      publish_func_ = std::bind(&rclcpp::GenericPublisher::publish, publisher_, _1);
-    } else {
-      publish_func_ = std::bind(&rclcpp::GenericPublisher::publish_as_loaned_msg, publisher_, _1);
-    }
-  }
-
-  ~DataPublisher() {}
-
-  void publish(const rclcpp::SerializedMessage & message)
-  {
-    publish_func_(message);
-  }
-
-  std::shared_ptr<rclcpp::GenericPublisher> generic_publisher()
-  {
-    return publisher_;
-  }
-
-private:
-  std::shared_ptr<rclcpp::GenericPublisher> publisher_;
-  std::function<void(const rclcpp::SerializedMessage &)> publish_func_;
-};
-
 class Player : public rclcpp::Node
 {
 public:
@@ -185,11 +154,43 @@ public:
   void seek(rcutils_time_point_value_t time_point);
 
 protected:
+  class PlayerPublisher final
+  {
+public:
+    explicit PlayerPublisher(
+      std::shared_ptr<rclcpp::GenericPublisher> pub,
+      bool disable_loan_message)
+    : publisher_(std::move(pub))
+    {
+      using std::placeholders::_1;
+      if (disable_loan_message || !publisher_->can_loan_messages()) {
+        publish_func_ = std::bind(&rclcpp::GenericPublisher::publish, publisher_, _1);
+      } else {
+        publish_func_ = std::bind(&rclcpp::GenericPublisher::publish_as_loaned_msg, publisher_, _1);
+      }
+    }
+
+    ~PlayerPublisher() {}
+
+    void publish(const rclcpp::SerializedMessage & message)
+    {
+      publish_func_(message);
+    }
+
+    std::shared_ptr<rclcpp::GenericPublisher> generic_publisher()
+    {
+      return publisher_;
+    }
+
+private:
+    std::shared_ptr<rclcpp::GenericPublisher> publisher_;
+    std::function<void(const rclcpp::SerializedMessage &)> publish_func_;
+  };
   bool is_ready_to_play_from_queue_{false};
   std::mutex ready_to_play_from_queue_mutex_;
   std::condition_variable ready_to_play_from_queue_cv_;
   rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr clock_publisher_;
-  std::unordered_map<std::string, std::shared_ptr<DataPublisher>> publishers_;
+  std::unordered_map<std::string, std::shared_ptr<PlayerPublisher>> publishers_;
 
 private:
   rosbag2_storage::SerializedBagMessageSharedPtr * peek_next_message_from_queue();

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -61,14 +61,14 @@ namespace rosbag2_transport
 class DataPublisher final
 {
 public:
-  explicit DataPublisher(std::shared_ptr<rclcpp::GenericPublisher> pub, bool enable_loan_message)
+  explicit DataPublisher(std::shared_ptr<rclcpp::GenericPublisher> pub, bool disable_loan_message)
   : publisher_(std::move(pub))
   {
     using std::placeholders::_1;
-    if (enable_loan_message && publisher_->can_loan_messages()) {
-      publish_func_ = std::bind(&rclcpp::GenericPublisher::publish_as_loaned_msg, publisher_, _1);
-    } else {
+    if (disable_loan_message || !publisher_->can_loan_messages()) {
       publish_func_ = std::bind(&rclcpp::GenericPublisher::publish, publisher_, _1);
+    } else {
+      publish_func_ = std::bind(&rclcpp::GenericPublisher::publish_as_loaned_msg, publisher_, _1);
     }
   }
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -524,7 +524,7 @@ void Player::prepare_publishers()
       std::shared_ptr<rclcpp::GenericPublisher> pub =
         create_generic_publisher(topic.name, topic.type, topic_qos);
       std::shared_ptr<DataPublisher> data_pub =
-        std::make_shared<DataPublisher>(std::move(pub), play_options_.enable_loan_message);
+        std::make_shared<DataPublisher>(std::move(pub), play_options_.disable_loan_message);
       publishers_.insert(std::make_pair(topic.name, data_pub));
       if (play_options_.wait_acked_timeout >= 0 &&
         topic_qos.reliability() == rclcpp::ReliabilityPolicy::BestEffort)

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -524,7 +524,7 @@ void Player::prepare_publishers()
       std::shared_ptr<rclcpp::GenericPublisher> pub =
         create_generic_publisher(topic.name, topic.type, topic_qos);
       std::shared_ptr<DataPublisher> data_pub =
-        std::make_shared<DataPublisher>(std::move(pub));
+        std::make_shared<DataPublisher>(std::move(pub), play_options_.enable_loan_message);
       publishers_.insert(std::make_pair(topic.name, data_pub));
       if (play_options_.wait_acked_timeout >= 0 &&
         topic_qos.reliability() == rclcpp::ReliabilityPolicy::BestEffort)

--- a/rosbag2_transport/test/rosbag2_transport/mock_player.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_player.hpp
@@ -35,7 +35,9 @@ public:
   {
     std::vector<rclcpp::PublisherBase *> pub_list;
     for (const auto & publisher : publishers_) {
-      pub_list.push_back(static_cast<rclcpp::PublisherBase *>(publisher.second.get()));
+      pub_list.push_back(
+        static_cast<rclcpp::PublisherBase *>(
+          publisher.second->generic_publisher().get()));
     }
     return pub_list;
   }


### PR DESCRIPTION
Address #914 

In order to avoid judgement on which publish function is called while sending a message,  I use a new class to wrap rclcpp::GenericPublisher.   
If you have a better idea, please let me know.    