### PR TITLE
Reader and writer can use default storage by not specifying

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -39,7 +39,6 @@ void Reader::open(const std::string & uri)
 {
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = uri;
-  storage_options.storage_id = "sqlite3";
 
   rosbag2_cpp::ConverterOptions converter_options{};
   return open(storage_options, converter_options);

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -53,7 +53,6 @@ void Writer::open(const std::string & uri)
 {
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = uri;
-  storage_options.storage_id = rosbag2_storage::get_default_storage_id();
 
   rosbag2_cpp::ConverterOptions converter_options{};
   return open(storage_options, converter_options);

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -29,6 +29,7 @@
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/logging.hpp"
 
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/storage_options.hpp"
 
 namespace rosbag2_cpp
@@ -84,6 +85,9 @@ void SequentialWriter::open(
 {
   base_folder_ = storage_options.uri;
   storage_options_ = storage_options;
+  if (storage_options_.storage_id.empty()) {
+    storage_options_.storage_id = rosbag2_storage::get_default_storage_id();
+  }
 
   if (converter_options.output_serialization_format !=
     converter_options.input_serialization_format)


### PR DESCRIPTION
Don't hardcode anything for reader, as it can now autodetect.

Allow users to not specify a storage id for writer, in which case it will fall back to the default.

Closes #1158 