### PR TITLE
Fix for rosbag2::Player freeze when ctrl+c in pause mode

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -478,7 +478,7 @@ void Player::play_messages_from_queue()
   }
   // while we're in pause state, make sure we don't return
   // if we happen to be at the end of queue
-  while (is_paused()) {
+  while (is_paused() && rclcpp::ok()) {
     clock_->sleep_until(clock_->now());
   }
 }


### PR DESCRIPTION
Fix for rosbag2::Player freeze when ctrl+c in pause mode
Addressing bug report #1000
Signed-off-by: Michael Orlov <michael.orlov@apex.ai>
- Closes #1000 