### PR TITLE
Added option to change node name for the recorder from the Python API

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -174,6 +174,10 @@ class RecordVerb(VerbExtension):
             '--use-sim-time', action='store_true', default=False,
             help='Use simulation time.'
         )
+        parser.add_argument(
+            '--node-name', type=str, default='rosbag2_recorder',
+            help='Specify the recorder node name. Default is rosbag2_recorder.'
+        )
         self._subparser = parser
 
     def main(self, *, args):  # noqa: D102
@@ -259,7 +263,7 @@ class RecordVerb(VerbExtension):
         recorder = Recorder()
 
         try:
-            recorder.record(storage_options, record_options)
+            recorder.record(storage_options, record_options, args.node_name)
         except KeyboardInterrupt:
             pass
 

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -211,7 +211,7 @@ public:
   void record(
     const rosbag2_storage::StorageOptions & storage_options,
     RecordOptions & record_options,
-	std::string & node_name)
+    std::string & node_name)
   {
     if (record_options.rmw_serialization_format.empty()) {
       record_options.rmw_serialization_format = std::string(rmw_get_serialization_format());
@@ -358,7 +358,7 @@ PYBIND11_MODULE(_transport, m) {
   py::class_<rosbag2_py::Recorder>(m, "Recorder")
   .def(py::init())
   .def("record", &rosbag2_py::Recorder::record, py::arg("storage_options"),
-	py::arg("record_options"), py::arg("node_name") = "rosbag2_recorder")
+    py::arg("record_options"), py::arg("node_name") = "rosbag2_recorder")
   .def("cancel", &rosbag2_py::Recorder::cancel)
   ;
 

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -358,7 +358,7 @@ PYBIND11_MODULE(_transport, m) {
   py::class_<rosbag2_py::Recorder>(m, "Recorder")
   .def(py::init())
   .def(
-    "record", &rosbag2_py::Recorder::record, py::arg(), py::arg(),
+    "record", &rosbag2_py::Recorder::record, py::arg("storage_options"), py::arg("record_options"),
     py::arg("node_name") = "rosbag2_recorder")
   .def("cancel", &rosbag2_py::Recorder::cancel)
   ;

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -357,8 +357,11 @@ PYBIND11_MODULE(_transport, m) {
 
   py::class_<rosbag2_py::Recorder>(m, "Recorder")
   .def(py::init())
-  .def("record", &rosbag2_py::Recorder::record, py::arg("storage_options"),
-    py::arg("record_options"), py::arg("node_name") = "rosbag2_recorder")
+  .def(
+    "record", &rosbag2_py::Recorder::record,
+    py::arg("storage_options"),
+    py::arg("record_options"),
+    py::arg("node_name") = "rosbag2_recorder")
   .def("cancel", &rosbag2_py::Recorder::cancel)
   ;
 

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -358,9 +358,7 @@ PYBIND11_MODULE(_transport, m) {
   py::class_<rosbag2_py::Recorder>(m, "Recorder")
   .def(py::init())
   .def(
-    "record", &rosbag2_py::Recorder::record,
-    py::arg("storage_options"),
-    py::arg("record_options"),
+    "record", &rosbag2_py::Recorder::record, py::arg(), py::arg(),
     py::arg("node_name") = "rosbag2_recorder")
   .def("cancel", &rosbag2_py::Recorder::cancel)
   ;

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -210,7 +210,8 @@ public:
 
   void record(
     const rosbag2_storage::StorageOptions & storage_options,
-    RecordOptions & record_options)
+    RecordOptions & record_options,
+	std::string & node_name)
   {
     if (record_options.rmw_serialization_format.empty()) {
       record_options.rmw_serialization_format = std::string(rmw_get_serialization_format());
@@ -218,7 +219,7 @@ public:
 
     auto writer = rosbag2_transport::ReaderWriterFactory::make_writer(record_options);
     auto recorder = std::make_shared<rosbag2_transport::Recorder>(
-      std::move(writer), storage_options, record_options);
+      std::move(writer), storage_options, record_options, node_name);
     recorder->record();
 
     exec_->add_node(recorder);
@@ -356,7 +357,8 @@ PYBIND11_MODULE(_transport, m) {
 
   py::class_<rosbag2_py::Recorder>(m, "Recorder")
   .def(py::init())
-  .def("record", &rosbag2_py::Recorder::record)
+  .def("record", &rosbag2_py::Recorder::record, py::arg("storage_options"),
+	py::arg("record_options"), py::arg("node_name") = "rosbag2_recorder")
   .def("cancel", &rosbag2_py::Recorder::cancel)
   ;
 


### PR DESCRIPTION
Fixes #1145 

This is a simple proposal to add the option to select the node name of the recorder.

My motivation is the ability to run multiple recorder nodes under the same ROS2 network (ROS_DOMAIN_ID) and be able to differentiate them.

Thanks everyone for your time!

Signed-off-by: Ricardo Manriquez <ricardo.manriquez+gh@gmail.com>