### PR TITLE
set_read_order: return success

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
@@ -36,7 +36,7 @@ public:
   MOCK_METHOD1(update_metadata, void(const rosbag2_storage::BagMetadata &));
   MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
-  MOCK_METHOD1(set_read_order, void(const rosbag2_storage::ReadOrder &));
+  MOCK_METHOD1(set_read_order, bool(const rosbag2_storage::ReadOrder &));
   MOCK_METHOD0(has_next, bool());
   MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());
   MOCK_METHOD1(write, void(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -68,6 +68,7 @@ public:
 
     ON_CALL(*storage_, get_all_topics_and_types()).WillByDefault(Return(topics_and_types));
     ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
+    ON_CALL(*storage_, set_read_order).WillByDefault(Return(true));
     ON_CALL(*storage_factory_, open_read_only(_)).WillByDefault(Return(storage_));
 
     initialize_dummy_storage_files();

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -66,6 +66,7 @@ public:
       [this](const rosbag2_storage::BagMetadata & metadata) {
         v_intercepted_update_metadata_.emplace_back(metadata);
       });
+    ON_CALL(*storage_, set_read_order).WillByDefault(Return(true));
   }
 
   ~SequentialCompressionWriterTest() override

--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -104,10 +104,12 @@ public:
    * read head timestamp.
    *
    * \param read_order Sorting criterion and direction to read messages in
-   * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
-   * or load_next_file() will cause undefined behavior
+   * \return true if the requested read order has been successfully set.
+   * \note set_read_order(order) should be called only after open(). Calling set_read_order(order)
+   * concurrently with has_next(), seek(t), has_next_file() or load_next_file() will cause
+   * undefined behavior.
    */
-  void set_read_order(const rosbag2_storage::ReadOrder & read_order);
+  bool set_read_order(const rosbag2_storage::ReadOrder & read_order);
 
   /**
    * Ask whether the underlying bagfile contains at least one more message.

--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -104,10 +104,10 @@ public:
    * read head timestamp.
    *
    * \param read_order Sorting criterion and direction to read messages in
+   * \throws runtime_error if the Reader is not open.
    * \return true if the requested read order has been successfully set.
-   * \note set_read_order(order) should be called only after open(). Calling set_read_order(order)
-   * concurrently with has_next(), seek(t), has_next_file() or load_next_file() will cause
-   * undefined behavior.
+   * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
+   * or load_next_file() will cause undefined behavior.
    */
   bool set_read_order(const rosbag2_storage::ReadOrder & read_order);
 

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -46,7 +46,7 @@ public:
 
   virtual void close() = 0;
 
-  virtual void set_read_order(const rosbag2_storage::ReadOrder &) = 0;
+  virtual bool set_read_order(const rosbag2_storage::ReadOrder &) = 0;
 
   virtual bool has_next() = 0;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -67,10 +67,11 @@ public:
   void close() override;
 
   /**
-   * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
-   * or load_next_file() will cause undefined behavior
+   * \note set_read_order(order) should be called only after open(). Calling set_read_order(order)
+   * concurrently with has_next(), seek(t), has_next_file() or load_next_file() will cause
+   * undefined behavior.
    */
-  void set_read_order(const rosbag2_storage::ReadOrder & order) override;
+  bool set_read_order(const rosbag2_storage::ReadOrder & order) override;
 
   bool has_next() override;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -67,9 +67,9 @@ public:
   void close() override;
 
   /**
-   * \note set_read_order(order) should be called only after open(). Calling set_read_order(order)
-   * concurrently with has_next(), seek(t), has_next_file() or load_next_file() will cause
-   * undefined behavior.
+   * \throws runtime_error if the Reader is not open.
+   * \note Calling set_read_order(order) concurrently with has_next(), seek(t), has_next_file()
+   * or load_next_file() will cause undefined behavior.
    */
   bool set_read_order(const rosbag2_storage::ReadOrder & order) override;
 

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -56,7 +56,7 @@ void Reader::close()
   reader_impl_->close();
 }
 
-void Reader::set_read_order(const rosbag2_storage::ReadOrder & order)
+bool Reader::set_read_order(const rosbag2_storage::ReadOrder & order)
 {
   return reader_impl_->set_read_order(order);
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> resolve_relative_paths(
 }
 }  // namespace details
 
