### PR TITLE
Added support for excluding topics via regular expressions

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -64,6 +64,10 @@ class PlayVerb(VerbExtension):
             help='filter topics by regular expression to replay, separated by space. If none '
                  'specified, all topics will be replayed.')
         parser.add_argument(
+            '-x', '--exclude', default='',
+            help='regular expressions to exclude topics from replay, separated by space. If none '
+                 'specified, all topics will be replayed.')
+        parser.add_argument(
             '--qos-profile-overrides-path', type=FileType('r'),
             help='Path to a yaml file defining overrides of the QoS profile for specific topics.')
         parser.add_argument(
@@ -191,6 +195,7 @@ class PlayVerb(VerbExtension):
         play_options.rate = args.rate
         play_options.topics_to_filter = args.topics
         play_options.topics_regex_to_filter = args.regex
+        play_options.topics_regex_to_exclude = args.exclude
         play_options.topic_qos_profile_overrides = qos_profile_overrides
         play_options.loop = args.loop
         play_options.topic_remapping_options = topic_remapping

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -279,6 +279,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("rate", &PlayOptions::rate)
   .def_readwrite("topics_to_filter", &PlayOptions::topics_to_filter)
   .def_readwrite("topics_regex_to_filter", &PlayOptions::topics_regex_to_filter)
+  .def_readwrite("topics_regex_to_exclude", &PlayOptions::topics_regex_to_exclude)
   .def_property(
     "topic_qos_profile_overrides",
     &PlayOptions::getTopicQoSProfileOverrides,

--- a/rosbag2_storage/include/rosbag2_storage/storage_filter.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_filter.hpp
@@ -32,6 +32,11 @@ struct StorageFilter
   // Only messages matching these specified topics will be played.
   // If list is empty, the filter is ignored and all messages are played.
   std::string topics_regex = "";
+
+  // Regular expression of topic names to exclude when playing a bag.
+  // Only messages not matching these specified topics will be played.
+  // If list is empty, the filter is ignored and all messages are played.
+  std::string topics_regex_to_exclude = "";
 };
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -410,6 +410,14 @@ void SqliteStorage::prepare_for_reading()
     statement_str += "(topics.name REGEXP '" + storage_filter_.topics_regex + "')";
     statement_str += " AND ";
   }
+  // exclude topics based on regular expressions
+  if (!storage_filter_.topics_regex_to_exclude.empty()) {
+    // Construct string for selected topics
+    statement_str += " (topics.name NOT IN ";
+    statement_str += " (SELECT topics.name FROM topics WHERE topics.name REGEXP '";
+    statement_str += storage_filter_.topics_regex_to_exclude + "')";
+    statement_str += " ) AND ";
+  }
   // add start time filter
   statement_str += "(((timestamp = " + std::to_string(seek_time_) + ") "
     "AND (messages.id >= " + std::to_string(seek_row_id_) + ")) "

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_storage.cpp
@@ -453,3 +453,49 @@ TEST_F(StorageTestFixture, read_next_returns_filtered_messages_regex) {
   EXPECT_THAT(fifth_message->topic_name, Eq("topic3"));
   EXPECT_FALSE(readable_storage2->has_next());
 }
+
+TEST_F(StorageTestFixture, read_next_returns_filtered_messages_topics_regex_to_exclude) {
+  std::vector<std::tuple<std::string, int64_t, std::string, std::string, std::string>>
+  string_messages =
+  {std::make_tuple("topic1 message", 1, "prefix_topic1", "", ""),
+    std::make_tuple("topic2 message", 2, "topic2", "", ""),
+    std::make_tuple("topic3 message", 3, "topic3", "", "")};
+
+  write_messages_to_sqlite(string_messages);
+  std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
+    std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+
+  auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  readable_storage->open({db_filename, kPluginID});
+
+  rosbag2_storage::StorageFilter storage_filter;
+  storage_filter.topics_regex_to_exclude = "prefix.*";
+  readable_storage->set_filter(storage_filter);
+
+  EXPECT_TRUE(readable_storage->has_next());
+  auto first_message = readable_storage->read_next();
+  EXPECT_THAT(first_message->topic_name, Eq("topic2"));
+  EXPECT_TRUE(readable_storage->has_next());
+  auto second_message = readable_storage->read_next();
+  EXPECT_THAT(second_message->topic_name, Eq("topic3"));
+  EXPECT_FALSE(readable_storage->has_next());
+
+  // Test reset filter
+  std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage2 =
+    std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+
+  readable_storage2->open({db_filename, kPluginID});
+  readable_storage2->set_filter(storage_filter);
+  readable_storage2->reset_filter();
+
+  EXPECT_TRUE(readable_storage2->has_next());
+  auto third_message = readable_storage2->read_next();
+  EXPECT_THAT(third_message->topic_name, Eq("prefix_topic1"));
+  EXPECT_TRUE(readable_storage2->has_next());
+  auto fourth_message = readable_storage2->read_next();
+  EXPECT_THAT(fourth_message->topic_name, Eq("topic2"));
+  EXPECT_TRUE(readable_storage2->has_next());
+  auto fifth_message = readable_storage2->read_next();
+  EXPECT_THAT(fifth_message->topic_name, Eq("topic3"));
+  EXPECT_FALSE(readable_storage2->has_next());
+}

