### PR TITLE
rosbag2_storage: set MCAP as default plugin

### DIFF
--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -23,8 +23,6 @@
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>
-  <!-- TODO: remove dependency when rosbag2_storage_default_plugins depends on MCAP -->
-  <test_depend>rosbag2_storage_mcap</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
 
   <export>

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -84,32 +84,30 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_basic'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_string_regex = re.compile(
-            r'\[rosbag2_storage]: Opened database .* for READ_WRITE')
+        expected_output = 'Listening for topics...'
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
-                condition=lambda output: expected_string_regex.search(output) is not None,
+                condition=lambda output: expected_output in output,
                 timeout=OUTPUT_WAIT_TIMEOUT)
         bag_command.wait_for_shutdown(timeout=SHUTDOWN_TIMEOUT)
         assert bag_command.terminated
-        matches = expected_string_regex.search(bag_command.output)
-        assert matches, ERROR_STRING_MSG.format(expected_string_regex.pattern, bag_command.output)
+        matches = expected_output in bag_command.output
+        assert matches, ERROR_STRING_MSG.format(expected_output, bag_command.output)
 
     def test_incomplete_qos_profile(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_profile.yaml'
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_string_regex = re.compile(
-            r'\[rosbag2_storage]: Opened database .* for READ_WRITE')
+        expected_output = 'Listening for topics...'
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
-                condition=lambda output: expected_string_regex.search(output) is not None,
+                condition=lambda output: expected_output in output,
                 timeout=OUTPUT_WAIT_TIMEOUT)
         bag_command.wait_for_shutdown(timeout=SHUTDOWN_TIMEOUT)
         assert bag_command.terminated
-        matches = expected_string_regex.search(bag_command.output)
-        assert matches, ERROR_STRING_MSG.format(expected_string_regex.pattern, bag_command.output)
+        matches = expected_output in bag_command.output
+        assert matches, ERROR_STRING_MSG.format(expected_output, bag_command.output)
 
     def test_incomplete_qos_duration(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_duration.yaml'

--- a/rosbag2_cpp/package.xml
+++ b/rosbag2_cpp/package.xml
@@ -27,9 +27,6 @@
   <depend>shared_queues_vendor</depend>
 
   <test_depend>rosbag2_storage_default_plugins</test_depend>
-  <!-- TODO: remove dependency when rosbag2_storage_default_plugins depends on MCAP -->
-  <test_depend>rosbag2_storage_mcap</test_depend>
-
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_py/package.xml
+++ b/rosbag2_py/package.xml
@@ -31,8 +31,6 @@
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>
-  <!-- TODO: remove dependency when rosbag2_storage_default_plugins depends on MCAP -->
-  <test_depend>rosbag2_storage_mcap</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
   <test_depend>rosidl_runtime_py</test_depend>
   <test_depend>std_msgs</test_depend>

--- a/rosbag2_storage/src/rosbag2_storage/default_storage_id.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/default_storage_id.cpp
@@ -18,7 +18,7 @@ namespace rosbag2_storage
 
 std::string get_default_storage_id()
 {
-  return "sqlite3";
+  return "mcap";
 }
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage_default_plugins/package.xml
+++ b/rosbag2_storage_default_plugins/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <!-- Default plugins -->
+  <exec_depend>rosbag2_storage_mcap</exec_depend>
   <exec_depend>rosbag2_storage_sqlite3</exec_depend>
 
   <export>

--- a/rosbag2_tests/package.xml
+++ b/rosbag2_tests/package.xml
@@ -24,8 +24,6 @@
   <test_depend>rosbag2_compression_zstd</test_depend>
   <test_depend>rosbag2_cpp</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>
-  <!-- TODO(mcap): remove when mcap is added to default plugins -->
-  <test_depend>rosbag2_storage_mcap</test_depend>
   <test_depend>rosbag2_storage</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
   <test_depend>std_msgs</test_depend>

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -30,7 +30,6 @@
   <test_depend>rosbag2_compression_zstd</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>
-  <test_depend>rosbag2_storage_mcap</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
switches the default storage plugin from `sqlite3` to `mcap`.

## Reason for change

Benchmarks suggest that MCAP can support higher write throughput than the `sqlite3` plugin in its default configuration, while also bringing the following other benefits:

* Append-only write behavior ensures that only the last few messages written can be corrupted in the case of a power outage or recorder crash. This is similar to the corruption guarantees offered by SQLite3 in [WAL mode](https://sqlite.org/wal.html), which is what is used in the `resilient` SQLite storage plugin preset.
* Ability to enable chunk compression, which should be more space-efficient than message compression for bags with many small messages. This also enables reader to use the message index, unlike file-level compression.
* Record message schemas to the bag by default, enabling applications outside the ROS 2 workspace to read message content.

## Benchmarks
Read the benchmarking analysis that lead to this conclusion [here](https://mcap.dev/performance-comparison/rosbag2-plugin-comparison.html).

### `rosbag2_performance_benchmarking`

There is a set of pre-existing benchmarks in the rosbag2 repo here: https://github.com/ros2/rosbag2/tree/rolling/rosbag2_performance/rosbag2_performance_benchmarking

We've run these in an attempt to compare the performance of MCAP against SQLite on these metrics, but at this point the results appear to be pure noise. A full analysis of why will be published to mcap.dev shortly, but for now the news is that we have not succeeded in producing a statistically significant difference in results between MCAP and SQLite.


## TODO
- [x] https://github.com/ros2/rosbag2/issues/1112
- [x] https://github.com/ros-tooling/rosbag2_storage_mcap/issues/61
- [x] https://github.com/ros-tooling/rosbag2_storage_mcap/issues/63
- [x] https://github.com/ros2/rosbag2/issues/1185
- [x] Parametrize `rosbag2_tests`