### PR TITLE
Add on play message callbacks to the `rosbag2::Player` class

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -122,6 +122,11 @@ function(create_tests_for_rmw_implementation)
     LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common)
 
+  rosbag2_transport_add_gmock(test_play_callbacks
+    test/rosbag2_transport/test_play_callbacks.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
   rosbag2_transport_add_gmock(test_play_seek
     test/rosbag2_transport/test_play_seek.cpp
     LINK_LIBS rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -169,15 +169,19 @@ public:
 
   /// \brief Adding callable object as handler for pre-callback on play message.
   /// \param callback Callable which will be called before next message will be published.
+  /// \note In case of registering multiple callbacks later-registered callbacks will be called
+  /// first.
   /// \return Returns newly created callback handle if callback was successfully added,
-  /// otherwise returns invalid_callback_handle
+  /// otherwise returns invalid_callback_handle.
   ROSBAG2_TRANSPORT_PUBLIC
   callback_handle_t add_on_play_message_pre_callback(const play_msg_callback_t & callback);
 
   /// \brief Adding callable object as handler for post-callback on play message.
   /// \param callback Callable which will be called after next message will be published.
+  /// \note In case of registering multiple callbacks later-registered callbacks will be called
+  /// first.
   /// \return Returns newly created callback handle if callback was successfully added,
-  /// otherwise returns invalid_callback_handle
+  /// otherwise returns invalid_callback_handle.
   ROSBAG2_TRANSPORT_PUBLIC
   callback_handle_t add_on_play_message_post_callback(const play_msg_callback_t & callback);
 

--- a/rosbag2_transport/test/rosbag2_transport/mock_player.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_player.hpp
@@ -47,6 +47,28 @@ public:
     std::unique_lock<std::mutex> lk(ready_to_play_from_queue_mutex_);
     ready_to_play_from_queue_cv_.wait(lk, [this] {return is_ready_to_play_from_queue_;});
   }
+
+  size_t get_number_of_registered_pre_callbacks()
+  {
+    size_t callback_counter = 0;
+    std::lock_guard<std::mutex> lk(on_play_msg_callbacks_mutex_);
+    for (auto & pre_callback_data : on_play_msg_pre_callbacks_) {
+      (void)pre_callback_data;
+      callback_counter++;
+    }
+    return callback_counter;
+  }
+
+  size_t get_number_of_registered_post_callbacks()
+  {
+    size_t callback_counter = 0;
+    std::lock_guard<std::mutex> lk(on_play_msg_callbacks_mutex_);
+    for (auto & post_callback_data : on_play_msg_post_callbacks_) {
+      (void)post_callback_data;
+      callback_counter++;
+    }
+    return callback_counter;
+  }
 };
 
 #endif  // ROSBAG2_TRANSPORT__MOCK_PLAYER_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -50,7 +50,7 @@ class Rosbag2TransportTestFixture : public Test
 public:
   Rosbag2TransportTestFixture()
   : storage_options_({"uri", "storage_id", 0, 100}), play_options_({1000}),
-    reader_(std::make_shared<rosbag2_cpp::Reader>(std::make_unique<MockSequentialReader>())),
+    reader_(std::make_unique<rosbag2_cpp::Reader>(std::make_unique<MockSequentialReader>())),
     writer_(std::make_shared<rosbag2_cpp::Writer>(std::make_unique<MockSequentialWriter>())) {}
 
   template<typename MessageT>
@@ -73,7 +73,7 @@ public:
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::PlayOptions play_options_;
 
