### PR TITLE
Add additional mode of publishing sim time updates

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -82,10 +82,20 @@ class PlayVerb(VerbExtension):
                  '  pragmas: [\"<setting_name>\" = <setting_value>]'
                  'Note that applicable settings are limited to read-only for ros2 bag play.'
                  'For a list of sqlite3 settings, refer to sqlite3 documentation')
-        parser.add_argument(
+        clock_args_group = parser.add_mutually_exclusive_group()
+        clock_args_group.add_argument(
             '--clock', type=positive_float, nargs='?', const=40, default=0,
             help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
                  'Value must be positive. Defaults to not publishing.')
+        clock_args_group.add_argument(
+            '--clock-topics', type=str, default=[], nargs='+',
+            help='List of topics separated by spaces that will trigger a /clock update '
+                 'when a message is published on them'
+        )
+        clock_args_group.add_argument(
+            '--clock-topics-all', default=False, action='store_true',
+            help='Publishes an update on /clock immediately before each replayed message'
+        )
         parser.add_argument(
             '-d', '--delay', type=positive_float, default=0.0,
             help='Sleep duration before play (each loop), in seconds. Negative durations invalid.')
@@ -185,6 +195,9 @@ class PlayVerb(VerbExtension):
         play_options.loop = args.loop
         play_options.topic_remapping_options = topic_remapping
         play_options.clock_publish_frequency = args.clock
+        if args.clock_topics_all or len(args.clock_topics) > 0:
+            play_options.clock_publish_on_topic_publish = True
+        play_options.clock_topics = args.clock_topics
         play_options.delay = args.delay
         play_options.playback_duration = args.playback_duration
         play_options.playback_until_timestamp = self.get_playback_until_from_arg_group(

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -286,6 +286,8 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("loop", &PlayOptions::loop)
   .def_readwrite("topic_remapping_options", &PlayOptions::topic_remapping_options)
   .def_readwrite("clock_publish_frequency", &PlayOptions::clock_publish_frequency)
+  .def_readwrite("clock_publish_on_topic_publish", &PlayOptions::clock_publish_on_topic_publish)
+  .def_readwrite("clock_topics", &PlayOptions::clock_trigger_topics)
   .def_property(
     "delay",
     &PlayOptions::getDelay,

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -53,6 +53,13 @@ public:
   // 0 (or negative) means that no publisher will be created
   double clock_publish_frequency = 0.0;
 
+  // Enable publishing to /clock when a replayed topic is published
+  bool clock_publish_on_topic_publish{false};
+
+  // If clock_publish_on_topic_publish is true, list of topics that will trigger
+  // a /clock update to be published. If list is empty, all topics will act as a trigger
+  std::vector<std::string> clock_trigger_topics = {};
+
   // Sleep before play. Negative durations invalid. Will delay at the beginning of each loop.
   rclcpp::Duration delay = rclcpp::Duration(0, 0);
 

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -275,6 +275,9 @@ private:
   std::mutex reader_mutex_;
   std::unique_ptr<rosbag2_cpp::Reader> reader_ RCPPUTILS_TSA_GUARDED_BY(reader_mutex_);
 
+  void publish_clock_update();
+  void publish_clock_update(const rclcpp::Time & time);
+
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::PlayOptions play_options_;
   rcutils_time_point_value_t play_until_timestamp_ = -1;

--- a/rosbag2_transport/test/rosbag2_transport/mock_player.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_player.hpp
@@ -41,6 +41,9 @@ public:
         static_cast<rclcpp::PublisherBase *>(
           publisher.second->generic_publisher().get()));
     }
+    if (clock_publisher_) {
+      pub_list.push_back(clock_publisher_.get());
+    }
     return pub_list;
   }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -44,6 +44,8 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
   const float rate = 1.0;
   const bool loop_playback = false;
   double clock_publish_frequency = 0.0;
+  bool clock_publish_per_topic = false;
+  std::vector<std::string> clock_trigger_topics;
   const rclcpp::Duration delay(1, 0);
 
   auto primitive_message1 = get_messages_basic_types()[0];
@@ -68,7 +70,7 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
 
   rosbag2_transport::PlayOptions play_options = {
     read_ahead_queue_size, "", rate, {}, {}, {}, loop_playback, {},
-    clock_publish_frequency, delay};
+    clock_publish_frequency, clock_publish_per_topic, clock_trigger_topics, delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);
@@ -104,6 +106,8 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   const float rate = 1.0;
   const bool loop_playback = true;
   const double clock_publish_frequency = 0.0;
+  bool clock_publish_per_topic = false;
+  std::vector<std::string> clock_trigger_topics;
   const rclcpp::Duration delay(1, 0);
 
   auto primitive_message1 = get_messages_basic_types()[0];
@@ -127,7 +131,8 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::PlayOptions play_options{read_ahead_queue_size, "", rate, {}, {},
-    {}, loop_playback, {}, clock_publish_frequency, delay};
+    {}, loop_playback, {}, clock_publish_frequency, clock_publish_per_topic, clock_trigger_topics,
+    delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);


### PR DESCRIPTION
Add an additional mode for publishing sim time updates when replaying. 

Instead of publishing /clock updates at a fixed rate, this option triggers an update every time a replayed message is published. Optionally, this can be configured to trigger only for a subset of replayed topics.

This mode is most useful when the application consuming the replayed data is doing some sanity checks or otherwise correlating received messages to the clock and where the application does not need a clock that updates at a consistent rate. In these cases, using this mode can lower the overhead of having sim time enabled.