### PR TITLE
Adds play until functionality -- follow up to #962

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -90,6 +90,10 @@ class PlayVerb(VerbExtension):
             help='Playback duration, in seconds. Negative durations mark an infinite playback. '
                  'Default is -1.0.')
         parser.add_argument(
+            '--playback_until', type=check_positive_float, default=-1.0,
+            help='Playback until timestamp, in seconds. Negative stamps disable this feature. '
+                 'Default is -1.0.')
+        parser.add_argument(
             '--disable-keyboard-controls', action='store_true',
             help='disables keyboard controls for playback')
         parser.add_argument(
@@ -155,6 +159,7 @@ class PlayVerb(VerbExtension):
         play_options.clock_publish_frequency = args.clock
         play_options.delay = args.delay
         play_options.playback_duration = args.playback_duration
+        play_options.playback_until = args.playback_until
         play_options.disable_keyboard_controls = args.disable_keyboard_controls
         play_options.start_paused = args.start_paused
         play_options.start_offset = args.start_offset

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -86,25 +86,32 @@ class PlayVerb(VerbExtension):
             '-d', '--delay', type=positive_float, default=0.0,
             help='Sleep duration before play (each loop), in seconds. Negative durations invalid.')
         parser.add_argument(
-            '--playback_duration', type=float, default=-1.0,
+            '--playback-duration', type=float, default=-1.0,
             help='Playback duration, in seconds. Negative durations mark an infinite playback. '
-                 'Default is -1.0. When positive, the maximum of `playback_until` and the one '
+                 'Default is -1.0. When positive, the maximum of `playback-until` and the one '
                  'that this attribute yields will be used to determine which one stops playback '
                  'execution.')
-        parser.add_argument(
-            '--playback_until_sec', type=int, default=-1,
-            help='Playback until timestamp, the seconds part. See \'--playback_until_nsec\' to '
-                 'complete the stamp information. Negative stamps disable this feature. '
-                 'Default is -1. When positive, the maximum of the effective time that '
-                 '`playback_duration` yields and this attribute will be used to determine which '
+
+        playback_until_arg_group = parser.add_mutually_exclusive_group()
+        playback_until_arg_group.add_argument(
+            '--playback-until-sec', type=float, default=-1.,
+            help='Playback until timestamp, expressed in seconds since epoch. '
+                 'Mutually exclusive argument with \'--playback-until-nsec\'. '
+                 'Use this argument when floating point to integer conversion error is not a '
+                 'problem for your application. Negative stamps disable this feature. Default is '
+                 '-1.0. When positive, the maximum of the effective time that '
+                 '`--playback-duration` yields and this attribute will be used to determine which '
                  'one stops playback execution.')
-        parser.add_argument(
-            '--playback_until_nsec', type=int, default=-1,
-            help='Playback until timestamp, the nanoseconds part. See \'--playback_until_sec\' to '
-                 'complete the stamp information. Negative stamps disable this feature. '
-                 'Default is -1. When positive, the maximum of the effective time that '
-                 '`playback_duration` yields and this attribute will be used to determine which '
-                 'one stops playback execution.')
+        playback_until_arg_group.add_argument(
+            '--playback-until-nsec', type=int, default=-1,
+            help='Playback until timestamp, expressed in nanoseconds since epoch.  '
+                 'Mutually exclusive argument with \'--playback-until-sec\'. '
+                 'Use this argument when floating point to integer conversion error matters for '
+                 'your application. Negative stamps disable this feature. Default is -1. When '
+                 'positive, the maximum of the effective time that `--playback-duration` yields '
+                 'and this attribute will be used to determine which one stops playback '
+                 'execution.')
+
         parser.add_argument(
             '--disable-keyboard-controls', action='store_true',
             help='disables keyboard controls for playback')
@@ -138,11 +145,9 @@ class PlayVerb(VerbExtension):
 
     def get_playback_until_from(self, playback_until_sec, playback_until_nsec) -> int:
         nano_scale = 1000 * 1000 * 1000
-        if playback_until_sec >= 0 and playback_until_nsec >= 0:
-            return playback_until_sec * nano_scale + playback_until_nsec
-        elif playback_until_sec >= 0 and playback_until_nsec < 0:
-            return playback_until_sec * nano_scale
-        elif playback_until_sec < 0 and playback_until_nsec >= 0:
+        if playback_until_sec and playback_until_sec >= 0.0:
+            return int(playback_until_sec * nano_scale)
+        if playback_until_nsec and playback_until_nsec >= 0:
             return playback_until_nsec
         return -1
 

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -88,11 +88,15 @@ class PlayVerb(VerbExtension):
         parser.add_argument(
             '--playback_duration', type=float, default=-1.0,
             help='Playback duration, in seconds. Negative durations mark an infinite playback. '
-                 'Default is -1.0.')
+                 'Default is -1.0. When positive, the maximum of `playback_until` and the one '
+                 'that this attribute yields will be used to determine which one stops playback '
+                 'execution.')
         parser.add_argument(
             '--playback_until', type=check_positive_float, default=-1.0,
             help='Playback until timestamp, in seconds. Negative stamps disable this feature. '
-                 'Default is -1.0.')
+                 'Default is -1.0. When positive, the maximum of the effective time that '
+                 '`playback_duration` yields and this attribute will be used to determine which '
+                 'one stops playback execution.')
         parser.add_argument(
             '--disable-keyboard-controls', action='store_true',
             help='disables keyboard controls for playback')

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -88,7 +88,7 @@ class PlayVerb(VerbExtension):
         parser.add_argument(
             '--playback-duration', type=float, default=-1.0,
             help='Playback duration, in seconds. Negative durations mark an infinite playback. '
-                 'Default is -1.0. When positive, the maximum of `playback-until` and the one '
+                 'Default is -1.0. When positive, the maximum of `playback-until-*` and the one '
                  'that this attribute yields will be used to determine which one stops playback '
                  'execution.')
 