-const static rosbag2_storage::ReadOrder kFallbackOrder(rosbag2_storage::ReadOrder::SortBy::File,
+static const rosbag2_storage::ReadOrder kFallbackOrder(rosbag2_storage::ReadOrder::SortBy::File,
   false);
 
 SequentialReader::SequentialReader(

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -57,6 +57,9 @@ std::vector<std::string> resolve_relative_paths(
 }
 }  // namespace details
 
+const static rosbag2_storage::ReadOrder kFallbackOrder(rosbag2_storage::ReadOrder::SortBy::File,
+  false);
+
 SequentialReader::SequentialReader(
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory,
@@ -108,7 +111,10 @@ void SequentialReader::open(
     }
     if (!set_read_order(read_order_)) {
       ROSBAG2_CPP_LOG_WARN(
-        "Could not set read order on open(), defaulting to storage plugin's default read order");
+        "Could not set read order on open(), falling back to file order");
+      if (!set_read_order(kFallbackOrder)) {
+        throw std::runtime_error("Could not set read order on open()");
+      }
     }
     metadata_ = storage_->get_metadata();
     if (metadata_.relative_file_paths.empty()) {

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
@@ -37,7 +37,7 @@ public:
   MOCK_METHOD1(update_metadata, void(const rosbag2_storage::BagMetadata &));
   MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
-  MOCK_METHOD1(set_read_order, void(const rosbag2_storage::ReadOrder &));
+  MOCK_METHOD1(set_read_order, bool(const rosbag2_storage::ReadOrder &));
   MOCK_METHOD0(has_next, bool());
   MOCK_METHOD0(has_next_file, bool());
   MOCK_METHOD0(read_next, std::shared_ptr<rosbag2_storage::SerializedBagMessage>());

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -67,6 +67,7 @@ public:
 
     EXPECT_CALL(*storage_, get_all_topics_and_types())
     .Times(AtMost(1)).WillRepeatedly(Return(topics_and_types));
+    ON_CALL(*storage_, set_read_order).WillByDefault(Return(true));
     ON_CALL(*storage_, read_next()).WillByDefault(Return(message));
     EXPECT_CALL(*storage_factory, open_read_only(_)).WillRepeatedly(Return(storage_));
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -93,6 +93,7 @@ public:
       });
     EXPECT_CALL(*storage_, has_next_file()).WillRepeatedly(Return(true));
     EXPECT_CALL(*storage_, read_next()).WillRepeatedly(Return(message));
+    ON_CALL(*storage_, set_read_order).WillByDefault(Return(true));
 
     EXPECT_CALL(*storage_factory, open_read_only(_)).Times(AnyNumber());
     ON_CALL(*storage_factory, open_read_only).WillByDefault(

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -328,10 +328,10 @@ public:
 TEST_F(ReadOrderTest, received_timestamp_order) {
   rosbag2_storage::ReadOrder order(rosbag2_storage::ReadOrder::ReceivedTimestamp, false);
   sort_expected(order);
-  reader.set_read_order(order);
 
   for (bool do_reset : {false, true}) {
     reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
+    EXPECT_TRUE(reader.set_read_order(order));
     check_against_sorted(do_reset);
     reader.close();
   }
@@ -340,8 +340,8 @@ TEST_F(ReadOrderTest, received_timestamp_order) {
 TEST_F(ReadOrderTest, reverse_received_timestamp_order) {
   rosbag2_storage::ReadOrder order(rosbag2_storage::ReadOrder::ReceivedTimestamp, true);
   sort_expected(order);
-  reader.set_read_order(order);
   reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
+  EXPECT_TRUE(reader.set_read_order(order));
   auto metadata = reader.get_metadata();
   // Seek to end before reading reverse messages
   auto end_timestamp = (metadata.starting_time + metadata.duration).time_since_epoch().count();
@@ -357,22 +357,19 @@ TEST_F(ReadOrderTest, reverse_received_timestamp_order) {
 
 TEST_F(ReadOrderTest, file_order) {
   reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
-  EXPECT_THROW(
-    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, false)),
-    std::runtime_error);
+  EXPECT_FALSE(
+    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, false)));
 }
 
 TEST_F(ReadOrderTest, reverse_file_order) {
   reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
-  EXPECT_THROW(
-    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, true)),
-    std::runtime_error);
+  EXPECT_FALSE(
+    reader.set_read_order(rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::File, true)));
 }
 
 TEST_F(ReadOrderTest, published_timestamp_order) {
   reader.open(storage_options, rosbag2_cpp::ConverterOptions{});
-  EXPECT_THROW(
+  EXPECT_FALSE(
     reader.set_read_order(
-      rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::PublishedTimestamp, false)),
-    std::runtime_error);
+      rosbag2_storage::ReadOrder(rosbag2_storage::ReadOrder::PublishedTimestamp, false)));
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -72,6 +72,7 @@ public:
       [this](const rosbag2_storage::BagMetadata & metadata) {
         v_intercepted_update_metadata_.emplace_back(metadata);
       });
+    ON_CALL(*storage_, set_read_order).WillByDefault(Return(true));
   }
 
   ~SequentialWriterTest() override

--- a/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
@@ -69,6 +69,7 @@ TEST_F(StorageWithoutMetadataFileTest, open_uses_storage_id_from_storage_options
     metadata.topics_with_message_count = {topic_information};
 
     EXPECT_CALL(*storage_, get_metadata).Times(1).WillOnce(Return(metadata));
+    EXPECT_CALL(*storage_, set_read_order).Times(1).WillOnce(Return(true));
   }
 
   auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
