### PR TITLE
Fix test rosbag2_py test compatibility with Python < 3.8

### DIFF
--- a/rosbag2_py/test/test_reindexer.py
+++ b/rosbag2_py/test/test_reindexer.py
@@ -47,4 +47,7 @@ def test_reindexer_multiple_files():
 
     assert(result_path.exists())
 
-    result_path.unlink(missing_ok=True)
+    try:
+        result_path.unlink()
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
RHEL is currently using a Python version older than 3.8, which is when the `missing_ok` argument was added to `Path.unlink`. For better compatibility, we can just catch and ignore the `FileNotFoundError`.

This should resolve the persistent test failure we're seeing on RHEL.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16561)](http://ci.ros2.org/job/ci_linux/16561/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11147)](http://ci.ros2.org/job/ci_linux-aarch64/11147/)
* Linux-RHEL [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=217)](http://ci.ros2.org/job/ci_linux-rhel/217/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16949)](http://ci.ros2.org/job/ci_windows/16949/)