@@ -96,7 +96,7 @@ class PlayVerb(VerbExtension):
         playback_until_arg_group.add_argument(
             '--playback-until-sec', type=float, default=-1.,
             help='Playback until timestamp, expressed in seconds since epoch. '
-                 'Mutually exclusive argument with \'--playback-until-nsec\'. '
+                 'Mutually exclusive argument with `--playback-until-nsec`. '
                  'Use this argument when floating point to integer conversion error is not a '
                  'problem for your application. Negative stamps disable this feature. Default is '
                  '-1.0. When positive, the maximum of the effective time that '
@@ -105,7 +105,7 @@ class PlayVerb(VerbExtension):
         playback_until_arg_group.add_argument(
             '--playback-until-nsec', type=int, default=-1,
             help='Playback until timestamp, expressed in nanoseconds since epoch.  '
-                 'Mutually exclusive argument with \'--playback-until-sec\'. '
+                 'Mutually exclusive argument with `--playback-until-sec`. '
                  'Use this argument when floating point to integer conversion error matters for '
                  'your application. Negative stamps disable this feature. Default is -1. When '
                  'positive, the maximum of the effective time that `--playback-duration` yields '
@@ -143,7 +143,7 @@ class PlayVerb(VerbExtension):
             help='Play for SEC seconds. Default is None, meaning that playback will continue '
                  'until the end of the bag. Valid range > 0.0')
 
-    def get_playback_until_from(self, playback_until_sec, playback_until_nsec) -> int:
+    def get_playback_until_from_arg_group(self, playback_until_sec, playback_until_nsec) -> int:
         nano_scale = 1000 * 1000 * 1000
         if playback_until_sec and playback_until_sec >= 0.0:
             return int(playback_until_sec * nano_scale)
@@ -186,8 +186,8 @@ class PlayVerb(VerbExtension):
         play_options.clock_publish_frequency = args.clock
         play_options.delay = args.delay
         play_options.playback_duration = args.playback_duration
-        play_options.playback_until = self.get_playback_until_from(args.playback_until_sec,
-                                                                   args.playback_until_nsec)
+        play_options.playback_until_timestamp = self.get_playback_until_from_arg_group(
+            args.playback_until_sec, args.playback_until_nsec)
         play_options.disable_keyboard_controls = args.disable_keyboard_controls
         play_options.start_paused = args.start_paused
         play_options.start_offset = args.start_offset

--- a/rosbag2_interfaces/srv/Play.srv
+++ b/rosbag2_interfaces/srv/Play.srv
@@ -2,8 +2,8 @@
 builtin_interfaces/Time start_offset
 # See rosbag2_transport::PlayOptions::playback_duration
 builtin_interfaces/Duration playback_duration
-# See rosbag2_transport::PlayOptions::playback_until
-builtin_interfaces/Time playback_until
+# See rosbag2_transport::PlayOptions::playback_until_timestamp
+builtin_interfaces/Time playback_until_timestamp
 ---
 # returns false when another playback execution is running, otherwise true
 bool success

--- a/rosbag2_interfaces/srv/Play.srv
+++ b/rosbag2_interfaces/srv/Play.srv
@@ -2,6 +2,8 @@
 builtin_interfaces/Time start_offset
 # See rosbag2_transport::PlayOptions::playback_duration
 builtin_interfaces/Duration playback_duration
+# See rosbag2_transport::PlayOptions::playback_until
+builtin_interfaces/Time playback_until
 ---
 # returns false when another playback execution is running, otherwise true
 bool success

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -299,7 +299,7 @@ PYBIND11_MODULE(_transport, m) {
     &PlayOptions::getStartOffset,
     &PlayOptions::setStartOffset)
   .def_property(
-    "start_offset",
+    "playback_until",
     &PlayOptions::getPlaybackUntil,
     &PlayOptions::setPlaybackUntil)
   .def_readwrite("wait_acked_timeout", &PlayOptions::wait_acked_timeout)

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -95,6 +95,16 @@ public:
     return RCUTILS_NS_TO_S(static_cast<double>(this->start_offset));
   }
 