@@ -62,8 +62,8 @@ public:
   ///   This affects the outcome of has_next and read_next.
   ///   Note that when setting to reverse order, this will not change the read head, so user
   ///   must first seek() to the end in order to read messages from the end.
-  ///   Also note that set_read_order should only be called after open() has been called.
   /// @param read_order The order in which to return messages.
+  /// @throws runtime_error if the reader is not open.
   /// @return true if the requested read order has been successfully set.
   virtual bool set_read_order(const ReadOrder & read_order) = 0;
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_read_interface.hpp
@@ -62,8 +62,10 @@ public:
   ///   This affects the outcome of has_next and read_next.
   ///   Note that when setting to reverse order, this will not change the read head, so user
   ///   must first seek() to the end in order to read messages from the end.
+  ///   Also note that set_read_order should only be called after open() has been called.
   /// @param read_order The order in which to return messages.
-  virtual void set_read_order(const ReadOrder & read_order) = 0;
+  /// @return true if the requested read order has been successfully set.
+  virtual bool set_read_order(const ReadOrder & read_order) = 0;
 
   virtual bool has_next() = 0;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -52,9 +52,10 @@ void TestPlugin::update_metadata(const rosbag2_storage::BagMetadata & metadata)
   (void)metadata;
 }
 
-void TestPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
+bool TestPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
 {
   std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
+  return true;
 }
 
 bool TestPlugin::has_next()

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -39,7 +39,7 @@ public:
 
   void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
 
-  void set_read_order(const rosbag2_storage::ReadOrder &) override;
+  bool set_read_order(const rosbag2_storage::ReadOrder &) override;
 
   bool has_next() override;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -43,9 +43,10 @@ void TestReadOnlyPlugin::open(
   std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
-void TestReadOnlyPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
+bool TestReadOnlyPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
 {
   std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
+  return true;
 }
 
 bool TestReadOnlyPlugin::has_next()

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.hpp
@@ -31,7 +31,7 @@ public:
     const rosbag2_storage::StorageOptions & storage_options,
     rosbag2_storage::storage_interfaces::IOFlag flag) override;
 
-  void set_read_order(const rosbag2_storage::ReadOrder &) override;
+  bool set_read_order(const rosbag2_storage::ReadOrder &) override;
 
   bool has_next() override;
 

--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -67,7 +67,7 @@ public:
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
   override;
 
-  void set_read_order(const rosbag2_storage::ReadOrder &) override;
+  bool set_read_order(const rosbag2_storage::ReadOrder &) override;
 
   bool has_next() override;
 

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -323,9 +323,11 @@ void SqliteStorage::write(
 bool SqliteStorage::set_read_order(const rosbag2_storage::ReadOrder & read_order)
 {
   if (read_order.sort_by == rosbag2_storage::ReadOrder::PublishedTimestamp) {
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_DEBUG("ReadOrder::PublishedTimestamp not implemented");
     return false;
   }
   if (read_order.sort_by == rosbag2_storage::ReadOrder::File) {
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_DEBUG("ReadOrder::File not implemented");
     return false;
   }
 

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -320,17 +320,18 @@ void SqliteStorage::write(
   commit_transaction();
 }
 
-void SqliteStorage::set_read_order(const rosbag2_storage::ReadOrder & read_order)
+bool SqliteStorage::set_read_order(const rosbag2_storage::ReadOrder & read_order)
 {
   if (read_order.sort_by == rosbag2_storage::ReadOrder::PublishedTimestamp) {
-    throw std::runtime_error("Not Implemented - PublishedTimestamp read order.");
+    return false;
   }
   if (read_order.sort_by == rosbag2_storage::ReadOrder::File) {
-    throw std::runtime_error("Not Implemented - File read order");
+    return false;
   }
 
   read_order_ = read_order;
   read_statement_ = nullptr;
+  return true;
 }
 
 bool SqliteStorage::has_next()

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -36,8 +36,10 @@ public:
 
   void close() override {}
 
-  void set_read_order(const rosbag2_storage::ReadOrder &) override
-  {}
+  bool set_read_order(const rosbag2_storage::ReadOrder &) override
+  {
+    return true;
+  }
 
   bool has_next() override
   {


### PR DESCRIPTION
This PR makes these changes:

1. Notes to client code that `set_read_order` should only be called after `open()`. There are cases where a storage plugin actually needs to read the underlying bag file in order to determine whether a given read order is supported. For example, if a timestamp index is required to read in timestamp order, the storage plugin needs to know whether that is present before accepting a request to read in timestamp order.
1. Throw an exception from within `SequentialReader` if read order is set before opening the underlying storage.
1. changes `set_read_order` to return a boolean for success or failure. This makes the flow for client code attempting to set a read order more ergonomic. Previously a client would have to check for a `std::runtime_error` and possibly inspect the exception text to ensure that the exception is about whether the read order is supported, rather than something unrelated.