### PR TITLE
Improve test_time_controller test

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <thread>
+#include <rclcpp/utilities.hpp>
 #include "rosbag2_cpp/clocks/time_controller_clock.hpp"
 
 using namespace testing;  // NOLINT

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -151,7 +151,21 @@ TEST_F(TimeControllerClockTest, unpaused_sleep_returns_true)
 
   clock.pause();
   clock.resume();
-  EXPECT_TRUE(clock.sleep_until(clock.now() + RCUTILS_S_TO_NS(1)));
+
+  auto sleep_until_timestamp = clock.now() + RCUTILS_S_TO_NS(1);
+  auto start = std::chrono::steady_clock::now();
+  bool sleep_result = clock.sleep_until(sleep_until_timestamp);
+  // clock.sleep_until can spuriously wake up and return false.
+  // Check it until true and use a timeout to avoid a hang
+  while (rclcpp::ok() && !sleep_result &&
+         (std::chrono::steady_clock::now() - start) < std::chrono::milliseconds(1200))
+  {
+    sleep_result = clock.sleep_until(sleep_until_timestamp);
+  }
+  auto end = std::chrono::steady_clock::now();
+  EXPECT_TRUE(end - start < std::chrono::milliseconds(1200));
+  EXPECT_TRUE(end - start >= std::chrono::seconds(1));
+  EXPECT_TRUE(sleep_result);
 }
 
 TEST_F(TimeControllerClockTest, paused_sleep_returns_false_quickly)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -158,7 +158,7 @@ TEST_F(TimeControllerClockTest, unpaused_sleep_returns_true)
   // clock.sleep_until can spuriously wake up and return false.
   // Check it until true and use a timeout to avoid a hang
   while (rclcpp::ok() && !sleep_result &&
-         (std::chrono::steady_clock::now() - start) < std::chrono::milliseconds(1200))
+    (std::chrono::steady_clock::now() - start) < std::chrono::milliseconds(1200))
   {
     sleep_result = clock.sleep_until(sleep_until_timestamp);
   }


### PR DESCRIPTION
Should close https://github.com/ros2/rosbag2/issues/992

It's a simple fix for a test that was heavily relying on the the OS not waking up as explained here:
https://github.com/ros2/rosbag2/issues/992#issuecomment-1120111985

This test right before it makes the same assumption: https://github.com/ros2/rosbag2/blob/5fa3a67e79a03206e4e721a7c714caff72966801/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp#L150
But as it haven't failed I decided not to change it with this PR.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>