-  std::shared_ptr<rosbag2_cpp::Reader> reader_;
+  std::unique_ptr<rosbag2_cpp::Reader> reader_;
   std::shared_ptr<rosbag2_cpp::Writer> writer_;
 };
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
@@ -130,10 +130,10 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, call_callbacks) {
   MockPlayer player(move(reader_), storage_options_, play_options_);
 
   testing::MockFunction<void(std::shared_ptr<SerializedBagMessage>)> mock_pre_callback;
-  EXPECT_CALL(mock_pre_callback, Call(_)).Times(Exactly(num_test_messages_));
+  EXPECT_CALL(mock_pre_callback, Call(_)).Times(Exactly(static_cast<int>(num_test_messages_)));
 
   testing::MockFunction<void(std::shared_ptr<SerializedBagMessage>)> mock_post_callback;
-  EXPECT_CALL(mock_post_callback, Call(_)).Times(Exactly(num_test_messages_));
+  EXPECT_CALL(mock_post_callback, Call(_)).Times(Exactly(static_cast<int>(num_test_messages_)));
 
   auto pre_callback_handle =
     player.add_on_play_message_pre_callback(mock_pre_callback.AsStdFunction());

--- a/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
@@ -1,0 +1,165 @@
+// Copyright 2020-2021, Apex.AI.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "mock_player.hpp"
+#include "rosbag2_transport_test_fixture.hpp"
+#include "rosbag2_transport/player.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+using namespace ::testing;  // NOLINT
+using namespace rosbag2_transport;  // NOLINT
+using namespace std::chrono_literals;  // NOLINT
+
+class Rosbag2PlayCallbacksTestFixture : public Rosbag2TransportTestFixture
+{
+public:
+  Rosbag2PlayCallbacksTestFixture()
+  : Rosbag2TransportTestFixture()
+  {
+    rclcpp::init(0, nullptr);
+
+    auto topics_and_types =
+      std::vector<rosbag2_storage::TopicMetadata>{{"topic1", "test_msgs/Strings", "", ""}};
+
+    std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages;
+    messages.reserve(num_test_messages_);
+
+    auto primitive_message = get_messages_strings()[0];
+    primitive_message->string_value = "Hello World";
+
+    rcutils_time_point_value_t current_timestamp =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+    for (size_t i = 0; i < num_test_messages_; i++) {
+      auto serialized_test_message =
+        serialize_test_message("topic1", RCUTILS_NS_TO_MS(current_timestamp), primitive_message);
+      messages.push_back(serialized_test_message);
+      current_timestamp += message_time_difference_.count();
+    }
+
+    auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+    prepared_mock_reader->prepare(messages, topics_and_types);
+    reader_ = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+  }
+
+  ~Rosbag2PlayCallbacksTestFixture() override
+  {
+    rclcpp::shutdown();
+  }
+
+  const size_t num_test_messages_ = 3;
+  const std::chrono::nanoseconds message_time_difference_ = 5ms;
+};
+
+TEST_F(Rosbag2PlayCallbacksTestFixture, nullptr_as_callback) {
+  MockPlayer player(move(reader_), storage_options_, play_options_);
+  EXPECT_EQ(player.add_on_play_message_pre_callback(nullptr), Player::invalid_callback_handle);
+  EXPECT_EQ(player.add_on_play_message_post_callback(nullptr), Player::invalid_callback_handle);
+
+  EXPECT_EQ(player.get_number_of_registered_pre_callbacks(), 0U);
+  EXPECT_EQ(player.get_number_of_registered_post_callbacks(), 0U);
+}
+
+TEST_F(Rosbag2PlayCallbacksTestFixture, register_unregister_callbacks) {
+  MockPlayer player(move(reader_), storage_options_, play_options_);
+
+  auto lambda_as_callback = [](std::shared_ptr<rosbag2_storage::SerializedBagMessage>) {
+      ASSERT_FALSE(true) << "This code should not be called \n";
+    };
+
+  auto pre_callback_handle = player.add_on_play_message_pre_callback(lambda_as_callback);
+  ASSERT_NE(pre_callback_handle, Player::invalid_callback_handle);
+  ASSERT_EQ(player.get_number_of_registered_pre_callbacks(), 1U);
+
+  auto post_callback_handle = player.add_on_play_message_post_callback(lambda_as_callback);
+  ASSERT_NE(post_callback_handle, Player::invalid_callback_handle);
+  ASSERT_EQ(player.get_number_of_registered_post_callbacks(), 1U);
+
+  // Check for correctness of call delete_on_play_message_callback with invalid_callback_handle
+  player.delete_on_play_message_callback(Player::invalid_callback_handle);
+  ASSERT_EQ(player.get_number_of_registered_pre_callbacks(), 1U);
+  ASSERT_EQ(player.get_number_of_registered_post_callbacks(), 1U);
+
+  player.delete_on_play_message_callback(pre_callback_handle);
+  ASSERT_EQ(player.get_number_of_registered_pre_callbacks(), 0U);
+  ASSERT_EQ(player.get_number_of_registered_post_callbacks(), 1U);
+
+  player.delete_on_play_message_callback(post_callback_handle);
+  ASSERT_EQ(player.get_number_of_registered_pre_callbacks(), 0U);
+  ASSERT_EQ(player.get_number_of_registered_post_callbacks(), 0U);
+
+  player.pause();   // Put player in pause mode before starting
+  ASSERT_TRUE(player.is_paused());
+
+  // Run play asynchronously in separate thread
+  std::future<void> play_future_result =
+    std::async(std::launch::async, [&]() {player.play();});
+
+  for (size_t i = 1; i < num_test_messages_; i++) {
+    EXPECT_TRUE(player.play_next());
+  }
+  player.resume();   // Resume playback for playing the last message
+  ASSERT_FALSE(player.is_paused());
+
+  play_future_result.wait();
+  play_future_result.get();
+  EXPECT_FALSE(player.play_next());
+}
+
+TEST_F(Rosbag2PlayCallbacksTestFixture, call_callbacks) {
+  using SerializedBagMessage = rosbag2_storage::SerializedBagMessage;
+  MockPlayer player(move(reader_), storage_options_, play_options_);
+
+  testing::MockFunction<void(std::shared_ptr<SerializedBagMessage>)> mock_pre_callback;
+  EXPECT_CALL(mock_pre_callback, Call(_)).Times(Exactly(num_test_messages_));
+
+  testing::MockFunction<void(std::shared_ptr<SerializedBagMessage>)> mock_post_callback;
+  EXPECT_CALL(mock_post_callback, Call(_)).Times(Exactly(num_test_messages_));
+
+  auto pre_callback_handle =
+    player.add_on_play_message_pre_callback(mock_pre_callback.AsStdFunction());
+  ASSERT_NE(pre_callback_handle, Player::invalid_callback_handle);
+  ASSERT_EQ(player.get_number_of_registered_pre_callbacks(), 1U);
+
+  auto post_callback_handle =
+    player.add_on_play_message_post_callback(mock_post_callback.AsStdFunction());
+  ASSERT_NE(post_callback_handle, Player::invalid_callback_handle);
+  ASSERT_EQ(player.get_number_of_registered_post_callbacks(), 1U);
+
+  player.pause();  // Put player in pause mode before starting
+  ASSERT_TRUE(player.is_paused());
+
+  // Run play asynchronously in separate thread
+  std::future<void> play_future_result =
+    std::async(std::launch::async, [&]() {player.play();});
+
+  for (size_t i = 1; i < num_test_messages_; i++) {
+    EXPECT_TRUE(player.play_next());
+  }
+
+  player.resume();  // Resume playback for playing the last message
+  ASSERT_FALSE(player.is_paused());
+
+  play_future_result.wait();
+  play_future_result.get();
+  EXPECT_FALSE(player.play_next());
+}


### PR DESCRIPTION
Address #1003 
Added new API:
add_on_play_message_pre_callback(const play_msg_callback_t & callback)
add_on_play_message_post_callback(const play_msg_callback_t & callback)
delete_on_play_message_callback(const callback_handle_t & handle)
- Closes #1003

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>