### PR TITLE
Rename --topics-regex

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -60,7 +60,7 @@ class PlayVerb(VerbExtension):
             help='topics to replay, separated by space. If none specified, all topics will be '
                  'replayed.')
         parser.add_argument(
-            '--topics-regex', type=str, default=[], nargs='+',
+            '-e', '--regex', type=str, default=[], nargs='+',
             help='filter topics by regular expression to replay, separated by space. If none '
                  'specified, all topics will be replayed.')
         parser.add_argument(
@@ -180,7 +180,7 @@ class PlayVerb(VerbExtension):
         play_options.node_prefix = NODE_NAME_PREFIX
         play_options.rate = args.rate
         play_options.topics_to_filter = args.topics
-        play_options.topics_to_filter_regex = args.topics_regex
+        play_options.regex_to_filter = args.regex
         play_options.topic_qos_profile_overrides = qos_profile_overrides
         play_options.loop = args.loop
         play_options.topic_remapping_options = topic_remapping

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -278,7 +278,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("node_prefix", &PlayOptions::node_prefix)
   .def_readwrite("rate", &PlayOptions::rate)
   .def_readwrite("topics_to_filter", &PlayOptions::topics_to_filter)
-  .def_readwrite("topics_to_filter_regex", &PlayOptions::topics_to_filter_regex)
+  .def_readwrite("regex_to_filter", &PlayOptions::regex_to_filter)
   .def_property(
     "topic_qos_profile_overrides",
     &PlayOptions::getTopicQoSProfileOverrides,

--- a/rosbag2_storage/include/rosbag2_storage/storage_filter.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_filter.hpp
@@ -31,7 +31,7 @@ struct StorageFilter
   // Regular expressions of topic names to whitelist when playing a bag.
   // Only messages matching these specified topics will be played.
   // If list is empty, the filter is ignored and all messages are played.
-  std::vector<std::string> topics_regex = {};
+  std::vector<std::string> regex = {};
 };
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -405,12 +405,12 @@ void SqliteStorage::prepare_for_reading()
     statement_str += "(topics.name IN (" + topic_list + ")) AND ";
   }
   // add topic filter based on regular expression
-  if (!storage_filter_.topics_regex.empty()) {
+  if (!storage_filter_.regex.empty()) {
     // Construct string for selected topics
     statement_str += "(";
-    for (auto & topic_regex : storage_filter_.topics_regex) {
+    for (auto & topic_regex : storage_filter_.regex) {
       statement_str += "(topics.name REGEXP '" + topic_regex + "')";
-      if (&topic_regex != &storage_filter_.topics_regex.back()) {
+      if (&topic_regex != &storage_filter_.regex.back()) {
         statement_str += " OR ";
       }
     }

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -423,7 +423,7 @@ TEST_F(StorageTestFixture, read_next_returns_filtered_messages_regex) {
   readable_storage->open({db_filename, kPluginID});
 
   rosbag2_storage::StorageFilter storage_filter;
-  storage_filter.topics_regex.push_back("topic.*");
+  storage_filter.regex.push_back("topic.*");
   readable_storage->set_filter(storage_filter);
 
   EXPECT_TRUE(readable_storage->has_next());

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -43,7 +43,7 @@ public:
   // Regular expressions of topic names to whitelist when playing a bag.
   // Only messages matching these specified topics will be played.
   // If list is empty, the filter is ignored and all messages are played.
-  std::vector<std::string> topics_to_filter_regex = {};
+  std::vector<std::string> regex_to_filter = {};
 
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides = {};
   bool loop = false;

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -596,7 +596,7 @@ void Player::prepare_publishers()
 {
   rosbag2_storage::StorageFilter storage_filter;
   storage_filter.topics = play_options_.topics_to_filter;
-  storage_filter.topics_regex = play_options_.topics_to_filter_regex;
+  storage_filter.regex = play_options_.regex_to_filter;
   reader_->set_filter(storage_filter);
 
   // Create /clock publisher


### PR DESCRIPTION
This PR renames the `--topics-regex` option in `ros2 bag play` to `--regex` (and `-e`) to match `ros2 bag record`