### PR TITLE
Reverse read order API and sqlite storage implementation

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
@@ -35,6 +35,7 @@ public:
     void(const rosbag2_storage::StorageOptions &, rosbag2_storage::storage_interfaces::IOFlag));
   MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
+  MOCK_METHOD1(set_read_order, void(rosbag2_storage::ReadOrder));
   MOCK_METHOD0(has_next, bool());
   MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());
   MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
@@ -35,7 +35,7 @@ public:
     void(const rosbag2_storage::StorageOptions &, rosbag2_storage::storage_interfaces::IOFlag));
   MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
-  MOCK_METHOD1(set_read_order, void(rosbag2_storage::ReadOrder));
+  MOCK_METHOD1(set_read_order, void(const rosbag2_storage::ReadOrder &));
   MOCK_METHOD0(has_next, bool());
   MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());
   MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -170,7 +170,7 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(test_sequential_reader
-    test/rosbag2_cpp/test_sequential_reader.cpp)
+    test/rosbag2_cpp/test_sequential_reader.cpp test/rosbag2_cpp/fake_data.cpp)
   if(TARGET test_sequential_reader)
     ament_target_dependencies(test_sequential_reader rosbag2_storage rosbag2_test_common test_msgs)
     target_link_libraries(test_sequential_reader ${PROJECT_NAME})
@@ -221,7 +221,7 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(test_sequential_writer
-    test/rosbag2_cpp/test_sequential_writer.cpp)
+    test/rosbag2_cpp/test_sequential_writer.cpp test/rosbag2_cpp/fake_data.cpp)
   if(TARGET test_sequential_writer)
     ament_target_dependencies(test_sequential_writer rosbag2_storage rosbag2_test_common test_msgs)
     target_link_libraries(test_sequential_writer ${PROJECT_NAME})

--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -107,7 +107,7 @@ public:
    * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
    * or load_next_file() will cause undefined behavior
    */
-  void set_read_order(rosbag2_storage::ReadOrder read_order);
+  void set_read_order(const rosbag2_storage::ReadOrder & read_order);
 
   /**
    * Ask whether the underlying bagfile contains at least one more message.

--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -104,6 +104,8 @@ public:
    * read head timestamp.
    *
    * \param read_order Sorting criterion and direction to read messages in
+   * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
+   * or load_next_file() will cause undefined behavior
    */
   void set_read_order(rosbag2_storage::ReadOrder read_order);
 

--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -52,7 +52,7 @@ class BaseReaderInterface;
 /**
  * The Reader allows opening and reading messages of a bag.
  */
-class ROSBAG2_CPP_PUBLIC Reader final
+class ROSBAG2_CPP_PUBLIC Reader
 {
 public:
   explicit Reader(
@@ -98,6 +98,14 @@ public:
    * Closing the reader instance.
    */
   void close();
+
+  /**
+   * Set the read order for continued iteration of messages, without changing the current
+   * read head timestamp.
+   *
+   * \param read_order Sorting criterion and direction to read messages in
+   */
+  void set_read_order(rosbag2_storage::ReadOrder read_order);
 
   /**
    * Ask whether the underlying bagfile contains at least one more message.

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -46,7 +46,7 @@ public:
 
   virtual void close() = 0;
 
-  virtual void set_read_order(rosbag2_storage::ReadOrder) = 0;
+  virtual void set_read_order(const rosbag2_storage::ReadOrder &) = 0;
 
   virtual bool has_next() = 0;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -26,6 +26,7 @@
 #include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 #include "rosbag2_storage/storage_filter.hpp"
+#include "rosbag2_storage/storage_interfaces/base_read_interface.hpp"
 #include "rosbag2_storage/storage_options.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 
@@ -44,6 +45,8 @@ public:
     const ConverterOptions & converter_options) = 0;
 
   virtual void close() = 0;
+
+  virtual void set_read_order(rosbag2_storage::ReadOrder) = 0;
 
   virtual bool has_next() = 0;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -66,6 +66,10 @@ public:
 
   void close() override;
 
+  /*
+   * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
+   * or load_next_file() will cause undefined behavior
+   */
   void set_read_order(rosbag2_storage::ReadOrder order) override;
 
   bool has_next() override;
@@ -189,7 +193,7 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 
   bag_events::EventCallbackManager callback_manager_;
-  rosbag2_storage::ReadOrder read_order_;
+  rosbag2_storage::ReadOrder read_order_{};
 };
 
 }  // namespace readers

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -70,7 +70,7 @@ public:
    * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
    * or load_next_file() will cause undefined behavior
    */
-  void set_read_order(rosbag2_storage::ReadOrder order) override;
+  void set_read_order(const rosbag2_storage::ReadOrder & order) override;
 
   bool has_next() override;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -66,6 +66,8 @@ public:
 
   void close() override;
 
+  void set_read_order(rosbag2_storage::ReadOrder order) override;
+
   bool has_next() override;
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
@@ -187,6 +189,7 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 
   bag_events::EventCallbackManager callback_manager_;
