### PR TITLE
:man_farmer: Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/shared_queues_vendor/CMakeLists.txt
+++ b/shared_queues_vendor/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(ament_cmake REQUIRED)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 include(ExternalProject)

--- a/shared_queues_vendor/CMakeLists.txt
+++ b/shared_queues_vendor/CMakeLists.txt
@@ -3,6 +3,11 @@ project(shared_queues_vendor)
 
 find_package(ament_cmake REQUIRED)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 include(ExternalProject)
 # Single producer single consumer queue by moodycamel - header only, don't build, install
 ExternalProject_Add(ext-singleproducerconsumer

--- a/sqlite3_vendor/CMakeLists.txt
+++ b/sqlite3_vendor/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(ament_cmake REQUIRED)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 option(FORCE_BUILD_VENDOR_PKG

--- a/sqlite3_vendor/CMakeLists.txt
+++ b/sqlite3_vendor/CMakeLists.txt
@@ -3,6 +3,11 @@ project(sqlite3_vendor)
 
 find_package(ament_cmake REQUIRED)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 option(FORCE_BUILD_VENDOR_PKG
   "Build SQLite3 from source, even if system-installed package is available"
   OFF)


### PR DESCRIPTION
Signed-off-by: Cristobal Arroyo <cristobal.arroyo@ekumenlabs.com>

Reference build: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy in `CMakeLists.txt`

CI launch:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17252)](http://ci.ros2.org/job/ci_linux/17252/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11792)](http://ci.ros2.org/job/ci_linux-aarch64/11792/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17733)](http://ci.ros2.org/job/ci_windows/17733/)