--- a/rosbag2_transport/include/rosbag2_transport/play_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/play_options.hpp
@@ -45,6 +45,11 @@ public:
   // If list is empty, the filter is ignored and all messages are played.
   std::string topics_regex_to_filter = "";
 
+  // Regular expression of topic names to exclude when playing a bag.
+  // Only messages not matching these specified topics will be played.
+  // If list is empty, the filter is ignored and all messages are played.
+  std::string topics_regex_to_exclude = "";
+
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides = {};
   bool loop = false;
   std::vector<std::string> topic_remapping_options = {};

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -597,6 +597,7 @@ void Player::prepare_publishers()
   rosbag2_storage::StorageFilter storage_filter;
   storage_filter.topics = play_options_.topics_to_filter;
   storage_filter.topics_regex = play_options_.topics_regex_to_filter;
+  storage_filter.topics_regex_to_exclude = play_options_.topics_regex_to_exclude;
   reader_->set_filter(storage_filter);
 
   // Create /clock publisher

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -69,7 +69,7 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::PlayOptions play_options = {
-    read_ahead_queue_size, "", rate, {}, {}, {}, loop_playback, {},
+    read_ahead_queue_size, "", rate, {}, {}, {}, {}, loop_playback, {},
     clock_publish_frequency, clock_publish_per_topic, clock_trigger_topics, delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
@@ -131,8 +131,8 @@ TEST_F(RosBag2PlayTestFixture, messages_played_in_loop) {
   auto await_received_messages = sub_->spin_subscriptions();
 
   rosbag2_transport::PlayOptions play_options{read_ahead_queue_size, "", rate, {}, {},
-    {}, loop_playback, {}, clock_publish_frequency, clock_publish_per_topic, clock_trigger_topics,
-    delay};
+    {}, {}, loop_playback, {}, clock_publish_frequency, clock_publish_per_topic,
+    clock_trigger_topics, delay};
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(
       reader), storage_options_, play_options);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -104,7 +104,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_recording)
   auto test_string_messages = get_messages_strings();
   auto test_array_messages = get_messages_arrays();
   std::string regex = "/[a-z]+_nice(_.*)";
-  std::string regex_exclude = "/[a-z]+_nice_[a-z]+/(.*)";
+  std::string topics_regex_to_exclude = "/[a-z]+_nice_[a-z]+/(.*)";
 
   // matching topics - the only ones that should be recorded
   std::string v1 = "/awesome_nice_topic";
@@ -119,7 +119,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_recording)
 
   // checking the test data itself
   std::regex re(regex);
-  std::regex exclude(regex_exclude);
+  std::regex exclude(topics_regex_to_exclude);
   ASSERT_TRUE(std::regex_match(v1, re));
   ASSERT_TRUE(std::regex_match(v2, re));
   ASSERT_FALSE(std::regex_match(b1, re));
@@ -131,7 +131,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_recording)
 
   rosbag2_transport::RecordOptions record_options = {false, false, {}, "rmw_format", 10ms};
   record_options.regex = regex;
-  record_options.exclude = regex_exclude;
+  record_options.exclude = topics_regex_to_exclude;
 
 
   // TODO(karsten1987) Refactor this into publication manager


### PR DESCRIPTION
This PR adds `--exclude` (and `-x`) as an option to `ros2 bag play` to exclude topics from being replayed.