+  rosbag2_storage::ReadOrder read_order_;
 };
 
 }  // namespace readers

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -66,7 +66,7 @@ public:
 
   void close() override;
 
-  /*
+  /**
    * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
    * or load_next_file() will cause undefined behavior
    */
@@ -147,7 +147,6 @@ protected:
     const std::vector<rosbag2_storage::TopicInformation> & topics);
 
   /**
-
   * Checks if the serialization format of the converter factory is the same as that of the storage
   * factory.
   * If not, changes the serialization format of the converter factory to use the serialization

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -57,7 +57,7 @@ void Reader::close()
   reader_impl_->close();
 }
 
-void Reader::set_read_order(rosbag2_storage::ReadOrder order)
+void Reader::set_read_order(const rosbag2_storage::ReadOrder & order)
 {
   return reader_impl_->set_read_order(order);
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -57,6 +57,11 @@ void Reader::close()
   reader_impl_->close();
 }
 
+void Reader::set_read_order(rosbag2_storage::ReadOrder order)
+{
+  return reader_impl_->set_read_order(order);
+}
+
 bool Reader::has_next()
 {
   return reader_impl_->has_next();

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -131,6 +131,12 @@ void SequentialReader::open(
 
 void SequentialReader::set_read_order(rosbag2_storage::ReadOrder order)
 {
+  if (order.sort_by == rosbag2_storage::ReadOrder::PublishedTimestamp) {
+    throw std::runtime_error("Not Implemented - PublishedTimestamp read order.");
+  }
+  if (order.sort_by == rosbag2_storage::ReadOrder::File && order.reverse) {
+    throw std::runtime_error("Not Implemented - Reverse File read order");
+  }
   read_order_ = order;
   if (storage_) {
     storage_->set_read_order(order);

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -129,7 +129,7 @@ void SequentialReader::open(
     topics[0].topic_metadata.serialization_format);
 }
 
-void SequentialReader::set_read_order(rosbag2_storage::ReadOrder order)
+void SequentialReader::set_read_order(const rosbag2_storage::ReadOrder & order)
 {
   if (storage_) {
     storage_->set_read_order(order);

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -144,7 +144,6 @@ bool SequentialReader::has_next()
     // to read from there. Otherwise, check if there's another message.
     bool current_storage_has_next = storage_->has_next();
     if (!current_storage_has_next && has_next_file()) {
-      // TODO(emersonknapp) has_next needs to roll to _previous_ file if necessary based on this
       load_next_file();
       // recursively call has_next again after rollover
       return has_next();

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -131,16 +131,10 @@ void SequentialReader::open(
 
 void SequentialReader::set_read_order(rosbag2_storage::ReadOrder order)
 {
-  if (order.sort_by == rosbag2_storage::ReadOrder::PublishedTimestamp) {
-    throw std::runtime_error("Not Implemented - PublishedTimestamp read order.");
-  }
-  if (order.sort_by == rosbag2_storage::ReadOrder::File && order.reverse) {
-    throw std::runtime_error("Not Implemented - Reverse File read order");
-  }
-  read_order_ = order;
   if (storage_) {
     storage_->set_read_order(order);
   }
+  read_order_ = order;
 }
 
 bool SequentialReader::has_next()

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -106,6 +106,7 @@ void SequentialReader::open(
     if (!storage_) {
       throw std::runtime_error{"No storage could be initialized from the inputs."};
     }
+    storage_->set_read_order(read_order_);
     metadata_ = storage_->get_metadata();
     if (metadata_.relative_file_paths.empty()) {
       ROSBAG2_CPP_LOG_WARN("No file paths were found in metadata.");
@@ -128,6 +129,14 @@ void SequentialReader::open(
     topics[0].topic_metadata.serialization_format);
 }
 
+void SequentialReader::set_read_order(rosbag2_storage::ReadOrder order)
+{
+  read_order_ = order;
+  if (storage_) {
+    storage_->set_read_order(order);
+  }
+}
+
 bool SequentialReader::has_next()
 {
   if (storage_) {
@@ -135,6 +144,7 @@ bool SequentialReader::has_next()
     // to read from there. Otherwise, check if there's another message.
     bool current_storage_has_next = storage_->has_next();
     if (!current_storage_has_next && has_next_file()) {
+      // TODO(emersonknapp) has_next needs to roll to _previous_ file if necessary based on this
       load_next_file();
       // recursively call has_next again after rollover
       return has_next();
@@ -194,7 +204,11 @@ void SequentialReader::seek(const rcutils_time_point_value_t & timestamp)
   seek_time_ = timestamp;
   if (storage_) {
     // reset to the first file
-    current_file_iterator_ = file_paths_.begin();
+    if (read_order_.reverse) {
+      current_file_iterator_ = std::prev(file_paths_.end());
+    } else {
+      current_file_iterator_ = file_paths_.begin();
+    }
     load_current_file();
     return;
   }
@@ -204,7 +218,11 @@ void SequentialReader::seek(const rcutils_time_point_value_t & timestamp)
 
 bool SequentialReader::has_next_file() const
 {
-  return current_file_iterator_ + 1 != file_paths_.end();
+  if (read_order_.reverse) {
+    return current_file_iterator_ != file_paths_.begin();
+  } else {
+    return (current_file_iterator_ + 1) != file_paths_.end();
+  }
 }
 
 void SequentialReader::load_current_file()
@@ -222,6 +240,7 @@ void SequentialReader::load_current_file()
     throw std::runtime_error{"No storage could be initialized. Abort"};
   }
   // set filters
+  storage_->set_read_order(read_order_);
   storage_->seek(seek_time_);
   set_filter(topics_filter_);
 }
@@ -231,7 +250,11 @@ void SequentialReader::load_next_file()
   assert(current_file_iterator_ != file_paths_.end());
   auto info = std::make_shared<bag_events::BagSplitInfo>();
   info->closed_file = get_current_file();
-  current_file_iterator_++;
+  if (read_order_.reverse) {
+    current_file_iterator_--;
+  } else {
+    current_file_iterator_++;
+  }
   info->opened_file = get_current_file();
   load_current_file();
   callback_manager_.execute_callbacks(bag_events::BagEvent::READ_SPLIT, info);

--- a/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
@@ -1,0 +1,53 @@
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "fake_data.hpp"
+
+#include "rosbag2_storage/ros_helper.hpp"
+
+void write_sample_split_bag(
+  const rosbag2_storage::StorageOptions & storage_options,
+  const std::vector<std::vector<rcutils_time_point_value_t>> & message_timestamps_by_file)
+{
+  std::string msg_content = "Hello";
+  auto msg_length = msg_content.length();
+  std::shared_ptr<rcutils_uint8_array_t> fake_data = rosbag2_storage::make_serialized_message(
+    msg_content.c_str(), msg_length);
+  std::string topic_name = "testtopic";
+
+  ManualSplitSequentialWriter writer{};
+  writer.open(storage_options, rosbag2_cpp::ConverterOptions{});
+  writer.create_topic(
+  {
+    topic_name,
+    "test_msgs/ByteMultiArray",
+    "cdr",
+    ""
+  });
+  for (const auto & file_messages : message_timestamps_by_file) {
+    for (const auto time_stamp : file_messages) {
+      auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+      msg->serialized_data = fake_data;
+      msg->time_stamp = time_stamp;
+      msg->topic_name = topic_name;
+      writer.write(msg);
+    }
+    writer.split_bagfile();
+  }
+  writer.close();
+}

--- a/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "fake_data.hpp"
@@ -22,12 +23,9 @@
 
 void write_sample_split_bag(
   const rosbag2_storage::StorageOptions & storage_options,
-  const std::vector<std::vector<rcutils_time_point_value_t>> & message_timestamps_by_file)
+  const std::vector<std::pair<rcutils_time_point_value_t, uint32_t>> & fake_messages,
+  size_t split_every)
 {
-  std::string msg_content = "Hello";
-  auto msg_length = msg_content.length();
-  std::shared_ptr<rcutils_uint8_array_t> fake_data = rosbag2_storage::make_serialized_message(
-    msg_content.c_str(), msg_length);
   std::string topic_name = "testtopic";
 
   ManualSplitSequentialWriter writer{};
@@ -39,15 +37,20 @@ void write_sample_split_bag(
     "cdr",
     ""
   });
-  for (const auto & file_messages : message_timestamps_by_file) {
-    for (const auto time_stamp : file_messages) {
-      auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-      msg->serialized_data = fake_data;
-      msg->time_stamp = time_stamp;
-      msg->topic_name = topic_name;
-      writer.write(msg);
+  for (size_t i = 0; i < fake_messages.size(); i++) {
+    if (i > 0 && (i % split_every == 0)) {
+      writer.split_bagfile();
     }
-    writer.split_bagfile();
+
+    const auto message = fake_messages[i];
+    rcutils_time_point_value_t time_stamp = message.first;
+    uint32_t value = message.second;
+
+    auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+    msg->serialized_data = rosbag2_storage::make_serialized_message(&value, sizeof(value));
+    msg->time_stamp = time_stamp;
+    msg->topic_name = topic_name;
+    writer.write(msg);
   }
   writer.close();
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/fake_data.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/fake_data.hpp
@@ -1,0 +1,32 @@
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_CPP__FAKE_DATA_HPP_
+#define ROSBAG2_CPP__FAKE_DATA_HPP_
+
+#include <vector>
+
+#include "rosbag2_cpp/writers/sequential_writer.hpp"
+
+class ManualSplitSequentialWriter : public rosbag2_cpp::writers::SequentialWriter
+{
+public:
+  using rosbag2_cpp::writers::SequentialWriter::split_bagfile;
+};
+
+void write_sample_split_bag(
+  const rosbag2_storage::StorageOptions & storage_options,
+  const std::vector<std::vector<rcutils_time_point_value_t>> & message_timestamps_by_file);
+
+#endif  // ROSBAG2_CPP__FAKE_DATA_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/fake_data.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/fake_data.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_CPP__FAKE_DATA_HPP_
 #define ROSBAG2_CPP__FAKE_DATA_HPP_
 
+#include <utility>
 #include <vector>
 
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
@@ -25,8 +26,10 @@ public:
   using rosbag2_cpp::writers::SequentialWriter::split_bagfile;
 };
 
+// Write vector of <timestamp, uint32_data_value> pairs to bag files, splitting every N messages
 void write_sample_split_bag(
   const rosbag2_storage::StorageOptions & storage_options,
-  const std::vector<std::vector<rcutils_time_point_value_t>> & message_timestamps_by_file);
+  const std::vector<std::pair<rcutils_time_point_value_t, uint32_t>> & fake_messages,
+  size_t split_every);
 
 #endif  // ROSBAG2_CPP__FAKE_DATA_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
@@ -36,7 +36,7 @@ public:
     void(const rosbag2_storage::StorageOptions &, rosbag2_storage::storage_interfaces::IOFlag));
   MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
-  MOCK_METHOD1(set_read_order, void(rosbag2_storage::ReadOrder));
+  MOCK_METHOD1(set_read_order, void(const rosbag2_storage::ReadOrder &));
   MOCK_METHOD0(has_next, bool());
   MOCK_METHOD0(has_next_file, bool());
   MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
@@ -36,6 +36,7 @@ public:
     void(const rosbag2_storage::StorageOptions &, rosbag2_storage::storage_interfaces::IOFlag));
   MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
+  MOCK_METHOD1(set_read_order, void(rosbag2_storage::ReadOrder));
   MOCK_METHOD0(has_next, bool());
   MOCK_METHOD0(has_next_file, bool());
   MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -356,24 +356,21 @@ TEST_F(ReadOrderTest, reverse_received_timestamp_order) {
 }
 
 TEST_F(ReadOrderTest, file_order) {
-  rosbag2_storage::ReadOrder order(rosbag2_storage::ReadOrder::File, false);
-  sort_expected(order);
-  reader.set_read_order(order);
-
-  for (bool do_reset : {false, true}) {
-    reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
-    check_against_sorted(do_reset);
-    reader.close();
-  }
+  reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
+  EXPECT_THROW(
+    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, false)),
+    std::runtime_error);
 }
 
 TEST_F(ReadOrderTest, reverse_file_order) {
+  reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
   EXPECT_THROW(
     reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, true)),
     std::runtime_error);
 }
 
 TEST_F(ReadOrderTest, published_timestamp_order) {
+  reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
   EXPECT_THROW(
     reader.set_read_order(
       rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::PublishedTimestamp, false)),

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -347,7 +347,6 @@ TEST_F(ReadOrderTest, reverse_received_timestamp_order) {
   reader.close();
 
   for (bool do_reset : {false, true}) {
-    printf("Testing with do_reset %d\n", do_reset);
     reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
     reader.seek(end_timestamp);
     check_against_sorted(do_reset);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -347,6 +347,7 @@ TEST_F(ReadOrderTest, reverse_received_timestamp_order) {
   reader.close();
 
   for (bool do_reset : {false, true}) {
+    printf("Testing with do_reset %d\n", do_reset);
     reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
     reader.seek(end_timestamp);
     check_against_sorted(do_reset);
@@ -367,17 +368,14 @@ TEST_F(ReadOrderTest, file_order) {
 }
 
 TEST_F(ReadOrderTest, reverse_file_order) {
-  sort_expected(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, true));
-  for (bool do_reset : {false, true}) {
-    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, false));
-    reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
-    // Not knowing a better way to reach the "last message ID in all files",
-    // just iterate to end and turn around
-    while (reader.has_next()) {
-      reader.read_next();
-    }
-    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, true));
-    check_against_sorted(do_reset);
-    reader.close();
-  }
+  EXPECT_THROW(
+    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, true)),
+    std::runtime_error);
+}
+
+TEST_F(ReadOrderTest, published_timestamp_order) {
+  EXPECT_THROW(
+    reader.set_read_order(
+      rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::PublishedTimestamp, false)),
+    std::runtime_error);
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -14,7 +14,6 @@
 
 #include <gmock/gmock.h>
 
-#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -570,14 +569,18 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
 
 
 TEST_F(TemporaryDirectoryFixture, split_bag_metadata_has_full_duration) {
-  const std::vector<std::vector<rcutils_time_point_value_t>> message_timestamps_by_file {
-    {100, 300, 200},
-    {500, 400, 600}
+  const std::vector<std::pair<rcutils_time_point_value_t, uint32_t>> fake_messages {
+    {100, 1},
+    {300, 2},
+    {200, 3},
+    {500, 4},
+    {400, 5},
+    {600, 6}
   };
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "split_duration_bag").string();
   storage_options.storage_id = "sqlite3";
-  write_sample_split_bag(storage_options, message_timestamps_by_file);
+  write_sample_split_bag(storage_options, fake_messages, 3);
 
   rosbag2_storage::MetadataIo metadata_io;
   auto metadata = metadata_io.read_metadata(storage_options.uri);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -32,6 +32,7 @@
 
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
+#include "fake_data.hpp"
 #include "mock_converter.hpp"
 #include "mock_converter_factory.hpp"
 #include "mock_metadata_io.hpp"
@@ -568,63 +569,18 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
 }
 
 
-class ManualSplitWriter : public rosbag2_cpp::writers::SequentialWriter
-{
-public:
-  // makes the method public for manual splitting
-  void split()
-  {
-    split_bagfile();
-  }
-};
-
-void write_sample_split_bag(
-  const std::string & uri,
-  const std::vector<std::vector<rcutils_time_point_value_t>> & message_timestamps_by_file)
-{
-  std::string msg_content = "Hello";
-  auto msg_length = msg_content.length();
-  std::shared_ptr<rcutils_uint8_array_t> fake_data = rosbag2_storage::make_serialized_message(
-    msg_content.c_str(), msg_length);
-  std::string topic_name = "testtopic";
-
-  rosbag2_storage::StorageOptions storage_options;
-  storage_options.uri = uri;
-  storage_options.storage_id = "sqlite3";
-
-  ManualSplitWriter writer;
-  writer.open(storage_options, rosbag2_cpp::ConverterOptions{});
-  writer.create_topic(
-  {
-    topic_name,
-    "test_msgs/ByteMultiArray",
-    "cdr",
-    ""
-  });
-  for (const auto & file_messages : message_timestamps_by_file) {
-    for (const auto time_stamp : file_messages) {
-      auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-      msg->serialized_data = fake_data;
-      msg->time_stamp = time_stamp;
-      msg->topic_name = topic_name;
-      writer.write(msg);
-    }
-    writer.split();
-  }
-  writer.close();
-}
-
-
 TEST_F(TemporaryDirectoryFixture, split_bag_metadata_has_full_duration) {
   const std::vector<std::vector<rcutils_time_point_value_t>> message_timestamps_by_file {
     {100, 300, 200},
     {500, 400, 600}
   };
-  std::string uri = (rcpputils::fs::path(temporary_dir_path_) / "split_duration_bag").string();
-  write_sample_split_bag(uri, message_timestamps_by_file);
+  rosbag2_storage::StorageOptions storage_options;
+  storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "split_duration_bag").string();
+  storage_options.storage_id = "sqlite3";
+  write_sample_split_bag(storage_options, message_timestamps_by_file);
 
   rosbag2_storage::MetadataIo metadata_io;
-  auto metadata = metadata_io.read_metadata(uri);
+  auto metadata = metadata_io.read_metadata(storage_options.uri);
   ASSERT_EQ(
     metadata.starting_time,
     std::chrono::high_resolution_clock::time_point(std::chrono::nanoseconds(100)));

--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -26,6 +26,8 @@ with add_dll_directories_from_env('PATH'):
     from rosbag2_py._storage import (
         ConverterOptions,
         FileInformation,
+        ReadOrder,
+        ReadOrderSortBy,
         StorageFilter,
         StorageOptions,
         TopicMetadata,
@@ -61,6 +63,8 @@ __all__ = [
     'get_registered_writers',
     'get_registered_compressors',
     'get_registered_serializers',
+    'ReadOrder',
+    'ReadOrderSortBy',
     'Reindexer',
     'SequentialCompressionReader',
     'SequentialCompressionWriter',

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -45,9 +45,9 @@ public:
 
   /// Return a tuple containing the topic name, the serialized ROS message, and
   /// the timestamp.
-  pybind11::tuple read_next_py()
+  pybind11::tuple read_next()
   {
-    const auto next = read_next();
+    const auto next = rosbag2_cpp::Reader::read_next();
     rcutils_uint8_array_t rcutils_data = *next->serialized_data.get();
     std::string serialized_data(rcutils_data.buffer,
       rcutils_data.buffer + rcutils_data.buffer_length);
@@ -87,7 +87,7 @@ PYBIND11_MODULE(_reader, m) {
       const rosbag2_storage::StorageOptions &, const rosbag2_cpp::ConverterOptions &
     >(&PyReader::open))
   .def("set_read_order", &PyReader::set_read_order)
-  .def("read_next", &PyReader::read_next_py)
+  .def("read_next", &PyReader::read_next)
   .def("has_next", &PyReader::has_next)
   .def("get_metadata", &PyReader::get_metadata)
   .def("get_all_topics_and_types", &PyReader::get_all_topics_and_types)
@@ -104,7 +104,7 @@ PYBIND11_MODULE(_reader, m) {
       const rosbag2_storage::StorageOptions &, const rosbag2_cpp::ConverterOptions &
     >(&PyCompressionReader::open))
   .def("set_read_order", &PyCompressionReader::set_read_order)
-  .def("read_next", &PyCompressionReader::read_next_py)
+  .def("read_next", &PyCompressionReader::read_next)
   .def("has_next", &PyCompressionReader::has_next)
   .def("get_metadata", &PyCompressionReader::get_metadata)
   .def("get_all_topics_and_types", &PyCompressionReader::get_all_topics_and_types)

--- a/rosbag2_py/src/rosbag2_py/_reader.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reader.cpp
@@ -35,66 +35,25 @@ namespace rosbag2_py
 {
 
 template<typename T>
-class Reader
+class Reader : public rosbag2_cpp::Reader
 {
 public:
   Reader()
-  : reader_(std::make_unique<rosbag2_cpp::Reader>(std::make_unique<T>()))
+  : rosbag2_cpp::Reader(std::make_unique<T>())
   {
-  }
-
-  void open(
-    rosbag2_storage::StorageOptions & storage_options,
-    rosbag2_cpp::ConverterOptions & converter_options = rosbag2_cpp::ConverterOptions())
-  {
-    reader_->open(storage_options, converter_options);
-  }
-
-  bool has_next()
-  {
-    return reader_->has_next();
   }
 
   /// Return a tuple containing the topic name, the serialized ROS message, and
   /// the timestamp.
-  pybind11::tuple read_next()
+  pybind11::tuple read_next_py()
   {
-    const auto next = reader_->read_next();
+    const auto next = read_next();
     rcutils_uint8_array_t rcutils_data = *next->serialized_data.get();
     std::string serialized_data(rcutils_data.buffer,
       rcutils_data.buffer + rcutils_data.buffer_length);
     return pybind11::make_tuple(
       next->topic_name, pybind11::bytes(serialized_data), next->time_stamp);
   }
-
-  /// Return a mapping from topic name to topic type.
-  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types()
-  {
-    return reader_->get_all_topics_and_types();
-  }
-
-  const rosbag2_storage::BagMetadata & get_metadata() const
-  {
-    return reader_->get_metadata();
-  }
-
-  void set_filter(const rosbag2_storage::StorageFilter & storage_filter)
-  {
-    return reader_->set_filter(storage_filter);
-  }
-
-  void reset_filter()
-  {
-    reader_->reset_filter();
-  }
-
-  void seek(const rcutils_time_point_value_t & timestamp)
-  {
-    reader_->seek(timestamp);
-  }
-
-protected:
-  std::unique_ptr<rosbag2_cpp::Reader> reader_;
 };
 
 std::unordered_set<std::string> get_registered_readers()
@@ -121,8 +80,14 @@ PYBIND11_MODULE(_reader, m) {
 
   pybind11::class_<PyReader>(m, "SequentialReader")
   .def(pybind11::init())
-  .def("open", &PyReader::open)
-  .def("read_next", &PyReader::read_next)
+  .def("open_uri", pybind11::overload_cast<const std::string &>(&PyReader::open))
+  .def(
+    "open",
+    pybind11::overload_cast<
+      const rosbag2_storage::StorageOptions &, const rosbag2_cpp::ConverterOptions &
+    >(&PyReader::open))
+  .def("set_read_order", &PyReader::set_read_order)
+  .def("read_next", &PyReader::read_next_py)
   .def("has_next", &PyReader::has_next)
   .def("get_metadata", &PyReader::get_metadata)
   .def("get_all_topics_and_types", &PyReader::get_all_topics_and_types)
@@ -132,8 +97,14 @@ PYBIND11_MODULE(_reader, m) {
 
   pybind11::class_<PyCompressionReader>(m, "SequentialCompressionReader")
   .def(pybind11::init())
-  .def("open", &PyCompressionReader::open)
-  .def("read_next", &PyCompressionReader::read_next)
+  .def("open_uri", pybind11::overload_cast<const std::string &>(&PyCompressionReader::open))
+  .def(
+    "open",
+    pybind11::overload_cast<
+      const rosbag2_storage::StorageOptions &, const rosbag2_cpp::ConverterOptions &
+    >(&PyCompressionReader::open))
+  .def("set_read_order", &PyCompressionReader::set_read_order)
+  .def("read_next", &PyCompressionReader::read_next_py)
   .def("has_next", &PyCompressionReader::has_next)
   .def("get_metadata", &PyCompressionReader::get_metadata)
   .def("get_all_topics_and_types", &PyCompressionReader::get_all_topics_and_types)

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -18,6 +18,7 @@
 #include "rosbag2_cpp/converter_options.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/storage_filter.hpp"
+#include "rosbag2_storage/storage_interfaces/base_read_interface.hpp"
 #include "rosbag2_storage/storage_options.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 
@@ -270,4 +271,17 @@ PYBIND11_MODULE(_storage, m) {
     "__repr__", [](const rosbag2_storage::BagMetadata & metadata) {
       return format_bag_meta_data(metadata);
     });
+
+  pybind11::enum_<rosbag2_storage::ReadOrder::SortBy>(m, "ReadOrderSortBy")
+  .value("ReceivedTimestamp", rosbag2_storage::ReadOrder::ReceivedTimestamp)
+  .value("PublishedTimestamp", rosbag2_storage::ReadOrder::PublishedTimestamp)
+  .value("File", rosbag2_storage::ReadOrder::File);
+
+  pybind11::class_<rosbag2_storage::ReadOrder>(m, "ReadOrder")
+  .def(
+    pybind11::init<rosbag2_storage::ReadOrder::SortBy, bool>(),
+    pybind11::arg("sort_by") = rosbag2_storage::ReadOrder{}.sort_by,
+    pybind11::arg("reverse") = rosbag2_storage::ReadOrder{}.reverse)
+  .def_readwrite("sort_by", &rosbag2_storage::ReadOrder::sort_by)
+  .def_readwrite("reverse", &rosbag2_storage::ReadOrder::reverse);
 }

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
@@ -25,6 +25,27 @@
 
 namespace rosbag2_storage
 {
+
+struct ReadOrder
+{
+  enum SortBy
+  {
+    ReceivedTimestamp,
+    PublishedTimestamp,  // NOTE: not yet implemented in ROS 2 core
+    File
+  };
+
+  // Sorting criterion for reading out messages, ascending by default
+  SortBy sort_by = ReceivedTimestamp;
+  // If true, changes sort order to descending
+  bool reverse = false;
+
+  bool operator==(const ReadOrder & other)
+  {
+    return sort_by == other.sort_by && reverse == other.reverse;
+  }
+};
+
 namespace storage_interfaces
 {
 
@@ -32,6 +53,11 @@ class ROSBAG2_STORAGE_PUBLIC BaseReadInterface
 {
 public:
   virtual ~BaseReadInterface() = default;
+
+  /// @brief Set the order to iterate messages in the storage.
+  ///   This affects the outcome of has_next and read_next
+  /// @param read_order The order in which to return messages.
+  virtual void set_read_order(ReadOrder read_order) = 0;
 
   virtual bool has_next() = 0;
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
@@ -31,7 +31,7 @@ struct ReadOrder
   enum SortBy
   {
     ReceivedTimestamp,
-    PublishedTimestamp,  // NOTE: not yet implemented in ROS 2 core
+    PublishedTimestamp,  // NOTE: not implemented in ROS 2 core
     File
   };
 
@@ -59,7 +59,9 @@ public:
   virtual ~BaseReadInterface() = default;
 
   /// @brief Set the order to iterate messages in the storage.
-  ///   This affects the outcome of has_next and read_next
+  ///   This affects the outcome of has_next and read_next.
+  ///   Note that when setting to reverse order, this will not change the read head, so user
+  ///   must first seek() to the end in order to read messages from the end.
   /// @param read_order The order in which to return messages.
   virtual void set_read_order(ReadOrder read_order) = 0;
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
@@ -40,11 +40,15 @@ struct ReadOrder
   // If true, changes sort order to descending
   bool reverse = false;
 
-  bool operator==(const ReadOrder & other)
-  {
-    return sort_by == other.sort_by && reverse == other.reverse;
-  }
+  ReadOrder(SortBy sort_by, bool reverse)
+  : sort_by(sort_by), reverse(reverse) {}
+  ReadOrder() {}
 };
+
+inline bool operator==(const ReadOrder & a, const ReadOrder & b)
+{
+  return a.sort_by == b.sort_by && a.reverse == b.reverse;
+}
 
 namespace storage_interfaces
 {

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
@@ -63,7 +63,7 @@ public:
   ///   Note that when setting to reverse order, this will not change the read head, so user
   ///   must first seek() to the end in order to read messages from the end.
   /// @param read_order The order in which to return messages.
-  virtual void set_read_order(ReadOrder read_order) = 0;
+  virtual void set_read_order(const ReadOrder & read_order) = 0;
 
   virtual bool has_next() = 0;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -46,8 +46,9 @@ void TestPlugin::open(
   std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
-void TestPlugin::set_read_order(rosbag2_storage::ReadOrder)
+void TestPlugin::set_read_order(rosbag2_storage::ReadOrder order)
 {
+  std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
 }
 
 bool TestPlugin::has_next()

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -46,6 +46,10 @@ void TestPlugin::open(
   std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
+void TestPlugin::set_read_order(rosbag2_storage::ReadOrder)
+{
+}
+
 bool TestPlugin::has_next()
 {
   return true;

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -46,7 +46,7 @@ void TestPlugin::open(
   std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
-void TestPlugin::set_read_order(rosbag2_storage::ReadOrder order)
+void TestPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
 {
   std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
 }

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -37,6 +37,8 @@ public:
 
   void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
 
+  void set_read_order(rosbag2_storage::ReadOrder) override;
+
   bool has_next() override;
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -37,7 +37,7 @@ public:
 
   void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
 
-  void set_read_order(rosbag2_storage::ReadOrder) override;
+  void set_read_order(const rosbag2_storage::ReadOrder &) override;
 
   bool has_next() override;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -43,7 +43,7 @@ void TestReadOnlyPlugin::open(
   std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
-void TestReadOnlyPlugin::set_read_order(rosbag2_storage::ReadOrder order)
+void TestReadOnlyPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
 {
   std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
 }

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -43,8 +43,9 @@ void TestReadOnlyPlugin::open(
   std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
-void TestReadOnlyPlugin::set_read_order(rosbag2_storage::ReadOrder)
+void TestReadOnlyPlugin::set_read_order(rosbag2_storage::ReadOrder order)
 {
+  std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
 }
 
 bool TestReadOnlyPlugin::has_next()

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -43,6 +43,10 @@ void TestReadOnlyPlugin::open(
   std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
+void TestReadOnlyPlugin::set_read_order(rosbag2_storage::ReadOrder)
+{
+}
+
 bool TestReadOnlyPlugin::has_next()
 {
   return true;

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -31,6 +31,8 @@ public:
     const rosbag2_storage::StorageOptions & storage_options,
     rosbag2_storage::storage_interfaces::IOFlag flag) override;
 
+  void set_read_order(rosbag2_storage::ReadOrder) override;
+
   bool has_next() override;
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -31,7 +31,7 @@ public:
     const rosbag2_storage::StorageOptions & storage_options,
     rosbag2_storage::storage_interfaces::IOFlag flag) override;
 
-  void set_read_order(rosbag2_storage::ReadOrder) override;
+  void set_read_order(const rosbag2_storage::ReadOrder &) override;
 
   bool has_next() override;
 

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -64,6 +64,8 @@ public:
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
   override;
 
+  void set_read_order(rosbag2_storage::ReadOrder) override;
+
   bool has_next() override;
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
@@ -104,6 +106,8 @@ private:
   void write_locked(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
   RCPPUTILS_TSA_REQUIRES(database_write_mutex_);
 
+  int get_last_rowid();
+
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string, int>;
 
@@ -120,6 +124,7 @@ private:
 
   rcutils_time_point_value_t seek_time_ = 0;
   int seek_row_id_ = 0;
+  rosbag2_storage::ReadOrder read_order_;
   rosbag2_storage::StorageFilter storage_filter_ {};
 
   // This mutex is necessary to protect:

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -64,6 +64,7 @@ public:
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
   override;
 
+  // Note: File-reverse order is not implemented
   void set_read_order(rosbag2_storage::ReadOrder) override;
 
   bool has_next() override;
@@ -105,7 +106,6 @@ private:
   void commit_transaction();
   void write_locked(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
   RCPPUTILS_TSA_REQUIRES(database_write_mutex_);
-
   int get_last_rowid();
 
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -124,7 +124,7 @@ private:
 
   rcutils_time_point_value_t seek_time_ = 0;
   int seek_row_id_ = 0;
-  rosbag2_storage::ReadOrder read_order_;
+  rosbag2_storage::ReadOrder read_order_{};
   rosbag2_storage::StorageFilter storage_filter_ {};
 
   // This mutex is necessary to protect:

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -64,8 +64,7 @@ public:
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
   override;
 
-  // Note: File-reverse order is not implemented
-  void set_read_order(rosbag2_storage::ReadOrder) override;
+  void set_read_order(const rosbag2_storage::ReadOrder &) override;
 
   bool has_next() override;
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -195,7 +195,6 @@ void SqliteStorage::open(
   if (is_read_write(io_flag)) {
     initialize();
   }
-  set_read_order(read_order_);
 
   // Reset the read and write statements in case the database changed.
   // These will be reinitialized lazily on the first read or write.
@@ -292,15 +291,15 @@ void SqliteStorage::write(
 
 void SqliteStorage::set_read_order(rosbag2_storage::ReadOrder read_order)
 {
-  read_order_ = read_order;
-  read_statement_ = nullptr;
-
-  if (read_order_.sort_by == rosbag2_storage::ReadOrder::PublishedTimestamp) {
+  if (read_order.sort_by == rosbag2_storage::ReadOrder::PublishedTimestamp) {
     throw std::runtime_error("Not Implemented - PublishedTimestamp read order.");
   }
-  if (read_order_.reverse && seek_row_id_ == 0) {
-    seek_row_id_ = get_last_rowid();
+  if (read_order.sort_by == rosbag2_storage::ReadOrder::File && read_order.reverse) {
+    throw std::runtime_error("Not Implemented - Reverse File read order");
   }
+
+  read_order_ = read_order;
+  read_statement_ = nullptr;
 }
 
 bool SqliteStorage::has_next()

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -289,7 +289,7 @@ void SqliteStorage::write(
   commit_transaction();
 }
 
-void SqliteStorage::set_read_order(rosbag2_storage::ReadOrder read_order)
+void SqliteStorage::set_read_order(const rosbag2_storage::ReadOrder & read_order)
 {
   if (read_order.sort_by == rosbag2_storage::ReadOrder::PublishedTimestamp) {
     throw std::runtime_error("Not Implemented - PublishedTimestamp read order.");

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -36,10 +36,8 @@ public:
 
   void close() override {}
 
-  void set_read_order(rosbag2_storage::ReadOrder) override
-  {
-    // TODO(emersonknapp)
-  }
+  void set_read_order(const rosbag2_storage::ReadOrder &) override
+  {}
 
   bool has_next() override
   {

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -36,6 +36,11 @@ public:
 
   void close() override {}
 
+  void set_read_order(rosbag2_storage::ReadOrder) override
+  {
+    // TODO(emersonknapp)
+  }
+
   bool has_next() override
   {
     if (filter_.topics.empty()) {


### PR DESCRIPTION
Add a new BaseReadInterface::set_read_order API, and implement it for the SqliteStorage.

Adds 2 new capabilities: reverse-timestamp reading, and file-order reading. Does not implement reverse-file-order reading.