### PR TITLE
Add plugin comparison benchmark

### DIFF
--- a/rosbag2_performance/rosbag2_compression_comparison/README.md
+++ b/rosbag2_performance/rosbag2_compression_comparison/README.md
@@ -1,0 +1,12 @@
+# Compression Size Comparison
+
+This folder contains a script to convert a bag into a variety of different compressed formats, in order to compare the resulting file sizes.
+
+To use this script, you need a bag (sqlite3 or MCAP format) containing a representative distribution of messages for your
+use-case. Then use `run.sh` with your bag as an argument:
+
+```
+./run.sh <your bag path>
+```
+
+This should print a csv-formatted list of names + sizes in bytes for each compression technique.

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/chunk_compressed_mcap.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/chunk_compressed_mcap.yaml
@@ -1,0 +1,5 @@
+output_bags:
+  - storage_id: mcap
+    uri: out/chunk_compressed_mcap
+    all: true
+    storage_config_uri: storage_config/chunk_compressed.yaml

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/chunk_high_compression.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/chunk_high_compression.yaml
@@ -1,0 +1,5 @@
+output_bags:
+  - storage_id: mcap
+    uri: out/chunk_high_compression_mcap
+    all: true
+    storage_config_uri: storage_config/high_compression.yaml

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/file_compressed_mcap.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/file_compressed_mcap.yaml
@@ -1,0 +1,6 @@
+output_bags:
+  - storage_id: mcap
+    uri: out/file_compressed_mcap
+    all: true
+    compression_mode: file
+    compression_format: zstd

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/file_compressed_sqlite3.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/file_compressed_sqlite3.yaml
@@ -1,0 +1,6 @@
+output_bags:
+  - storage_id: sqlite3
+    uri: out/file_compressed_sqlite3
+    all: true
+    compression_mode: file
+    compression_format: zstd

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/message_compressed_mcap.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/message_compressed_mcap.yaml
@@ -1,0 +1,7 @@
+output_bags:
+  - storage_id: mcap
+    uri: out/message_compressed_mcap
+    all: true
+    compression_mode: message
+    compression_format: zstd
+    compression_queue_size: 0

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/message_compressed_sqlite3.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/message_compressed_sqlite3.yaml
@@ -1,0 +1,7 @@
+output_bags:
+  - storage_id: sqlite3
+    uri: out/message_compressed_sqlite3
+    all: true
+    compression_mode: message
+    compression_format: zstd
+    compression_queue_size: 0

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/uncompressed_mcap.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/uncompressed_mcap.yaml
@@ -1,0 +1,5 @@
+output_bags:
+  - storage_id: mcap
+    uri: out/uncompressed_mcap
+    all: true
+    storage_config_uri: storage_config/uncompressed.yaml

--- a/rosbag2_performance/rosbag2_compression_comparison/output_config/uncompressed_sqlite3.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/output_config/uncompressed_sqlite3.yaml
@@ -1,0 +1,4 @@
+output_bags:
+  - storage_id: sqlite3
+    uri: out/uncompressed_sqlite3
+    all: true

