### PR TITLE
Added support for filtering topics via regular expressions

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -60,6 +60,10 @@ class PlayVerb(VerbExtension):
             help='topics to replay, separated by space. If none specified, all topics will be '
                  'replayed.')
         parser.add_argument(
+            '--topics-regex', type=str, default=[], nargs='+',
+            help='filter topics by regular expression to replay, separated by space. If none '
+                 'specified, all topics will be replayed.')
+        parser.add_argument(
             '--qos-profile-overrides-path', type=FileType('r'),
             help='Path to a yaml file defining overrides of the QoS profile for specific topics.')
         parser.add_argument(
@@ -176,6 +180,7 @@ class PlayVerb(VerbExtension):
         play_options.node_prefix = NODE_NAME_PREFIX
         play_options.rate = args.rate
         play_options.topics_to_filter = args.topics
+        play_options.topics_to_filter_regex = args.topics_regex
         play_options.topic_qos_profile_overrides = qos_profile_overrides
         play_options.loop = args.loop
         play_options.topic_remapping_options = topic_remapping

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -278,6 +278,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("node_prefix", &PlayOptions::node_prefix)
   .def_readwrite("rate", &PlayOptions::rate)
   .def_readwrite("topics_to_filter", &PlayOptions::topics_to_filter)
+  .def_readwrite("topics_to_filter_regex", &PlayOptions::topics_to_filter_regex)
   .def_property(
     "topic_qos_profile_overrides",
     &PlayOptions::getTopicQoSProfileOverrides,

--- a/rosbag2_storage/include/rosbag2_storage/storage_filter.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_filter.hpp
@@ -27,6 +27,11 @@ struct StorageFilter
   // specified topics will be returned. If list is empty, the filter is ignored
   // and all messages are returned.
   std::vector<std::string> topics;
+
+  // Regular expressions of topic names to whitelist when playing a bag.
+  // Only messages matching these specified topics will be played.
+  // If list is empty, the filter is ignored and all messages are played.
+  std::vector<std::string> topics_regex = {};
 };
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -30,6 +30,11 @@
 namespace rosbag2_storage_plugins
 {
 
+namespace sqlite3_application_functions
+{
+void sqlite_regexp(sqlite3_context * context, int argc, sqlite3_value ** values);
+}   // namespace sqlite3_application_functions
+
 class ROSBAG2_STORAGE_DEFAULT_PLUGINS_PUBLIC SqliteWrapper
 {
 public:
@@ -53,6 +58,8 @@ private:
   void apply_pragma_settings(
     std::unordered_map<std::string, std::string> & pragmas,
     rosbag2_storage::storage_interfaces::IOFlag io_flag);
+
+  void initialize_application_functions();
 
   sqlite3 * db_ptr;
 };

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -404,6 +404,18 @@ void SqliteStorage::prepare_for_reading()
     }
     statement_str += "(topics.name IN (" + topic_list + ")) AND ";
   }
+  // add topic filter based on regular expression
+  if (!storage_filter_.topics_regex.empty()) {
+    // Construct string for selected topics
+    statement_str += "(";
+    for (auto & topic_regex : storage_filter_.topics_regex) {
+      statement_str += "(topics.name REGEXP '" + topic_regex + "')";
+      if (&topic_regex != &storage_filter_.topics_regex.back()) {
+        statement_str += " OR ";
+      }
+    }
+    statement_str += ") AND ";
+  }
   // add start time filter
   statement_str += "(((timestamp = " + std::to_string(seek_time_) + ") "
     "AND (messages.id >= " + std::to_string(seek_row_id_) + ")) "

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -167,8 +167,8 @@ sqlite3 * SqliteWrapper::get_database()
 void SqliteWrapper::initialize_application_functions()
 {
   sqlite3_create_function(
-    db_ptr, "regexp", 2, SQLITE_ANY, 0,
-    &sqlite3_application_functions::sqlite_regexp, 0, 0);
+    db_ptr, "regexp", 2, SQLITE_ANY, nullptr,
+    &sqlite3_application_functions::sqlite_regexp, nullptr, nullptr);
 }
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -32,6 +33,30 @@
 
 namespace rosbag2_storage_plugins
 {
+
+namespace sqlite3_application_functions
+{
+void sqlite_regexp(sqlite3_context * context, int argc, sqlite3_value ** values)
+{
+  const char * regex = reinterpret_cast<const char *>(sqlite3_value_text(values[0]));
+  const char * text = reinterpret_cast<const char *>(sqlite3_value_text(values[1]));
+
+  if (argc != 2 || regex == nullptr || text == nullptr) {
+    sqlite3_result_error(context, "Invalid arguments when calling regexp() function.\n", -1);
+    return;
+  }
+
+  std::regex input_regex(std::string(regex), std::regex::extended | std::regex::nosubs);
+
+  std::smatch re_match;
+
+  std::string s_text{text};
+
+  bool ret = std::regex_match(s_text, re_match, input_regex);
+  sqlite3_result_int(context, ret);
+}
+
+}   // namespace sqlite3_application_functions
 
 SqliteWrapper::SqliteWrapper(
   const std::string & uri,
@@ -63,6 +88,7 @@ SqliteWrapper::SqliteWrapper(
 
   apply_pragma_settings(pragmas, io_flag);
   sqlite3_extended_result_codes(db_ptr, 1);
+  initialize_application_functions();
 }
 
 SqliteWrapper::SqliteWrapper()
@@ -136,6 +162,13 @@ SqliteWrapper::operator bool()
 sqlite3 * SqliteWrapper::get_database()
 {
   return db_ptr;
+}
+
+void SqliteWrapper::initialize_application_functions()
+{
+  sqlite3_create_function(
+    db_ptr, "regexp", 2, SQLITE_ANY, 0,
+    &sqlite3_application_functions::sqlite_regexp, 0, 0);
 }
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -407,3 +407,49 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
     }, writable_storage);
   });
 }
