### PR TITLE
rosbag2_cpp: test more than one storage plugin

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -28,7 +28,7 @@ macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG dc6561d9ba867901709e36526dcf7f7359861e9c # releases/cpp/v0.7.0
+    GIT_TAG 801c4ae3f34b23e9a27eb34b88ab7a0180d4b40f # v0.8.0
   )
   fetchcontent_makeavailable(mcap)
 

--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -22,6 +22,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>rosbag2_storage_default_plugins</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rosbag2_cpp/package.xml
+++ b/rosbag2_cpp/package.xml
@@ -26,7 +26,9 @@
   <depend>rosidl_typesupport_introspection_cpp</depend>
   <depend>shared_queues_vendor</depend>
 
-  <exec_depend>rosbag2_storage_default_plugins</exec_depend>
+  <test_depend>rosbag2_storage_default_plugins</test_depend>
+  <!-- TODO: remove dependency when rosbag2_storage_default_plugins depends on MCAP -->
+  <test_depend>rosbag2_storage_mcap</test_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -25,18 +25,18 @@
 #include "rosbag2_cpp/writer.hpp"
 
 #include "rosbag2_storage/bag_metadata.hpp"
-#include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
+#include "rosbag2_test_common/tested_storage_ids.hpp"
 
 #include "test_msgs/msg/basic_types.hpp"
 
 using namespace ::testing;  // NOLINT
-using rosbag2_test_common::TemporaryDirectoryFixture;
+using rosbag2_test_common::ParametrizedTemporaryDirectoryFixture;
 
-TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_2) {
-  const auto expected_storage_id = rosbag2_storage::get_default_storage_id();
+TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_2) {
+  const auto expected_storage_id = GetParam();
   const std::string bagfile = "rosbag2_bagfile_information:\n"
     "  version: 2\n"
     "  storage_identifier: " + expected_storage_id + "\n"
@@ -102,10 +102,9 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_2) {
   }
 }
 
-TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_6) {
-  const auto expected_storage_id = rosbag2_storage::get_default_storage_id();
+TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_6) {
+  const auto expected_storage_id = GetParam();
   const auto expected_storage_file = "test.testbag";
-
   const std::string bagfile = "rosbag2_bagfile_information:\n"
     "  version: 6\n"
     "  storage_identifier: " + expected_storage_id + "\n"
@@ -203,8 +202,10 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_supports_version_6) {
   }
 }
 
-TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metadata_io_method) {
-  const auto expected_storage_id = rosbag2_storage::get_default_storage_id();
+TEST_P(
+  ParametrizedTemporaryDirectoryFixture,
+  read_metadata_makes_appropriate_call_to_metadata_io_method) {
+  const auto expected_storage_id = GetParam();
   std::string bagfile(
     "rosbag2_bagfile_information:\n"
     "  version: 3\n"
@@ -282,12 +283,16 @@ TEST_F(TemporaryDirectoryFixture, read_metadata_makes_appropriate_call_to_metada
   EXPECT_EQ(read_metadata.compression_mode, "FILE");
 }
 
-TEST_F(TemporaryDirectoryFixture, info_for_standalone_bagfile) {
+TEST_P(ParametrizedTemporaryDirectoryFixture, info_for_standalone_bagfile) {
+  const auto storage_id = GetParam();
   const auto bag_path = rcpputils::fs::path(temporary_dir_path_) / "bag";
   {
     // Create an empty bag with default storage
     rosbag2_cpp::Writer writer;
-    writer.open(bag_path.string());
+    rosbag2_storage::StorageOptions storage_options;
+    storage_options.storage_id = storage_id;
+    storage_options.uri = bag_path.string();
+    writer.open(storage_options);
     test_msgs::msg::BasicTypes msg;
     writer.write(msg, "testtopic", rclcpp::Time{});
   }
@@ -305,3 +310,9 @@ TEST_F(TemporaryDirectoryFixture, info_for_standalone_bagfile) {
   );
   EXPECT_THAT(metadata.topics_with_message_count, SizeIs(1));
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  RosbagInfoTests,
+  ParametrizedTemporaryDirectoryFixture,
+  ValuesIn(rosbag2_test_common::kTestedStorageIDs)
+);

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -85,7 +85,6 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(rcpputils REQUIRED)
-  find_package(rosbag2_cpp REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   find_package(std_msgs REQUIRED)
 
@@ -101,7 +100,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_mcap_storage test/rosbag2_storage_mcap/test_mcap_storage.cpp)
   target_link_libraries(test_mcap_storage ${PROJECT_NAME})
-  ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_cpp rosbag2_test_common std_msgs)
+  ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_test_common std_msgs)
   target_compile_definitions(test_mcap_storage PRIVATE ${MCAP_COMPILE_DEFS})
 
   ament_add_gmock(test_message_definition_cache test/rosbag2_storage_mcap/test_message_definition_cache.cpp)

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -21,7 +21,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rcpputils</test_depend>
-  <test_depend>rosbag2_cpp</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>rosbag2_storage_mcap_testdata</test_depend>

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -42,6 +42,14 @@ public:
   std::string temporary_dir_path_;
 };
 
+/**
+ * @brief parametrizes the temporary directory fixture above with a string parameter,
+ * which can be used for testing across several storage plugins.
+ */
+class ParametrizedTemporaryDirectoryFixture
+  : public TemporaryDirectoryFixture,
+  public WithParamInterface<std::string> {};
+
 }  // namespace rosbag2_test_common
 
 #endif  // ROSBAG2_TEST_COMMON__TEMPORARY_DIRECTORY_FIXTURE_HPP_

--- a/rosbag2_test_common/include/rosbag2_test_common/tested_storage_ids.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/tested_storage_ids.hpp
@@ -1,0 +1,42 @@
+// Copyright 2022, Foxglove Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_TEST_COMMON__TESTED_STORAGE_IDS_HPP_
+#define ROSBAG2_TEST_COMMON__TESTED_STORAGE_IDS_HPP_
+#include <array>
+#include <string>
+
+
+namespace rosbag2_test_common
+{
+static const std::array<std::string, 2> kTestedStorageIDs = {
+  "sqlite3",
+  "mcap",
+};
+
+std::string bag_filename_for_storage_id(const std::string & name, const std::string & storage_id)
+{
+  const std::array<std::string, 2> extensions = {".db3", ".mcap"};
+  static_assert(kTestedStorageIDs.size() == extensions.size());
+  for (size_t i = 0; i < extensions.size(); ++i) {
+    if (kTestedStorageIDs[i] == storage_id) {
+      return name + extensions[i];
+    }
+  }
+  throw std::runtime_error("unknown storage id: " + storage_id);
+}
+
+}  // namespace rosbag2_test_common
+
+#endif  // ROSBAG2_TEST_COMMON__TESTED_STORAGE_IDS_HPP_

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -29,6 +29,7 @@
   <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>rosbag2_compression_zstd</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
+  <test_depend>rosbag2_storage_default_plugins</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
This PR parametrizes rosbag2_cpp unit tests to run using some set of "tested" storage plugins - for now this is just `sqlite3` and `mcap`, but once https://github.com/ros2/rosbag2/pull/1160 is done I expect this would be defined as "the set of default storage plugins".

It also updates `rosbag2_storage_mcap` to pass those tests. Before this PR the mcap storage plugin reader does not correctly restart iteration from after the last read message.

# TODO
- [x] Merge and release https://github.com/foxglove/mcap/pull/760