### PR TITLE
Serialize offered_qos_profiles YAML properly with newlines

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -42,7 +42,7 @@ struct FileInformation
 
 struct BagMetadata
 {
-  int version = 6;  // upgrade this number when changing the content of the struct
+  int version = 7;  // upgrade this number when changing the content of the struct
   uint64_t bag_size = 0;  // Will not be serialized
   std::string storage_identifier;
   std::vector<std::string> relative_file_paths;

--- a/rosbag2_storage/include/rosbag2_storage/yaml.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/yaml.hpp
@@ -95,7 +95,8 @@ struct convert<rosbag2_storage::TopicMetadata>
     node["name"] = topic.name;
     node["type"] = topic.type;
     node["serialization_format"] = topic.serialization_format;
-    node["offered_qos_profiles"] = topic.offered_qos_profiles;
+    YAML::Node profiles = YAML::Load(topic.offered_qos_profiles);
+    node["offered_qos_profiles"] = profiles;
     return node;
   }
 
@@ -104,7 +105,11 @@ struct convert<rosbag2_storage::TopicMetadata>
     topic.name = node["name"].as<std::string>();
     topic.type = node["type"].as<std::string>();
     topic.serialization_format = node["serialization_format"].as<std::string>();
-    if (version >= 4) {
+    if (version >= 7) {
+      std::stringstream profiles;
+      profiles << node["offered_qos_profiles"];
+      topic.offered_qos_profiles = profiles.str();
+    } else if (version >= 4) {
       topic.offered_qos_profiles = node["offered_qos_profiles"].as<std::string>();
     } else {
       topic.offered_qos_profiles = "";


### PR DESCRIPTION
Fixes #609 

Load the `offered_qos_profiles` data as a YAML node before adding it to the total `TopicMetadata` YAML output, that way it has properly formatted newlines for easier user reading/editing.