### PR TITLE
Add support for old db3 schema used on distros prior to Foxy

### DIFF
--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -45,6 +45,7 @@ public:
   SqliteWrapper();
   ~SqliteWrapper();
 
+  bool is_field_exist(const std::string & table_name, const std::string & field_name);
   SqliteStatement prepare_statement(const std::string & query);
   std::string query_pragma_value(const std::string & key);
 

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp
@@ -45,7 +45,7 @@ public:
   SqliteWrapper();
   ~SqliteWrapper();
 
-  bool is_field_exist(const std::string & table_name, const std::string & field_name);
+  bool field_exists(const std::string & table_name, const std::string & field_name);
   SqliteStatement prepare_statement(const std::string & query);
   std::string query_pragma_value(const std::string & key);
 

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -471,7 +471,7 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
   rcutils_time_point_value_t min_time = INT64_MAX;
   rcutils_time_point_value_t max_time = 0;
 
-  if (database_->is_field_exist("topics", "offered_qos_profiles")) {
+  if (database_->field_exists("topics", "offered_qos_profiles")) {
     std::string query =
       "SELECT name, type, serialization_format, COUNT(messages.id), MIN(messages.timestamp), "
       "MAX(messages.timestamp), offered_qos_profiles "

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -468,27 +468,54 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
   metadata.message_count = 0;
   metadata.topics_with_message_count = {};
 
-  auto statement = database_->prepare_statement(
-    "SELECT name, type, serialization_format, COUNT(messages.id), MIN(messages.timestamp), "
-    "MAX(messages.timestamp), offered_qos_profiles "
-    "FROM messages JOIN topics on topics.id = messages.topic_id "
-    "GROUP BY topics.name;");
-  auto query_results = statement->execute_query<
-    std::string, std::string, std::string, int, rcutils_time_point_value_t,
-    rcutils_time_point_value_t, std::string>();
-
   rcutils_time_point_value_t min_time = INT64_MAX;
   rcutils_time_point_value_t max_time = 0;
-  for (auto result : query_results) {
-    metadata.topics_with_message_count.push_back(
-      {
-        {std::get<0>(result), std::get<1>(result), std::get<2>(result), std::get<6>(result)},
-        static_cast<size_t>(std::get<3>(result))
-      });
 
-    metadata.message_count += std::get<3>(result);
-    min_time = std::get<4>(result) < min_time ? std::get<4>(result) : min_time;
-    max_time = std::get<5>(result) > max_time ? std::get<5>(result) : max_time;
+  if (database_->is_field_exist("topics", "offered_qos_profiles")) {
+    std::string query =
+      "SELECT name, type, serialization_format, COUNT(messages.id), MIN(messages.timestamp), "
+      "MAX(messages.timestamp), offered_qos_profiles "
+      "FROM messages JOIN topics on topics.id = messages.topic_id "
+      "GROUP BY topics.name;";
+
+    auto statement = database_->prepare_statement(query);
+    auto query_results = statement->execute_query<
+      std::string, std::string, std::string, int, rcutils_time_point_value_t,
+      rcutils_time_point_value_t, std::string>();
+
+    for (auto result : query_results) {
+      metadata.topics_with_message_count.push_back(
+        {
+          {std::get<0>(result), std::get<1>(result), std::get<2>(result), std::get<6>(result)},
+          static_cast<size_t>(std::get<3>(result))
+        });
+
+      metadata.message_count += std::get<3>(result);
+      min_time = std::get<4>(result) < min_time ? std::get<4>(result) : min_time;
+      max_time = std::get<5>(result) > max_time ? std::get<5>(result) : max_time;
+    }
+  } else {
+    std::string query =
+      "SELECT name, type, serialization_format, COUNT(messages.id), MIN(messages.timestamp), "
+      "MAX(messages.timestamp) "
+      "FROM messages JOIN topics on topics.id = messages.topic_id "
+      "GROUP BY topics.name;";
+    auto statement = database_->prepare_statement(query);
+    auto query_results = statement->execute_query<
+      std::string, std::string, std::string, int, rcutils_time_point_value_t,
+      rcutils_time_point_value_t>();
+
+    for (auto result : query_results) {
+      metadata.topics_with_message_count.push_back(
+        {
+          {std::get<0>(result), std::get<1>(result), std::get<2>(result), ""},
+          static_cast<size_t>(std::get<3>(result))
+        });
+
+      metadata.message_count += std::get<3>(result);
+      min_time = std::get<4>(result) < min_time ? std::get<4>(result) : min_time;
+      max_time = std::get<5>(result) > max_time ? std::get<5>(result) : max_time;
+    }
   }
 
   if (metadata.message_count == 0) {

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -144,6 +144,21 @@ std::string SqliteWrapper::query_pragma_value(const std::string & key)
   return std::get<0>(pragma_value);
 }
 
+bool SqliteWrapper::is_field_exist(const std::string & table_name, const std::string & field_name)
+{
+  auto query = "SELECT INSTR(sql, '" + field_name + "') FROM sqlite_master WHERE type='table' AND "
+    "name='" + table_name + "';";
+  auto query_result = prepare_statement(query)->execute_query<int>();
+  auto query_result_begin = query_result.begin();
+  if (query_result_begin == query_result.end()) {
+    std::stringstream errmsg;
+    errmsg << "is_field_exist(..) failed. Table `" << table_name << "` doesn't exist!";
+    throw SqliteException{errmsg.str()};
+  }
+  auto position = *(query_result_begin);
+  return std::get<0>(position);
+}
+
 SqliteStatement SqliteWrapper::prepare_statement(const std::string & query)
 {
   return std::make_shared<SqliteStatementWrapper>(db_ptr, query);

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.cpp
@@ -144,7 +144,7 @@ std::string SqliteWrapper::query_pragma_value(const std::string & key)
   return std::get<0>(pragma_value);
 }
 
-bool SqliteWrapper::is_field_exist(const std::string & table_name, const std::string & field_name)
+bool SqliteWrapper::field_exists(const std::string & table_name, const std::string & field_name)
 {
   auto query = "SELECT INSTR(sql, '" + field_name + "') FROM sqlite_master WHERE type='table' AND "
     "name='" + table_name + "';";
@@ -152,7 +152,7 @@ bool SqliteWrapper::is_field_exist(const std::string & table_name, const std::st
   auto query_result_begin = query_result.begin();
   if (query_result_begin == query_result.end()) {
     std::stringstream errmsg;
-    errmsg << "is_field_exist(..) failed. Table `" << table_name << "` doesn't exist!";
+    errmsg << "field_exists(..) failed. Table `" << table_name << "` doesn't exist!";
     throw SqliteException{errmsg.str()};
   }
   auto position = *(query_result_begin);

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/storage_test_fixture.hpp
@@ -26,6 +26,7 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include <unordered_map>
 
 #include "rcpputils/filesystem_helper.hpp"
 
@@ -35,6 +36,7 @@
 #include "rosbag2_storage/metadata_io.hpp"
 
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp"
+#include "rosbag2_storage_default_plugins/sqlite/sqlite_wrapper.hpp"
 
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
@@ -119,6 +121,84 @@ public:
     metadata_io_.write_metadata(temporary_dir_path_, rw_storage.get_metadata());
 
     return writable_storage;
+  }
+
+  void write_messages_to_sqlite_in_pre_foxy_format(
+    const std::vector<
+      std::tuple<std::string, int64_t, std::string, std::string, std::string>
+    > & messages)
+  {
+    auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+    std::string relative_path = db_file + ".db3";
+
+    // READ_WRITE requires the DB to not exist.
+    if (rcpputils::fs::path(relative_path).exists()) {
+      throw std::runtime_error(
+              "Failed to create bag: File '" + relative_path + "' already exists!");
+    }
+    using rosbag2_storage_plugins::SqliteWrapper;
+    using rosbag2_storage_plugins::SqliteException;
+    std::unordered_map<std::string, std::string> pragmas;
+
+    std::shared_ptr<SqliteWrapper> database;
+    try {
+      database = std::make_unique<SqliteWrapper>(
+        relative_path,
+        rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE,
+        std::move(pragmas));
+    } catch (const SqliteException & e) {
+      throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));
+    }
+
+    // Init database
+    std::string create_stmt = "CREATE TABLE topics(" \
+      "id INTEGER PRIMARY KEY," \
+      "name TEXT NOT NULL," \
+      "type TEXT NOT NULL," \
+      "serialization_format TEXT NOT NULL);";
+    database->prepare_statement(create_stmt)->execute_and_reset();
+    create_stmt = "CREATE TABLE messages(" \
+      "id INTEGER PRIMARY KEY," \
+      "topic_id INTEGER NOT NULL," \
+      "timestamp INTEGER NOT NULL, " \
+      "data BLOB NOT NULL);";
+    database->prepare_statement(create_stmt)->execute_and_reset();
+    create_stmt = "CREATE INDEX timestamp_idx ON messages (timestamp ASC);";
+    database->prepare_statement(create_stmt)->execute_and_reset();
+
+    std::unordered_map<std::string, int> topics;
+
+    using SqliteStatement = std::shared_ptr<rosbag2_storage_plugins::SqliteStatementWrapper>;
+    SqliteStatement write_statement = database->prepare_statement(
+      "INSERT INTO messages (timestamp, topic_id, data) VALUES (?, ?, ?);");
+
+    for (const auto & msg : messages) {
+      std::string topic_name = std::get<2>(msg);
+      std::string type_name = std::get<3>(msg);
+      std::string rmw_format = std::get<4>(msg);
+
+      // Create topic in DB if message with new topic name
+      if (topics.find(topic_name) == std::end(topics)) {
+        auto insert_topic = database->prepare_statement(
+          "INSERT INTO topics (name, type, serialization_format) VALUES (?, ?, ?)");
+        insert_topic->bind(topic_name, type_name, rmw_format);
+        insert_topic->execute_and_reset();
+        topics.emplace(topic_name, static_cast<int>(database->get_last_insert_id()));
+      }
+
+      // Prepare rosbag2 serialized message to write
+      auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+      message->serialized_data = make_serialized_message(std::get<0>(msg));
+      message->time_stamp = std::get<1>(msg);
+      message->topic_name = topic_name;
+      // Write message to DB
+      auto topic_entry = topics.find(topic_name);
+      if (topic_entry == end(topics)) {
+        throw SqliteException("Topic '" + topic_name + "' has not been created yet!");
+      }
+      write_statement->bind(message->time_stamp, topic_entry->second, message->serialized_data);
+      write_statement->execute_and_reset();
+    }
   }
 
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_wrapper.cpp
@@ -147,3 +147,19 @@ TEST_F(SqliteWrapperTestFixture, get_single_line_handles_empty_result_set) {
 
   EXPECT_THROW(result.get_single_line(), rosbag2_storage_plugins::SqliteException);
 }
+
+TEST_F(SqliteWrapperTestFixture, is_field_exist) {
+  db_.prepare_statement("CREATE TABLE test_table (timestamp INTEGER, data BLOB);")
+  ->execute_and_reset();
+  rcutils_time_point_value_t time = 1099511627783;
+  auto msg_content = "message";
+  std::shared_ptr<rcutils_uint8_array_t> message = make_serialized_message(msg_content);
+
+  db_.prepare_statement("INSERT INTO test_table (timestamp, data) VALUES (?, ?);")
+  ->bind(time, message)->execute_and_reset();
+
+  EXPECT_TRUE(db_.is_field_exist("test_table", "data"));
+  EXPECT_FALSE(db_.is_field_exist("test_table", "non_existent_field"));
+  EXPECT_THROW(
+    db_.is_field_exist("non_existent_table", "data"), rosbag2_storage_plugins::SqliteException);
+}

--- a/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_wrapper.cpp
+++ b/rosbag2_storage_default_plugins/test/rosbag2_storage_default_plugins/sqlite/test_sqlite_wrapper.cpp
@@ -148,7 +148,7 @@ TEST_F(SqliteWrapperTestFixture, get_single_line_handles_empty_result_set) {
   EXPECT_THROW(result.get_single_line(), rosbag2_storage_plugins::SqliteException);
 }
 
-TEST_F(SqliteWrapperTestFixture, is_field_exist) {
+TEST_F(SqliteWrapperTestFixture, field_exists) {
   db_.prepare_statement("CREATE TABLE test_table (timestamp INTEGER, data BLOB);")
   ->execute_and_reset();
   rcutils_time_point_value_t time = 1099511627783;
@@ -158,8 +158,8 @@ TEST_F(SqliteWrapperTestFixture, is_field_exist) {
   db_.prepare_statement("INSERT INTO test_table (timestamp, data) VALUES (?, ?);")
   ->bind(time, message)->execute_and_reset();
 
-  EXPECT_TRUE(db_.is_field_exist("test_table", "data"));
-  EXPECT_FALSE(db_.is_field_exist("test_table", "non_existent_field"));
+  EXPECT_TRUE(db_.field_exists("test_table", "data"));
+  EXPECT_FALSE(db_.field_exists("test_table", "non_existent_field"));
   EXPECT_THROW(
-    db_.is_field_exist("non_existent_table", "data"), rosbag2_storage_plugins::SqliteException);
+    db_.field_exists("non_existent_table", "data"), rosbag2_storage_plugins::SqliteException);
 }


### PR DESCRIPTION
- Closes #1089

Support SqliteStorage::get_metadata() for db3 files recorded on distros prior to the `Foxy` by checking whether `offered_qos_profiles` field exist or not in `topics` table and forming SQL request accordingly.