### PR TITLE
Fix hangout in rosbag2 player and recorder when pressing `CTRL+C`

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -116,7 +116,12 @@ Player::Player(
   const rclcpp::NodeOptions & node_options)
 : Player(std::move(reader),
     // only call KeyboardHandler when using default keyboard handler implementation
+#ifndef _WIN32
+    std::make_shared<KeyboardHandler>(false),
+#else
+    // We don't have signal handler option in constructor for windows version
     std::shared_ptr<KeyboardHandler>(new KeyboardHandler()),
+#endif
     storage_options, play_options,
     node_name, node_options)
 {}

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -59,7 +59,12 @@ Recorder::Recorder(
   const rclcpp::NodeOptions & node_options)
 : Recorder(
     std::move(writer),
-    std::make_shared<KeyboardHandler>(),
+#ifndef _WIN32
+    std::make_shared<KeyboardHandler>(false),
+#else
+    // We don't have signal handler option in constructor for windows version
+    std::shared_ptr<KeyboardHandler>(new KeyboardHandler()),
+#endif
     storage_options,
     record_options,
     node_name,


### PR DESCRIPTION
- Closes #1079 
We don't need to explicitly handle `SIGINT` in `KeyboardHandler` instantiated from rosbag2 executables since we have already overriding `SIGINT` on upper python level or inside `rclcpp::init()` and correctly finishing application with proper calling of all destructors upon receiving `SIGINT` via checking `rclcpp::ok()` method in infinite loop.

Please note that it's almost impossible to cover this fix in unit tests since `gtest` using redirection of the standard input to the file and `KeyboardHandler` has detection for this special case and automatically disable keyboard handling from standard input on construction.