### PR TITLE
Make rosbag2_tests agnostic to storage implementation

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
@@ -61,21 +61,22 @@ public:
     auto publisher = pub_node_->create_publisher<MsgT>(topic_name, qos);
 
     auto publisher_fcn = [publisher, message, repetition, interval](bool verbose = false) {
-        for (auto i = 0u; i < repetition && rclcpp::ok(); ++i) {
-          publisher->publish(message);
-          if (verbose) {
-            RCLCPP_INFO(
-              rclcpp::get_logger("publication_manager"),
-              "publish on topic %s", publisher->get_topic_name());
+        for (auto i = 0u; i < repetition; ++i) {
+          if (rclcpp::ok()) {
+            publisher->publish(message);
+            if (verbose) {
+              RCLCPP_INFO(
+                rclcpp::get_logger("publication_manager"),
+                "publish on topic %s", publisher->get_topic_name());
+            }
+            std::this_thread::sleep_for(interval);
           }
-          std::this_thread::sleep_for(interval);
         }
       };
 
     publishers_.push_back(std::make_pair(publisher, publisher_fcn));
   }
 
-  /// \brief Synchronously, sequentially run all setup publishers one at a time.
   void run_publishers(bool verbose = false) const
   {
     for (const auto & pub : publishers_) {

--- a/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
@@ -61,22 +61,21 @@ public:
     auto publisher = pub_node_->create_publisher<MsgT>(topic_name, qos);
 
     auto publisher_fcn = [publisher, message, repetition, interval](bool verbose = false) {
-        for (auto i = 0u; i < repetition; ++i) {
-          if (rclcpp::ok()) {
-            publisher->publish(message);
-            if (verbose) {
-              RCLCPP_INFO(
-                rclcpp::get_logger("publication_manager"),
-                "publish on topic %s", publisher->get_topic_name());
-            }
-            std::this_thread::sleep_for(interval);
+        for (auto i = 0u; i < repetition && rclcpp::ok(); ++i) {
+          publisher->publish(message);
+          if (verbose) {
+            RCLCPP_INFO(
+              rclcpp::get_logger("publication_manager"),
+              "publish on topic %s", publisher->get_topic_name());
           }
+          std::this_thread::sleep_for(interval);
         }
       };
 
     publishers_.push_back(std::make_pair(publisher, publisher_fcn));
   }
 
+  /// \brief Synchronously, sequentially run all setup publishers one at a time.
   void run_publishers(bool verbose = false) const
   {
     for (const auto & pub : publishers_) {

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -52,6 +52,7 @@ if(BUILD_TESTING)
       rosbag2_storage_default_plugins
       rosbag2_test_common
       test_msgs)
+    ament_add_test_label(test_rosbag2_record_end_to_end xfail)
   endif()
 
   ament_add_gmock(test_rosbag2_play_end_to_end
@@ -61,6 +62,7 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_rosbag2_play_end_to_end
       rclcpp
       rosbag2_storage
+      rosbag2_storage_default_plugins
       rosbag2_test_common
       test_msgs)
     ament_add_test_label(test_rosbag2_play_end_to_end xfail)

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BUILD_TESTING)
       rosbag2_compression
       rosbag2_compression_zstd
       rosbag2_storage
+      rosbag2_storage_default_plugins
       rosbag2_test_common
       test_msgs)
   endif()

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -35,7 +35,6 @@ if(BUILD_TESTING)
   find_package(rosbag2_compression REQUIRED)
   find_package(rosbag2_cpp REQUIRED)
   find_package(rosbag2_storage REQUIRED)
-  find_package(rosbag2_storage_sqlite3 REQUIRED)
   find_package(rosbag2_storage_default_plugins REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   find_package(std_msgs REQUIRED)
@@ -50,7 +49,6 @@ if(BUILD_TESTING)
       rosbag2_compression
       rosbag2_compression_zstd
       rosbag2_storage
-      rosbag2_storage_sqlite3
       rosbag2_test_common
       test_msgs)
   endif()
@@ -62,7 +60,6 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_rosbag2_play_end_to_end
       rclcpp
       rosbag2_storage
-      rosbag2_storage_sqlite3
       rosbag2_test_common
       test_msgs)
     ament_add_test_label(test_rosbag2_play_end_to_end xfail)

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -53,7 +53,6 @@ if(BUILD_TESTING)
       rosbag2_storage_sqlite3
       rosbag2_test_common
       test_msgs)
-    ament_add_test_label(test_rosbag2_record_end_to_end xfail)
   endif()
 
   ament_add_gmock(test_rosbag2_play_end_to_end

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -29,6 +29,7 @@
 
 #include "rosbag2_compression/sequential_compression_reader.hpp"
 #include "rosbag2_cpp/reader.hpp"
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/storage_filter.hpp"
 #include "rosbag2_test_common/memory_management.hpp"
 

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -99,13 +99,6 @@ public:
     return bag_file_name.str();
   }
 
-  rcpputils::fs::path get_relative_bag_file_path(int split_index)
-  {
-    const auto storage_id = GetParam();
-    const auto extension = storage_plugins_to_extension.at(storage_id);
-    return rcpputils::fs::path(get_bag_file_name(split_index) + extension);
-  }
-
   rcpputils::fs::path get_compressed_bag_file_path(int split_index)
   {
     return rcpputils::fs::path(get_bag_file_path(split_index).string() + ".zstd");
@@ -114,6 +107,13 @@ public:
   rcpputils::fs::path get_bag_file_path(int split_index)
   {
     return root_bag_path_ / get_relative_bag_file_path(split_index);
+  }
+
+  rcpputils::fs::path get_relative_bag_file_path(int split_index)
+  {
+    const auto storage_id = GetParam();
+    const auto extension = storage_plugins_to_extension.at(storage_id);
+    return rcpputils::fs::path(get_bag_file_name(split_index) + extension);
   }
 
   void wait_for_metadata(std::chrono::duration<float> timeout = std::chrono::seconds(5)) const

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -58,11 +58,10 @@ TEST_F(ReindexTestFixture, test_multiple_files) {
   std::unique_ptr<rosbag2_cpp::Reindexer> reindexer =
     std::make_unique<rosbag2_cpp::Reindexer>();
 
-  rosbag2_storage::StorageOptions so = rosbag2_storage::StorageOptions();
-  so.uri = bag_dir.string();
-  so.storage_id = "sqlite3";
+  rosbag2_storage::StorageOptions storage_options = rosbag2_storage::StorageOptions();
+  storage_options.uri = bag_dir.string();
 
-  reindexer->reindex(so);
+  reindexer->reindex(storage_options);
 
   auto generated_file = rcpputils::fs::path(bag_dir) / "metadata.yaml";
   EXPECT_TRUE(generated_file.exists());

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -45,16 +45,16 @@ class ReindexTestFixture : public Test
 public:
   ReindexTestFixture()
   {
-    database_path = rcpputils::fs::path(_SRC_RESOURCES_DIR_PATH) / "reindex_test_bags";
-    target_dir = database_path / "target_metadata";
+    bags_path = rcpputils::fs::path(_SRC_RESOURCES_DIR_PATH) / "reindex_test_bags";
+    target_dir = bags_path / "target_metadata";
   }
 
-  rcpputils::fs::path database_path;
+  rcpputils::fs::path bags_path;
   rcpputils::fs::path target_dir;
 };
 
 TEST_F(ReindexTestFixture, test_multiple_files) {
-  auto bag_dir = database_path / "multiple_files";
+  auto bag_dir = bags_path / "multiple_files";
   std::unique_ptr<rosbag2_cpp::Reindexer> reindexer =
     std::make_unique<rosbag2_cpp::Reindexer>();
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -28,15 +28,15 @@ class InfoEndToEndTestFixture : public Test
 public:
   InfoEndToEndTestFixture()
   {
-    database_path_ = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
+    bags_path_ = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
   }
 
-  std::string database_path_;
+  std::string bags_path_;
 };
 
 TEST_F(InfoEndToEndTestFixture, info_end_to_end_test) {
   internal::CaptureStdout();
-  auto exit_code = execute_and_wait_until_completion("ros2 bag info cdr_test", database_path_);
+  auto exit_code = execute_and_wait_until_completion("ros2 bag info cdr_test", bags_path_);
   std::string output = internal::GetCapturedStdout();
 
   EXPECT_THAT(exit_code, Eq(EXIT_SUCCESS));
@@ -65,7 +65,7 @@ TEST_F(InfoEndToEndTestFixture, info_end_to_end_test) {
 TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_bag_does_not_exist) {
   internal::CaptureStderr();
   auto exit_code =
-    execute_and_wait_until_completion("ros2 bag info does_not_exist", database_path_);
+    execute_and_wait_until_completion("ros2 bag info does_not_exist", bags_path_);
   auto error_output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Ne(EXIT_SUCCESS));
@@ -75,7 +75,7 @@ TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_bag_does_not_exist) {
 TEST_F(InfoEndToEndTestFixture, info_fails_gracefully_if_metadata_yaml_file_does_not_exist) {
   internal::CaptureStderr();
   auto exit_code =
-    execute_and_wait_until_completion("ros2 bag info " + database_path_, database_path_);
+    execute_and_wait_until_completion("ros2 bag info " + bags_path_, bags_path_);
   auto error_output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <thread>
 
+#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_test_common/process_execution_helpers.hpp"
 
 using namespace ::testing;  // NOLINT
@@ -44,7 +45,7 @@ TEST_F(InfoEndToEndTestFixture, info_end_to_end_test) {
     output, ContainsRegex(
       "\nFiles:             cdr_test_0\\.db3"
       "\nBag size:          .*B"
-      "\nStorage id:        sqlite3"
+      "\nStorage id:        " + rosbag2_storage::get_default_storage_id() +
       "\nDuration:          0\\.151s"
       "\nStart:             Apr  .+ 2020 .*:.*:36.763 \\(1586406456\\.763\\)"
       "\nEnd:               Apr  .+ 2020 .*:.*:36.914 \\(1586406456\\.914\\)"

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -39,7 +39,7 @@ class PlayEndToEndTestFixture : public Test
 public:
   PlayEndToEndTestFixture()
   {
-    database_path_ = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
+    bags_path_ = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
     sub_ = std::make_unique<SubscriptionManager>();
   }
 
@@ -53,7 +53,7 @@ public:
     rclcpp::shutdown();
   }
 
-  std::string database_path_;
+  std::string bags_path_;
   std::unique_ptr<SubscriptionManager> sub_;
 };
 
@@ -64,7 +64,7 @@ TEST_F(PlayEndToEndTestFixture, play_end_to_end_test) {
 
   auto subscription_future = sub_->spin_subscriptions();
 
-  auto exit_code = execute_and_wait_until_completion("ros2 bag play cdr_test", database_path_);
+  auto exit_code = execute_and_wait_until_completion("ros2 bag play cdr_test", bags_path_);
 
   subscription_future.get();
 
@@ -99,7 +99,7 @@ TEST_F(PlayEndToEndTestFixture, play_end_to_end_test) {
 TEST_F(PlayEndToEndTestFixture, play_fails_gracefully_if_bag_does_not_exist) {
   internal::CaptureStderr();
   auto exit_code =
-    execute_and_wait_until_completion("ros2 bag play does_not_exist", database_path_);
+    execute_and_wait_until_completion("ros2 bag play does_not_exist", bags_path_);
   auto error_output = internal::GetCapturedStderr();
 
   // Exit code could be EXIT_FAILURE (1) or 2 (no such file or directory)
@@ -110,7 +110,7 @@ TEST_F(PlayEndToEndTestFixture, play_fails_gracefully_if_bag_does_not_exist) {
 TEST_F(PlayEndToEndTestFixture, play_fails_gracefully_if_needed_coverter_plugin_does_not_exist) {
   internal::CaptureStderr();
   auto exit_code =
-    execute_and_wait_until_completion("ros2 bag play wrong_rmw_test", database_path_);
+    execute_and_wait_until_completion("ros2 bag play wrong_rmw_test", bags_path_);
   auto error_output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
@@ -134,7 +134,7 @@ TEST_F(PlayEndToEndTestFixture, play_filters_by_topic) {
 
   auto exit_code = execute_and_wait_until_completion(
     "ros2 bag play cdr_test --topics /test_topic",
-    database_path_);
+    bags_path_);
 
   subscription_future.get();
 
@@ -155,7 +155,7 @@ TEST_F(PlayEndToEndTestFixture, play_filters_by_topic) {
 
   exit_code = execute_and_wait_until_completion(
     "ros2 bag play --topics /array_topic -- cdr_test",
-    database_path_);
+    bags_path_);
 
   subscription_future.get();
 
@@ -176,7 +176,7 @@ TEST_F(PlayEndToEndTestFixture, play_filters_by_topic) {
 
   exit_code = execute_and_wait_until_completion(
     "ros2 bag play --topics /test_topic /array_topic -- cdr_test",
-    database_path_);
+    bags_path_);
 
   subscription_future.get();
 
@@ -196,7 +196,7 @@ TEST_F(PlayEndToEndTestFixture, play_filters_by_topic) {
   subscription_future = sub_->spin_subscriptions();
 
   exit_code = execute_and_wait_until_completion(
-    "ros2 bag play --topics /nonexistent_topic -- cdr_test", database_path_);
+    "ros2 bag play --topics /nonexistent_topic -- cdr_test", bags_path_);
 
   subscription_future.get();
 
@@ -216,7 +216,7 @@ TEST_F(PlayEndToEndTestFixture, play_end_to_end_exits_gracefully_on_sigint) {
   sub_->add_subscription<test_msgs::msg::Arrays>("/array_topic", 2);
 
   // Start playback in child process
-  auto process_id = start_execution("ros2 bag play --loop " + database_path_ + "/cdr_test");
+  auto process_id = start_execution("ros2 bag play --loop " + bags_path_ + "/cdr_test");
   auto cleanup_process_handle = rcpputils::make_scope_exit(
     [process_id]() {
       stop_execution(process_id);

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -24,8 +24,6 @@
 // rclcpp must be included before process_execution_helpers.hpp
 #include "rclcpp/rclcpp.hpp"
 
-#include "rosbag2_storage_sqlite3/sqlite_storage.hpp"
-
 #include "rosbag2_test_common/subscription_manager.hpp"
 #include "rosbag2_test_common/process_execution_helpers.hpp"
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -104,11 +104,11 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
   rosbag2_compression_zstd::ZstdDecompressor decompressor;
 
   const auto decompressed_uri = decompressor.decompress_uri(compressed_bag_file_path.string());
-  const auto database_path = get_bag_file_path(0).string();
+  const auto bag_path = get_bag_file_path(0).string();
 
-  ASSERT_EQ(decompressed_uri, database_path) <<
+  ASSERT_EQ(decompressed_uri, bag_path) <<
     "Expected decompressed URI to be same as uncompressed bag file path!";
-  ASSERT_TRUE(rcpputils::fs::exists(database_path)) <<
+  ASSERT_TRUE(rcpputils::fs::exists(bag_path)) <<
     "Expected decompressed first bag file to exist!";
 
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>(
@@ -274,11 +274,10 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 }
 #endif
 
-/*
 TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size) {
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
-  constexpr const int expected_splits = 4;
+  constexpr const int expected_splits = 3;
   constexpr const char message_str[] = "Test";
   constexpr const int message_size = 512 * 1024;  // 512KB
   const auto message = create_string_message(message_str, message_size);
@@ -308,28 +307,11 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 
   pub_manager.run_publishers();
 
-  rosbag2_storage::MetadataIo metadata_io;
-
-#ifdef FAKE_METADATA_FOR_TEST
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.version = 4;
-    metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
-
-    // Loop until expected_splits in case it split or the bagfile doesn't exist.
-    for (int i = 0; i < expected_splits; ++i) {
-      const auto bag_file_path = get_relative_bag_file_path(i);
-      if (rcpputils::fs::exists(root_bag_path_ / bag_file_path)) {
-        metadata.relative_file_paths.push_back(bag_file_path.string());
-      }
-    }
-
-    metadata_io.write_metadata(root_bag_path_.string(), metadata);
-  }
-#endif
-
+  finalize_metadata_kludge(expected_splits);
   wait_for_metadata();
+  rosbag2_storage::MetadataIo metadata_io;
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+
   const auto actual_splits = static_cast<int>(metadata.files.size());
 
   // TODO(zmichaels11): Support reliable sync-to-disk for more accurate splits.
@@ -382,22 +364,9 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
   stop_execution(process_handle);
   cleanup_process_handle.cancel();
 
-  rosbag2_storage::MetadataIo metadata_io;
-
-// TODO(zmichaels11): Remove when stop_execution properly SIGINT on Windows.
-// This is required since stop_execution hard kills the proces on Windows,
-// which prevents the metadata from being written.
-#ifdef FAKE_METADATA_FOR_TEST
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.version = 4;
-    metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
-    metadata.relative_file_paths = {get_relative_bag_file_path(0)};
-    metadata_io.write_metadata(root_bag_path_.string(), metadata);
-  }
-#endif
-
+  finalize_metadata_kludge();
   wait_for_metadata();
+  rosbag2_storage::MetadataIo metadata_io;
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   // Check that there's only 1 bagfile and that it exists.
@@ -446,35 +415,12 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   stop_execution(process_handle);
   cleanup_process_handle.cancel();
 
-  rosbag2_storage::MetadataIo metadata_io;
-
-// TODO(zmichaels11): Remove when stop_execution properly SIGINT on Windows.
-// This is required since stop_execution hard kills the proces on Windows,
-// which prevents the metadata from being written.
-#ifdef FAKE_METADATA_FOR_TEST
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.version = 4;
-    metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
-
-    for (int i = 0; i < expected_splits; ++i) {
-      const auto rel_bag_file_path = get_relative_bag_file_path(i);
-
-      // There is no guarantee that the bagfile split expected_split times
-      // due to possible io sync delays. Instead, assert that the bagfile split
-      // at least once
-      if (rcpputils::fs::exists(root_bag_path_ / rel_bag_file_path)) {
-        metadata.relative_file_paths.push_back(rel_bag_file_path.string());
-      }
-    }
-
-    ASSERT_GE(metadata.relative_file_paths.size(), 1) << "Bagfile never split!";
-    metadata_io.write_metadata(root_bag_path_.string(), metadata);
-  }
-#endif
-
   wait_for_metadata();
+  finalize_metadata_kludge(expected_splits);
+  rosbag2_storage::MetadataIo metadata_io;
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+
+  ASSERT_GE(metadata.relative_file_paths.size(), 1u) << "Bagfile never split!";
 
   for (const auto & file : metadata.files) {
     auto path = root_bag_path_ / rcpputils::fs::path(file.path);
@@ -517,27 +463,9 @@ TEST_F(RecordFixture, record_end_to_end_with_duration_splitting_splits_bagfile) 
   stop_execution(process_handle);
   cleanup_process_handle.cancel();
 
-  rosbag2_storage::MetadataIo metadata_io;
-
-#ifdef FAKE_METADATA_FOR_TEST
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.version = 4;
-    metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
-
-    // Loop until expected_splits in case it split or the bagfile doesn't exist.
-    for (int i = 0; i < expected_splits; ++i) {
-      const auto bag_file_path = get_relative_bag_file_path(i);
-      if (rcpputils::fs::exists(root_bag_path_ / bag_file_path)) {
-        metadata.relative_file_paths.push_back(bag_file_path.string());
-      }
-    }
-
-    metadata_io.write_metadata(root_bag_path_.string(), metadata);
-  }
-#endif
-
+  finalize_metadata_kludge();
   wait_for_metadata();
+  rosbag2_storage::MetadataIo metadata_io;
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   for (const auto & file : metadata.files) {
@@ -583,36 +511,9 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
   stop_execution(process_handle);
   cleanup_process_handle.cancel();
 
-  rosbag2_storage::MetadataIo metadata_io;
-
-  // TODO(zmichaels11): Remove when stop_execution properly SIGINT on Windows.
-  // This is required since stop_execution hard kills the proces on Windows,
-  // which prevents the metadata from being written.
-  #ifdef FAKE_METADATA_FOR_TEST
-  {
-    rosbag2_storage::BagMetadata metadata;
-    metadata.version = 3;
-    metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
-    metadata.compression_mode = "file";
-    metadata.compression_format = "zstd";
-
-    for (int i = 0; i < expected_splits; ++i) {
-      const auto compressed_bag_path = get_compressed_bag_file_path(i);
-
-      // There is no guarantee that the bagfile split expected_split times
-      // due to possible io sync delays. Instead, assert that the bagfile
-      // split at least once.
-      if (compressed_bag_path.exists()) {
-        metadata.relative_file_paths.push_back(compressed_bag_path.string());
-      }
-    }
-
-    ASSERT_GE(metadata.relative_file_paths.size(), 1) << "Bagfile never split!";
-    metadata_io.write_metadata(root_bag_path_.string(), metadata);
-  }
-  #endif
-
+  finalize_metadata_kludge(expected_splits);
   wait_for_metadata();
+  rosbag2_storage::MetadataIo metadata_io;
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
 
   for (const auto & path : metadata.relative_file_paths) {
@@ -626,11 +527,11 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
 }
 
 TEST_F(RecordFixture, record_fails_gracefully_if_bag_already_exists) {
-  auto database_path = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
+  auto bag_path = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
 
   internal::CaptureStderr();
   auto exit_code =
-    execute_and_wait_until_completion("ros2 bag record --output cdr_test -a", database_path);
+    execute_and_wait_until_completion("ros2 bag record --output cdr_test -a", bag_path);
   auto error_output = internal::GetCapturedStderr();
 
   EXPECT_THAT(exit_code, Eq(EXIT_FAILURE));
@@ -697,21 +598,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_cache) {
   stop_execution(process_handle);
   cleanup_process_handle.cancel();
 
-  // TODO(Martin-Idel-SI): Find out how to correctly send a Ctrl-C signal on Windows
-  // This is necessary as the process is killed hard on Windows and doesn't write a metadata file
-#ifdef FAKE_METADATA_FOR_TEST
-  rosbag2_storage::BagMetadata metadata{};
-  metadata.version = 1;
-  metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
-  metadata.relative_file_paths = {get_bag_file_path(0).string()};
-  metadata.duration = std::chrono::nanoseconds(0);
-  metadata.starting_time =
-    std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));
-  metadata.message_count = 0;
-  rosbag2_storage::MetadataIo metadata_io;
-  metadata_io.write_metadata(root_bag_path_.string(), metadata);
-#endif
-
+  finalize_metadata_kludge();
   wait_for_metadata();
   auto test_topic_messages =
     get_messages_for_topic<test_msgs::msg::Strings>(topic_name);
@@ -778,4 +665,3 @@ TEST_F(RecordFixture, rosbag2_record_and_play_multiple_topics_with_filter) {
   // stops thread
   sub->add_subscription<test_msgs::msg::Strings>(first_topic_name, 0);
 }
-*/

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<test_msgs::msg::Strings> create_string_message(
 }  // namespace
 
 #ifndef _WIN32
-TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
+TEST_P(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
   constexpr const char topic_name[] = "/test_topic";
   const auto compression_format = "zstd";
 
@@ -121,7 +121,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
 }
 #endif
 
-TEST_F(RecordFixture, record_end_to_end_test) {
+TEST_P(RecordFixture, record_end_to_end_test) {
   auto message = get_messages_strings()[0];
   message->string_value = "test";
   size_t expected_test_messages = 3;
@@ -168,7 +168,7 @@ TEST_F(RecordFixture, record_end_to_end_test) {
   EXPECT_THAT(unrecorded_topic_messages, IsEmpty());
 }
 
-TEST_F(RecordFixture, record_end_to_end_test_start_paused) {
+TEST_P(RecordFixture, record_end_to_end_test_start_paused) {
   auto message = get_messages_strings()[0];
   message->string_value = "test";
 
@@ -199,7 +199,7 @@ TEST_F(RecordFixture, record_end_to_end_test_start_paused) {
   EXPECT_THAT(test_topic_messages, IsEmpty());
 }
 
-TEST_F(RecordFixture, record_end_to_end_exits_gracefully_on_sigterm) {
+TEST_P(RecordFixture, record_end_to_end_exits_gracefully_on_sigterm) {
   const std::string topic_name = "/test_sigterm";
   auto message = get_messages_strings()[0];
   message->string_value = "test";
@@ -217,7 +217,7 @@ TEST_F(RecordFixture, record_end_to_end_exits_gracefully_on_sigterm) {
 // This tests depends on the ability to read the metadata file.
 // Stopping the process on Windows does a hard kill and the metadata file is not written.
 #ifndef _WIN32
-TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_topics) {
+TEST_P(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_topics) {
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   constexpr const char first_topic_name[] = "/test_topic0";
   constexpr const char second_topic_name[] = "/test_topic1";
@@ -274,7 +274,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 }
 #endif
 
-TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size) {
+TEST_P(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size) {
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   constexpr const int expected_splits = 3;
@@ -331,7 +331,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   }
 }
 
-TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
+TEST_P(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   constexpr const int message_size = 512 * 1024;  // 512KB
@@ -381,7 +381,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
     next_bag_file.string() << "\" to not exist!";
 }
 
-TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
+TEST_P(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   constexpr const int expected_splits = 4;
@@ -428,7 +428,7 @@ TEST_F(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   }
 }
 
-TEST_F(RecordFixture, record_end_to_end_with_duration_splitting_splits_bagfile) {
+TEST_P(RecordFixture, record_end_to_end_with_duration_splitting_splits_bagfile) {
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_duration = 1000;   // 1 second
   constexpr const int expected_splits = 4;
@@ -474,7 +474,7 @@ TEST_F(RecordFixture, record_end_to_end_with_duration_splitting_splits_bagfile) 
   }
 }
 
-TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compresses_files) {
+TEST_P(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compresses_files) {
   constexpr const char topic_name[] = "/test_topic";
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   constexpr const int expected_splits = 4;
@@ -526,7 +526,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
   }
 }
 
-TEST_F(RecordFixture, record_fails_gracefully_if_bag_already_exists) {
+TEST_P(RecordFixture, record_fails_gracefully_if_bag_already_exists) {
   auto bag_path = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
 
   internal::CaptureStderr();
@@ -538,7 +538,7 @@ TEST_F(RecordFixture, record_fails_gracefully_if_bag_already_exists) {
   EXPECT_THAT(error_output, HasSubstr("Output folder 'cdr_test' already exists"));
 }
 
-TEST_F(RecordFixture, record_fails_if_both_all_and_topic_list_is_specified) {
+TEST_P(RecordFixture, record_fails_if_both_all_and_topic_list_is_specified) {
   internal::CaptureStderr();
   auto exit_code =
     execute_and_wait_until_completion("ros2 bag record -a /some_topic", temporary_dir_path_);
@@ -548,7 +548,7 @@ TEST_F(RecordFixture, record_fails_if_both_all_and_topic_list_is_specified) {
   EXPECT_FALSE(error_output.empty());
 }
 
-TEST_F(RecordFixture, record_fails_if_neither_all_nor_topic_list_are_specified) {
+TEST_P(RecordFixture, record_fails_if_neither_all_nor_topic_list_are_specified) {
   internal::CaptureStderr();
   auto exit_code =
     execute_and_wait_until_completion("ros2 bag record", temporary_dir_path_);
@@ -558,7 +558,7 @@ TEST_F(RecordFixture, record_fails_if_neither_all_nor_topic_list_are_specified) 
   EXPECT_FALSE(output.empty());
 }
 
-TEST_F(RecordFixture, record_fails_gracefully_if_plugin_for_given_encoding_does_not_exist) {
+TEST_P(RecordFixture, record_fails_gracefully_if_plugin_for_given_encoding_does_not_exist) {
   internal::CaptureStderr();
   auto exit_code =
     execute_and_wait_until_completion("ros2 bag record -a -f some_rmw", temporary_dir_path_);
@@ -569,7 +569,7 @@ TEST_F(RecordFixture, record_fails_gracefully_if_plugin_for_given_encoding_does_
     error_output, HasSubstr("invalid choice: 'some_rmw'"));
 }
 
-TEST_F(RecordFixture, record_end_to_end_test_with_cache) {
+TEST_P(RecordFixture, record_end_to_end_test_with_cache) {
   auto max_cache_size = 10;
   auto topic_name = "/rosbag2_cache_test_topic";
 
@@ -605,7 +605,7 @@ TEST_F(RecordFixture, record_end_to_end_test_with_cache) {
   EXPECT_THAT(test_topic_messages, SizeIs(Ge(expected_test_messages)));
 }
 
-TEST_F(RecordFixture, rosbag2_record_and_play_multiple_topics_with_filter) {
+TEST_P(RecordFixture, rosbag2_record_and_play_multiple_topics_with_filter) {
   constexpr const int bagfile_split_size = 4 * 1024 * 1024;  // 4MB.
   constexpr const char first_topic_name[] = "/test_topic0";
   constexpr const char second_topic_name[] = "/test_topic1";
@@ -665,3 +665,8 @@ TEST_F(RecordFixture, rosbag2_record_and_play_multiple_topics_with_filter) {
   // stops thread
   sub->add_subscription<test_msgs::msg::Strings>(first_topic_name, 0);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  TestRecordEndToEnd,
+  RecordFixture,
+  ::testing::Values(std::string("sqlite3")));

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -311,7 +311,6 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   wait_for_metadata();
   rosbag2_storage::MetadataIo metadata_io;
   const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
-
   const auto actual_splits = static_cast<int>(metadata.files.size());
 
   // TODO(zmichaels11): Support reliable sync-to-disk for more accurate splits.


### PR DESCRIPTION
Closes https://github.com/ros2/rosbag2/issues/1112

Remove all Sqlite3-specific logic from rosbag2_tests, including language around "database"/"db", and explicit usage of the ".db3" storage file extension. 

Parameterize the recording tests so that mcap can be easily slotted in to be tested as well.