### PR TITLE
Add the /bigobj flag to Windows Debug builds.

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -14,6 +14,11 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND MSVC)
+  # /bigobj is needed to avoid error C1128:
+  #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+endif()
 
 # Windows supplies macros for min and max by default. We should only use min and max from stl
 if(WIN32)


### PR DESCRIPTION
Windows debug builds generate a lot more sections, so when
building in debug mode we need to add the /bigobj flag to
avoid failing the build.  More details are in the link in
the code comment.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the failing Windows Debug builds that have happened the last two nights.