--- a/rosbag2_performance/rosbag2_compression_comparison/run.sh
+++ b/rosbag2_performance/rosbag2_compression_comparison/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# usage: run.sh <your input bag directory or filename>
+set -e 
+
+rm -rf out
+mkdir out
+
+for name in output_config/*.yaml; do
+	echo "converting with $name..." 1>&2
+	ros2 bag convert -i $1 -o $name 1>&2
+done
+
+echo "name, size_bytes"
+find out -type f ! -name metadata.yaml -exec stat --printf="%N, %s\n" {} \;

--- a/rosbag2_performance/rosbag2_compression_comparison/storage_config/chunk_compressed.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/storage_config/chunk_compressed.yaml
@@ -1,0 +1,1 @@
+compression: "Zstd"

--- a/rosbag2_performance/rosbag2_compression_comparison/storage_config/high_compression.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/storage_config/high_compression.yaml
@@ -1,0 +1,3 @@
+compression: "Zstd"
+compressionLevel: "Slowest"
+chunkSize: 4194304 # 4 * 1024 * 1024

--- a/rosbag2_performance/rosbag2_compression_comparison/storage_config/uncompressed.yaml
+++ b/rosbag2_performance/rosbag2_compression_comparison/storage_config/uncompressed.yaml
@@ -1,0 +1,1 @@
+compression: "None"

--- a/rosbag2_performance/rosbag2_storage_plugin_comparison/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_storage_plugin_comparison/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.5)
+project(rosbag2_storage_plugin_comparison)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(rosbag2_compression REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
+find_package(rosbag2_storage REQUIRED)
+find_package(rosbag2_storage_mcap REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
+
+add_executable(single_benchmark
+  src/single_benchmark.cpp
+  src/config.hpp)
+
+ament_target_dependencies(single_benchmark
+  rclcpp
+  rcutils
+  rosbag2_compression
+  rosbag2_cpp
+  rosbag2_storage
+  yaml_cpp_vendor
+)
+install(TARGETS single_benchmark
+    DESTINATION lib/${PROJECT_NAME})
+
+install(PROGRAMS scripts/sweep.py
+    DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rosbag2_performance/rosbag2_storage_plugin_comparison/README.md
+++ b/rosbag2_performance/rosbag2_storage_plugin_comparison/README.md
@@ -1,0 +1,47 @@
+# Rosbag2 storage plugin comparison
+
+This package contains a benchmark for comparing the write throughput and overall memory
+usage of different storage plugins in different configurations. This can be used to determine
+the storage options that best suit your use-case.
+
+## How to use
+
+### Building
+
+```
+colcon build --packages-up-to rosbag2_storage_plugin_comparison
+```
+
+### Running the benchmark
+```
+ros2 run rosbag2_storage_plugin_comparison sweep.py results.csv
+```
+
+### Interpreting the results
+
+The resulting CSV contains the following columns:
+| Name | Units | Description |
+| ---- | ---- | ---- |
+| name |      | A concatenated string of all parameter labels and values for this run. |
+| messages |     | The name of the "messages" parameter variant used for this run. |
+| batch_size |    |  The name of the "batch_size" parameter variant used for this run. |
+| plugin_config |    |  The name of the "plugin_config" parameter variant used for this run. |
+| plugin_config |    |  The name of the "plugin_config" parameter variant used for this run. |
+| avg_byte_throughput | bytes/second | The average write throughput of the plugin for this run. |
+| max_arena_size | bytes | The max additional bytes that were added to the allocator arena for creating the writer and writing all messages. |
+| max_in_use_size | bytes | The max bytes that were allocated when writing messages for this run. |
+| max_mmap_size | bytes | The max bytes that were mmapped by the allocator when writing for this run. |
+| close_time | seconds | The time taken to finish and close the file, once all messages were written. |
+
+#### Memory usage notes
+
+All memory usage measurements are taken as a difference from a baseline measurement. The baseline
+is measured just before allocating a Writer instance. all memory usage values include the memory allocated
+on the heap for the Writer instance itself, as well as any that remain allocated after a write() call
+finishes.
+
+### Changing the benchmark sweep parameters
+
+`sweep.py` runs the benchmark binary a number of times across a set of parameters. The parameters
+and their values are defined in `CONFIG_DIMENSIONS` in sweep.py. Check `config.hpp` for the the set
+of config parameters available to you.

--- a/rosbag2_performance/rosbag2_storage_plugin_comparison/package.xml
+++ b/rosbag2_performance/rosbag2_storage_plugin_comparison/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbag2_storage_plugin_comparison</name>
+  <version>0.1.0</version>
+  <description>For comparing rosbag2 storage plugins</description>
+  <maintainer email="james@foxglove.dev">James Smith</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rosbag2_compression</depend>
+  <depend>rosbag2_cpp</depend>
+  <depend>rosbag2_storage</depend>
+  <depend>rosbag2_storage_mcap</depend>
+  <depend>rmw</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>yaml_cpp_vendor</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <exec_depend>python3-yaml</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosbag2_performance/rosbag2_storage_plugin_comparison/scripts/sweep.py
+++ b/rosbag2_performance/rosbag2_storage_plugin_comparison/scripts/sweep.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+""" Runs a parametric sweep of runs measuring the throughput and memory usage of
+rosbag2_storage::BaseWriteInterface implementations. Writes a CSV summary of each run to
+stdout, or to a file if a path is provided.
+"""
+
+from pathlib import Path
+import subprocess
+import shutil
+from tempfile import mkdtemp
+import csv
+import sys
+from io import StringIO
+
+import yaml
+
+"""CONFIG_DIMENSIONS contains the parameters to sweep across and their values.
+CONFIG_DIMENSIONS is structured as `{ parameter label : { variant label : config fragment } }`.
+the function `build_configs()` iterates through the variants of each parameter and produces
+a config for each combination."""
+CONFIG_DIMENSIONS = {
+    # The size and distribution of messages to write.
+    "messages": {
+        "large": { "topics": [{"name": "/large", "message_size": 1_000_000}]},
+        "medium": { "topics": [{"name": "/medium", "message_size": 10_000}]},
+        "small": { "topics": [{"name": "/small", "message_size": 100}]},
+        "mixed": { "topics": [
+            {"name": "/small", "message_size": 100, "write_proportion": 0.1},
+            {"name": "/medium", "message_size": 10_000, "write_proportion": 0.2},
+            {"name": "/large", "message_size": 1_000_000, "write_proportion": 0.7},
+        ]},
+    },
+    # The size of batches to write in each write() call.
+    "batch_size": {
+        "small": { "min_batch_size_bytes": 1000 },
+        "default": { "min_batch_size_bytes": 10000000 },
+    },
+    # Configuration parameters for the writer plugin to use.
+    "plugin_config": {
+        "mcap_default": {"storage_id": "mcap"},
+        "mcap_nocrc": {
+            "storage_id": "mcap",
+            "storage_options": {
+                "noCRC": True,
+            }
+        },
+        "mcap_zstdfast": {
+            "storage_id": "mcap",
+            "storage_options": {
+                "chunkSize": 10_000_000,
+                "compression": "Zstd",
+                "compressionLevel": "Fastest",
+            }
+        },
+        "mcap_uncompressed": {
+            "storage_id": "mcap",
+            "storage_options": {
+                "compression": "None",
+            }
+        },
+        "mcap_nochunking": {
+            "storage_id": "mcap",
+            "storage_options": {
+                "noCRC": True,
+                "noChunking": True,
+            }
+        },
+        "sqlite_default": {"storage_id": "sqlite3"},
+        "sqlite_resilient": {
+            "storage_id": "sqlite3",
+            "storage_options": {
+                "write": {"pragmas": [
+                    "journal_mode=WAL",
+                    "synchronous=NORMAL",
+                ]},
+            }
+        },
+    }
+}
+
+
+def should_ignore(name_dict):
+    return (
+        name_dict.get("plugin_config", "").startswith("mcap_") and
+        name_dict.get("batch_size", "") in ["medium", "large"]
+    )
+
+
+def executable_path():
+    """Returns the path to the benchmark binary that actually writes the bag file.
+    This is separated out into a separate process so that all resources are cleaned up
+    between runs.
+    """
+    return Path(__file__).resolve().parent / "single_benchmark"
+
+def build_configs():
+    """ Iterates through each combination of variants in CONFIG_DIMENSIONS and produces a list of
+    ({parameter label : variant label}, config) tuples.
+    """
+    configs = [({}, {})]
+    for dimension_name, dimension in CONFIG_DIMENSIONS.items():
+        new_configs = []
+        for (existing_name, existing_config) in configs:
+            for variant_name, variant_fragment in dimension.items():
+                label = f"{dimension_name}_{variant_name}"
+                new_name = label if existing_name == "" else f"{existing_name}-{label}"
+                new_name = dict(**existing_name)
+                new_name[dimension_name] = variant_name
+                if should_ignore(new_name):
+                    print(f"ignoring configuration {new_name}", file=sys.stderr)
+                    continue
+                new_config = dict(**existing_config)
+                new_config.update(variant_fragment)
+                new_configs.append((new_name, new_config))
+        configs = new_configs
+    return configs
+
+def run_once(config):
+    """ Runs `single_benchmark` with the given config and returns the resulting CSV content. """
+    outdir = mkdtemp()
+    try:
+        res = subprocess.run(
+            [executable_path(), yaml.dump(config), outdir],
+            check=True,
+            stdout=subprocess.PIPE
+        )
+    finally:
+        shutil.rmtree(outdir)
+    return res.stdout.decode("utf-8")
+
+def make_digest(name, csv_content):
+    """ Aggregates the results of one benchmark run into a row for the final digest CSV. """
+    reader = csv.DictReader(StringIO(csv_content))
+    write_times = []
+    arena_sizes = []
+    in_use_sizes = []
+    byte_throughputs = []
+    mmap_sizes = []
+    close_time = None
+    for row in reader:
+        if row["close_ns"]:
+            close_time = float(row["close_ns"]) / 1e9
+        else:
+            write_times.append(float(row["write_ns"]) / 1e9)
+            arena_sizes.append(int(row["arena_bytes"]))
+            byte_throughputs.append(float(row["num_bytes"]) / (float(row["write_ns"]) / 1e9))
+            in_use_sizes.append(int(row["in_use_bytes"]))
+            mmap_sizes.append(int(row["mmap_bytes"]))
+    res = dict(**name)
+    res.update({
+        "name": ";".join([f"{k}={v}" for k, v in name.items()]),
+        "avg_byte_throughput": sum(byte_throughputs) / len(byte_throughputs),
+        "max_arena_size": max(arena_sizes),
+        "max_in_use_size": max(in_use_sizes),
+        "max_mmap_size": max(mmap_sizes),
+        "close_time": close_time,
+    })
+    return res
+
+
+def write_csv_from_dicts(outfile, rows):
+    """ takes a list of {column name: value} dicts and writes a CSV to a file-like object `outfile`. """
+    writer = csv.DictWriter(
+        outfile,
+        list(rows[0].keys()),
+    )
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+
+
+def main():
+    configs = build_configs()
+    digest_rows = []
+    for name, config in configs:
+        print(f"Running benchmark: {name}...", file=sys.stderr)
+        result = run_once(config)
+        digest_rows.append(make_digest(name, result))
+    if len(sys.argv) > 1:
+        with open(sys.argv[1], "w") as f:
+            write_csv_from_dicts(f, digest_rows)
+    else:
+        s = StringIO()
+        write_csv_from_dicts(s, digest_rows)
+        print(s.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/rosbag2_performance/rosbag2_storage_plugin_comparison/src/config.hpp
+++ b/rosbag2_performance/rosbag2_storage_plugin_comparison/src/config.hpp
@@ -1,0 +1,91 @@
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <string>
+#include "yaml-cpp/yaml.h"
+
+struct Config
+{
+  /// The storage ID to pass in StorageOptions.
+  std::string storage_id = "sqlite3";
+  /// The number of bytes to reach in a given batch before starting a new one.
+  /// Writes are always batched when passed to rosbag2_storage::ReadWriteInterface.
+  /// A small limit (like 10) means that only one message will be in each batch.
+  size_t min_batch_size_bytes = 10;
+  /// The number of bytes to write in total. Defaults to 1G.
+  size_t write_total_bytes = 250'000'000;
+
+  /// A set of topics to write to the bag. All messages contain only random data and the
+  /// topics are meaningless except as unique labels for data of different sizes.
+  struct TopicConfig
+  {
+    /// The topic name. Should be unique.
+    std::string name;
+    /// The size of each message to write in bytes.
+    size_t message_size;
+    /// The proportion of `write_total_bytes` that should be written as messages of this topic.
+    /// If using multiple topics, these proportion values should sum to 1.0.
+    double write_proportion = 1.0;
+  };
+  std::vector<TopicConfig> topics = {{"/large", 1'000'000, 0.9}, {"/small", 1000, 0.1}};
+
+  YAML::Node storage_options;
+};
+
+
+/// Conversions to/from YAML for Config.
+namespace YAML
+{
+template<>
+struct convert<Config>
+{
+  static Node encode(const Config & rhs)
+  {
+    Node node;
+    node["storage_id"] = rhs.storage_id;
+    node["min_batch_size_bytes"] = rhs.min_batch_size_bytes;
+    node["write_total_bytes"] = rhs.write_total_bytes;
+    Node topic_configs_node;
+    for (const auto & topic_config : rhs.topics) {
+      Node topic_config_node;
+      topic_config_node["name"] = topic_config.name;
+      topic_config_node["message_size"] = topic_config.message_size;
+      topic_config_node["write_proportion"] = topic_config.write_proportion;
+      topic_configs_node.push_back(topic_config_node);
+    }
+    node["topics"] = topic_configs_node;
+    node["storage_options"] = rhs.storage_options;
+    return node;
+  }
+
+  static bool decode(const Node & node, Config & rhs)
+  {
+    optional_assign<std::string>(node, "storage_id", rhs.storage_id);
+    optional_assign<size_t>(node, "min_batch_size_bytes", rhs.min_batch_size_bytes);
+    optional_assign<size_t>(node, "write_total_bytes", rhs.write_total_bytes);
+    if (node["topics"]) {
+      rhs.topics.clear();
+      auto topics_node = node["topics"];
+      for (auto it = topics_node.begin(); it != topics_node.end(); ++it) {
+        Config::TopicConfig topic;
+        topic.name = (*it)["name"].as<std::string>();
+        topic.message_size = (*it)["message_size"].as<size_t>();
+        optional_assign<double>(*it, "write_proportion", topic.write_proportion);
+        rhs.topics.push_back(topic);
+      }
+    }
+    optional_assign<Node>(node, "storage_options", rhs.storage_options);
+    return true;
+  }
+};
+}

--- a/rosbag2_performance/rosbag2_storage_plugin_comparison/src/single_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_storage_plugin_comparison/src/single_benchmark.cpp
@@ -1,0 +1,280 @@
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file single_benchmark.cpp
+/// @brief writes some number of messages to a bag file using the
+/// rosbag2_storage::ReadWriteInterface API, and measures timing and memory usage data for each
+/// write call.
+///
+/// Arguments:
+///   1. A YAML string to configure the benchmark run.
+///   2. a path to write the bag file to.
+///
+/// Prints a csv-formatted table containing metrics from each write call. This binary isn't meant
+/// to be called manually by humans, instead use `sweep.py` to run a parametric sweep across a range
+/// of configs.
+///
+/// Example usage:
+///  ./single_benchmark "$(cat your_config.yaml)" /tmp/some_existing_temp_dir > results.csv
+
+#include <malloc.h>
+#include <random>
+#include <fstream>
+#include <climits>
+#include <algorithm>
+#include <functional>
+#include <vector>
+#include <iostream>
+#include <unordered_map>
+
+#include "rosbag2_cpp/writer.hpp"
+#include "rosbag2_storage/ros_helper.hpp"
+#include "rcutils/logging_macros.h"
+
+#include "config.hpp"
+
+using RandomEngine = std::independent_bits_engine<std::default_random_engine, CHAR_BIT,
+    unsigned char>;
+using hrc = std::chrono::high_resolution_clock;
+using Batch = std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>;
+
+/**
+ * @brief Generates the TopicMetadata objects needed by ReadWriteInterface before writing the
+ * topics produced by this benchmark.
+ * @param config the benchmark config for this run.
+ * @return std::vector<rosbag2_storage::TopicMetadata> all TopicMetadata objects to go into the bag.
+ */
+std::vector<rosbag2_storage::TopicMetadata> generate_topics(const Config & config)
+{
+  std::vector<rosbag2_storage::TopicMetadata> topics;
+  for (const auto & topic : config.topics) {
+    rosbag2_storage::TopicMetadata metadata;
+    metadata.name = topic.name;
+    // The topic type doesn't matter here - we're not doing any serialization,
+    // just throwing random bytes into the serialized message.
+    // It still needs to be a valid typename because the MCAP plugin will search the resource
+    // index for it.
+    metadata.type = "std_msgs/String";
+    metadata.serialization_format = "cdr";
+    metadata.offered_qos_profiles = "";
+    topics.push_back(metadata);
+  }
+  return topics;
+}
+
+/**
+ * @brief Produce a random byte array, suitable for the serialized_data field of SerializedBagMessage.
+ *
+ * @param size The size of the array to produce
+ * @param engine The random number generator, shared between runs.
+ * @return std::shared_ptr<rcutils_uint8_array_t> A bytearray full of random data of length `size`.
+ */
+std::shared_ptr<rcutils_uint8_array_t> random_uint8_array(size_t size, RandomEngine & engine)
+{
+  std::vector<unsigned char> data(size);
+  // std::generate(begin(data), end(data), std::ref(engine));
+  return rosbag2_storage::make_serialized_message(data.data(), data.size());
+}
+
+/**
+ * @brief Generates all messages to write to the bag.
+ *
+ * @param config The benchmark config for this run.
+ * @return std::vector<Batch> The messages to write in this run, broken up into Batches. Each
+ * batch is written to the bag in its own write() call.
+ */
+std::vector<Batch> generate_messages(Config config)
+{
+  std::vector<Batch> out;
+  Batch current_batch;
+  size_t current_batch_bytes = 0;
+  RandomEngine engine;
+  // We use a second random engine for shuffling the vector of messages, to ensure
+  // roughly-evenly-sized batches.
+  std::default_random_engine shuffle_engine(0);
+
+  // build a long vector of pointers to the relevant topic config for each message that will be
+  // created.
+  std::vector<const Config::TopicConfig *> config_to_write;
+  double proportion_sum = 0.0;
+  for (size_t i = 0; i < config.topics.size(); ++i) {
+    const auto * topic_config = &config.topics[i];
+    proportion_sum += topic_config->write_proportion;
+    double this_topic_bytes = (double)(config.write_total_bytes) * topic_config->write_proportion;
+    size_t num_msgs = (size_t)(this_topic_bytes / double(topic_config->message_size));
+    for (size_t j = 0; j < num_msgs; ++j) {
+      config_to_write.push_back(topic_config);
+    }
+  }
+  if ((proportion_sum > 1.0001) || (proportion_sum < 0.9999)) {
+    throw std::runtime_error("topic config proportions do not sum close to 1");
+  }
+  // shuffle the messages to be created, to make the batches all roughly the same size.
+  std::shuffle(config_to_write.begin(), config_to_write.end(), shuffle_engine);
+
+  for (auto topic_config: config_to_write) {
+    auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+    msg->topic_name = topic_config->name;
+    msg->serialized_data = random_uint8_array(topic_config->message_size, engine);
+    current_batch_bytes += topic_config->message_size;
+    current_batch.push_back(msg);
+    if (current_batch_bytes >= config.min_batch_size_bytes) {
+      out.emplace_back(std::move(current_batch));
+      current_batch = {};
+      current_batch_bytes = 0;
+    }
+  }
+  if (current_batch.size() != 0) {
+    out.emplace_back(std::move(current_batch));
+  }
+  return out;
+}
+
+/**
+ * @brief Returns the number of bytes in all messages in this batch.
+ */
+size_t message_bytes(const Batch & batch)
+{
+  size_t total = 0;
+  for (const auto & msgPtr : batch) {
+    total += msgPtr->serialized_data->buffer_length;
+  }
+  return total;
+}
+
+/**
+ * @brief Contains the baseline memory usage of the application before creating a writer and calling
+ * `write()`.
+ */
+struct BaselineStat
+{
+  size_t arena_bytes;
+  size_t in_use_bytes;
+  size_t mmap_bytes;
+
+  BaselineStat()
+  {
+    struct mallinfo2 info = mallinfo2();
+    arena_bytes = info.arena;
+    in_use_bytes = info.uordblks;
+    mmap_bytes = info.hblkhd;
+  }
+};
+
+/**
+ * @brief The metrics measured from a single writer.write() call.
+ */
+struct WriteStat
+{
+  uint32_t sqc;
+  size_t bytes_written;
+  size_t num_msgs;
+  hrc::duration write_duration;
+  ssize_t arena_bytes;
+  ssize_t in_use_bytes;
+  ssize_t mmap_bytes;
+
+  WriteStat(
+    const BaselineStat & baseline_stat, uint32_t sqc_, const Batch & batch,
+    hrc::duration write_duration)
+  : sqc(sqc_),
+    bytes_written(message_bytes(batch)),
+    num_msgs(batch.size()),
+    write_duration(write_duration)
+  {
+    struct mallinfo2 info = mallinfo2();
+    arena_bytes = info.arena - baseline_stat.arena_bytes;
+    in_use_bytes = info.uordblks - baseline_stat.in_use_bytes;
+    mmap_bytes = info.hblkhd - baseline_stat.mmap_bytes;
+  }
+};
+
+
+int main(int argc, const char ** argv)
+{
+  if (argc < 3) {
+    std::cerr << "Usage: " << argv[0] << " <config yaml string> <output dir>" << std::endl;
+    std::cerr <<
+      "Use ros2 run rosbag2_storage_plugin_comparison sweep.py for a more ergonomic experience" <<
+      std::endl;
+    return 1;
+  }
+  YAML::Node config_yaml = YAML::Load(argv[1]);
+  Config config = config_yaml.as<Config>();
+  RCUTILS_LOG_INFO_NAMED("single_benchmark", "generating %ld topics", config.topics.size());
+  auto topics = generate_topics(config);
+  RCUTILS_LOG_INFO_NAMED("single_benchmark", "generating some messages");
+  auto messages = generate_messages(config);
+  RCUTILS_LOG_INFO_NAMED("single_benchmark", "configuring writer");
+  rosbag2_storage::StorageFactory factory;
+  rosbag2_storage::StorageOptions options;
+  options.uri = std::string(argv[2]) + "/out";
+  options.storage_id = config.storage_id;
+
+  if (config.storage_options.IsMap()) {
+    std::string storage_options_uri = std::string(argv[2]) + "/storage_options.yaml";
+    RCUTILS_LOG_INFO_NAMED(
+      "single_benchmark", "using storage options %s",
+      storage_options_uri.c_str());
+    std::ofstream fout(storage_options_uri.c_str());
+    fout << config.storage_options;
+    options.storage_config_uri = storage_options_uri;
+  }
+
+  std::vector<WriteStat> write_stats;
+  write_stats.reserve(messages.size());
+  std::chrono::high_resolution_clock::time_point close_start_time;
+  RCUTILS_LOG_INFO_NAMED("single_benchmark", "writing messages");
+  BaselineStat baseline;
+  {
+    auto writer = factory.open_read_write(options);
+
+    for (const auto & topic : topics) {
+      writer->create_topic(topic);
+    }
+
+    uint32_t sqc = 0;
+    // write messages, timing each write
+    for (const auto & message_batch : messages) {
+      auto start_time = hrc::now();
+      writer->write(message_batch);
+      hrc::duration duration = hrc::now() - start_time;
+      write_stats.emplace_back(baseline, sqc, message_batch, duration);
+      sqc++;
+    }
+
+    close_start_time = hrc::now();
+    // writer destructor closes the output file, so we time that too.
+  }
+  auto close_duration = hrc::now() - close_start_time;
+
+  std::cout << "sqc,num_bytes,num_msgs,write_ns,arena_bytes,in_use_bytes,mmap_bytes,close_ns" <<
+    std::endl;
+  for (const auto & stat : write_stats) {
+    auto duration =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(stat.write_duration).count();
+    std::cout <<
+      stat.sqc << "," <<
+      stat.bytes_written << "," <<
+      stat.num_msgs << "," <<
+      duration << "," <<
+      stat.arena_bytes << "," <<
+      stat.in_use_bytes << "," <<
+      stat.mmap_bytes << "," <<
+      std::endl;
+  }
+  std::cout << ",,,,,,," <<
+    std::chrono::duration_cast<std::chrono::nanoseconds>(close_duration).count() << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Add a package for comparing the write performance of rosbag2 storage plugins. This package can be pretty easily extended to cover more variants and more plugins as ROS2 evolves.

`rosbag2_storage_plugin_comparison` Produces results that look like this: 
[digest.csv](https://github.com/ros2/rosbag2/files/9681108/digest.csv)

Fixes #1092 