### PR TITLE
Topics remapping in `bag_rewriter.cpp`

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -48,6 +48,7 @@ public:
   bool ignore_leaf_topics = false;
   bool start_paused = false;
   bool use_sim_time = false;
+  std::unordered_map<std::string, std::string> topics_map{};
 };
 
 }  // namespace rosbag2_transport


### PR DESCRIPTION
Relates #1026

This is implementation for topics remapping feature in `bag_rewriter` 
For a  while I implemented only C++ part. 
Most probably will need to add yaml converter for `unordered_map` with strings.

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>