### PR TITLE
Remove explicit sqlite3 from code

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -67,7 +67,7 @@ public:
    * This must be called before any other function is used.
    *
    * \note This will open URI with the default storage options
-   * * using sqlite3 storage backend
+   * * using default storage backend
    * * using no converter options, storing messages with the incoming serialization format
    * \sa rmw_get_serialization_format.
    * For specifications, please see \sa open, which let's you specify

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -67,7 +67,7 @@ public:
    * This must be called before any other function is used.
    *
    * \note This will open URI with the default storage options
-   * * using sqlite3 storage backend
+   * * using default storage backend
    * * using no converter options, storing messages with the incoming serialization format
    * \sa rmw_get_serialization_format.
    * For specifications, please see \sa open, which let's you specify

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -23,6 +23,8 @@
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/reader_interfaces/base_reader_interface.hpp"
 
+#include "rosbag2_storage/default_storage_id.hpp"
+
 namespace rosbag2_cpp
 {
 
@@ -39,6 +41,7 @@ void Reader::open(const std::string & uri)
 {
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = uri;
+  storage_options.storage_id = rosbag2_storage::get_default_storage_id();
 
   rosbag2_cpp::ConverterOptions converter_options{};
   return open(storage_options, converter_options);

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -23,8 +23,6 @@
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/reader_interfaces/base_reader_interface.hpp"
 
-#include "rosbag2_storage/default_storage_id.hpp"
-
 namespace rosbag2_cpp
 {
 
@@ -41,7 +39,6 @@ void Reader::open(const std::string & uri)
 {
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = uri;
-  storage_options.storage_id = rosbag2_storage::get_default_storage_id();
 
   rosbag2_cpp::ConverterOptions converter_options{};
   return open(storage_options, converter_options);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -25,6 +25,7 @@
 #include "rosbag2_cpp/writer.hpp"
 
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
@@ -35,9 +36,10 @@ using namespace ::testing;  // NOLINT
 using rosbag2_test_common::TemporaryDirectoryFixture;
 
 TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_2) {
+  const auto expected_storage_id = rosbag2_storage::get_default_storage_id();
   const std::string bagfile = "rosbag2_bagfile_information:\n"
     "  version: 2\n"
-    "  storage_identifier: sqlite3\n"
+    "  storage_identifier: " + expected_storage_id + "\n"
     "  relative_file_paths:\n"
     "    - some_relative_path\n"
     "    - some_other_relative_path\n"
@@ -69,7 +71,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_2) {
   const auto metadata = info.read_metadata(temporary_dir_path_);
 
   EXPECT_EQ(metadata.version, 2);
-  EXPECT_EQ(metadata.storage_identifier, "sqlite3");
+  EXPECT_EQ(metadata.storage_identifier, expected_storage_id);
 
   const auto expected_paths =
     std::vector<std::string>{"some_relative_path", "some_other_relative_path"};
@@ -101,9 +103,10 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_2) {
 }
 
 TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_6) {
+  const auto expected_storage_id = rosbag2_storage::get_default_storage_id();
   const std::string bagfile = "rosbag2_bagfile_information:\n"
     "  version: 6\n"
-    "  storage_identifier: sqlite3\n"
+    "  storage_identifier: " + expected_storage_id + "\n"
     "  relative_file_paths:\n"
     "    - some_relative_path\n"
     "    - some_other_relative_path\n"
@@ -149,7 +152,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_6) {
   const auto metadata = info.read_metadata(temporary_dir_path_);
 
   EXPECT_EQ(metadata.version, 6);
-  EXPECT_EQ(metadata.storage_identifier, "sqlite3");
+  EXPECT_EQ(metadata.storage_identifier, expected_storage_id);
 
   const auto expected_paths =
     std::vector<std::string>{"some_relative_path", "some_other_relative_path"};
@@ -199,10 +202,11 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_6) {
 }
 
 TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metadata_io_method) {
+  const auto expected_storage_id = rosbag2_storage::get_default_storage_id();
   std::string bagfile(
     "rosbag2_bagfile_information:\n"
     "  version: 3\n"
-    "  storage_identifier: sqlite3\n"
+    "  storage_identifier: " + expected_storage_id + "\n"
     "  relative_file_paths:\n"
     "    - some_relative_path\n"
     "    - some_other_relative_path\n"
@@ -235,7 +239,7 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
   rosbag2_cpp::Info info;
   auto read_metadata = info.read_metadata(temporary_dir_path_);
 
-  EXPECT_THAT(read_metadata.storage_identifier, Eq("sqlite3"));
+  EXPECT_EQ(read_metadata.storage_identifier, expected_storage_id);
   EXPECT_THAT(
     read_metadata.relative_file_paths,
     Eq(std::vector<std::string>({"some_relative_path", "some_other_relative_path"})));

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -26,6 +26,7 @@
 #include "rosbag2_cpp/writer.hpp"
 
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
@@ -244,7 +245,7 @@ public:
   ReadOrderTest()
   {
     storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "ordertest").string();
-    storage_options.storage_id = "sqlite3";
+    storage_options.storage_id = rosbag2_storage::get_default_storage_id();
     write_sample_split_bag(storage_options, fake_messages, split_every);
   }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -26,6 +26,7 @@
 #include "rosbag2_cpp/writer.hpp"
 
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 
@@ -579,7 +580,7 @@ TEST_F(TemporaryDirectoryFixture, split_bag_metadata_has_full_duration) {
   };
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "split_duration_bag").string();
-  storage_options.storage_id = "sqlite3";
+  storage_options.storage_id = rosbag2_storage::get_default_storage_id();
   write_sample_split_bag(storage_options, fake_messages, 3);
 
   rosbag2_storage::MetadataIo metadata_io;

--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
@@ -19,6 +19,7 @@
 
 #include "rclcpp/qos.hpp"
 #include "rosbag2_performance_benchmarking/producer_config.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 
 namespace config_utils
 {
@@ -109,7 +110,7 @@ BagConfig bag_config_from_node_parameters(
   const std::string default_bag_folder("/tmp/rosbag2_test");
   BagConfig bag_config;
 
-  node.declare_parameter<std::string>("storage_id", "sqlite3");
+  node.declare_parameter<std::string>("storage_id", rosbag2_storage::get_default_storage_id());
   node.declare_parameter<int>("max_cache_size", 10000000);
   node.declare_parameter<int>("max_bag_size", 0);
   node.declare_parameter<std::string>("db_folder", default_bag_folder);

--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
@@ -41,10 +41,6 @@ WriterBenchmark::WriterBenchmark(const std::string & name)
   }
 
   bag_config_ = config_utils::bag_config_from_node_parameters(*this);
-  if (bag_config_.storage_options.storage_id != "sqlite3") {
-    RCLCPP_ERROR(get_logger(), "Benchmarking only supported for sqlite3 for now");
-    return;
-  }
 
   this->declare_parameter("results_file", bag_config_.storage_options.uri + "/results.csv");
   this->get_parameter("results_file", results_file_);

--- a/rosbag2_py/test/common.py
+++ b/rosbag2_py/test/common.py
@@ -30,7 +30,8 @@ import rosbag2_py  # noqa
 
 
 def get_rosbag_options(path, serialization_format='cdr'):
-    storage_options = rosbag2_py.StorageOptions(uri=path, storage_id='sqlite3')
+    storage_options = rosbag2_py.StorageOptions(
+        uri=path, storage_id=rosbag2_py.get_default_storage_id())
 
     converter_options = rosbag2_py.ConverterOptions(
         input_serialization_format=serialization_format,

--- a/rosbag2_py/test/test_convert.py
+++ b/rosbag2_py/test/test_convert.py
@@ -20,6 +20,7 @@ import unittest
 import common  # noqa
 from rosbag2_py import (
     bag_rewrite,
+    get_default_storage_id,
     StorageOptions,
 )
 
@@ -64,22 +65,23 @@ output_bags:
     def test_basic_convert(self):
         # This test is just to test that the rosbag2_py wrapper parses input
         # It is not a comprehensive test of bag_rewrite.
+        storage_id = get_default_storage_id()
         bag_a_path = RESOURCES_PATH / 'convert_a'
         bag_b_path = RESOURCES_PATH / 'convert_b'
         output_uri_1 = self.tmp_path / 'converted_1'
         output_uri_2 = self.tmp_path / 'converted_2'
         input_options = [
             StorageOptions(uri=str(bag_a_path)),
-            StorageOptions(uri=str(bag_b_path), storage_id='sqlite3'),
+            StorageOptions(uri=str(bag_b_path)),
         ]
         output_options_path = self.tmp_path / 'simple_convert.yml'
         output_options_content = f"""
 output_bags:
 - uri: {output_uri_1}
-  storage_id: sqlite3
+  storage_id: {storage_id}
   topics: [a_empty]
 - uri: {output_uri_2}
-  storage_id: sqlite3
+  storage_id: {storage_id}
   exclude: ".*empty.*"
 """
         with output_options_path.open('w') as f:

--- a/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
@@ -46,7 +47,7 @@ TEST_F(MetadataFixture, test_writing_and_reading_yaml)
 {
   BagMetadata metadata{};
   metadata.version = 1;
-  metadata.storage_identifier = "sqlite3";
+  metadata.storage_identifier = get_default_storage_id();
   metadata.relative_file_paths.emplace_back("some_relative_path");
   metadata.relative_file_paths.emplace_back("some_other_relative_path");
   metadata.duration = std::chrono::nanoseconds(100);

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -44,7 +44,7 @@ public:
     const rcpputils::fs::path base{_SRC_RESOURCES_DIR_PATH};
     const rcpputils::fs::path bag_path = base / "test_bag_for_seek";
 
-    storage_options_ = rosbag2_storage::StorageOptions({bag_path.string(), "sqlite3", 0, 0, 0});
+    storage_options_.uri = bag_path.string();
     play_options_.read_ahead_queue_size = 2;
     reader_ = std::make_unique<rosbag2_cpp::Reader>();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -44,7 +44,7 @@ public:
     const rcpputils::fs::path base{_SRC_RESOURCES_DIR_PATH};
     const rcpputils::fs::path bag_path = base / "test_bag_for_seek";
 
-    storage_options_.uri = bag_path.string();
+    storage_options_ = rosbag2_storage::StorageOptions({bag_path.string(), "", 0, 0, 0});
     play_options_.read_ahead_queue_size = 2;
     reader_ = std::make_unique<rosbag2_cpp::Reader>();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
@@ -84,7 +84,6 @@ TEST_F(TestRewrite, test_noop_rewrite) {
 
   rosbag2_storage::StorageOptions output_storage;
   output_storage.uri = (output_dir_ / "unchanged").string();
-  output_storage.storage_id = "sqlite3";
   rosbag2_transport::RecordOptions output_record;
   output_record.all = true;
   output_bags_.push_back({output_storage, output_record});
@@ -105,7 +104,6 @@ TEST_F(TestRewrite, test_merge) {
 
   rosbag2_storage::StorageOptions output_storage;
   output_storage.uri = (output_dir_ / "merged").string();
-  output_storage.storage_id = "sqlite3";
   rosbag2_transport::RecordOptions output_record;
   output_record.all = true;
   output_bags_.push_back({output_storage, output_record});
@@ -137,7 +135,6 @@ TEST_F(TestRewrite, test_filter_split) {
   {
     rosbag2_storage::StorageOptions storage_opts;
     storage_opts.uri = (output_dir_ / "split1").string();
-    storage_opts.storage_id = "sqlite3";
     rosbag2_transport::RecordOptions rec_opts;
     rec_opts.all = true;
     rec_opts.exclude = "basic";
@@ -146,7 +143,6 @@ TEST_F(TestRewrite, test_filter_split) {
   {
     rosbag2_storage::StorageOptions storage_opts;
     storage_opts.uri = (output_dir_ / "split2").string();
-    storage_opts.storage_id = "sqlite3";
     rosbag2_transport::RecordOptions rec_opts;
     rec_opts.all = false;
     rec_opts.topics = {"b_basictypes"};
@@ -180,7 +176,6 @@ TEST_F(TestRewrite, test_compress) {
 
   rosbag2_storage::StorageOptions output_storage;
   output_storage.uri = (output_dir_ / "compressed").string();
-  output_storage.storage_id = "sqlite3";
   rosbag2_transport::RecordOptions output_record;
   output_record.all = true;
   output_record.compression_mode = "file";

--- a/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include "rcpputils/filesystem_helper.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_transport/bag_rewrite.hpp"
 #include "rosbag2_transport/reader_writer_factory.hpp"
 
@@ -84,6 +85,7 @@ TEST_F(TestRewrite, test_noop_rewrite) {
 
   rosbag2_storage::StorageOptions output_storage;
   output_storage.uri = (output_dir_ / "unchanged").string();
+  output_storage.storage_id = rosbag2_storage::get_default_storage_id();
   rosbag2_transport::RecordOptions output_record;
   output_record.all = true;
   output_bags_.push_back({output_storage, output_record});
@@ -104,6 +106,7 @@ TEST_F(TestRewrite, test_merge) {
 
   rosbag2_storage::StorageOptions output_storage;
   output_storage.uri = (output_dir_ / "merged").string();
+  output_storage.storage_id = rosbag2_storage::get_default_storage_id();
   rosbag2_transport::RecordOptions output_record;
   output_record.all = true;
   output_bags_.push_back({output_storage, output_record});
@@ -135,6 +138,7 @@ TEST_F(TestRewrite, test_filter_split) {
   {
     rosbag2_storage::StorageOptions storage_opts;
     storage_opts.uri = (output_dir_ / "split1").string();
+    storage_opts.storage_id = rosbag2_storage::get_default_storage_id();
     rosbag2_transport::RecordOptions rec_opts;
     rec_opts.all = true;
     rec_opts.exclude = "basic";
@@ -143,6 +147,7 @@ TEST_F(TestRewrite, test_filter_split) {
   {
     rosbag2_storage::StorageOptions storage_opts;
     storage_opts.uri = (output_dir_ / "split2").string();
+    storage_opts.storage_id = rosbag2_storage::get_default_storage_id();
     rosbag2_transport::RecordOptions rec_opts;
     rec_opts.all = false;
     rec_opts.topics = {"b_basictypes"};
@@ -176,6 +181,7 @@ TEST_F(TestRewrite, test_compress) {
 
   rosbag2_storage::StorageOptions output_storage;
   output_storage.uri = (output_dir_ / "compressed").string();
+  output_storage.storage_id = rosbag2_storage::get_default_storage_id();
   rosbag2_transport::RecordOptions output_record;
   output_record.all = true;
   output_record.compression_mode = "file";


### PR DESCRIPTION
Removes all code mentions of "sqlite3" from packages
* rosbag2_cpp
* rosbag2_performance_benchmarking
* rosbag2_py
* rosbag2_storage
* rosbag2_transport

`rosbag2_tests` and the CLI/README will be in separate PRs