### PR TITLE
expose py Reader metadata, improve `rosbag2_py.BagMetadata` usability

### DIFF
--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -118,12 +118,13 @@ if(BUILD_TESTING)
     set(set_env_vars "${set_env_vars} ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL=True")
   endif()
 
-  # message(FATAL_ERROR "HELP I AM THE PATH ${CMAKE_CURRENT_SOURCE_DIR}")
-  ament_add_pytest_test(test_sequential_reader_py "test/test_sequential_reader.py"
+  ament_add_pytest_test(test_sequential_reader_py
+    "test/test_sequential_reader.py"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )
-  ament_add_pytest_test(test_sequential_reader_multiple_files_py "test/test_sequential_reader_multiple_files.py"
+  ament_add_pytest_test(test_sequential_reader_multiple_files_py
+    "test/test_sequential_reader_multiple_files.py"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )
@@ -144,6 +145,12 @@ if(BUILD_TESTING)
   )
   ament_add_pytest_test(test_convert_py
     "test/test_convert.py"
+    APPEND_ENV "${append_env_vars}"
+    ENV "${set_env_vars}"
+  )
+
+  ament_add_pytest_test(test_storage_py
+    "test/test_storage.py"
     APPEND_ENV "${append_env_vars}"
     ENV "${set_env_vars}"
   )

--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -25,6 +25,7 @@ with add_dll_directories_from_env('PATH'):
     )
     from rosbag2_py._storage import (
         ConverterOptions,
+        FileInformation,
         StorageFilter,
         StorageOptions,
         TopicMetadata,
@@ -55,6 +56,7 @@ with add_dll_directories_from_env('PATH'):
 __all__ = [
     'bag_rewrite',
     'ConverterOptions',
+    'FileInformation',
     'get_registered_readers',
     'get_registered_writers',
     'get_registered_compressors',

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -45,7 +45,7 @@ public:
 
   void open(
     rosbag2_storage::StorageOptions & storage_options,
-    rosbag2_cpp::ConverterOptions & converter_options)
+    rosbag2_cpp::ConverterOptions & converter_options = rosbag2_cpp::ConverterOptions())
   {
     reader_->open(storage_options, converter_options);
   }
@@ -71,6 +71,11 @@ public:
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types()
   {
     return reader_->get_all_topics_and_types();
+  }
+
+  const rosbag2_storage::BagMetadata & get_metadata() const
+  {
+    return reader_->get_metadata();
   }
 
   void set_filter(const rosbag2_storage::StorageFilter & storage_filter)
@@ -108,44 +113,33 @@ std::unordered_set<std::string> get_registered_readers()
 
 }  // namespace rosbag2_py
 
