### PR TITLE
Install zstd in an alternate directory (#1172)

### DIFF
--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -52,7 +52,7 @@ macro(build_zstd)
 
   install(
     DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/opt/zstd_vendor
     USE_SOURCE_PERMISSIONS)
 endmacro()
 
@@ -64,4 +64,4 @@ endif()
 
 install(DIRECTORY cmake DESTINATION share/${PROJECT_NAME})
 
-ament_package(CONFIG_EXTRAS zstd_vendor-extras.cmake)
+ament_package(CONFIG_EXTRAS zstd_vendor-extras.cmake.in)

--- a/zstd_vendor/zstd_vendor-extras.cmake
+++ b/zstd_vendor/zstd_vendor-extras.cmake
@@ -1,1 +1,0 @@
-list(INSERT CMAKE_MODULE_PATH 0 "${zstd_vendor_DIR}/Modules")

--- a/zstd_vendor/zstd_vendor-extras.cmake.in
+++ b/zstd_vendor/zstd_vendor-extras.cmake.in
@@ -1,0 +1,5 @@
+if(NOT DEFINED ENV{zstd_ROOT_DIR})
+  set(zstd_ROOT_DIR "${@PROJECT_NAME@_DIR}/../../../opt/zstd_vendor")
+endif()
+
+list(INSERT CMAKE_MODULE_PATH 0 "${zstd_vendor_DIR}/Modules")


### PR DESCRIPTION
This prevents the compiled libzstd from being used by the host's cmake executable

Fixes ros2/rosbag2#1172