### PR TITLE
Add option to prevent message loss while converting

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -201,8 +201,8 @@ class RecordVerb(VerbExtension):
             return print_error('Invalid choice: Cannot specify compression format '
                                'without a compression mode.')
 
-        if args.compression_queue_size < 1:
-            return print_error('Compression queue size must be at least 1.')
+        if args.compression_queue_size < 0:
+            return print_error('Compression queue size must be at least 0.')
 
         args.compression_mode = args.compression_mode.upper()
 

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -200,6 +200,11 @@ private:
 
   // Prepares the metadata by setting initial values.
   void init_metadata() override;
+
+  // Compress a single message and write it
+  void compress_and_write_message(
+    std::shared_ptr<rosbag2_compression::BaseCompressorInterface> & compressor,
+    std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message);
 };
 }  // namespace rosbag2_compression
 #endif  // ROSBAG2_COMPRESSION__SEQUENTIAL_COMPRESSION_WRITER_HPP_

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -200,11 +200,6 @@ private:
 
   // Prepares the metadata by setting initial values.
   void init_metadata() override;
-
-  // Compress a single message and write it
-  void compress_and_write_message(
-    std::shared_ptr<rosbag2_compression::BaseCompressorInterface> & compressor,
-    std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message);
 };
 }  // namespace rosbag2_compression
 #endif  // ROSBAG2_COMPRESSION__SEQUENTIAL_COMPRESSION_WRITER_HPP_

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -334,7 +334,8 @@ void SequentialCompressionWriter::write(
       compressor_message_queue_.pop();
     }
 
-    // If no message should be dropped and the queue has still messages, compress and write immediately
+    // If no message should be dropped and the queue has still messages,
+    // compress and write immediately
     if (compression_options_.compression_queue_size == 0u &&
       compressor_message_queue_.size() > 0u)
     {

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -337,7 +337,7 @@ void SequentialCompressionWriter::write(
     // If no message should be dropped and the queue has still messages,
     // compress and write immediately
     if (compression_options_.compression_queue_size == 0u &&
-      compressor_message_queue_.size() > 0u)
+      compressor_message_queue_.size() > compression_options_.compression_threads)
     {
       compress_and_write_message(compressor_, message);
     } else {

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -303,6 +303,8 @@ SequentialCompressionWriter::compress_message(
   std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
 {
   auto compressed_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  compressed_message->time_stamp = message->time_stamp;
+  compressed_message->topic_name = message->topic_name;
   compressor.compress_serialized_bag_message(message.get(), compressed_message.get());
   return compressed_message;
 }


### PR DESCRIPTION
because the SequentialCompressionWriter uses threads for compression messages can be dropped if the writer-thread is slower than reading. To prevent this (without having a very big queue size) the messages are written directly if compression_queue_size is 0.

Use case:
offline converting (compression) --> no messages should be dropped, execution time is not that relevant