+using PyReader = rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>;
+using PyCompressionReader = rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>;
+
 PYBIND11_MODULE(_reader, m) {
   m.doc() = "Python wrapper of the rosbag2_cpp reader API";
 
-  pybind11::class_<rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>>(
-    m, "SequentialReader")
+  pybind11::class_<PyReader>(m, "SequentialReader")
   .def(pybind11::init())
-  .def("open", &rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>::open)
-  .def("read_next", &rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>::read_next)
-  .def("has_next", &rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>::has_next)
-  .def(
-    "get_all_topics_and_types",
-    &rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>::get_all_topics_and_types)
-  .def("set_filter", &rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>::set_filter)
-  .def("reset_filter", &rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>::reset_filter)
-  .def("seek", &rosbag2_py::Reader<rosbag2_cpp::readers::SequentialReader>::seek);
+  .def("open", &PyReader::open)
+  .def("read_next", &PyReader::read_next)
+  .def("has_next", &PyReader::has_next)
+  .def("get_metadata", &PyReader::get_metadata)
+  .def("get_all_topics_and_types", &PyReader::get_all_topics_and_types)
+  .def("set_filter", &PyReader::set_filter)
+  .def("reset_filter", &PyReader::reset_filter)
+  .def("seek", &PyReader::seek);
 
-  pybind11::class_<rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>>(
-    m, "SequentialCompressionReader")
+  pybind11::class_<PyCompressionReader>(m, "SequentialCompressionReader")
   .def(pybind11::init())
-  .def("open", &rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>::open)
-  .def(
-    "read_next", &rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>::read_next)
-  .def("has_next", &rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>::has_next)
-  .def(
-    "get_all_topics_and_types",
-    &rosbag2_py::Reader<
-      rosbag2_compression::SequentialCompressionReader
-    >::get_all_topics_and_types)
-  .def(
-    "set_filter",
-    &rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>::set_filter)
-  .def(
-    "reset_filter",
-    &rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>::reset_filter)
-  .def(
-    "seek",
-    &rosbag2_py::Reader<rosbag2_compression::SequentialCompressionReader>::seek);
-
+  .def("open", &PyCompressionReader::open)
+  .def("read_next", &PyCompressionReader::read_next)
+  .def("has_next", &PyCompressionReader::has_next)
+  .def("get_metadata", &PyCompressionReader::get_metadata)
+  .def("get_all_topics_and_types", &PyCompressionReader::get_all_topics_and_types)
+  .def("set_filter", &PyCompressionReader::set_filter)
+  .def("reset_filter", &PyCompressionReader::reset_filter)
+  .def("seek", &PyCompressionReader::seek);
   m.def(
     "get_registered_readers",
     &rosbag2_py::get_registered_readers,

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -117,9 +117,15 @@ PYBIND11_MODULE(_storage, m) {
 
   pybind11::class_<rosbag2_storage::StorageFilter>(m, "StorageFilter")
   .def(
-    pybind11::init<std::vector<std::string>>(),
-    pybind11::arg("topics") = std::vector<std::string>())
-  .def_readwrite("topics", &rosbag2_storage::StorageFilter::topics);
+    pybind11::init<std::vector<std::string>, std::string, std::string>(),
+    pybind11::arg("topics") = std::vector<std::string>(),
+    pybind11::arg("topics_regex") = "",
+    pybind11::arg("topics_regex_to_exclude") = "")
+  .def_readwrite("topics", &rosbag2_storage::StorageFilter::topics)
+  .def_readwrite("topics_regex", &rosbag2_storage::StorageFilter::topics_regex)
+  .def_readwrite(
+    "topics_regex_to_exclude",
+    &rosbag2_storage::StorageFilter::topics_regex_to_exclude);
 
   pybind11::class_<rosbag2_storage::TopicMetadata>(m, "TopicMetadata")
   .def(

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -190,17 +190,17 @@ PYBIND11_MODULE(_storage, m) {
       std::vector<rosbag2_storage::TopicInformation>,
       std::string,
       std::string>(),
-    pybind11::arg("version"),
-    pybind11::arg("bag_size"),
-    pybind11::arg("storage_identifier"),
-    pybind11::arg("relative_file_paths"),
-    pybind11::arg("files"),
-    pybind11::arg("duration"),
-    pybind11::arg("starting_time"),
-    pybind11::arg("message_count"),
-    pybind11::arg("topics_with_message_count"),
-    pybind11::arg("compression_format"),
-    pybind11::arg("compression_mode"))
+    pybind11::arg("version") = 6,
+    pybind11::arg("bag_size") = 0,
+    pybind11::arg("storage_identifier") = "",
+    pybind11::arg("relative_file_paths") = std::vector<std::string>(),
+    pybind11::arg("files") = std::vector<rosbag2_storage::FileInformation>(),
+    pybind11::arg("duration") = std::chrono::nanoseconds{0},
+    pybind11::arg("starting_time") = std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds{0}),
+    pybind11::arg("message_count") = 0,
+    pybind11::arg("topics_with_message_count") = std::vector<rosbag2_storage::TopicInformation>(),
+    pybind11::arg("compression_format") = "",
+    pybind11::arg("compression_mode") = "")
   .def_readwrite("version", &rosbag2_storage::BagMetadata::version)
   .def_readwrite("bag_size", &rosbag2_storage::BagMetadata::bag_size)
   .def_readwrite("storage_identifier", &rosbag2_storage::BagMetadata::storage_identifier)

--- a/rosbag2_py/test/common.py
+++ b/rosbag2_py/test/common.py
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
 import time
 from typing import Callable
 
-from rclpy.clock import Clock, ClockType
-from rclpy.duration import Duration
-import rosbag2_py
+if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
+    # This is needed on Linux when compiling with clang/libc++.
+    # TL;DR This makes class_loader work when using a python extension compiled with libc++.
+    #
+    # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
+    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
+
+from rclpy.clock import Clock, ClockType  # noqa
+from rclpy.duration import Duration  # noqa
+import rosbag2_py  # noqa
 
 
 def get_rosbag_options(path, serialization_format='cdr'):

--- a/rosbag2_py/test/test_convert.py
+++ b/rosbag2_py/test/test_convert.py
@@ -14,23 +14,14 @@
 
 import os
 from pathlib import Path
-import sys
 import tempfile
 import unittest
 
-if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
-    # This is needed on Linux when compiling with clang/libc++.
-    # TL;DR This makes class_loader work when using a python extension compiled with libc++.
-    #
-    # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
-    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
-
-from common import get_rosbag_options  # noqa
-import rosbag2_py  # noqa
+import common  # noqa
 from rosbag2_py import (
     bag_rewrite,
     StorageOptions,
-)  # noqa
+)
 
 RESOURCES_PATH = Path(os.environ['ROSBAG2_PY_TEST_RESOURCES_DIR'])
 

