### PR TITLE
[Humble] make recorder node composable by inheritance (backport #1093)

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -114,6 +114,10 @@ public:
 protected:
   ROSBAG2_TRANSPORT_EXPORT
   std::unordered_map<std::string, std::string> get_requested_or_available_topics();
+  std::shared_ptr<rosbag2_cpp::Writer> writer_;
+  rosbag2_storage::StorageOptions storage_options_;
+  rosbag2_transport::RecordOptions record_options_;
+  std::atomic<bool> stop_discovery_;
 
 private:
   void topics_discovery();
@@ -145,10 +149,6 @@ private:
 
   void warn_if_new_qos_for_subscribed_topic(const std::string & topic_name);
 
-  std::shared_ptr<rosbag2_cpp::Writer> writer_;
-  rosbag2_storage::StorageOptions storage_options_;
-  rosbag2_transport::RecordOptions record_options_;
-  std::atomic<bool> stop_discovery_;
   std::future<void> discovery_future_;
   std::unordered_map<std::string, std::shared_ptr<rclcpp::GenericSubscription>> subscriptions_;
   std::unordered_set<std::string> topics_warned_about_incompatibility_;


### PR DESCRIPTION
Same as #1093 and #892 but for branch Humble

Signed-off-by: Bernardo Taveira <taveira@student.chalmers.se>