### PR TITLE
Fix: SequentialWriter incorrect metadata total duration for split bags

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -223,7 +223,7 @@ if(BUILD_TESTING)
   ament_add_gmock(test_sequential_writer
     test/rosbag2_cpp/test_sequential_writer.cpp)
   if(TARGET test_sequential_writer)
-    ament_target_dependencies(test_sequential_writer rosbag2_storage)
+    ament_target_dependencies(test_sequential_writer rosbag2_storage rosbag2_test_common test_msgs)
     target_link_libraries(test_sequential_writer ${PROJECT_NAME})
   endif()
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -318,7 +318,7 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
 
   metadata_.files.back().starting_time =
     std::min(metadata_.files.back().starting_time, message_timestamp);
-  const auto duration = message_timestamp - metadata_.files.back().starting_time;
+  const auto duration = message_timestamp - metadata_.starting_time;
   metadata_.duration = std::max(metadata_.duration, duration);
 
   const auto file_duration = message_timestamp - metadata_.files.back().starting_time;


### PR DESCRIPTION
Fixes https://github.com/ros2/rosbag2/issues/841

This fix should get backported to Foxy/Galactic/Humble, it's been persistent for a long time. The test infra might not port well but the fix itself is very simple.