### PR TITLE
Readers/info can accept a single bag storage file, and detect its storage id automatically

### DIFF
--- a/ros2bag/ros2bag/api/__init__.py
+++ b/ros2bag/ros2bag/api/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
+from argparse import ArgumentParser, ArgumentTypeError
 import os
 from typing import Any
 from typing import Dict
@@ -24,6 +24,7 @@ from rclpy.qos import QoSHistoryPolicy
 from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
+import rosbag2_py
 
 # This map needs to be updated when new policies are introduced
 _QOS_POLICY_FROM_SHORT_NAME = {
@@ -104,7 +105,7 @@ def check_path_exists(value: Any) -> str:
     try:
         if os.path.exists(value):
             return value
-        raise ArgumentTypeError("Bag file '{}' does not exist!".format(value))
+        raise ArgumentTypeError("Bag path '{}' does not exist!".format(value))
     except ValueError:
         raise ArgumentTypeError('{} is not the valid type (string)'.format(value))
 
@@ -118,3 +119,13 @@ def check_not_negative_int(arg: str) -> int:
         return value
     except ValueError:
         raise ArgumentTypeError('{} is not the valid type (int)'.format(value))
+
+
+def add_standard_reader_args(parser: ArgumentParser) -> None:
+    reader_choices = rosbag2_py.get_registered_readers()
+    parser.add_argument(
+        'bag_path', type=check_path_exists, help='Bag to open')
+    parser.add_argument(
+        '-s', '--storage', default='', choices=reader_choices,
+        help='Storage implementation of bag. '
+             'By default attempts to detect automatically - use this argument to override.')

--- a/ros2bag/ros2bag/verb/burst.py
+++ b/ros2bag/ros2bag/verb/burst.py
@@ -15,14 +15,13 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
+from ros2bag.api import add_standard_reader_args
 from ros2bag.api import check_not_negative_int
-from ros2bag.api import check_path_exists
 from ros2bag.api import check_positive_float
 from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_readers
 from rosbag2_py import Player
 from rosbag2_py import PlayOptions
 from rosbag2_py import StorageOptions
@@ -33,13 +32,8 @@ class BurstVerb(VerbExtension):
     """Burst data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        reader_choices = get_registered_readers()
+        add_standard_reader_args(parser)
 
-        parser.add_argument(
-            'bag_file', type=check_path_exists, help='bag file to replay')
-        parser.add_argument(
-            '-s', '--storage', default='', choices=reader_choices,
-            help='Storage implementation of bag. By default tries to determine from metadata.')
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
@@ -91,7 +85,7 @@ class BurstVerb(VerbExtension):
             topic_remapping.append(remap_rule)
 
         storage_options = StorageOptions(
-            uri=args.bag_file,
+            uri=args.bag_path,
             storage_id=args.storage,
             storage_config_uri=storage_config_file,
         )

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -12,37 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
+from ros2bag.api import add_standard_reader_args
 from ros2bag.verb import VerbExtension
+from rosbag2_py._info import Info
 
 
 class InfoVerb(VerbExtension):
     """Print information about a bag to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        parser.add_argument(
-            'bag_file', help='bag file to introspect')
-        parser.add_argument(
-            '-s', '--storage', default='sqlite3',
-            help='storage identifier to be used to open storage, if no yaml file exists.'
-                 ' Defaults to "sqlite3"')
+        add_standard_reader_args(parser)
 
     def main(self, *, args):  # noqa: D102
-        bag_file = args.bag_file
-        if not os.path.exists(bag_file):
-            return "[ERROR] [ros2bag]: bag file '{}' does not exist!".format(bag_file)
-        # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
-        #               combined with constrained environments (as imposed by colcon test)
-        #               may result in DLL loading failures when attempting to import a C
-        #               extension. Therefore, do not import rosbag2_transport at the module
-        #               level but on demand, right before first use.
-        from rosbag2_py._info import Info
-        try:
-            m = Info().read_metadata(bag_file, args.storage)
-            print(m)
-        except RuntimeError:
-            return ('Could not read metadata for {}.'
-                    'Please specify the path to the folder containing '
-                    "an existing 'metadata.yaml' file or provide correct storage id "
-                    "if metadata file doesn't exist (see help).".format(bag_file))
+        m = Info().read_metadata(args.bag_path, args.storage)
+        print(m)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -15,14 +15,13 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
+from ros2bag.api import add_standard_reader_args
 from ros2bag.api import check_not_negative_int
-from ros2bag.api import check_path_exists
 from ros2bag.api import check_positive_float
 from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_readers
 from rosbag2_py import Player
 from rosbag2_py import PlayOptions
 from rosbag2_py import StorageOptions
@@ -40,13 +39,7 @@ class PlayVerb(VerbExtension):
     """Play back ROS data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        reader_choices = get_registered_readers()
-
-        parser.add_argument(
-            'bag_file', type=check_path_exists, help='bag file to replay')
-        parser.add_argument(
-            '-s', '--storage', default='', choices=reader_choices,
-            help='Storage implementation of bag. By default tries to determine from metadata.')
+        add_standard_reader_args(parser)
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
@@ -181,7 +174,7 @@ class PlayVerb(VerbExtension):
             topic_remapping.append(remap_rule)
 
         storage_options = StorageOptions(
-            uri=args.bag_file,
+            uri=args.bag_path,
             storage_id=args.storage,
             storage_config_uri=storage_config_file,
         )

--- a/ros2bag/ros2bag/verb/reindex.py
+++ b/ros2bag/ros2bag/verb/reindex.py
@@ -22,32 +22,24 @@
 
 import os
 
-from ros2bag.api import check_path_exists
+from ros2bag.api import add_standard_reader_args
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
-from rosbag2_py import get_registered_readers, Reindexer, StorageOptions
+from rosbag2_py import Reindexer, StorageOptions
 
 
 class ReindexVerb(VerbExtension):
     """Reconstruct metadata file for a bag."""
 
     def add_arguments(self, parser, cli_name):
-        storage_choices = get_registered_readers()
-        default_storage = 'sqlite3' if 'sqlite3' in storage_choices else \
-            next(iter(storage_choices))
-
-        parser.add_argument(
-            'bag_directory', type=check_path_exists, help='bag to reindex')
-        parser.add_argument(
-            'storage_id', default=default_storage, choices=storage_choices,
-            help=f"storage identifier to be used, defaults to '{default_storage}'")
+        add_standard_reader_args(parser)
 
     def main(self, *, args):
-        if not os.path.isdir(args.bag_directory):
+        if not os.path.isdir(args.bag_path):
             return print_error('Must specify a bag directory')
 
         storage_options = StorageOptions(
-            uri=args.bag_directory,
+            uri=args.bag_path,
             storage_id=args.storage_id,
         )
 

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -172,7 +172,7 @@ if(BUILD_TESTING)
   ament_add_gmock(test_sequential_reader
     test/rosbag2_cpp/test_sequential_reader.cpp)
   if(TARGET test_sequential_reader)
-    ament_target_dependencies(test_sequential_reader rosbag2_storage)
+    ament_target_dependencies(test_sequential_reader rosbag2_storage rosbag2_test_common)
     target_link_libraries(test_sequential_reader ${PROJECT_NAME})
   endif()
 

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -166,13 +166,13 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_info)
     target_link_libraries(test_info ${PROJECT_NAME})
-    ament_target_dependencies(test_info rosbag2_test_common)
+    ament_target_dependencies(test_info rosbag2_test_common test_msgs)
   endif()
 
   ament_add_gmock(test_sequential_reader
     test/rosbag2_cpp/test_sequential_reader.cpp)
   if(TARGET test_sequential_reader)
-    ament_target_dependencies(test_sequential_reader rosbag2_storage rosbag2_test_common)
+    ament_target_dependencies(test_sequential_reader rosbag2_storage rosbag2_test_common test_msgs)
     target_link_libraries(test_sequential_reader ${PROJECT_NAME})
   endif()
 

--- a/rosbag2_cpp/include/rosbag2_cpp/info.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/info.hpp
@@ -30,7 +30,7 @@ public:
   virtual ~Info() = default;
 
   virtual rosbag2_storage::BagMetadata read_metadata(
-    const std::string & uri, const std::string & storage_id);
+    const std::string & uri, const std::string & storage_id = "");
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/info.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/info.cpp
@@ -32,21 +32,13 @@ rosbag2_storage::BagMetadata Info::read_metadata(
   if (metadata_io.metadata_file_exists(uri)) {
     return metadata_io.read_metadata(uri);
   }
-  if (!storage_id.empty()) {
-    rosbag2_storage::StorageFactory factory;
-    std::shared_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> storage;
-    storage = factory.open_read_only({uri, storage_id});
-    if (!storage) {
-      throw std::runtime_error(
-              "The metadata.yaml file does not exist and the bag could not be "
-              "opened.");
-    }
-    auto bag_metadata = storage->get_metadata();
-    return bag_metadata;
+
+  rosbag2_storage::StorageFactory factory;
+  auto storage = factory.open_read_only({uri, storage_id});
+  if (!storage) {
+    throw std::runtime_error("Unable to open storage implementation for provided arguments.");
   }
-  throw std::runtime_error(
-          "The metadata.yaml file does not exist. Please specify a the "
-          "storage id of the bagfile to query it directly");
+  return storage->get_metadata();
 }
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -87,8 +87,7 @@ void SequentialReader::open(
   base_folder_ = storage_options.uri;
 
   // If there is a metadata.yaml file present, load it.
-  // If not, let's ask the storage with the given URI for its metadata.
-  // This is necessary for non ROS2 bags (aka ROS1 legacy bags).
+  // If not, assume a single storage file, attempt to load, and ask storage for metadata.
   if (metadata_io_->metadata_file_exists(storage_options.uri)) {
     metadata_ = metadata_io_->read_metadata(storage_options.uri);
     if (storage_options_.storage_id.empty()) {
@@ -103,14 +102,9 @@ void SequentialReader::open(
     current_file_iterator_ = file_paths_.begin();
     load_current_file();
   } else {
-    if (storage_options_.storage_id.empty()) {
-      throw std::runtime_error(
-              "No metadata found and no storage_id specified. "
-              "Can't open bag.");
-    }
     storage_ = storage_factory_->open_read_only(storage_options_);
     if (!storage_) {
-      throw std::runtime_error{"No storage could be initialized. Abort"};
+      throw std::runtime_error{"No storage could be initialized from the inputs."};
     }
     metadata_ = storage_->get_metadata();
     if (metadata_.relative_file_paths.empty()) {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -29,6 +29,8 @@
 
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
+#include "test_msgs/msg/basic_types.hpp"
+
 using namespace ::testing;  // NOLINT
 using rosbag2_test_common::TemporaryDirectoryFixture;
 
@@ -64,7 +66,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_2) {
   }
 
   rosbag2_cpp::Info info;
-  const auto metadata = info.read_metadata(temporary_dir_path_, "sqlite3");
+  const auto metadata = info.read_metadata(temporary_dir_path_);
 
   EXPECT_EQ(metadata.version, 2);
   EXPECT_EQ(metadata.storage_identifier, "sqlite3");
@@ -144,7 +146,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_6) {
   }
 
   rosbag2_cpp::Info info;
-  const auto metadata = info.read_metadata(temporary_dir_path_, "sqlite3");
+  const auto metadata = info.read_metadata(temporary_dir_path_);
 
   EXPECT_EQ(metadata.version, 6);
   EXPECT_EQ(metadata.storage_identifier, "sqlite3");
@@ -231,7 +233,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
   fout.close();
 
   rosbag2_cpp::Info info;
-  auto read_metadata = info.read_metadata(temporary_dir_path_, "sqlite3");
+  auto read_metadata = info.read_metadata(temporary_dir_path_);
 
   EXPECT_THAT(read_metadata.storage_identifier, Eq("sqlite3"));
   EXPECT_THAT(
@@ -281,12 +283,14 @@ TEST_F(TemporaryDirectoryFixture, info_for_standalone_bagfile) {
     // Create an empty bag with default storage
     rosbag2_cpp::Writer writer;
     writer.open(bag_path.string());
+    test_msgs::msg::BasicTypes msg;
+    writer.write(msg, "testtopic", rclcpp::Time{});
   }
 
   rosbag2_cpp::Info info;
   rosbag2_storage::BagMetadata metadata;
   EXPECT_NO_THROW(
-    metadata = info.read_metadata(expected_bagfile_path.string(), "")
+    metadata = info.read_metadata(expected_bagfile_path.string())
   );
-  EXPECT_EQ(metadata.storage_identifier, "sqlite3");
+  EXPECT_THAT(metadata.topics_with_message_count, SizeIs(1));
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -30,7 +30,7 @@
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
 using namespace ::testing;  // NOLINT
-using namespace rosbag2_test_common;  // NOLINT
+using rosbag2_test_common::TemporaryDirectoryFixture;
 
 TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_2) {
   const std::string bagfile = "rosbag2_bagfile_information:\n"
@@ -272,4 +272,21 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
 
   EXPECT_EQ(read_metadata.compression_format, "zstd");
   EXPECT_EQ(read_metadata.compression_mode, "FILE");
+}
+
+TEST_F(TemporaryDirectoryFixture, info_for_standalone_bagfile) {
+  const auto bag_path = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  const auto expected_bagfile_path = bag_path / "bag_0.db3";
+  {
+    // Create an empty bag with default storage
+    rosbag2_cpp::Writer writer;
+    writer.open(bag_path.string());
+  }
+
+  rosbag2_cpp::Info info;
+  rosbag2_storage::BagMetadata metadata;
+  EXPECT_NO_THROW(
+    metadata = info.read_metadata(expected_bagfile_path.string(), "")
+  );
+  EXPECT_EQ(metadata.storage_identifier, "sqlite3");
 }

--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -89,7 +89,7 @@ try_detect_and_open_storage(
       ROSBAG2_STORAGE_LOG_DEBUG_STREAM(
         "Success, using implementation '" << registered_class << "'.");
       return instance;
-    } catch (const std::runtime_error & ex) {
+    } catch (const std::runtime_error & /* ex */) {
       continue;
     }
   }

--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -72,7 +72,7 @@ try_detect_and_open_storage(
 {
   bool creating_file = flag != storage_interfaces::IOFlag::READ_ONLY;
   if (creating_file) {
-    ROSBAG2_STORAGE_LOG_WARN_STREAM("Can not auto-choose storage for writing.");
+    ROSBAG2_STORAGE_LOG_ERROR("Can not auto-choose storage for writing.");
     return nullptr;
   }
 
@@ -82,11 +82,11 @@ try_detect_and_open_storage(
     if (instance == nullptr) {
       continue;
     }
-    ROSBAG2_STORAGE_LOG_INFO_STREAM(
-      "Checking storage implementation '" << registered_class << "' to open bag.");
+    ROSBAG2_STORAGE_LOG_DEBUG_STREAM(
+      "Trying storage implementation '" << registered_class << "'.");
     try {
       instance->open(storage_options, flag);
-      ROSBAG2_STORAGE_LOG_INFO_STREAM(
+      ROSBAG2_STORAGE_LOG_DEBUG_STREAM(
         "Success, using implementation '" << registered_class << "'.");
       return instance;
     } catch (const std::runtime_error & ex) {
@@ -115,7 +115,7 @@ get_interface_instance(
     registered_classes.end(), storage_options.storage_id);
   if (class_exists == registered_classes.end()) {
     ROSBAG2_STORAGE_LOG_WARN_STREAM(
-      "Requested storage id '" << storage_options.storage_id << "' does not exist");
+      "No plugin found with id '" << storage_options.storage_id << "'.");
     return nullptr;
   }
 
@@ -163,8 +163,13 @@ public:
       get_interface_instance(read_write_class_loader_, storage_options);
 
     if (instance == nullptr) {
-      ROSBAG2_STORAGE_LOG_ERROR_STREAM(
-        "Could not load/open plugin with storage id '" << storage_options.storage_id << "'.");
+      if (storage_options.storage_id.empty()) {
+        ROSBAG2_STORAGE_LOG_ERROR_STREAM(
+          "No storage id specified, and no plugin found that could open URI");
+      } else {
+        ROSBAG2_STORAGE_LOG_ERROR_STREAM(
+          "Could not load/open plugin with storage id '" << storage_options.storage_id << "'");
+      }
     }
 
     return instance;
@@ -183,8 +188,13 @@ public:
     }
 
     if (instance == nullptr) {
-      ROSBAG2_STORAGE_LOG_ERROR_STREAM(
-        "Could not load/open plugin with storage id '" << storage_options.storage_id << "'.");
+      if (storage_options.storage_id.empty()) {
+        ROSBAG2_STORAGE_LOG_ERROR_STREAM(
+          "No storage id specified, and no plugin found that could open URI");
+      } else {
+        ROSBAG2_STORAGE_LOG_ERROR_STREAM(
+          "Could not load/open plugin with storage id '" << storage_options.storage_id << "'");
+      }
     }
 
     return instance;

--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -55,7 +55,7 @@ try_load_plugin(
     instance = std::shared_ptr<InterfaceT>(unmanaged_instance);
   } catch (const std::runtime_error & ex) {
     ROSBAG2_STORAGE_LOG_ERROR_STREAM(
-      "Unable to load plugin: " << ex.what());
+      "Unable to load plugin '" << plugin_name << "': " << ex.what());
   }
   return instance;
 }
@@ -90,6 +90,8 @@ try_detect_and_open_storage(
         "Success, using implementation '" << registered_class << "'.");
       return instance;
     } catch (const std::runtime_error & /* ex */) {
+      ROSBAG2_STORAGE_LOG_DEBUG_STREAM(
+        "Failed to open with implementation '" << registered_class << "'. Continuing loop.");
       continue;
     }
   }
@@ -115,7 +117,7 @@ get_interface_instance(
     registered_classes.end(), storage_options.storage_id);
   if (class_exists == registered_classes.end()) {
     ROSBAG2_STORAGE_LOG_WARN_STREAM(
-      "No plugin found with id '" << storage_options.storage_id << "'.");
+      "No storage plugin found with id '" << storage_options.storage_id << "'.");
     return nullptr;
   }
 

--- a/rosbag2_storage/test/rosbag2_storage/test_constants.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_constants.hpp
@@ -20,8 +20,8 @@ namespace test_constants
 {
 constexpr const char * const READ_WRITE_PLUGIN_EXTENSION = ".rwplugin";
 constexpr const char * const READ_ONLY_PLUGIN_EXTENSION = ".roplugin";
-constexpr const char * const READ_WRITE_PLUGIN_IDENTIFIER = "ReadWritePlugin";
-constexpr const char * const READ_ONLY_PLUGIN_IDENTIFIER = "ReadOnlyPlugin";
+constexpr const char * const READ_WRITE_PLUGIN_IDENTIFIER = "my_test_plugin";
+constexpr const char * const READ_ONLY_PLUGIN_IDENTIFIER = "my_read_only_test_plugin";
 constexpr const char * const DUMMY_FILEPATH = "/path/to/storage";
 constexpr const uint64_t MAX_BAGFILE_SIZE = 0;
 constexpr const uint64_t MIN_SPLIT_FILE_SIZE = UINT64_MAX;

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -34,6 +34,9 @@ void TestPlugin::open(
   const rosbag2_storage::StorageOptions & storage_options,
   rosbag2_storage::storage_interfaces::IOFlag flag)
 {
+  if (storage_options.storage_id != test_constants::READ_WRITE_PLUGIN_IDENTIFIER) {
+    throw std::runtime_error{"storage_id did not match. TestReadOnlyPlugin won't open."};
+  }
   if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     std::cout << "opening testplugin read only: ";
   } else if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) {

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -31,6 +31,9 @@ void TestReadOnlyPlugin::open(
   const rosbag2_storage::StorageOptions & storage_options,
   rosbag2_storage::storage_interfaces::IOFlag flag)
 {
+  if (storage_options.storage_id != test_constants::READ_ONLY_PLUGIN_IDENTIFIER) {
+    throw std::runtime_error{"storage_id did not match. TestReadOnlyPlugin won't open."};
+  }
   if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     std::cout << "opening testplugin read only: ";
   } else if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) {

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
@@ -33,16 +33,14 @@ class StorageFactoryTest : public ::testing::Test
 public:
   rosbag2_storage::StorageFactory factory;
 
-  std::string bag_file_path = "file/to/be/loaded.bag";
-  std::string test_plugin_id = "my_test_plugin";
-  std::string test_read_only_plugin_id = "my_read_only_test_plugin";
+  std::string bag_file_path = "path/to/be/loaded.bag";
   std::string test_unavailable_plugin_id = "my_unavailable_plugin";
 };
 
 TEST_F(StorageFactoryTest, load_test_plugin) {
   // Load plugin for read and write
   auto read_write_storage = factory.open_read_write(
-    {bag_file_path, test_plugin_id});
+    {bag_file_path, test_constants::READ_WRITE_PLUGIN_IDENTIFIER});
   ASSERT_NE(nullptr, read_write_storage);
 
   EXPECT_EQ(
@@ -62,14 +60,14 @@ TEST_F(StorageFactoryTest, load_test_plugin) {
 
   // Load plugin for read only even though it provides read and write interfaces
   auto read_only_storage = factory.open_read_only(
-    {bag_file_path, test_plugin_id});
+    {bag_file_path, test_constants::READ_WRITE_PLUGIN_IDENTIFIER});
   ASSERT_NE(nullptr, read_only_storage);
   msg = read_only_storage->read_next();
 }
 
 TEST_F(StorageFactoryTest, loads_readonly_plugin_only_for_read_only_storage) {
   auto storage_for_reading = factory.open_read_only(
-    {bag_file_path, test_read_only_plugin_id});
+    {bag_file_path, test_constants::READ_ONLY_PLUGIN_IDENTIFIER});
   ASSERT_NE(nullptr, storage_for_reading);
 
   EXPECT_EQ(
@@ -87,7 +85,7 @@ TEST_F(StorageFactoryTest, loads_readonly_plugin_only_for_read_only_storage) {
   storage_for_reading->read_next();
 
   auto storage_for_reading_and_writing = factory.open_read_write(
-    {bag_file_path, test_read_only_plugin_id});
+    {bag_file_path, test_constants::READ_ONLY_PLUGIN_IDENTIFIER});
   ASSERT_EQ(nullptr, storage_for_reading_and_writing);
 }
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -78,5 +78,5 @@ TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_metadata_yaml_file_does
   auto error_output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
-  EXPECT_THAT(error_output, HasSubstr("Could not read metadata for " + database_path_));
+  EXPECT_THAT(error_output, HasSubstr("Could not find metadata"));
 }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -67,7 +67,7 @@ TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_bag_does_not_exist) {
     execute_and_wait_until_completion("ros2 bag info does_not_exist", database_path_);
   auto error_output = internal::GetCapturedStderr();
 
-  EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
+  EXPECT_THAT(exit_code, Ne(EXIT_SUCCESS));
   EXPECT_THAT(error_output, HasSubstr("'does_not_exist' does not exist"));
 }
 


### PR DESCRIPTION
Closes #972

API-level allowance for bare bag files as input. Main improvement is the storage factory loop over all plugins, when storage id is not provided.

To expose this new capability consistently, factor out common options into a single place for all `ros2 bag` verbs that read bags.