### PR TITLE
Add cmake-build-* folders to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea/
 .ipynb_checkpoints/
-cmake-build-debug/
-cmake-build-release/
+cmake-build-*/
 build/
 venv/
 **/.pytest_cache/


### PR DESCRIPTION
It could be more custom cmake build configurations rather than debug and
release. Exclude all of them from git tree with regex.

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>

It's quite annoying to have notifications from CLion about unversioned files from build folders.  
This PR will exclude all cmake build flavors with regex `cmake-build-*`