### PR TITLE
Reduce message spam when topics to be recorded do not exist

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -36,6 +36,7 @@
 
 #include "rosbag2_transport/record_options.hpp"
 #include "rosbag2_transport/visibility_control.hpp"
+#include "rosbag2_transport/topic_filter.hpp"
 
 namespace rosbag2_cpp
 {
@@ -115,6 +116,7 @@ protected:
 
 private:
   void topics_discovery();
+  std::unique_ptr<TopicFilter> topic_filter;
 
   std::unordered_map<std::string, std::string>
   get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics);

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -116,7 +116,6 @@ protected:
 
 private:
   void topics_discovery();
-  std::unique_ptr<TopicFilter> topic_filter;
 
   std::unordered_map<std::string, std::string>
   get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics);
@@ -145,6 +144,7 @@ private:
 
   void warn_if_new_qos_for_subscribed_topic(const std::string & topic_name);
 
+  std::unique_ptr<TopicFilter> topic_filter_;
   std::shared_ptr<rosbag2_cpp::Writer> writer_;
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::RecordOptions record_options_;

--- a/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
@@ -42,7 +42,6 @@ public:
     RecordOptions record_options,
     rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph = nullptr,
     bool allow_unknown_types = false);
-
   virtual ~TopicFilter();
 
   /// Filter all topic_names_and_types via take_topic method, return the resulting filtered set

--- a/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
@@ -42,6 +42,7 @@ public:
     RecordOptions record_options,
     rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph = nullptr,
     bool allow_unknown_types = false);
+
   virtual ~TopicFilter();
 
   /// Filter all topic_names_and_types via take_topic method, return the resulting filtered set

--- a/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
@@ -27,7 +27,7 @@
 #include "rosbag2_transport/reader_writer_factory.hpp"
 
 #include "logging.hpp"
-#include "topic_filter.hpp"
+#include "rosbag2_transport/topic_filter.hpp"
 
 namespace
 {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -34,7 +34,7 @@
 #include "rosbag2_storage/yaml.hpp"
 #include "rosbag2_transport/qos.hpp"
 
-#include "topic_filter.hpp"
+#include "rosbag2_transport/topic_filter.hpp"
 
 namespace rosbag2_transport
 {
@@ -88,6 +88,7 @@ Recorder::Recorder(
     [this](KeyboardHandler::KeyCode /*key_code*/,
     KeyboardHandler::KeyModifiers /*key_modifiers*/) {this->toggle_paused();},
     Recorder::kPauseResumeToggleKey);
+  topic_filter = std::make_unique<TopicFilter>(record_options, this->get_node_graph_interface());
   // show instructions
   RCLCPP_INFO_STREAM(
     get_logger(),
@@ -199,8 +200,7 @@ std::unordered_map<std::string, std::string>
 Recorder::get_requested_or_available_topics()
 {
   auto all_topics_and_types = this->get_topic_names_and_types();
-  TopicFilter topic_filter{record_options_, this->get_node_graph_interface()};
-  return topic_filter.filter_topics(all_topics_and_types);
+  return topic_filter->filter_topics(all_topics_and_types);
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -88,7 +88,7 @@ Recorder::Recorder(
     [this](KeyboardHandler::KeyCode /*key_code*/,
     KeyboardHandler::KeyModifiers /*key_modifiers*/) {this->toggle_paused();},
     Recorder::kPauseResumeToggleKey);
-  topic_filter = std::make_unique<TopicFilter>(record_options, this->get_node_graph_interface());
+  topic_filter_ = std::make_unique<TopicFilter>(record_options, this->get_node_graph_interface());
   // show instructions
   RCLCPP_INFO_STREAM(
     get_logger(),
@@ -200,7 +200,7 @@ std::unordered_map<std::string, std::string>
 Recorder::get_requested_or_available_topics()
 {
   auto all_topics_and_types = this->get_topic_names_and_types();
-  return topic_filter->filter_topics(all_topics_and_types);
+  return topic_filter_->filter_topics(all_topics_and_types);
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -25,7 +25,7 @@
 #include "rosbag2_cpp/typesupport_helpers.hpp"
 
 #include "logging.hpp"
-#include "topic_filter.hpp"
+#include "rosbag2_transport/topic_filter.hpp"
 
 namespace
 {

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -22,7 +22,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "./topic_filter.hpp"
+#include "rosbag2_transport/topic_filter.hpp"
 
 using namespace ::testing;  // NOLINT
 


### PR DESCRIPTION
Commits extend lifetime of `TopicFilter` to avoid emitting warning messages on instantiation. `topic_filter.hpp` moved to make it accessible from `recorder.hpp`.

- closes #1011