### PR TITLE
Allow topic remapping in output YAML format for `ros2 bag convert`

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ output_bags:
   compression_threads: 0
   include_hidden_topics: false
   include_unpublished_topics: false
+  remappings: []
 ```
 
 Example merge:
@@ -265,6 +266,25 @@ output_bags:
   compression_mode: file
   compression_format: zstd
 ```
+
+Example topic remap:
+
+```
+$ ros2 bag convert -i bag1 -o out.yaml
+
+# out.yaml
+output_bags:
+- uri: remapped
+  storage_id: sqlite3
+  topics: [/topic1, /topic2]
+  remappings: [
+    "/topic1:=/old/topic1"
+  ]
+```
+
+This will create a new bag with `/topic1` remapped to `/old/topic1`. The remappings are declared in the same that one might
+declare them using the `--ros-args -r <remap1> -r <remap2> ... -r <remapN>` command-line arguments when launching.
+
 
 ### Overriding QoS Profiles
 

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -48,6 +48,7 @@ public:
   bool ignore_leaf_topics = false;
   bool start_paused = false;
   bool use_sim_time = false;
+  std::unordered_map<std::string, std::string> topics_map{};
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -43,12 +43,12 @@ public:
   uint64_t compression_queue_size = 1;
   uint64_t compression_threads = 0;
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides{};
+  std::vector<std::string> remappings{};
   bool include_hidden_topics = false;
   bool include_unpublished_topics = false;
   bool ignore_leaf_topics = false;
   bool start_paused = false;
   bool use_sim_time = false;
-  std::unordered_map<std::string, std::string> topics_map{};
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -58,6 +58,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
     record_options.topic_qos_profile_overrides.begin(),
     record_options.topic_qos_profile_overrides.end());
   node["topic_qos_profile_overrides"] = qos_overrides;
+  node["remappings"] = record_options.remappings;
   node["include_hidden_topics"] = record_options.include_hidden_topics;
   node["include_unpublished_topics"] = record_options.include_unpublished_topics;
   return node;
@@ -87,6 +88,7 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
     node, "topic_qos_profile_overrides", qos_overrides);
   record_options.topic_qos_profile_overrides.insert(qos_overrides.begin(), qos_overrides.end());
 
+  optional_assign<std::vector<std::string>>(node, "remappings", record_options.remappings);
   optional_assign<bool>(node, "include_hidden_topics", record_options.include_hidden_topics);
   optional_assign<bool>(
     node, "include_unpublished_topics",

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -34,6 +34,7 @@ TEST(record_options, test_yaml_serialization)
   original.compression_queue_size = 2;
   original.compression_threads = 123;
   original.topic_qos_profile_overrides.emplace("topic", rclcpp::QoS(10).transient_local());
+  original.remappings.emplace_back("/foo:=/bar");
   original.include_hidden_topics = true;
   original.include_unpublished_topics = true;
 


### PR DESCRIPTION
Relates to #1026. I have the README changes, YAML parsing and remapping code implemented, but I think I have a problem with local versus global namespacing of topics in a bag, which is surfaced by the two unit tests I added. I suspect that I'm not calling `rcl_remap_topic_name` properly.