### PR TITLE
Change the topic names in test_record.cpp

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -91,7 +91,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
 {
   auto string_message = get_messages_strings()[1];
-  std::string topic = "/chatter";
+  std::string topic = "/qos_chatter";
 
   rosbag2_test_common::PublicationManager pub_manager;
   pub_manager.setup_publisher(topic, string_message, 2);
@@ -151,7 +151,7 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
 TEST_F(RecordIntegrationTestFixture, records_sensor_data)
 {
   auto string_message = get_messages_strings()[1];
-  std::string topic = "/chatter";
+  std::string topic = "/sensor_chatter";
 
   rosbag2_test_common::PublicationManager pub_manager;
   pub_manager.setup_publisher(topic, string_message, 2, rclcpp::SensorDataQoS());
@@ -189,7 +189,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
 TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
 {
   auto string_message = get_messages_strings()[1];
-  std::string topic = "/chatter";
+  std::string topic = "/latched_chatter";
 
   size_t num_latched_messages = 3;
   auto profile_transient_local = rclcpp::QoS(num_latched_messages).transient_local();


### PR DESCRIPTION
We've observed the 'test_record' series of tests sometimes
succeeding and sometimes failing on https://ci.ros2.org, particularly
in Windows builds.  When it does fail, it shows error messages
like this:

[ERROR] [1649769476.588754000] [ROSBAG2_TRANSPORT]: Topic '/chatter' has more than one type associated. Only topics with one type are supported

Given that we run tests sequentially (i.e. not in parallel), that
really shouldn't be the case.

However, we have noticed in the past that Windows can sometimes
be extremely slow to cleanup processes from previous tests.
Since many of our tests use a topic name of 'chatter', that is
likely what is happening in this case.  This change works around
this problem by using an alternate name for the topics.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>