+  void setPlaybackUntil(double playback_until)
+  {
+    this->playback_until = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(playback_until));
+  }
+
+  double getPlaybackUntil() const
+  {
+    return RCUTILS_NS_TO_S(static_cast<double>(this->playback_until));
+  }
+
   void setTopicQoSProfileOverrides(const py::dict & overrides)
   {
     py_dict = overrides;
@@ -288,6 +298,10 @@ PYBIND11_MODULE(_transport, m) {
     "start_offset",
     &PlayOptions::getStartOffset,
     &PlayOptions::setStartOffset)
+  .def_property(
+    "start_offset",
+    &PlayOptions::getPlaybackUntil,
+    &PlayOptions::setPlaybackUntil)
   .def_readwrite("wait_acked_timeout", &PlayOptions::wait_acked_timeout)
   .def_readwrite("disable_loan_message", &PlayOptions::disable_loan_message)
   ;

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -95,14 +95,14 @@ public:
     return RCUTILS_NS_TO_S(static_cast<double>(this->start_offset));
   }
 
-  void setPlaybackUntil(double playback_until)
+  void setPlaybackUntil(int64_t playback_until)
   {
-    this->playback_until = static_cast<rcutils_time_point_value_t>(RCUTILS_S_TO_NS(playback_until));
+    this->playback_until = static_cast<rcutils_time_point_value_t>(playback_until);
   }
 
-  double getPlaybackUntil() const
+  int64_t getPlaybackUntil() const
   {
-    return RCUTILS_NS_TO_S(static_cast<double>(this->playback_until));
+    return this->playback_until;
   }
 
   void setTopicQoSProfileOverrides(const py::dict & overrides)

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -95,14 +95,15 @@ public:
     return RCUTILS_NS_TO_S(static_cast<double>(this->start_offset));
   }
 
-  void setPlaybackUntil(int64_t playback_until)
+  void setPlaybackUntilTimestamp(int64_t playback_until_timestamp)
   {
-    this->playback_until = static_cast<rcutils_time_point_value_t>(playback_until);
+    this->playback_until_timestamp =
+      static_cast<rcutils_time_point_value_t>(playback_until_timestamp);
   }
 
-  int64_t getPlaybackUntil() const
+  int64_t getPlaybackUntilTimestamp() const
   {
-    return this->playback_until;
+    return this->playback_until_timestamp;
   }
 
   void setTopicQoSProfileOverrides(const py::dict & overrides)
