### PR TITLE
[WIP] Readers: Autodetect storage implementation when reading bare storage file

### DIFF
--- a/ros2bag/ros2bag/api/__init__.py
+++ b/ros2bag/ros2bag/api/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
+from argparse import ArgumentParser, ArgumentTypeError
 import os
 from typing import Any
 from typing import Dict
@@ -24,6 +24,7 @@ from rclpy.qos import QoSHistoryPolicy
 from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
+import rosbag2_py
 
 # This map needs to be updated when new policies are introduced
 _QOS_POLICY_FROM_SHORT_NAME = {
@@ -104,7 +105,7 @@ def check_path_exists(value: Any) -> str:
     try:
         if os.path.exists(value):
             return value
-        raise ArgumentTypeError("Bag file '{}' does not exist!".format(value))
+        raise ArgumentTypeError("Bag path '{}' does not exist!".format(value))
     except ValueError:
         raise ArgumentTypeError('{} is not the valid type (string)'.format(value))
 
@@ -118,3 +119,13 @@ def check_not_negative_int(arg: str) -> int:
         return value
     except ValueError:
         raise ArgumentTypeError('{} is not the valid type (int)'.format(value))
+
+
+def add_standard_reader_args(parser: ArgumentParser) -> None:
+    reader_choices = rosbag2_py.get_registered_readers()
+    parser.add_argument(
+        'bag_path', type=check_path_exists, help='Bag to open')
+    parser.add_argument(
+        '-s', '--storage', default='', choices=reader_choices,
+        help='Storage implementation of bag. '
+             'By default attempts to detect automatically - use this argument to override.')

--- a/ros2bag/ros2bag/verb/burst.py
+++ b/ros2bag/ros2bag/verb/burst.py
@@ -15,13 +15,11 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
-from ros2bag.api import (
-    add_standard_reader_args,
-    check_not_negative_int,
-    check_positive_float,
-    convert_yaml_to_qos_profile,
-    print_error,
-)
+from ros2bag.api import add_standard_reader_args
+from ros2bag.api import check_not_negative_int
+from ros2bag.api import check_positive_float
+from ros2bag.api import convert_yaml_to_qos_profile
+from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
 from rosbag2_py import Player

--- a/ros2bag/ros2bag/verb/burst.py
+++ b/ros2bag/ros2bag/verb/burst.py
@@ -15,14 +15,15 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
-from ros2bag.api import check_not_negative_int
-from ros2bag.api import check_path_exists
-from ros2bag.api import check_positive_float
-from ros2bag.api import convert_yaml_to_qos_profile
-from ros2bag.api import print_error
+from ros2bag.api import (
+    add_standard_reader_args,
+    check_not_negative_int,
+    check_positive_float,
+    convert_yaml_to_qos_profile,
+    print_error,
+)
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_readers
 from rosbag2_py import Player
 from rosbag2_py import PlayOptions
 from rosbag2_py import StorageOptions
@@ -33,13 +34,8 @@ class BurstVerb(VerbExtension):
     """Burst data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        reader_choices = get_registered_readers()
+        add_standard_reader_args(parser)
 
-        parser.add_argument(
-            'bag_file', type=check_path_exists, help='bag file to replay')
-        parser.add_argument(
-            '-s', '--storage', default='', choices=reader_choices,
-            help='Storage implementation of bag. By default tries to determine from metadata.')
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
@@ -91,7 +87,7 @@ class BurstVerb(VerbExtension):
             topic_remapping.append(remap_rule)
 
         storage_options = StorageOptions(
-            uri=args.bag_file,
+            uri=args.bag_path,
             storage_id=args.storage,
             storage_config_uri=storage_config_file,
         )

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -12,37 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
+from ros2bag.api import add_standard_reader_args
 from ros2bag.verb import VerbExtension
+from rosbag2_py._info import Info
 
 
 class InfoVerb(VerbExtension):
     """Print information about a bag to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        parser.add_argument(
-            'bag_file', help='bag file to introspect')
-        parser.add_argument(
-            '-s', '--storage', default='sqlite3',
-            help='storage identifier to be used to open storage, if no yaml file exists.'
-                 ' Defaults to "sqlite3"')
+        add_standard_reader_args(parser)
 
     def main(self, *, args):  # noqa: D102
-        bag_file = args.bag_file
-        if not os.path.exists(bag_file):
-            return "[ERROR] [ros2bag]: bag file '{}' does not exist!".format(bag_file)
-        # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
-        #               combined with constrained environments (as imposed by colcon test)
-        #               may result in DLL loading failures when attempting to import a C
-        #               extension. Therefore, do not import rosbag2_transport at the module
-        #               level but on demand, right before first use.
-        from rosbag2_py._info import Info
-        try:
-            m = Info().read_metadata(bag_file, args.storage)
-            print(m)
-        except RuntimeError:
-            return ('Could not read metadata for {}.'
-                    'Please specify the path to the folder containing '
-                    "an existing 'metadata.yaml' file or provide correct storage id "
-                    "if metadata file doesn't exist (see help).".format(bag_file))
+        m = Info().read_metadata(args.bag_path, args.storage)
+        print(m)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -15,13 +15,11 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
-from ros2bag.api import (
-    add_standard_reader_args,
-    check_not_negative_int,
-    check_positive_float,
-    convert_yaml_to_qos_profile,
-    print_error,
-)
+from ros2bag.api import add_standard_reader_args
+from ros2bag.api import check_not_negative_int
+from ros2bag.api import check_positive_float
+from ros2bag.api import convert_yaml_to_qos_profile
+from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
 from rosbag2_py import Player

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -15,14 +15,15 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
-from ros2bag.api import check_not_negative_int
-from ros2bag.api import check_path_exists
-from ros2bag.api import check_positive_float
-from ros2bag.api import convert_yaml_to_qos_profile
-from ros2bag.api import print_error
+from ros2bag.api import (
+    add_standard_reader_args,
+    check_not_negative_int,
+    check_positive_float,
+    convert_yaml_to_qos_profile,
+    print_error,
+)
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_readers
 from rosbag2_py import Player
 from rosbag2_py import PlayOptions
 from rosbag2_py import StorageOptions
@@ -40,13 +41,7 @@ class PlayVerb(VerbExtension):
     """Play back ROS data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        reader_choices = get_registered_readers()
-
-        parser.add_argument(
-            'bag_file', type=check_path_exists, help='bag file to replay')
-        parser.add_argument(
-            '-s', '--storage', default='', choices=reader_choices,
-            help='Storage implementation of bag. By default tries to determine from metadata.')
+        add_standard_reader_args(parser)
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
@@ -181,7 +176,7 @@ class PlayVerb(VerbExtension):
             topic_remapping.append(remap_rule)
 
         storage_options = StorageOptions(
-            uri=args.bag_file,
+            uri=args.bag_path,
             storage_id=args.storage,
             storage_config_uri=storage_config_file,
         )

--- a/ros2bag/ros2bag/verb/reindex.py
+++ b/ros2bag/ros2bag/verb/reindex.py
@@ -22,32 +22,26 @@
 
 import os
 
-from ros2bag.api import check_path_exists
-from ros2bag.api import print_error
+from ros2bag.api import (
+    add_standard_reader_args,
+    print_error,
+)
 from ros2bag.verb import VerbExtension
-from rosbag2_py import get_registered_readers, Reindexer, StorageOptions
+from rosbag2_py import Reindexer, StorageOptions
 
 
 class ReindexVerb(VerbExtension):
     """Reconstruct metadata file for a bag."""
 
     def add_arguments(self, parser, cli_name):
-        storage_choices = get_registered_readers()
-        default_storage = 'sqlite3' if 'sqlite3' in storage_choices else \
-            next(iter(storage_choices))
-
-        parser.add_argument(
-            'bag_directory', type=check_path_exists, help='bag to reindex')
-        parser.add_argument(
-            'storage_id', default=default_storage, choices=storage_choices,
-            help=f"storage identifier to be used, defaults to '{default_storage}'")
+        add_standard_reader_args(parser)
 
     def main(self, *, args):
-        if not os.path.isdir(args.bag_directory):
+        if not os.path.isdir(args.bag_path):
             return print_error('Must specify a bag directory')
 
         storage_options = StorageOptions(
-            uri=args.bag_directory,
+            uri=args.bag_path,
             storage_id=args.storage_id,
         )
 

--- a/ros2bag/ros2bag/verb/reindex.py
+++ b/ros2bag/ros2bag/verb/reindex.py
@@ -22,10 +22,8 @@
 
 import os
 
-from ros2bag.api import (
-    add_standard_reader_args,
-    print_error,
-)
+from ros2bag.api import add_standard_reader_args
+from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from rosbag2_py import Reindexer, StorageOptions
 

--- a/rosbag2_cpp/src/rosbag2_cpp/info.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/info.cpp
@@ -32,21 +32,14 @@ rosbag2_storage::BagMetadata Info::read_metadata(
   if (metadata_io.metadata_file_exists(uri)) {
     return metadata_io.read_metadata(uri);
   }
-  if (!storage_id.empty()) {
-    rosbag2_storage::StorageFactory factory;
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage;
-    storage = factory.open_read_only({uri, storage_id});
-    if (!storage) {
-      throw std::runtime_error(
-              "The metadata.yaml file does not exist and the bag could not be "
-              "opened.");
-    }
-    auto bag_metadata = storage->get_metadata();
-    return bag_metadata;
+
+  rosbag2_storage::StorageFactory factory;
+  auto storage = factory.open_read_only({uri, storage_id});
+  if (!storage) {
+    throw std::runtime_error(
+            "The metadata.yaml file does not exist and the bag could not be opened.");
   }
-  throw std::runtime_error(
-          "The metadata.yaml file does not exist. Please specify a the "
-          "storage id of the bagfile to query it directly");
+  return storage->get_metadata();
 }
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -87,8 +87,7 @@ void SequentialReader::open(
   base_folder_ = storage_options.uri;
 
   // If there is a metadata.yaml file present, load it.
-  // If not, let's ask the storage with the given URI for its metadata.
-  // This is necessary for non ROS2 bags (aka ROS1 legacy bags).
+  // If not, assume a single storage file, attempt to load, and ask storage for metadata.
   if (metadata_io_->metadata_file_exists(storage_options.uri)) {
     metadata_ = metadata_io_->read_metadata(storage_options.uri);
     if (storage_options_.storage_id.empty()) {
@@ -103,14 +102,9 @@ void SequentialReader::open(
     current_file_iterator_ = file_paths_.begin();
     load_current_file();
   } else {
-    if (storage_options_.storage_id.empty()) {
-      throw std::runtime_error(
-              "No metadata found and no storage_id specified. "
-              "Can't open bag.");
-    }
     storage_ = storage_factory_->open_read_only(storage_options_);
     if (!storage_) {
-      throw std::runtime_error{"No storage could be initialized. Abort"};
+      throw std::runtime_error{"No storage could be initialized from the inputs."};
     }
     metadata_ = storage_->get_metadata();
     if (metadata_.relative_file_paths.empty()) {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -273,3 +273,25 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
   EXPECT_EQ(read_metadata.compression_format, "zstd");
   EXPECT_EQ(read_metadata.compression_mode, "FILE");
 }
+
+TEST_F(TemporaryDirectoryFixture, info_for_standalone_bagfile) {
+  const auto path = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  // Create an empty bag with default storage
+  {
+    rosbag2_cpp::Writer writer;
+    writer.open(path.string());
+  }
+
+  // Delete the metadata file, just to assure that the info has to guess
+  const auto metadata_path = path / "metadata.yaml";
+  EXPECT_TRUE(rcpputils::fs::remove(metadata_path));
+
+  // Expect to be able to get info for a single file without specifying the storage ID.
+  const auto bagfile_path = path / "bag_0.db3";
+  rosbag2_cpp::Info info;
+  rosbag2_storage::BagMetadata metadata;
+  EXPECT_NO_THROW(
+    metadata = info.read_metadata(bagfile_path.string(), "")
+  );
+  EXPECT_EQ(metadata.storage_identifier, "sqlite3");
+}

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -34,6 +34,9 @@ void TestPlugin::open(
   const rosbag2_storage::StorageOptions & storage_options,
   rosbag2_storage::storage_interfaces::IOFlag flag)
 {
+  if (storage_options.storage_id != test_constants::READ_WRITE_PLUGIN_IDENTIFIER) {
+    throw std::runtime_error{"storage_id did not match. TestReadOnlyPlugin won't open."};
+  }
   if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     std::cout << "opening testplugin read only: ";
   } else if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) {

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -31,6 +31,9 @@ void TestReadOnlyPlugin::open(
   const rosbag2_storage::StorageOptions & storage_options,
   rosbag2_storage::storage_interfaces::IOFlag flag)
 {
+  if (storage_options.storage_id != test_constants::READ_ONLY_PLUGIN_IDENTIFIER) {
+    throw std::runtime_error{"storage_id did not match. TestReadOnlyPlugin won't open."};
+  }
   if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     std::cout << "opening testplugin read only: ";
   } else if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) {

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
@@ -33,16 +33,14 @@ class StorageFactoryTest : public ::testing::Test
 public:
   rosbag2_storage::StorageFactory factory;
 
-  std::string bag_file_path = "file/to/be/loaded.bag";
-  std::string test_plugin_id = "my_test_plugin";
-  std::string test_read_only_plugin_id = "my_read_only_test_plugin";
+  std::string bag_file_path = "path/to/be/loaded.bag";
   std::string test_unavailable_plugin_id = "my_unavailable_plugin";
 };
 
 TEST_F(StorageFactoryTest, load_test_plugin) {
   // Load plugin for read and write
   auto read_write_storage = factory.open_read_write(
-    {bag_file_path, test_plugin_id});
+    {bag_file_path, test_constants::READ_WRITE_PLUGIN_IDENTIFIER});
   ASSERT_NE(nullptr, read_write_storage);
 
   EXPECT_EQ(
@@ -69,7 +67,7 @@ TEST_F(StorageFactoryTest, load_test_plugin) {
 
 TEST_F(StorageFactoryTest, loads_readonly_plugin_only_for_read_only_storage) {
   auto storage_for_reading = factory.open_read_only(
-    {bag_file_path, test_read_only_plugin_id});
+    {bag_file_path, test_constants::READ_ONLY_PLUGIN_IDENTIFIER});
   ASSERT_NE(nullptr, storage_for_reading);
 
   EXPECT_EQ(


### PR DESCRIPTION
Work in progress, opening draft for visibility.

Part of #972

For reading verbs (`burst`, `info`, `convert`, `play`) allow user to provide a bare file (e.g. `my_bag.mcap`, `somedata.db3`) - and autodetect the storage implementation to open and use that file, without requiring a directory containing `metadata.yaml`