### PR TITLE
Add short -v option to ros2 bag list for verbose

### DIFF
--- a/ros2bag/ros2bag/verb/list.py
+++ b/ros2bag/ros2bag/verb/list.py
@@ -31,7 +31,7 @@ class ListVerb(VerbExtension):
             help='lists available plugins',
             choices=['storage', 'converter', 'compressor', 'decompressor'])
         parser.add_argument(
-            '--verbose', help='output verbose information about the available plugin',
+            '-v', '--verbose', help='output verbose information about the available plugin',
             action='store_true')
 
     def main(self, *, args):  # noqa: D102


### PR DESCRIPTION
Just a convenience thing, pretty standard usage