### PR TITLE
Fix for broken RHEL-8 build

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -620,7 +620,7 @@ TEST_F(TemporaryDirectoryFixture, split_bag_metadata_has_full_duration) {
     {100, 300, 200},
     {500, 400, 600}
   };
-  std::string uri = (std::filesystem::path(temporary_dir_path_) / "split_duration_bag").string();
+  std::string uri = (rcpputils::fs::path(temporary_dir_path_) / "split_duration_bag").string();
   write_sample_split_bag(uri, message_timestamps_by_file);
 
   rosbag2_storage::MetadataIo metadata_io;


### PR DESCRIPTION
Follow up to the https://github.com/ros2/rosbag2/pull/1098#issuecomment-1259480914
[RHEL-8 build](https://ci.ros2.org/view/nightly/job/nightly_linux-rhel_release/1273/console) fails due to the lack of adequate support for `std::filesystem::path(..)` on `RHEL-8`

Replaced `std::filesystem::path(..)` with `rcpputils::fs::path(..)` in `split_bag_metadata_has_full_duration` unit test.