+
+TEST_F(StorageTestFixture, read_next_returns_filtered_messages_regex) {
+  std::vector<std::tuple<std::string, int64_t, std::string, std::string, std::string>>
+  string_messages =
+  {std::make_tuple("topic1 message", 1, "prefix_topic1", "", ""),
+    std::make_tuple("topic2 message", 2, "topic2", "", ""),
+    std::make_tuple("topic3 message", 3, "topic3", "", "")};
+
+  write_messages_to_sqlite(string_messages);
+  std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
+    std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+
+  auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  readable_storage->open({db_filename, kPluginID});
+
+  rosbag2_storage::StorageFilter storage_filter;
+  storage_filter.topics_regex.push_back("topic.*");
+  readable_storage->set_filter(storage_filter);
+
+  EXPECT_TRUE(readable_storage->has_next());
+  auto first_message = readable_storage->read_next();
+  EXPECT_THAT(first_message->topic_name, Eq("topic2"));
+  EXPECT_TRUE(readable_storage->has_next());
+  auto second_message = readable_storage->read_next();
+  EXPECT_THAT(second_message->topic_name, Eq("topic3"));
+  EXPECT_FALSE(readable_storage->has_next());
+
+  // Test reset filter
+  std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage2 =
+    std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+
+  readable_storage2->open({db_filename, kPluginID});
+  readable_storage2->set_filter(storage_filter);
+  readable_storage2->reset_filter();
+
+  EXPECT_TRUE(readable_storage2->has_next());
+  auto third_message = readable_storage2->read_next();
+  EXPECT_THAT(third_message->topic_name, Eq("prefix_topic1"));
+  EXPECT_TRUE(readable_storage2->has_next());
+  auto fourth_message = readable_storage2->read_next();
+  EXPECT_THAT(fourth_message->topic_name, Eq("topic2"));
+  EXPECT_TRUE(readable_storage2->has_next());
+  auto fifth_message = readable_storage2->read_next();
+  EXPECT_THAT(fifth_message->topic_name, Eq("topic3"));
+  EXPECT_FALSE(readable_storage2->has_next());
+}

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -40,6 +40,11 @@ public:
   // If list is empty, the filter is ignored and all messages are played.
   std::vector<std::string> topics_to_filter = {};
 
+  // Regular expressions of topic names to whitelist when playing a bag.
+  // Only messages matching these specified topics will be played.
+  // If list is empty, the filter is ignored and all messages are played.
+  std::vector<std::string> topics_to_filter_regex = {};
+
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides = {};
   bool loop = false;
   std::vector<std::string> topic_remapping_options = {};

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -596,6 +596,7 @@ void Player::prepare_publishers()
 {
   rosbag2_storage::StorageFilter storage_filter;
   storage_filter.topics = play_options_.topics_to_filter;
+  storage_filter.topics_regex = play_options_.topics_to_filter_regex;
   reader_->set_filter(storage_filter);
 
   // Create /clock publisher

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -67,7 +67,7 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::PlayOptions play_options = {
-    read_ahead_queue_size, "", rate, {}, {}, loop_playback, {},
+    read_ahead_queue_size, "", rate, {}, {}, {}, loop_playback, {},
     clock_publish_frequency, delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
@@ -127,7 +127,7 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::PlayOptions play_options{read_ahead_queue_size, "", rate, {}, {},
-    loop_playback, {}, clock_publish_frequency, delay};
+    {}, loop_playback, {}, clock_publish_frequency, delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);


### PR DESCRIPTION
This PR adds a new option `--topics-regex` that allows filtering topics via regular expressions.