### PR TITLE
Fix for ros2 bag play exit with non-zero code on SIGINT

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -207,4 +207,7 @@ class PlayVerb(VerbExtension):
         play_options.disable_loan_message = args.disable_loan_message
 
         player = Player()
-        player.play(storage_options, play_options)
+        try:
+            player.play(storage_options, play_options)
+        except KeyboardInterrupt:
+            pass

--- a/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
@@ -22,11 +22,30 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <vector>
 #include <string>
 
 using namespace ::testing;  // NOLINT
 
 using ProcessHandle = int;
+
+/// \brief Split command string on words separated by spaces for further usage with execvp(..)
+/// \param [in] command - command line string with arguments split by spaces
+/// \return vector of char pointers
+std::vector<char *> command_string_to_arguments(const std::string & command)
+{
+  std::vector<char *> arguments;
+  std::istringstream ss(command);
+  std::string token;
+  while (std::getline(ss, token, ' ')) {
+    // dup strings to get non-const, should be free'd after execvp
+    if (!token.empty()) {  // Skipping extra spaces between arguments
+      arguments.push_back(strdup(token.c_str()));
+    }
+  }
+  arguments.push_back(nullptr);  // explicit nullptr to tell execvp where to stop
+  return arguments;
+}
 
 int execute_and_wait_until_completion(const std::string & command, const std::string & path)
 {
@@ -52,21 +71,55 @@ int execute_and_wait_until_completion(const std::string & command, const std::st
 ProcessHandle start_execution(const std::string & command)
 {
   auto process_id = fork();
-  if (process_id == 0) {
-    setpgid(0, 0);
-    execl("/bin/sh", "sh", "-c", command.c_str(), static_cast<char *>(nullptr));
+  if (process_id == -1) {
+    throw std::runtime_error("Failed to start process via fork()");
+  }
+  if (process_id == 0) {  // In child process
+    // Split command on words separated by spaces to further use in execvp
+    // Note alternative approach with execl("/bin/sh", "sh", "-c", command.c_str(), nullptr);
+    // will spawn one more child process with default SIG_INT handler and will incorrectly return
+    // exit codes in case of signal handling.
+    std::vector<char *> arguments{command_string_to_arguments(command)};
+    const char * cmd = arguments[0];
+    int ret = execvp(cmd, arguments.data());
+    for (auto str : arguments) {
+      free(str);
+      str = nullptr;
+    }
+    if (ret == -1) {
+      throw std::runtime_error("Failed to call execvp(cmd, args)");
+    }
   }
   return process_id;
 }
 
-void stop_execution(const ProcessHandle & handle, int signum = SIGINT)
+void stop_execution(
+  const ProcessHandle & process_id,
+  int signum = SIGINT,
+  std::chrono::seconds timeout = std::chrono::seconds(10))
 {
-  killpg(handle, signum);
-  int child_return_code;
-  waitpid(handle, &child_return_code, 0);
-  // this call will make sure that the process does execute without issues before it is killed by
+  EXPECT_NE(kill(process_id, signum), -1) << "Failed to send signal " << signum <<
+    " to process: " << process_id;
+  int status = EXIT_FAILURE;
+  pid_t wait_ret_code = 0;
+  std::chrono::steady_clock::time_point const start = std::chrono::steady_clock::now();
+  // Wait for process to finish with timeout
+  while (wait_ret_code == 0 && std::chrono::steady_clock::now() - start < timeout) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    // WNOHANG - wait for processes without causing the caller to be blocked
+    wait_ret_code = waitpid(process_id, &status, WNOHANG);
+  }
+  if (wait_ret_code == 0) {
+    std::cerr << "Testing process " << process_id << " hangout. Killing it with SIGKILL \n";
+    kill(process_id, SIGKILL);
+  }
+  // Make sure that the process does execute without issues before it is killed by
   // the user in the test or, in case it runs until completion, that it has correctly executed.
-  EXPECT_THAT(WEXITSTATUS(child_return_code), EXIT_SUCCESS);
+  EXPECT_NE(wait_ret_code, -1);
+  EXPECT_EQ(wait_ret_code, process_id);
+  EXPECT_EQ(WIFEXITED(status), true) << "status = " << status;
+  EXPECT_EQ(WIFSIGNALED(status), false) << "Process terminated by signal: " << WTERMSIG(status);
+  EXPECT_EQ(WEXITSTATUS(status), EXIT_SUCCESS) << "status = " << status;
 }
 
 #endif  // ROSBAG2_TEST_COMMON__PROCESS_EXECUTION_HELPERS_UNIX_HPP_

--- a/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/subscription_manager.hpp
@@ -139,6 +139,15 @@ public:
       });
   }
 
+  void spin_subscriptions_sync()
+  {
+    rclcpp::executors::SingleThreadedExecutor exec;
+    auto start = std::chrono::high_resolution_clock::now();
+    while (rclcpp::ok() && continue_spinning(expected_topics_with_size_, start)) {
+      exec.spin_node_some(subscriber_node_);
+    }
+  }
+
 private:
   bool continue_spinning(
     const std::unordered_map<std::string, size_t> & expected_topics_with_sizes,


### PR DESCRIPTION
Fix for ros2 bag play exit with non-zero code on SIGINT
- Closes #1123
- Don't allow to propagate `KeyboardInterrupt` exception on upper level from python wrapper for `play` verb.
- Fixed incorrect error checks in process_execution infrastructure when `SIGINT` not processed in child process.
