### PR TITLE
Check & create database dirs before writing bags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .idea/
 .ipynb_checkpoints/
+.vscode/
 cmake-build-debug/
 cmake-build-release/
-build/
+build
+install
+log
 venv/
 **/.pytest_cache/

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -18,7 +18,6 @@ import os
 
 from rclpy.qos import InvalidQoSProfileException
 from ros2bag.api import convert_yaml_to_qos_profile
-from ros2bag.api import create_bag_directory
 from ros2bag.api import print_error
 from ros2bag.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
@@ -107,8 +106,6 @@ class RecordVerb(VerbExtension):
                     qos_profile_dict)
             except (InvalidQoSProfileException, ValueError) as e:
                 return print_error(str(e))
-
-        create_bag_directory(uri)
 
         if args.all:
             # NOTE(hidmic): in merged install workspaces on Windows, Python entrypoint lookups

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -112,6 +112,21 @@ void SequentialCompressionWriter::open(
     converter_ = std::make_unique<rosbag2_cpp::Converter>(converter_options, converter_factory_);
   }
 
+  rcpputils::fs::path db_path(base_folder_);
+  if (db_path.is_directory()) {
+    std::stringstream error;
+    error << "Database directory already exists (" << db_path.string() <<
+      "), can't overwrite existing database";
+    throw std::runtime_error{error.str()};
+  }
+
+  bool dir_created = rcpputils::fs::create_directories(db_path);
+  if (!dir_created) {
+    std::stringstream error;
+    error << "Failed to create database directory (" << db_path.string() << ").";
+    throw std::runtime_error{error.str()};
+  }
+
   const auto storage_uri = format_storage_uri(base_folder_, 0);
   storage_ = storage_factory_->open_read_write(storage_uri, storage_options.storage_id);
   if (!storage_) {

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -19,6 +19,8 @@
 #include <utility>
 #include <vector>
 
+#include "rcpputils/filesystem_helper.hpp"
+
 #include "rosbag2_compression/compression_options.hpp"
 #include "rosbag2_compression/sequential_compression_writer.hpp"
 
@@ -44,8 +46,17 @@ public:
     storage_options_{},
     serialization_format_{"rmw_format"}
   {
+    rcpputils::fs::path dir(storage_options_.uri);
+    rcpputils::fs::remove_all(dir);
+
     ON_CALL(*storage_factory_, open_read_write(_, _)).WillByDefault(Return(storage_));
     EXPECT_CALL(*storage_factory_, open_read_write(_, _)).Times(AtLeast(0));
+  }
+
+  ~SequentialCompressionWriterTest()
+  {
+    rcpputils::fs::path dir(storage_options_.uri);
+    rcpputils::fs::remove_all(dir);
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -95,6 +95,21 @@ void SequentialWriter::open(
     converter_ = std::make_unique<Converter>(converter_options, converter_factory_);
   }
 
+  rcpputils::fs::path db_path(storage_options.uri);
+  if (db_path.is_directory()) {
+    std::stringstream error;
+    error << "Database directory already exists (" << db_path.string() <<
+      "), can't overwrite existing database";
+    throw std::runtime_error{error.str()};
+  }
+
+  bool dir_created = rcpputils::fs::create_directories(db_path);
+  if (!dir_created) {
+    std::stringstream error;
+    error << "Failed to create database directory (" << db_path.string() << ").";
+    throw std::runtime_error{error.str()};
+  }
+
   const auto storage_uri = format_storage_uri(base_folder_, 0);
 
   storage_ = storage_factory_->open_read_write(storage_uri, storage_options.storage_id);

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -95,7 +95,7 @@ void SequentialWriter::open(
     converter_ = std::make_unique<Converter>(converter_options, converter_factory_);
   }
 
-  rcpputils::fs::path db_path(storage_options.uri);
+  rcpputils::fs::path db_path(base_folder_);
   if (db_path.is_directory()) {
     std::stringstream error;
     error << "Database directory already exists (" << db_path.string() <<

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -47,6 +47,9 @@ public:
     storage_options_ = rosbag2_cpp::StorageOptions{};
     storage_options_.uri = "uri";
 
+    rcpputils::fs::path dir(storage_options_.uri);
+    rcpputils::fs::remove_all(dir);
+
     ON_CALL(*storage_factory_, open_read_write(_, _)).WillByDefault(
       DoAll(
         Invoke(
@@ -57,6 +60,12 @@ public:
         Return(storage_)));
     EXPECT_CALL(
       *storage_factory_, open_read_write(_, _)).Times(AtLeast(0));
+  }
+
+  ~SequentialWriterTest()
+  {
+    rcpputils::fs::path dir(storage_options_.uri);
+    rcpputils::fs::remove_all(dir);
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;


### PR DESCRIPTION
Ref: https://github.com/ros2/rosbag2/pull/450

This feature is necessary for using writer to create bags in foxy distribution.

1. Port db checking & creation to sequential_writer and sequential_compression_writer.
2. Port test code for sequential_writer and sequential_compression_writer.
3. Remove db dir creation from verb record.py in ros2bag.
4. Add .vscode, install, log dirs in .gitignore.

Signed-off-by: homalozoa <nx.tardis@gmail.com>