### PR TITLE
Don't reopen file for every seek if we don't have to. Search directionally for the correct file

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -237,7 +237,7 @@ TEST_F(SequentialCompressionReaderTest, compression_called_when_loading_split_ba
     std::move(metadata_io_));
 
   compression_reader->open(storage_options_, converter_options_);
-  EXPECT_EQ(compression_reader->has_next_file(), true);
+  EXPECT_EQ(compression_reader->has_next_file(false), true);
   EXPECT_EQ(compression_reader->has_next(), true);  // false then true
   compression_reader->read_next();  // calls has_next true
 }
@@ -246,7 +246,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_v4_names)
 {
   auto reader = create_reader();
   reader->open(storage_options_, converter_options_);
-  EXPECT_TRUE(reader->has_next_file());
+  EXPECT_TRUE(reader->has_next_file(false));
 }
 
 TEST_F(SequentialCompressionReaderTest, throws_on_incorrect_filenames)
@@ -268,7 +268,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames)
   auto reader = create_reader();
 
   EXPECT_NO_THROW(reader->open(storage_options_, converter_options_));
-  EXPECT_TRUE(reader->has_next_file());
+  EXPECT_TRUE(reader->has_next_file(false));
 }
 
 TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames_in_renamed_bag)
@@ -282,7 +282,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames_in_renamed_b
   auto reader = create_reader();
 
   EXPECT_NO_THROW(reader->open(storage_options_, converter_options_));
-  EXPECT_TRUE(reader->has_next_file());
+  EXPECT_TRUE(reader->has_next_file(false));
 }
 
 TEST_F(SequentialCompressionReaderTest, does_not_decompress_again_on_seek)

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -237,7 +237,7 @@ TEST_F(SequentialCompressionReaderTest, compression_called_when_loading_split_ba
     std::move(metadata_io_));
 
   compression_reader->open(storage_options_, converter_options_);
-  EXPECT_EQ(compression_reader->has_next_file(false), true);
+  EXPECT_EQ(compression_reader->has_next_file(), true);
   EXPECT_EQ(compression_reader->has_next(), true);  // false then true
   compression_reader->read_next();  // calls has_next true
 }
@@ -246,7 +246,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_v4_names)
 {
   auto reader = create_reader();
   reader->open(storage_options_, converter_options_);
-  EXPECT_TRUE(reader->has_next_file(false));
+  EXPECT_TRUE(reader->has_next_file());
 }
 
 TEST_F(SequentialCompressionReaderTest, throws_on_incorrect_filenames)
@@ -268,7 +268,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames)
   auto reader = create_reader();
 
   EXPECT_NO_THROW(reader->open(storage_options_, converter_options_));
-  EXPECT_TRUE(reader->has_next_file(false));
+  EXPECT_TRUE(reader->has_next_file());
 }
 
 TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames_in_renamed_bag)
@@ -282,7 +282,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames_in_renamed_b
   auto reader = create_reader();
 
   EXPECT_NO_THROW(reader->open(storage_options_, converter_options_));
-  EXPECT_TRUE(reader->has_next_file(false));
+  EXPECT_TRUE(reader->has_next_file());
 }
 
 TEST_F(SequentialCompressionReaderTest, does_not_decompress_again_on_seek)

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -91,13 +91,18 @@ public:
   void seek(const rcutils_time_point_value_t & timestamp) override;
 
   /**
-   * Ask whether there is another storage file to read from the list of relative
-   * file paths.
+   * Ask whether there is another storage file to read from the list of relative file paths.
    *
-   * \param reverse Look for a previous file instead of a next file
-   * \return true if there are still files to read in the list
+   * \return true if iteration is not on the last file
    */
-  virtual bool has_next_file(bool reverse) const;
+  virtual bool has_next_file() const;
+
+  /**
+   * Ask whether there is a previous file to read from the list of relative file paths.
+   *
+   * \return true if iteration is not on the first file
+   */
+  virtual bool has_prev_file() const;
 
   /**
   * Return the relative file path pointed to by the current file iterator.
@@ -128,14 +133,24 @@ protected:
   */
   virtual void load_current_file();
 
+
   /**
   * Increment the current file iterator to point to the next file in the list of relative file
-  * paths, and opens the next file by calling open_current_file()
+  * paths, and opens that file by calling open_current_file()
   *
   * Expected usage:
   * if (has_next_file()) load_next_file();
   */
-  virtual void load_next_file(bool reverse);
+  virtual void load_next_file();
+
+  /**
+  * Increment the current file iterator to point to the previous file in the list of relative file
+  * paths, and opens that file by calling open_current_file()
+  *
+  * Expected usage:
+  * if (has_prev_file()) load_prev_file();
+  */
+  virtual void load_prev_file();
 
   /**
    * Checks if all topics in the bagfile have the same RMW serialization format.

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -91,12 +91,13 @@ public:
   void seek(const rcutils_time_point_value_t & timestamp) override;
 
   /**
-   * Ask whether there is another database file to read from the list of relative
+   * Ask whether there is another storage file to read from the list of relative
    * file paths.
    *
+   * \param reverse Look for a previous file instead of a next file
    * \return true if there are still files to read in the list
    */
-  virtual bool has_next_file() const;
+  virtual bool has_next_file(bool reverse) const;
 
   /**
   * Return the relative file path pointed to by the current file iterator.
@@ -134,7 +135,7 @@ protected:
   * Expected usage:
   * if (has_next_file()) load_next_file();
   */
-  virtual void load_next_file();
+  virtual void load_next_file(bool reverse);
 
   /**
    * Checks if all topics in the bagfile have the same RMW serialization format.

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -228,9 +228,8 @@ TEST_F(MultifileReaderTest, seek_bag)
 {
   init();
   reader_->open(default_storage_options_, {"", storage_serialization_format_});
-  EXPECT_CALL(*storage_, has_next()).Times(3).WillRepeatedly(Return(false));
+  EXPECT_CALL(*storage_, has_next()).Times(1).WillRepeatedly(Return(false));
   EXPECT_CALL(*storage_, seek(_)).Times(3);
-  EXPECT_CALL(*storage_, set_filter(_)).Times(3);
   reader_->seek(9999999999999);
   reader_->has_next();
 }

--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -116,8 +116,9 @@ get_interface_instance(
     registered_classes.begin(),
     registered_classes.end(), storage_options.storage_id);
   if (class_exists == registered_classes.end()) {
-    ROSBAG2_STORAGE_LOG_WARN_STREAM(
-      "No storage plugin found with id '" << storage_options.storage_id << "'.");
+    // This should not print a warning, because it can be used by open_read_only twice,
+    // legitimately expecting to fail for READ_ONLY but succeed for READ_WRITE
+    // The extra output is misleading to end users.
     return nullptr;
   }
 


### PR DESCRIPTION
Use case: `rqt_bag` uses frequent seek (for every message). This might not be the best way to use rosbag, but regardless it highlights a big performance issue with `seek` - that we reopen the storage file every single time. Change this to directionally look for a file that contains the requested timestamp, then seek within that bag. This makes it so that repeated seeks within the same file keep that file open.

Discovered in testing for https://github.com/ros-visualization/rqt_bag/pull/126