### PR TITLE
Backport. Add use_sim_time option to record verb

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -163,6 +163,10 @@ class RecordVerb(VerbExtension):
         parser.add_argument(
             '--start-paused', action='store_true', default=False,
             help='Start the recorder in a paused state.')
+        parser.add_argument(
+            '--use-sim-time', action='store_true', default=False,
+            help='Use simulation time.'
+        )
         self._subparser = parser
 
     def main(self, *, args):  # noqa: D102
@@ -236,6 +240,7 @@ class RecordVerb(VerbExtension):
         record_options.include_unpublished_topics = args.include_unpublished_topics
         record_options.start_paused = args.start_paused
         record_options.ignore_leaf_topics = args.ignore_leaf_topics
+        record_options.use_sim_time = args.use_sim_time
 
         recorder = Recorder()
 

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -194,7 +194,8 @@ private:
   void split_bagfile() override;
 
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
-  bool should_split_bagfile();
+  bool should_split_bagfile(
+    const std::chrono::time_point<std::chrono::high_resolution_clock> & current_time);
 
   // Prepares the metadata by setting initial values.
   void init_metadata() override;

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -322,7 +322,8 @@ void SequentialCompressionWriter::write(
   }
 }
 
-bool SequentialCompressionWriter::should_split_bagfile()
+bool SequentialCompressionWriter::should_split_bagfile(
+  const std::chrono::time_point<std::chrono::high_resolution_clock> & current_time)
 {
   if (storage_options_.max_bagfile_size ==
     rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT)
@@ -330,7 +331,7 @@ bool SequentialCompressionWriter::should_split_bagfile()
     return false;
   } else {
     std::lock_guard<std::recursive_mutex> lock(storage_mutex_);
-    return SequentialWriter::should_split_bagfile();
+    return SequentialWriter::should_split_bagfile(current_time);
   }
 }
 

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -143,7 +143,8 @@ protected:
   virtual void split_bagfile();
 
   // Checks if the current recording bagfile needs to be split and rolled over to a new file.
-  bool should_split_bagfile() const;
+  bool should_split_bagfile(
+    const std::chrono::time_point<std::chrono::high_resolution_clock> & current_time) const;
 
   // Prepares the metadata by setting initial values.
   virtual void init_metadata();

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -273,6 +273,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("include_unpublished_topics", &RecordOptions::include_unpublished_topics)
   .def_readwrite("start_paused", &RecordOptions::start_paused)
   .def_readwrite("ignore_leaf_topics", &RecordOptions::ignore_leaf_topics)
+  .def_readwrite("use_sim_time", &RecordOptions::use_sim_time)
   ;
 
   py::class_<rosbag2_py::Player>(m, "Player")

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -183,6 +183,11 @@ function(create_tests_for_rmw_implementation)
     LINK_LIBS rosbag2_transport
     AMENT_DEPS test_msgs rosbag2_test_common)
 