--- a/rosbag2_py/test/test_reindexer.py
+++ b/rosbag2_py/test/test_reindexer.py
@@ -22,17 +22,9 @@
 
 import os
 from pathlib import Path
-import sys
 
-if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
-    # This is needed on Linux when compiling with clang/libc++.
-    # TL;DR This makes class_loader work when using a python extension compiled with libc++.
-    #
-    # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
-    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
-
-from common import get_rosbag_options  # noqa
-import rosbag2_py  # noqa
+from common import get_rosbag_options
+import rosbag2_py
 
 RESOURCES_PATH = Path(os.environ['ROSBAG2_PY_TEST_RESOURCES_DIR'])
 

--- a/rosbag2_py/test/test_sequential_reader.py
+++ b/rosbag2_py/test/test_sequential_reader.py
@@ -14,22 +14,15 @@
 
 import os
 from pathlib import Path
-import sys
+
+from common import get_rosbag_options
 
 from rcl_interfaces.msg import Log
 from rclpy.serialization import deserialize_message
+import rosbag2_py
 from rosidl_runtime_py.utilities import get_message
 from std_msgs.msg import String
 
-if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
-    # This is needed on Linux when compiling with clang/libc++.
-    # TL;DR This makes class_loader work when using a python extension compiled with libc++.
-    #
-    # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
-    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
-
-from common import get_rosbag_options  # noqa
-import rosbag2_py  # noqa
 
 RESOURCES_PATH = Path(os.environ['ROSBAG2_PY_TEST_RESOURCES_DIR'])
 

--- a/rosbag2_py/test/test_sequential_reader_multiple_files.py
+++ b/rosbag2_py/test/test_sequential_reader_multiple_files.py
@@ -14,18 +14,9 @@
 
 import os
 from pathlib import Path
-import sys
 
-
-if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
-    # This is needed on Linux when compiling with clang/libc++.
-    # TL;DR This makes class_loader work when using a python extension compiled with libc++.
-    #
-    # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
-    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
-
-from common import get_rosbag_options  # noqa
-import rosbag2_py  # noqa
+from common import get_rosbag_options
+import rosbag2_py
 
 RESOURCES_PATH = Path(os.environ['ROSBAG2_PY_TEST_RESOURCES_DIR'])
 

--- a/rosbag2_py/test/test_sequential_writer.py
+++ b/rosbag2_py/test/test_sequential_writer.py
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
+from common import get_rosbag_options
 
 from rclpy.serialization import deserialize_message, serialize_message
+import rosbag2_py
 from rosidl_runtime_py.utilities import get_message
 from std_msgs.msg import String
