### PR TITLE
Split up the include of rclcpp.hpp

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -21,8 +21,18 @@
 #include <unordered_map>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"  // rclcpp must be included before the Windows specific includes.
+#include "rclcpp/clock.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/intra_process_setting.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/node_options.hpp"
+#include "rclcpp/publisher_base.hpp"
+#include "rclcpp/qos.hpp"
 #include "rclcpp/serialization.hpp"
+#include "rclcpp/serialized_message.hpp"
+#include "rclcpp/subscription_base.hpp"
+#include "rclcpp/subscription_options.hpp"
+#include "rclcpp/utilities.hpp"
 
 namespace rosbag2_test_common
 {

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -22,8 +22,6 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
-
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/types.hpp"
 #include "rosbag2_cpp/writer.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_play_for.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_for.cpp
@@ -22,7 +22,10 @@
 #include <unordered_map>
 #include <utility>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/duration.hpp"
+#include "rclcpp/experimental/buffers/intra_process_buffer.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/qos_event.hpp"
 
 #include "rosbag2_test_common/subscription_manager.hpp"
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_for.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_for.cpp
@@ -17,20 +17,10 @@
 #include <chrono>
 #include <future>
 #include <memory>
-#include <string>
 #include <vector>
-#include <unordered_map>
 #include <utility>
 
 #include "rclcpp/duration.hpp"
-#include "rclcpp/experimental/buffers/intra_process_buffer.hpp"
-#include "rclcpp/node.hpp"
-#include "rclcpp/qos_event.hpp"
-
-#include "rosbag2_test_common/subscription_manager.hpp"
-
-#include "rosbag2_transport/player.hpp"
-#include "rosbag2_transport/qos.hpp"
 
 #include "test_msgs/msg/arrays.hpp"
 #include "test_msgs/msg/basic_types.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -21,9 +21,7 @@
 
 #include "rclcpp/client.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
-#include "rclcpp/experimental/buffers/intra_process_buffer.hpp"
 #include "rclcpp/node.hpp"
-#include "rclcpp/qos_event.hpp"
 #include "rclcpp/subscription.hpp"
 #include "rclcpp/utilities.hpp"
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -19,7 +19,13 @@
 #include <vector>
 #include <utility>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/client.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/experimental/buffers/intra_process_buffer.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/qos_event.hpp"
+#include "rclcpp/subscription.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "rosbag2_interfaces/srv/is_paused.hpp"
 #include "rosbag2_interfaces/srv/pause.hpp"


### PR DESCRIPTION
Instead, just bring in the headers we need.  That should
help reduce compilation time and memory.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should improve (though likely won't solve) https://github.com/ros2/rosbag2/issues/872