### PR TITLE
Address flakiness in record_all_with_sim_time test

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -77,7 +77,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   size_t expected_messages = 10;
   auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(10),
+    std::chrono::seconds(5),
     [&mock_writer, &expected_messages]() {
       return mock_writer.get_messages().size() >= expected_messages;
     });

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -86,6 +86,10 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
     "recorded messages = " << recorded_messages.size();
   stop_spinning();
 
+  auto messages_per_topic = mock_writer.messages_per_topic();
+  EXPECT_EQ(messages_per_topic[clock_topic], 5);
+  EXPECT_EQ(messages_per_topic[string_topic], 5);
+
   EXPECT_THAT(recorded_messages, SizeIs(Ge(expected_messages)));
 
   std::vector<rosbag2_storage::SerializedBagMessageSharedPtr> string_messages;

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -87,8 +87,8 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
   stop_spinning();
 
   auto messages_per_topic = mock_writer.messages_per_topic();
-  EXPECT_EQ(messages_per_topic[clock_topic], 5);
-  EXPECT_EQ(messages_per_topic[string_topic], 5);
+  EXPECT_EQ(messages_per_topic[clock_topic], 5u);
+  EXPECT_EQ(messages_per_topic[string_topic], 5u);
 
   EXPECT_THAT(recorded_messages, SizeIs(Ge(expected_messages)));
 


### PR DESCRIPTION
Trying to fix flaky `record_all_with_sim_time` test

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>