### PR TITLE
rosbag2_cpp: sequential reader specifies no order

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include <optional>
 
 #include "rosbag2_cpp/bag_events.hpp"
 #include "rosbag2_cpp/converter.hpp"
@@ -208,7 +209,7 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 
   bag_events::EventCallbackManager callback_manager_;
-  rosbag2_storage::ReadOrder read_order_{};
+  std::optional<rosbag2_storage::ReadOrder> read_order_;
 };
 
 }  // namespace readers

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -146,7 +146,7 @@ bool SequentialReader::has_next()
     // to read from there. Otherwise, check if there's another message.
     bool current_storage_has_next = storage_->has_next();
     if (!current_storage_has_next) {
-      if (read_order_ == std::nullopt || (!read_order_->reverse && has_next_file())) {
+      if ((read_order_ == std::nullopt || !read_order_->reverse) && has_next_file()) {
         load_next_file();
         return has_next();
       }


### PR DESCRIPTION
Right now `SequentialReader` chooses a default read order (by default constructing `ReadOrder`) and calls `set_read_order()` on the underlying storage plugin. However, the underlying storage plugin may not support that read order. If the user hasn't specified the read order they want, the plugin should just decide for them.

It doesn't really make sense for SequentialReader to always specify the read order, unless the user has actually called `set_read_order` on SequentialReader. With that in mind this PR removes that constraint.

Fixes https://github.com/ros-tooling/rosbag2_storage_mcap/issues/61