### PR TITLE
Move python get_default_storage_id to storage module instead of writer

### DIFF
--- a/rosbag2_py/rosbag2_py/__init__.py
+++ b/rosbag2_py/rosbag2_py/__init__.py
@@ -33,6 +33,7 @@ with add_dll_directories_from_env('PATH'):
         TopicMetadata,
         TopicInformation,
         BagMetadata,
+        get_default_storage_id,
     )
     from rosbag2_py._writer import (
         SequentialCompressionWriter,
@@ -40,7 +41,6 @@ with add_dll_directories_from_env('PATH'):
         get_registered_writers,
         get_registered_compressors,
         get_registered_serializers,
-        get_default_storage_id,
     )
     from rosbag2_py._info import (
         Info,

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -17,6 +17,7 @@
 
 #include "rosbag2_cpp/converter_options.hpp"
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/storage_filter.hpp"
 #include "rosbag2_storage/storage_interfaces/base_read_interface.hpp"
 #include "rosbag2_storage/storage_options.hpp"
@@ -284,4 +285,9 @@ PYBIND11_MODULE(_storage, m) {
     pybind11::arg("reverse") = rosbag2_storage::ReadOrder{}.reverse)
   .def_readwrite("sort_by", &rosbag2_storage::ReadOrder::sort_by)
   .def_readwrite("reverse", &rosbag2_storage::ReadOrder::reverse);
+
+  m.def(
+    "get_default_storage_id",
+    &rosbag2_storage::get_default_storage_id,
+    "Returns the default storage ID used when unspecified in StorageOptions");
 }

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -23,7 +23,6 @@
 #include "rosbag2_cpp/writer.hpp"
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
 #include "rosbag2_cpp/serialization_format_converter_factory.hpp"
-#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/storage_filter.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
@@ -142,9 +141,4 @@ PYBIND11_MODULE(_writer, m) {
     "get_registered_serializers",
     &rosbag2_py::get_registered_serializers,
     "Returns list of serialization format plugins available for rosbag2 recording");
-
-  m.def(
-    "get_default_storage_id",
-    &rosbag2_storage::get_default_storage_id,
-    "Returns the default storage ID used when unspecified in StorageOptions");
 }


### PR DESCRIPTION
This has no behavior change - it just seemed like this function was in the wrong place.