### PR TITLE
ros2bag: move storage preset validation to sqlite3 plugin

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -146,12 +146,9 @@ class RecordVerb(VerbExtension):
             help='Path to a yaml file defining overrides of the QoS profile for specific topics.'
         )
         parser.add_argument(
-            '--storage-preset-profile', type=str, default='none', choices=['none', 'resilient'],
-            help='Select a configuration preset for storage.'
-                 'resilient (sqlite3):'
-                 'indicate preference for avoiding data corruption in case of crashes,'
-                 'at the cost of performance. Setting this flag disables optimization settings '
-                 'for storage (the defaut). This flag settings can still be overriden by '
+            '--storage-preset-profile', type=str, default='',
+            help='Select a configuration preset for storage. '
+                 'This flag settings can still be overriden by '
                  'corresponding settings in the config passed with --storage-config-file.'
         )
         parser.add_argument(

--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -96,6 +96,13 @@ public:
    */
   SqliteWrapper & get_sqlite_database_wrapper();
 
+  enum class PresetProfile
+  {
+    Resilient,
+    WriteOptimized,
+  };
+  static PresetProfile parse_preset_profile(const std::string & profile_string);
+
 private:
   void initialize();
   void prepare_for_writing();
@@ -131,6 +138,7 @@ private:
   // b) topics_ collection - since we could be writing and reading it at the same time
   std::mutex database_write_mutex_;
 };
+
 
 }  // namespace rosbag2_storage_plugins
 

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -560,3 +560,21 @@ TEST_F(StorageTestFixture, read_next_returns_filtered_messages_topics_regex_to_e
   EXPECT_THAT(fifth_message->topic_name, Eq("topic3"));
   EXPECT_FALSE(readable_storage2->has_next());
 }
+
+TEST(StoragePresetProfileValidation, parse_storage_preset_profile_works) {
+  EXPECT_EQ(
+    rosbag2_storage_plugins::SqliteStorage::parse_preset_profile(""),
+    rosbag2_storage_plugins::SqliteStorage::PresetProfile::WriteOptimized
+  );
+  EXPECT_EQ(
+    rosbag2_storage_plugins::SqliteStorage::parse_preset_profile("none"),
+    rosbag2_storage_plugins::SqliteStorage::PresetProfile::WriteOptimized
+  );
+  EXPECT_EQ(
+    rosbag2_storage_plugins::SqliteStorage::parse_preset_profile("resilient"),
+    rosbag2_storage_plugins::SqliteStorage::PresetProfile::Resilient
+  );
+  EXPECT_THROW(
+    rosbag2_storage_plugins::SqliteStorage::parse_preset_profile("anything"),
+    std::runtime_error);
+}


### PR DESCRIPTION
Currently storage plugin authors can't use any storage preset profiles other than "none" and "resilient", which is a little sad. This PR removes that restriction and moves the validation logic into the plugin for `rosbag2_storage_sqlite3`.

Partially addresses #1134 
Unblocks https://github.com/ros-tooling/rosbag2_storage_mcap/pull/57