### PR TITLE
make recorder node composable by inheritance

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -115,6 +115,11 @@ public:
 protected:
   ROSBAG2_TRANSPORT_EXPORT
   std::unordered_map<std::string, std::string> get_requested_or_available_topics();
+  
+  std::shared_ptr<rosbag2_cpp::Writer> writer_;
+  rosbag2_storage::StorageOptions storage_options_;
+  rosbag2_transport::RecordOptions record_options_;
+  std::atomic<bool> stop_discovery_;
 
 private:
   void topics_discovery();
@@ -147,10 +152,6 @@ private:
   void warn_if_new_qos_for_subscribed_topic(const std::string & topic_name);
 
   std::unique_ptr<TopicFilter> topic_filter_;
-  std::shared_ptr<rosbag2_cpp::Writer> writer_;
-  rosbag2_storage::StorageOptions storage_options_;
-  rosbag2_transport::RecordOptions record_options_;
-  std::atomic<bool> stop_discovery_;
   std::future<void> discovery_future_;
   std::unordered_map<std::string, std::shared_ptr<rclcpp::GenericSubscription>> subscriptions_;
   std::unordered_set<std::string> topics_warned_about_incompatibility_;

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -115,7 +115,6 @@ public:
 protected:
   ROSBAG2_TRANSPORT_EXPORT
   std::unordered_map<std::string, std::string> get_requested_or_available_topics();
-  
   std::shared_ptr<rosbag2_cpp::Writer> writer_;
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::RecordOptions record_options_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -34,6 +34,7 @@
 
 #include "rosbag2_storage/yaml.hpp"
 #include "rosbag2_transport/qos.hpp"
+#include "rosbag2_transport/reader_writer_factory.hpp"
 
 #include "rosbag2_transport/topic_filter.hpp"
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -43,7 +43,14 @@ namespace rosbag2_transport
 Recorder::Recorder(
   const std::string & node_name,
   const rclcpp::NodeOptions & node_options)
-: rclcpp::Node(node_name, node_options)
+: Recorder(
+    std::move(
+      rosbag2_transport::ReaderWriterFactory::make_writer(
+        rosbag2_transport::RecordOptions())),
+    rosbag2_storage::StorageOptions(),
+    rosbag2_transport::RecordOptions(),
+    node_name,
+    node_options)
 {
   // TODO(karsten1987): Use this constructor later with parameter parsing.
   // The reader, storage_options as well as record_options can be loaded via parameter.

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -48,7 +48,6 @@ Recorder::Recorder(
   // TODO(karsten1987): Use this constructor later with parameter parsing.
   // The reader, storage_options as well as record_options can be loaded via parameter.
   // That way, the recorder can be used as a simple component in a component manager.
-  throw rclcpp::exceptions::UnimplementedError();
 }
 
 Recorder::Recorder(

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -34,7 +34,6 @@
 
 #include "rosbag2_storage/yaml.hpp"
 #include "rosbag2_transport/qos.hpp"
-#include "rosbag2_transport/reader_writer_factory.hpp"
 
 #include "rosbag2_transport/topic_filter.hpp"
 
@@ -44,18 +43,12 @@ namespace rosbag2_transport
 Recorder::Recorder(
   const std::string & node_name,
   const rclcpp::NodeOptions & node_options)
-: Recorder(
-    std::move(
-      rosbag2_transport::ReaderWriterFactory::make_writer(
-        rosbag2_transport::RecordOptions())),
-    rosbag2_storage::StorageOptions(),
-    rosbag2_transport::RecordOptions(),
-    node_name,
-    node_options)
+: rclcpp::Node(node_name, node_options)
 {
   // TODO(karsten1987): Use this constructor later with parameter parsing.
   // The reader, storage_options as well as record_options can be loaded via parameter.
   // That way, the recorder can be used as a simple component in a component manager.
+  throw rclcpp::exceptions::UnimplementedError();
 }
 
 Recorder::Recorder(
@@ -165,13 +158,13 @@ void Recorder::record()
   rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
   callbacks.write_split_callback =
     [this](rosbag2_cpp::bag_events::BagSplitInfo & info) {
-      {
-        std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-        bag_split_info_ = info;
-        write_split_has_occurred_ = true;
-      }
-      event_publisher_thread_wake_cv_.notify_all();
-    };
+    {
+      std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+      bag_split_info_ = info;
+      write_split_has_occurred_ = true;
+    }
+    event_publisher_thread_wake_cv_.notify_all();
+  };
   writer_->add_event_callbacks(callbacks);
 
   serialization_format_ = record_options_.rmw_serialization_format;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -158,13 +158,13 @@ void Recorder::record()
   rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
   callbacks.write_split_callback =
     [this](rosbag2_cpp::bag_events::BagSplitInfo & info) {
-    {
-      std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-      bag_split_info_ = info;
-      write_split_has_occurred_ = true;
-    }
-    event_publisher_thread_wake_cv_.notify_all();
-  };
+      {
+        std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+        bag_split_info_ = info;
+        write_split_has_occurred_ = true;
+      }
+      event_publisher_thread_wake_cv_.notify_all();
+    };
   writer_->add_event_callbacks(callbacks);
 
   serialization_format_ = record_options_.rmw_serialization_format;


### PR DESCRIPTION
Recreate changes made in #892 for the Galactic branch on the Rolling branch.

This basically enables users to write their own recording nodes by inheriting the rosbag2_transport::Recorder node and keep access to the options and writer.

Very useful for writing a node that starts recording and stops recording on a service call or on a topic value change.