@@ -299,9 +300,9 @@ PYBIND11_MODULE(_transport, m) {
     &PlayOptions::getStartOffset,
     &PlayOptions::setStartOffset)
   .def_property(
-    "playback_until",
-    &PlayOptions::getPlaybackUntil,
-    &PlayOptions::setPlaybackUntil)
+    "playback_until_timestamp",
+    &PlayOptions::getPlaybackUntilTimestamp,
+    &PlayOptions::setPlaybackUntilTimestamp)
   .def_readwrite("wait_acked_timeout", &PlayOptions::wait_acked_timeout)
   .def_readwrite("disable_loan_message", &PlayOptions::disable_loan_message)
   ;

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -160,7 +160,13 @@ function(create_tests_for_rmw_implementation)
       LINK_LIBS rosbag2_transport
       AMENT_DEPS test_msgs rosbag2_test_common)
 
-  rosbag2_transport_add_gmock(test_burst
+  rosbag2_transport_add_gmock(test_play_until
+      test/rosbag2_transport/test_play_until.cpp
+      INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
+      LINK_LIBS rosbag2_transport
+      AMENT_DEPS test_msgs rosbag2_test_common)
+
+    rosbag2_transport_add_gmock(test_burst
       test/rosbag2_transport/test_burst.cpp
       INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
       LINK_LIBS rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -53,15 +53,15 @@ public:
 
   // Determines the maximum duration of the playback. Negative durations will make the playback to
   // not stop. Default configuration makes the player to not stop execution.
-  // When positive, the maximum of `playback_until` and the one that this attribute yields will be
-  // used to determine which one stops playback execution.
+  // When positive, the maximum of `play_until_timestamp` and the one that this attribute yields
+  // will be used to determine which one stops playback execution.
   rclcpp::Duration playback_duration = rclcpp::Duration(-1, 0);
 
   // Determines the timestamp at which the playback will stop. Negative timestamps will make the
   // playback to not stop. Default configuration makes the player to not stop execution.
   // When positive, the maximum of the effective time that `playback_duration` yields and this
   // attribute will be used to determine which one stops playback execution.
-  rcutils_time_point_value_t playback_until = -1;
+  rcutils_time_point_value_t playback_until_timestamp = -1;
 
   // Start paused.
   bool start_paused = false;

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -22,6 +22,7 @@
 
 #include "keyboard_handler/keyboard_handler.hpp"
 #include "rclcpp/duration.hpp"
+#include "rclcpp/time.hpp"
 #include "rclcpp/qos.hpp"
 
 namespace rosbag2_transport
@@ -52,7 +53,15 @@ public:
 
   // Determines the maximum duration of the playback. Negative durations will make the playback to
   // not stop. Default configuration makes the player to not stop execution.
+  // When positive, the maximum of `playback_until` and the one that this attribute yields will be
+  // used to determine which one stops playback execution.
   rclcpp::Duration playback_duration = rclcpp::Duration(-1, 0);
+
+  // Determines the timestamp at which the playback will stop. Negative timestamps will make the
+  // playback to not stop. Default configuration makes the player to not stop execution.
+  // When positive, the maximum of the effective time that `playback_duration` yields and this
+  // attribute will be used to determine which one stops playback execution.
+  rcutils_time_point_value_t playback_until = -1;
 
   // Start paused.
   bool start_paused = false;

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -20,7 +20,6 @@
 #include <functional>
 #include <future>
 #include <memory>
-#include <optional>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -249,7 +248,7 @@ private:
   bool is_storage_completely_loaded() const;
   void enqueue_up_to_boundary(size_t boundary) RCPPUTILS_TSA_REQUIRES(reader_mutex_);
   void wait_for_filled_queue() const;
-  void play_messages_from_queue();
+  void play_messages_from_queue(const rcutils_time_point_value_t & play_until_timestamp);
   void prepare_publishers();
   bool publish_message(rosbag2_storage::SerializedBagMessageSharedPtr message);
   static callback_handle_t get_new_on_play_msg_callback_handle();
@@ -270,7 +269,7 @@ private:
 
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::PlayOptions play_options_;
-  rcutils_time_point_value_t play_until_time_ = -1;
+  rcutils_time_point_value_t play_until_timestamp_ = -1;
   moodycamel::ReaderWriterQueue<rosbag2_storage::SerializedBagMessageSharedPtr> message_queue_;
   mutable std::future<void> storage_loading_future_;
   std::atomic_bool load_storage_content_{true};

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -248,7 +248,7 @@ private:
   bool is_storage_completely_loaded() const;
   void enqueue_up_to_boundary(size_t boundary) RCPPUTILS_TSA_REQUIRES(reader_mutex_);
   void wait_for_filled_queue() const;
-  void play_messages_from_queue(const rcutils_time_point_value_t & play_until_timestamp);
+  void play_messages_from_queue();
   void prepare_publishers();
   bool publish_message(rosbag2_storage::SerializedBagMessageSharedPtr message);
   static callback_handle_t get_new_on_play_msg_callback_handle();
@@ -266,6 +266,8 @@ private:
   void add_keyboard_callbacks();
 
   void create_control_services();
+
+  void configure_play_until_timestamp();
 
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::PlayOptions play_options_;

--- a/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
@@ -358,18 +358,40 @@ TEST_F(RosBag2PlayUntilTestFixture, playback_duration_overrides_play_until)
 
 TEST_F(RosBag2PlayUntilTestFixture, play_until_is_equal_to_the_total_duration)
 {
-  InitPlayerWithPlaybackUntilAndPlay(
-    150 /* playback_until_timestamp_millis */, 1 /* num messages topic 1 */,
-    1 /* num messages topic 2 */, 150 /* playback_duration_millis */);
+  auto primitive_message1 = get_messages_basic_types()[0];
+  auto primitive_message2 = get_messages_basic_types()[0];
+  primitive_message1->int32_value = 1;
+  primitive_message2->int32_value = 2;
 
-  auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
-    kTopic1_);
-  EXPECT_THAT(replayed_test_primitives, SizeIs(Eq(1u)));
-  EVAL_REPLAYED_PRIMITIVES(replayed_test_primitives);
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {kTopic1Name_, "test_msgs/BasicTypes", "", ""}};
 
-  auto replayed_test_arrays = sub_->get_received_messages<test_msgs::msg::Arrays>(
-    kTopic2_);
-  EXPECT_THAT(replayed_test_arrays, SizeIs(Eq(1u)));
-  EVAL_REPLAYED_BOOL_ARRAY_PRIMITIVES(replayed_test_arrays);
-  EVAL_REPLAYED_FLOAT_ARRAY_PRIMITIVES(replayed_test_arrays);
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {
+    serialize_test_message(kTopic1Name_, 10, primitive_message1),
+    serialize_test_message(kTopic1Name_, 50, primitive_message2),
+  };
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  // Expect to receive 1 message from play() and 2 messages from play_next in second round
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(kTopic1_, messages.size());
+  play_options_.playback_until_timestamp = RCL_MS_TO_NS(50);
+
+  std::shared_ptr<MockPlayer> player_ = std::make_shared<MockPlayer>(
+    std::move(reader), storage_options_, play_options_);
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+  ASSERT_TRUE(player_->play());
+
+  await_received_messages.get();
+  auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
+  EXPECT_THAT(replayed_topic1, SizeIs(messages.size()));
+  EXPECT_EQ(replayed_topic1[0]->int32_value, 1);
+  EXPECT_EQ(replayed_topic1[1]->int32_value, 2);
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
@@ -1,0 +1,362 @@
+// Copyright 2022, Open Source Robotics Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.Bosch Software Innovations GmbH.
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "rosbag2_test_common/subscription_manager.hpp"
+
+#include "rosbag2_transport/player.hpp"
+#include "rosbag2_transport/qos.hpp"
+
+#include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+#include "rosbag2_play_test_fixture.hpp"
+#include "rosbag2_transport_test_fixture.hpp"
+
+#include "mock_player.hpp"
+
+using namespace ::testing;  // NOLINT
+using namespace rosbag2_transport;  // NOLINT
+using namespace std::chrono_literals;  // NOLINT
+using namespace rosbag2_test_common;  // NOLINT
+
+constexpr int kIntValue{32};
+
+constexpr float kFloat1Value{40.};
+constexpr float kFloat2Value{2.};
+constexpr float kFloat3Value{0.};
+
+constexpr bool kBool1Value{false};
+constexpr bool kBool2Value{true};
+constexpr bool kBool3Value{false};
+
+#define EVAL_REPLAYED_PRIMITIVES(replayed_primitives) \
+  EXPECT_THAT( \
+    replayed_primitives, \
+    Each(Pointee(Field(&test_msgs::msg::BasicTypes::int32_value, kIntValue))))
+
+#define EVAL_REPLAYED_FLOAT_ARRAY_PRIMITIVES(replayed_float_array_primitive) \
+  EXPECT_THAT( \
+    replayed_float_array_primitive, \
+    Each( \
+      Pointee( \
+        Field( \
+          &test_msgs::msg::Arrays::float32_values, \
+          ElementsAre(kFloat1Value, kFloat2Value, kFloat3Value)))))
+
+#define EVAL_REPLAYED_BOOL_ARRAY_PRIMITIVES(replayed_bool_array_primitive) \
+  EXPECT_THAT( \
+    replayed_bool_array_primitive, \
+    Each( \
+      Pointee( \
+        Field( \
+          &test_msgs::msg::Arrays::bool_values, \
+          ElementsAre(kBool1Value, kBool2Value, kBool3Value)))))
+
+class RosBag2PlayUntilTestFixture : public RosBag2PlayTestFixture
+{
+public:
+  static constexpr const char * kTopic1Name_{"topic1"};
+  static constexpr const char * kTopic2Name_{"topic2"};
+  static constexpr const char * kTopic1_{"/topic1"};
+  static constexpr const char * kTopic2_{"/topic2"};
+
+  std::vector<rosbag2_storage::TopicMetadata> get_topic_types()
+  {
+    return {{kTopic1Name_, "test_msgs/BasicTypes", "", ""},
+      {kTopic2Name_, "test_msgs/Arrays", "", ""}};
+  }
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
+  get_serialized_messages()
+  {
+    auto primitive_message1 = get_messages_basic_types()[0];
+    primitive_message1->int32_value = kIntValue;
+
+    auto complex_message1 = get_messages_arrays()[0];
+    complex_message1->float32_values = {{kFloat1Value, kFloat2Value, kFloat3Value}};
+    complex_message1->bool_values = {{kBool1Value, kBool2Value, kBool3Value}};
+
+    // @{ Ordering matters. The mock reader implementation moves messages
+    //    around without any knowledge about message chronology. It just picks
+    //    the next one Make sure to keep the list in order or sort it!
+    std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+    {serialize_test_message(kTopic1Name_, 100, primitive_message1),
+      serialize_test_message(kTopic2Name_, 120, complex_message1),
+      serialize_test_message(kTopic1Name_, 200, primitive_message1),
+      serialize_test_message(kTopic2Name_, 220, complex_message1),
+      serialize_test_message(kTopic1Name_, 300, primitive_message1),
+      serialize_test_message(kTopic2Name_, 320, complex_message1)};
+    // @}
+    return messages;
+  }
+
+  void InitPlayerWithPlaybackUntilAndPlay(
+    int64_t playback_until_millis,
+    size_t expected_number_of_messages_on_topic1 = 3,
+    size_t expected_number_of_messages_on_topic2 = 3,
+    int64_t playback_for_millis = -1)
+  {
+    auto topic_types = get_topic_types();
+    auto messages = get_serialized_messages();
+
+    auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+    prepared_mock_reader->prepare(messages, topic_types);
+    auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+    sub_->add_subscription<test_msgs::msg::BasicTypes>(
+      kTopic1_, expected_number_of_messages_on_topic1);
+    sub_->add_subscription<test_msgs::msg::Arrays>(kTopic2_, expected_number_of_messages_on_topic2);
+
+    play_options_.playback_until = RCL_MS_TO_NS(playback_until_millis);
+    play_options_.playback_duration = rclcpp::Duration(
+      std::chrono::milliseconds(
+        playback_for_millis));
+    player_ = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+    // Wait for discovery to match publishers with subscribers
+    ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
+
+    auto await_received_messages = sub_->spin_subscriptions();
+    ASSERT_TRUE(player_->play());
+    await_received_messages.get();
+  }
+
+  std::shared_ptr<MockPlayer> player_;
+};
+
+
+TEST_F(RosBag2PlayUntilTestFixture, play_until_all_are_played_due_to_duration)
+{
+  InitPlayerWithPlaybackUntilAndPlay(350);
+
+  auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
+    kTopic1_);
+  EXPECT_THAT(replayed_test_primitives, SizeIs(Eq(3u)));
+  EVAL_REPLAYED_PRIMITIVES(replayed_test_primitives);
+
+  auto replayed_test_arrays = sub_->get_received_messages<test_msgs::msg::Arrays>(
+    kTopic2_);
+  EXPECT_THAT(replayed_test_arrays, SizeIs(Eq(3u)));
+  EVAL_REPLAYED_BOOL_ARRAY_PRIMITIVES(replayed_test_arrays);
+  EVAL_REPLAYED_FLOAT_ARRAY_PRIMITIVES(replayed_test_arrays);
+}
+
+TEST_F(RosBag2PlayUntilTestFixture, play_until_none_are_played_due_to_timestamp)
+{
+  auto primitive_message1 = get_messages_basic_types()[0];
+  auto primitive_message2 = get_messages_basic_types()[0];
+  primitive_message1->int32_value = 1;
+  primitive_message2->int32_value = 2;
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {kTopic1Name_, "test_msgs/BasicTypes", "", ""}};
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {
+    serialize_test_message(kTopic1Name_, 50, primitive_message1),
+    serialize_test_message(kTopic1Name_, 100, primitive_message2),
+  };
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  // Expect to receive messages only from play_next in second round
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(kTopic1_, messages.size());
+  play_options_.playback_until = RCL_MS_TO_NS(49);
+
+  std::shared_ptr<MockPlayer> player_ = std::make_shared<MockPlayer>(
+    std::move(reader), storage_options_, play_options_);
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+  ASSERT_TRUE(player_->play());
+
+  // Playing one more time with play_next to save time and count messages
+  player_->pause();
+  auto player_future = std::async(std::launch::async, [&player_]() -> void {player_->play();});
+
+  EXPECT_TRUE(player_->play_next());
+  EXPECT_TRUE(player_->play_next());
+  EXPECT_FALSE(player_->play_next());
+  player_->resume();
+  player_future.get();
+  await_received_messages.get();
+  auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
+  EXPECT_THAT(replayed_topic1, SizeIs(2));
+  EXPECT_EQ(replayed_topic1[0]->int32_value, 1);
+  EXPECT_EQ(replayed_topic1[1]->int32_value, 2);
+}
+
+TEST_F(RosBag2PlayUntilTestFixture, play_until_less_than_the_total_duration)
+{
+  auto primitive_message1 = get_messages_basic_types()[0];
+  auto primitive_message2 = get_messages_basic_types()[0];
+  primitive_message1->int32_value = 1;
+  primitive_message2->int32_value = 2;
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {kTopic1Name_, "test_msgs/BasicTypes", "", ""}};
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {
+    serialize_test_message(kTopic1Name_, 10, primitive_message1),
+    serialize_test_message(kTopic1Name_, 50, primitive_message2),
+  };
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  // Expect to receive 1 message from play() and 2 messages from play_next in second round
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(kTopic1_, messages.size() + 1);
+  play_options_.playback_until = RCL_MS_TO_NS(49);
+
+  std::shared_ptr<MockPlayer> player_ = std::make_shared<MockPlayer>(
+    std::move(reader), storage_options_, play_options_);
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+  ASSERT_TRUE(player_->play());
+
+  // Playing one more time with play_next to save time and count messages
+  player_->pause();
+  auto player_future = std::async(std::launch::async, [&player_]() -> void {player_->play();});
+
+  ASSERT_TRUE(player_->play_next());
+  ASSERT_TRUE(player_->play_next());
+  ASSERT_FALSE(player_->play_next());
+  player_->resume();
+  player_future.get();
+  await_received_messages.get();
+  auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
+  EXPECT_THAT(replayed_topic1, SizeIs(3));
+  EXPECT_EQ(replayed_topic1[0]->int32_value, 1);
+  EXPECT_EQ(replayed_topic1[1]->int32_value, 1);
+  EXPECT_EQ(replayed_topic1[2]->int32_value, 2);
+}
+
+TEST_F(
+  RosBag2PlayUntilTestFixture,
+  play_until_intermediate_duration_recorded_messages_with_filtered_topics)
+{
+  // Filter allows /topic2, blocks /topic1
+  play_options_.topics_to_filter = {"topic2"};
+  InitPlayerWithPlaybackUntilAndPlay(270, 0, 2);
+
+  auto replayed_test_primitives =
+    sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
+  // No messages are allowed to have arrived
+  EXPECT_THAT(replayed_test_primitives, SizeIs(Eq(0u)));
+
+  auto replayed_test_arrays = sub_->get_received_messages<test_msgs::msg::Arrays>("/topic2");
+  // Some messages should have arrived.
+  EXPECT_THAT(replayed_test_arrays, SizeIs(Eq(2u)));
+  EVAL_REPLAYED_BOOL_ARRAY_PRIMITIVES(replayed_test_arrays);
+  EVAL_REPLAYED_FLOAT_ARRAY_PRIMITIVES(replayed_test_arrays);
+}
+
+TEST_F(RosBag2PlayUntilTestFixture, play_should_return_false_when_interrupted)
+{
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {kTopic1Name_, "test_msgs/BasicTypes", "", ""}};
+
+  auto primitive_message = get_messages_basic_types()[0];
+  primitive_message->int32_value = kIntValue;
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {
+    serialize_test_message(kTopic1Name_, 50, primitive_message),
+    serialize_test_message(kTopic1Name_, 100, primitive_message),
+  };
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  // Let the player only reproduce one message.
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(kTopic1_, 1);
+  play_options_.playback_until = RCL_MS_TO_NS(75);
+
+  std::shared_ptr<MockPlayer> player_ = std::make_shared<MockPlayer>(
+    std::move(reader), storage_options_, play_options_);
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+  player_->pause();
+  auto player_future = std::async(std::launch::async, [player_]() {return player_->play();});
+  player_->wait_for_playback_to_start();
+  ASSERT_TRUE(player_->is_paused());
+  ASSERT_FALSE(player_->play());
+
+  player_->resume();
+  player_future.get();
+  await_received_messages.get();
+  auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
+  EXPECT_THAT(replayed_topic1, SizeIs(1));
+}
+
+TEST_F(RosBag2PlayUntilTestFixture, play_until_all_are_played_until_is_bigger_than_for)
+{
+  InitPlayerWithPlaybackUntilAndPlay(
+    350 /* playback_until */, 3 /* num messages topic 1 */,
+    3 /* num messages topic 2 */, 50 /* playback_for */);
+
+  auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
+    kTopic1_);
+  EXPECT_THAT(replayed_test_primitives, SizeIs(Eq(3u)));
+  EVAL_REPLAYED_PRIMITIVES(replayed_test_primitives);
+
+  auto replayed_test_arrays = sub_->get_received_messages<test_msgs::msg::Arrays>(
+    kTopic2_);
+  EXPECT_THAT(replayed_test_arrays, SizeIs(Eq(3u)));
+  EVAL_REPLAYED_BOOL_ARRAY_PRIMITIVES(replayed_test_arrays);
+  EVAL_REPLAYED_FLOAT_ARRAY_PRIMITIVES(replayed_test_arrays);
+}
+
+TEST_F(RosBag2PlayUntilTestFixture, play_until_all_are_played_until_is_smaller_than_for)
+{
+  InitPlayerWithPlaybackUntilAndPlay(
+    50 /* playback_until */, 1 /* num messages topic 1 */,
+    1 /* num messages topic 2 */, 150 /* playback_for */);
+
+  auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
+    kTopic1_);
+  EXPECT_THAT(replayed_test_primitives, SizeIs(Eq(1u)));
+  EVAL_REPLAYED_PRIMITIVES(replayed_test_primitives);
+
+  auto replayed_test_arrays = sub_->get_received_messages<test_msgs::msg::Arrays>(
+    kTopic2_);
+  EXPECT_THAT(replayed_test_arrays, SizeIs(Eq(1u)));
+  EVAL_REPLAYED_BOOL_ARRAY_PRIMITIVES(replayed_test_arrays);
+  EVAL_REPLAYED_FLOAT_ARRAY_PRIMITIVES(replayed_test_arrays);
+}


### PR DESCRIPTION
This PR offers the same functionality than #962 but is done directly on top of the latest version of #960 ( commit 59c52eff2ef84fc8273e25493bcc3e2e8ea2c222 ). It has been done this way because to re-work the PR so it follows the style agreed on #960 a revert was required of the entire patch.

This PR requires https://github.com/ros2/rosbag2/pull/960 to be merged first (at which point it will probably need to be rebased).

This PR was co-authored with @gbiggs 

Fore reviewers, you should start from df793c7457acde1c8f49c095f3a5935ca8202f7e onwards.