-
-if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
-    # This is needed on Linux when compiling with clang/libc++.
-    # TL;DR This makes class_loader work when using a python extension compiled with libc++.
-    #
-    # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
-    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
-
-from common import get_rosbag_options  # noqa
-import rosbag2_py  # noqa
 
 
 def create_topic(writer, topic_name, topic_type, serialization_format='cdr'):

--- a/rosbag2_py/test/test_storage.py
+++ b/rosbag2_py/test/test_storage.py
@@ -1,0 +1,111 @@
+# Copyright 2022, Foxglove Technologies. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import common  # noqa
+
+from rclpy.duration import Duration
+from rclpy.time import Time
+from rosbag2_py import (
+    BagMetadata,
+    ConverterOptions,
+    FileInformation,
+    StorageFilter,
+    StorageOptions,
+    TopicInformation,
+    TopicMetadata,
+)
+
+
+class TestStorageStructs(unittest.TestCase):
+
+    def test_bag_metadata_default_ctor(self):
+        metadata = BagMetadata()
+        assert metadata
+
+    def test_converter_options_ctor(self):
+        converter_options = ConverterOptions()
+        assert converter_options
+
+    def test_file_information_ctor(self):
+        file_information = FileInformation(
+            path='test_path',
+            starting_time=Time(nanoseconds=1000),
+            duration=Duration(),
+            message_count=1234,
+        )
+        assert file_information
+
+    def test_storage_options_ctor(self):
+        storage_options = StorageOptions(uri='path')
+        assert storage_options
+
+    def test_storage_filter_ctor(self):
+        storage_filter = StorageFilter()
+        assert storage_filter
+
+    def test_topic_metadata_ctor(self):
+        topic_metadata = TopicMetadata(
+            name='topic',
+            type='msgs/Msg',
+            serialization_format='format'
+        )
+        assert topic_metadata
+
+    def test_topic_information_ctor(self):
+        topic_information = TopicInformation(
+            topic_metadata=TopicMetadata(
+                name='topic',
+                type='msgs/Msg',
+                serialization_format='format'),
+            message_count=10
+        )
+        assert topic_information
+
+    def test_bag_metadata_ctor_named_args(self):
+        duration = Duration(nanoseconds=200)
+        starting_time = Time(nanoseconds=100)
+
+        file_information = FileInformation(
+            path='something',
+            starting_time=starting_time,
+            duration=duration,
+            message_count=12)
+        topic_information = TopicInformation(
+            topic_metadata=TopicMetadata(
+                name='topic',
+                type='msgs/Msg',
+                serialization_format='format'),
+            message_count=10
+        )
+
+        metadata = BagMetadata(
+            version=1,
+            bag_size=2,
+            storage_identifier='foo',
+            relative_file_paths=['bar', 'baz'],
+            files=[file_information],
+            duration=duration,
+            starting_time=starting_time,
+            message_count=12,
+            topics_with_message_count=[topic_information],
+            compression_format='aaaa',
+            compression_mode='bbbbb',
+            custom_data={
+                'keya': 'valuea',
+                'keyb': 'valueb'
+            }
+        )
+        assert metadata

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -13,24 +13,14 @@
 # limitations under the License.
 
 import datetime
-import os
 from pathlib import Path
-import sys
 import threading
-
 
 from common import get_rosbag_options, wait_for
 import rclpy
 from rclpy.qos import QoSProfile
 import rosbag2_py
 from std_msgs.msg import String
-
-if os.environ.get('ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL', None) is not None:
-    # This is needed on Linux when compiling with clang/libc++.
-    # TL;DR This makes class_loader work when using a python extension compiled with libc++.
-    #
-    # For the fun RTTI ABI details, see https://whatofhow.wordpress.com/2015/03/17/odr-rtti-dso/.
-    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_LAZY)
 
 
 def test_options_qos_conversion():


### PR DESCRIPTION
Add method `Reader.get_metadata()`.

Update bindings for `BagMetadata` to return `rclpy.Time` and `rclpy.Duration` values. The current conversions change the nanosecond-precision timestamps to microsecond-precision `datetime` python objects. No matter what we think about whether nanosecond timestamps are accurate, we do need to be able to compare exact values without losing digits, which happens with the builtin conversions.