+  rosbag2_transport_add_gmock(test_record_all_use_sim_time
+    test/rosbag2_transport/test_record_all_use_sim_time.cpp
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
+
   rosbag2_transport_add_gmock(test_keyboard_controls
     test/rosbag2_transport/test_keyboard_controls.cpp
     LINK_LIBS rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -47,6 +47,7 @@ public:
   bool include_unpublished_topics = false;
   bool ignore_leaf_topics = false;
   bool start_paused = false;
+  bool use_sim_time = false;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -72,7 +72,9 @@ Recorder::Recorder(
   const rosbag2_transport::RecordOptions & record_options,
   const std::string & node_name,
   const rclcpp::NodeOptions & node_options)
-: rclcpp::Node(node_name, rclcpp::NodeOptions(node_options).start_parameter_event_publisher(false)),
+: rclcpp::Node(node_name, rclcpp::NodeOptions(node_options)
+    .start_parameter_event_publisher(false)
+    .parameter_overrides({rclcpp::Parameter("use_sim_time", record_options.use_sim_time)})),
   writer_(std::move(writer)),
   storage_options_(storage_options),
   record_options_(record_options),
@@ -258,7 +260,7 @@ Recorder::create_subscription(
     qos,
     [this, topic_name, topic_type](std::shared_ptr<rclcpp::SerializedMessage> message) {
       if (!paused_.load()) {
-        writer_->write(message, topic_name, topic_type, rclcpp::Clock(RCL_SYSTEM_TIME).now());
+        writer_->write(message, topic_name, topic_type, this->get_clock()->now());
       }
     });
   return subscription;

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -1,0 +1,90 @@
+// Copyright 2018, Bosch Software Innovations GmbH.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "rosbag2_test_common/publication_manager.hpp"
+#include "rosbag2_test_common/wait_for.hpp"
+
+#include "rosbag2_transport/recorder.hpp"
+
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+#include "record_integration_fixture.hpp"
+#include "rosgraph_msgs/msg/clock.hpp"
+
+TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
+{
+  std::string string_topic = "/string_topic";
+  auto string_message = get_messages_strings()[0];
+  string_message->string_value = "Hello World";
+
+  // clock
+  std::string clock_topic = "/clock";
+  auto clock_message = std::make_shared<rosgraph_msgs::msg::Clock>();
+  clock_message->clock.sec = 1234567890;
+  clock_message->clock.nanosec = 123456789;
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher(clock_topic, clock_message, 5);
+  pub_manager.setup_publisher(string_topic, string_message, 5);
+
+  rosbag2_transport::RecordOptions record_options =
+  {
+    true, true, {string_topic, clock_topic}, "rmw_format", 100ms
+  };
+  record_options.use_sim_time = true;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(clock_topic.c_str()));
+  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
+
+  pub_manager.run_publishers();
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  size_t expected_messages = 10;
+  auto ret = rosbag2_test_common::wait_until_shutdown(
+    std::chrono::seconds(2),
+    [&mock_writer, &expected_messages]() {
+      return mock_writer.get_messages().size() >= expected_messages;
+    });
+  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
+
+  auto recorded_messages = mock_writer.get_messages();
+  EXPECT_THAT(recorded_messages, SizeIs(Ge(expected_messages)));
+
+  std::vector<rosbag2_storage::SerializedBagMessageSharedPtr> string_messages;
+  for (const auto & message : recorded_messages) {
+    if (message->topic_name == string_topic) {
+      string_messages.push_back(message);
+    }
+  }
+  // check that the timestamp is same as the clock message
+  EXPECT_THAT(string_messages[0]->time_stamp, 1234567890123456789);
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -31,6 +31,7 @@
 
 #include "record_integration_fixture.hpp"
 #include "rosgraph_msgs/msg/clock.hpp"
+#include "mock_recorder.hpp"
 
 TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 {
@@ -50,10 +51,10 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   rosbag2_transport::RecordOptions record_options =
   {
-    true, true, {string_topic, clock_topic}, "rmw_format", 100ms
+    false, false, {string_topic, clock_topic}, "rmw_format", 100ms
   };
   record_options.use_sim_time = true;
-  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+  auto recorder = std::make_shared<MockRecorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
 
@@ -61,6 +62,12 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   ASSERT_TRUE(pub_manager.wait_for_matched(clock_topic.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
+
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(clock_topic));
+
+  ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
+  ASSERT_TRUE(recorder->topic_available_for_recording(clock_topic));
 
   pub_manager.run_publishers();
 
@@ -70,13 +77,19 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   size_t expected_messages = 10;
   auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(2),
+    std::chrono::seconds(5),
     [&mock_writer, &expected_messages]() {
       return mock_writer.get_messages().size() >= expected_messages;
     });
-  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
-
   auto recorded_messages = mock_writer.get_messages();
+  EXPECT_TRUE(ret) << "failed to capture expected messages in time. " <<
+    "recorded messages = " << recorded_messages.size();
+  stop_spinning();
+
+  auto messages_per_topic = mock_writer.messages_per_topic();
+  EXPECT_EQ(messages_per_topic[clock_topic], 5u);
+  EXPECT_EQ(messages_per_topic[string_topic], 5u);
+
   EXPECT_THAT(recorded_messages, SizeIs(Ge(expected_messages)));
 
   std::vector<rosbag2_storage::SerializedBagMessageSharedPtr> string_messages;


### PR DESCRIPTION
This is backport of the #994 and #1014 to the Humble branch
Addressing issue #764 