### PR TITLE
Reader CLI argument consistency pass (coherently enables bare-file)

### DIFF
--- a/ros2bag/ros2bag/api/__init__.py
+++ b/ros2bag/ros2bag/api/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
+from argparse import ArgumentParser, ArgumentTypeError
 import os
 from typing import Any
 from typing import Dict
@@ -24,6 +24,7 @@ from rclpy.qos import QoSHistoryPolicy
 from rclpy.qos import QoSLivelinessPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
+import rosbag2_py
 
 # This map needs to be updated when new policies are introduced
 _QOS_POLICY_FROM_SHORT_NAME = {
@@ -104,7 +105,7 @@ def check_path_exists(value: Any) -> str:
     try:
         if os.path.exists(value):
             return value
-        raise ArgumentTypeError("Bag file '{}' does not exist!".format(value))
+        raise ArgumentTypeError("Bag path '{}' does not exist!".format(value))
     except ValueError:
         raise ArgumentTypeError('{} is not the valid type (string)'.format(value))
 
@@ -118,3 +119,13 @@ def check_not_negative_int(arg: str) -> int:
         return value
     except ValueError:
         raise ArgumentTypeError('{} is not the valid type (int)'.format(value))
+
+
+def add_standard_reader_args(parser: ArgumentParser) -> None:
+    reader_choices = rosbag2_py.get_registered_readers()
+    parser.add_argument(
+        'bag_path', type=check_path_exists, help='Bag to open')
+    parser.add_argument(
+        '-s', '--storage', default='', choices=reader_choices,
+        help='Storage implementation of bag. '
+             'By default attempts to detect automatically - use this argument to override.')

--- a/ros2bag/ros2bag/verb/burst.py
+++ b/ros2bag/ros2bag/verb/burst.py
@@ -15,14 +15,13 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
+from ros2bag.api import add_standard_reader_args
 from ros2bag.api import check_not_negative_int
-from ros2bag.api import check_path_exists
 from ros2bag.api import check_positive_float
 from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_readers
 from rosbag2_py import Player
 from rosbag2_py import PlayOptions
 from rosbag2_py import StorageOptions
@@ -33,13 +32,8 @@ class BurstVerb(VerbExtension):
     """Burst data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        reader_choices = get_registered_readers()
+        add_standard_reader_args(parser)
 
-        parser.add_argument(
-            'bag_file', type=check_path_exists, help='bag file to replay')
-        parser.add_argument(
-            '-s', '--storage', default='', choices=reader_choices,
-            help='Storage implementation of bag. By default tries to determine from metadata.')
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
@@ -91,7 +85,7 @@ class BurstVerb(VerbExtension):
             topic_remapping.append(remap_rule)
 
         storage_options = StorageOptions(
-            uri=args.bag_file,
+            uri=args.bag_path,
             storage_id=args.storage,
             storage_config_uri=storage_config_file,
         )

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -12,37 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
+from ros2bag.api import add_standard_reader_args
 from ros2bag.verb import VerbExtension
+from rosbag2_py._info import Info
 
 
 class InfoVerb(VerbExtension):
     """Print information about a bag to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        parser.add_argument(
-            'bag_file', help='bag file to introspect')
-        parser.add_argument(
-            '-s', '--storage', default='sqlite3',
-            help='storage identifier to be used to open storage, if no yaml file exists.'
-                 ' Defaults to "sqlite3"')
+        add_standard_reader_args(parser)
 
     def main(self, *, args):  # noqa: D102
-        bag_file = args.bag_file
-        if not os.path.exists(bag_file):
-            return "[ERROR] [ros2bag]: bag file '{}' does not exist!".format(bag_file)
-        # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups
-        #               combined with constrained environments (as imposed by colcon test)
-        #               may result in DLL loading failures when attempting to import a C
-        #               extension. Therefore, do not import rosbag2_transport at the module
-        #               level but on demand, right before first use.
-        from rosbag2_py._info import Info
-        try:
-            m = Info().read_metadata(bag_file, args.storage)
-            print(m)
-        except RuntimeError:
-            return ('Could not read metadata for {}.'
-                    'Please specify the path to the folder containing '
-                    "an existing 'metadata.yaml' file or provide correct storage id "
-                    "if metadata file doesn't exist (see help).".format(bag_file))
+        m = Info().read_metadata(args.bag_path, args.storage)
+        print(m)

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -15,14 +15,13 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
+from ros2bag.api import add_standard_reader_args
 from ros2bag.api import check_not_negative_int
-from ros2bag.api import check_path_exists
 from ros2bag.api import check_positive_float
 from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_readers
 from rosbag2_py import Player
 from rosbag2_py import PlayOptions
 from rosbag2_py import StorageOptions
@@ -40,13 +39,7 @@ class PlayVerb(VerbExtension):
     """Play back ROS data from a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        reader_choices = get_registered_readers()
-
-        parser.add_argument(
-            'bag_file', type=check_path_exists, help='bag file to replay')
-        parser.add_argument(
-            '-s', '--storage', default='', choices=reader_choices,
-            help='Storage implementation of bag. By default tries to determine from metadata.')
+        add_standard_reader_args(parser)
         parser.add_argument(
             '--read-ahead-queue-size', type=int, default=1000,
             help='size of message queue rosbag tries to hold in memory to help deterministic '
@@ -181,7 +174,7 @@ class PlayVerb(VerbExtension):
             topic_remapping.append(remap_rule)
 
         storage_options = StorageOptions(
-            uri=args.bag_file,
+            uri=args.bag_path,
             storage_id=args.storage,
             storage_config_uri=storage_config_file,
         )

--- a/ros2bag/ros2bag/verb/reindex.py
+++ b/ros2bag/ros2bag/verb/reindex.py
@@ -22,32 +22,24 @@
 
 import os
 
-from ros2bag.api import check_path_exists
+from ros2bag.api import add_standard_reader_args
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
-from rosbag2_py import get_registered_readers, Reindexer, StorageOptions
+from rosbag2_py import Reindexer, StorageOptions
 
 
 class ReindexVerb(VerbExtension):
     """Reconstruct metadata file for a bag."""
 
     def add_arguments(self, parser, cli_name):
-        storage_choices = get_registered_readers()
-        default_storage = 'sqlite3' if 'sqlite3' in storage_choices else \
-            next(iter(storage_choices))
-
-        parser.add_argument(
-            'bag_directory', type=check_path_exists, help='bag to reindex')
-        parser.add_argument(
-            'storage_id', default=default_storage, choices=storage_choices,
-            help=f"storage identifier to be used, defaults to '{default_storage}'")
+        add_standard_reader_args(parser)
 
     def main(self, *, args):
-        if not os.path.isdir(args.bag_directory):
+        if not os.path.isdir(args.bag_path):
             return print_error('Must specify a bag directory')
 
         storage_options = StorageOptions(
-            uri=args.bag_directory,
+            uri=args.bag_path,
             storage_id=args.storage_id,
         )
 


### PR DESCRIPTION
Depends on #1072
Part of #972

For all `ros2 bag` verbs that create a reader, factor out common options into a single place for consistency. This helps consistently expose the bare file workflow enabled in #1072