### PR TITLE
Use target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -37,12 +37,13 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(${PROJECT_NAME}
-  pluginlib
-  rcpputils
-  rcutils
-  rosbag2_cpp
-  rosbag2_storage)
+target_link_libraries(${PROJECT_NAME}
+  pluginlib::pluginlib
+  rcpputils::rcpputils
+  rcutils::rcutils
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
+)
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROSBAG2_COMPRESSION_BUILDING_DLL)
 
 install(
@@ -94,13 +95,19 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_sequential_compression_reader
     test/rosbag2_compression/test_sequential_compression_reader.cpp)
-  target_link_libraries(test_sequential_compression_reader ${PROJECT_NAME})
-  ament_target_dependencies(test_sequential_compression_reader rosbag2_cpp rosbag2_storage)
+  target_link_libraries(test_sequential_compression_reader
+    ${PROJECT_NAME}
+    rosbag2_cpp::rosbag2_cpp
+    rosbag2_storage::rosbag2_storage
+  )
 
   ament_add_gmock(test_sequential_compression_writer
     test/rosbag2_compression/test_sequential_compression_writer.cpp)
-  target_link_libraries(test_sequential_compression_writer ${PROJECT_NAME})
-  ament_target_dependencies(test_sequential_compression_writer rosbag2_cpp rosbag2_storage)
+  target_link_libraries(test_sequential_compression_writer
+    ${PROJECT_NAME}
+    rosbag2_cpp::rosbag2_cpp
+    rosbag2_storage::rosbag2_storage
+  )
 endif()
 
 ament_package()

--- a/rosbag2_compression_zstd/CMakeLists.txt
+++ b/rosbag2_compression_zstd/CMakeLists.txt
@@ -35,10 +35,11 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(${PROJECT_NAME}
-  rcpputils
-  rosbag2_compression
-  zstd)
+target_link_libraries(${PROJECT_NAME}
+  rcpputils::rcpputils
+  rosbag2_compression::rosbag2_compression
+  zstd::zstd
+)
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROSBAG2_COMPRESSION_ZSTD_BUILDING_DLL)
 pluginlib_export_plugin_description_file(rosbag2_compression plugin_description.xml)
 
@@ -73,8 +74,11 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_zstd_compressor
     test/rosbag2_compression_zstd/test_zstd_compressor.cpp)
-  target_link_libraries(test_zstd_compressor ${PROJECT_NAME})
-  ament_target_dependencies(test_zstd_compressor rclcpp rosbag2_test_common)
+  target_link_libraries(test_zstd_compressor
+    ${PROJECT_NAME}
+    rclcpp::rclcpp
+    rosbag2_test_common::rosbag2_test_common
+  )
 endif()
 
 ament_package()

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -140,9 +140,9 @@ if(BUILD_TESTING)
     test/rosbag2_cpp/serializer_test_plugin.cpp
     test/rosbag2_cpp/converter_test_plugin.cpp)
   target_link_libraries(converter_test_plugins
+    ${PROJECT_NAME}
     rosbag2_storage::rosbag2_storage
   )
-  target_link_libraries(converter_test_plugins ${PROJECT_NAME})
   install(
     TARGETS converter_test_plugins
     ARCHIVE DESTINATION lib

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -72,20 +72,20 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/writers/sequential_writer.cpp
   src/rosbag2_cpp/reindexer.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
   PUBLIC
-  ament_index_cpp
-  pluginlib
-  rclcpp
-  rcpputils
-  rcutils
-  rmw
-  rmw_implementation
-  rosbag2_storage
-  rosidl_runtime_c
-  rosidl_runtime_cpp
-  rosidl_typesupport_cpp
-  rosidl_typesupport_introspection_cpp
+  ament_index_cpp::ament_index_cpp
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rcpputils::rcpputils
+  rcutils::rcutils
+  rmw::rmw
+  rmw_implementation::rmw_implementation
+  rosbag2_storage::rosbag2_storage
+  rosidl_runtime_c::rosidl_runtime_c
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+  rosidl_typesupport_cpp::rosidl_typesupport_cpp
+  rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -139,7 +139,9 @@ if(BUILD_TESTING)
     SHARED
     test/rosbag2_cpp/serializer_test_plugin.cpp
     test/rosbag2_cpp/converter_test_plugin.cpp)
-  ament_target_dependencies(converter_test_plugins rosbag2_storage)
+  target_link_libraries(converter_test_plugins
+    rosbag2_storage::rosbag2_storage
+  )
   target_link_libraries(converter_test_plugins ${PROJECT_NAME})
   install(
     TARGETS converter_test_plugins
@@ -210,28 +212,35 @@ if(BUILD_TESTING)
     target_include_directories(test_ros2_message
       PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-    ament_target_dependencies(test_ros2_message
-      ament_index_cpp
-      rcpputils
-      rosbag2_storage
-      rosidl_runtime_cpp
-      rosidl_typesupport_introspection_cpp
-      rosidl_typesupport_cpp
-      test_msgs)
+    target_link_libraries(test_ros2_message
+      ament_index_cpp::ament_index_cpp
+      rcpputils::rcpputils
+      rosbag2_storage::rosbag2_storage
+      rosidl_runtime_cpp::rosidl_runtime_cpp
+      rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp
+      rosidl_typesupport_cpp::rosidl_typesupport_cpp
+      ${test_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gmock(test_sequential_writer
     test/rosbag2_cpp/test_sequential_writer.cpp test/rosbag2_cpp/fake_data.cpp)
   if(TARGET test_sequential_writer)
-    ament_target_dependencies(test_sequential_writer rosbag2_storage rosbag2_test_common test_msgs)
-    target_link_libraries(test_sequential_writer ${PROJECT_NAME})
+    target_link_libraries(test_sequential_writer
+      ${PROJECT_NAME}
+      rosbag2_storage::rosbag2_storage
+      rosbag2_test_common::rosbag2_test_common
+      ${test_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gmock(test_multifile_reader
     test/rosbag2_cpp/test_multifile_reader.cpp)
   if(TARGET test_multifile_reader)
-    ament_target_dependencies(test_multifile_reader rosbag2_storage)
-    target_link_libraries(test_multifile_reader ${PROJECT_NAME})
+    target_link_libraries(test_multifile_reader
+      ${PROJECT_NAME}
+      rosbag2_storage::rosbag2_storage
+    )
   endif()
 
   ament_add_gmock(test_time_controller_clock

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -22,7 +22,11 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(example_interfaces REQUIRED)
 
 add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
-ament_target_dependencies(simple_bag_recorder rclcpp rosbag2_cpp example_interfaces)
+target_link_libraries(simple_bag_recorder
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  ${example_interfaces_TARGETS}
+)
 
 install(TARGETS
   simple_bag_recorder
@@ -30,7 +34,11 @@ install(TARGETS
 )
 
 add_executable(data_generator_node src/data_generator_node.cpp)
-ament_target_dependencies(data_generator_node rclcpp rosbag2_cpp example_interfaces)
+target_link_libraries(data_generator_node
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  ${example_interfaces_TARGETS}
+)
 
 install(TARGETS
   data_generator_node
@@ -38,7 +46,11 @@ install(TARGETS
 )
 
 add_executable(data_generator_executable src/data_generator_executable.cpp)
-ament_target_dependencies(data_generator_executable rclcpp rosbag2_cpp example_interfaces)
+target_link_libraries(data_generator_executable
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  ${example_interfaces_TARGETS}
+)
 
 install(TARGETS
   data_generator_executable

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -41,27 +41,27 @@ add_executable(results_writer
   src/result_utils.cpp
   src/results_writer.cpp)
 
-ament_target_dependencies(writer_benchmark
-  rclcpp
-  rosbag2_performance_benchmarking_msgs
-  sensor_msgs
-  rosbag2_compression
-  rosbag2_cpp
-  rosbag2_storage
-  yaml_cpp_vendor
+target_link_libraries(writer_benchmark
+  rclcpp::rclcpp
+  ${rosbag2_performance_benchmarking_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  rosbag2_compression::rosbag2_compression
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
+  ${YAML_CPP_LIBRARIES}
 )
 
-ament_target_dependencies(benchmark_publishers
-  rclcpp
-  rosbag2_storage
-  rosbag2_performance_benchmarking_msgs
-  sensor_msgs
-  yaml_cpp_vendor
+target_link_libraries(benchmark_publishers
+  rclcpp::rclcpp
+  rosbag2_storage::rosbag2_storage
+  ${rosbag2_performance_benchmarking_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${YAML_CPP_LIBRARIES}
 )
 
-ament_target_dependencies(results_writer
-  rclcpp
-  rosbag2_storage
+target_link_libraries(results_writer
+  rclcpp::rclcpp
+  rosbag2_storage::rosbag2_storage
 )
 
 target_include_directories(writer_benchmark

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(writer_benchmark
   rosbag2_compression::rosbag2_compression
   rosbag2_cpp::rosbag2_cpp
   rosbag2_storage::rosbag2_storage
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp
 )
 
 target_link_libraries(benchmark_publishers
@@ -56,7 +56,7 @@ target_link_libraries(benchmark_publishers
   rosbag2_storage::rosbag2_storage
   ${rosbag2_performance_benchmarking_msgs_TARGETS}
   ${sensor_msgs_TARGETS}
-  yaml-cpp::yaml-cpp
+  yaml-cpp
 )
 
 target_link_libraries(results_writer

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(benchmark_publishers
   rosbag2_storage::rosbag2_storage
   ${rosbag2_performance_benchmarking_msgs_TARGETS}
   ${sensor_msgs_TARGETS}
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp::yaml-cpp
 )
 
 target_link_libraries(results_writer

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -43,54 +43,54 @@ ament_python_install_package(${PROJECT_NAME})
 pybind11_add_module(_reader SHARED
   src/rosbag2_py/_reader.cpp
 )
-ament_target_dependencies(_reader PUBLIC
-  "rosbag2_compression"
-  "rosbag2_cpp"
-  "rosbag2_storage"
+target_link_libraries(_reader PUBLIC
+  rosbag2_compression::rosbag2_compression
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
 )
 
 pybind11_add_module(_storage SHARED
   src/rosbag2_py/_storage.cpp
   src/rosbag2_py/format_bag_metadata.cpp
 )
-ament_target_dependencies(_storage PUBLIC
-  "rosbag2_cpp"
-  "rosbag2_storage"
+target_link_libraries(_storage PUBLIC
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
 )
 
 pybind11_add_module(_writer SHARED
   src/rosbag2_py/_writer.cpp
 )
-ament_target_dependencies(_writer PUBLIC
-  "rosbag2_compression"
-  "rosbag2_cpp"
-  "rosbag2_storage"
+target_link_libraries(_writer PUBLIC
+  rosbag2_compression::rosbag2_compression
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
 )
 
 pybind11_add_module(_info SHARED
   src/rosbag2_py/_info.cpp
 )
-ament_target_dependencies(_info PUBLIC
-  "rosbag2_cpp"
-  "rosbag2_storage"
+target_link_libraries(_info PUBLIC
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
 )
 
 pybind11_add_module(_transport SHARED
   src/rosbag2_py/_transport.cpp
 )
-ament_target_dependencies(_transport PUBLIC
-  "rosbag2_compression"
-  "rosbag2_cpp"
-  "rosbag2_storage"
-  "rosbag2_transport"
+target_link_libraries(_transport PUBLIC
+  rosbag2_compression::rosbag2_compression
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
+  rosbag2_transport::rosbag2_transport
 )
 
 pybind11_add_module(_reindexer SHARED
   src/rosbag2_py/_reindexer.cpp
 )
-ament_target_dependencies(_reindexer PUBLIC
-  "rosbag2_cpp"
-  "rosbag2_storage"
+target_link_libraries(_reindexer PUBLIC
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_storage::rosbag2_storage
 )
 
 # Install cython modules as sub-modules of the project

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -40,12 +40,12 @@ target_include_directories(${PROJECT_NAME}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  pluginlib
-  rcpputils
-  rcutils
-  yaml_cpp_vendor)
+target_link_libraries(${PROJECT_NAME}
+  pluginlib::pluginlib
+  rcpputils::rcpputils
+  rcutils::rcutils
+  ${YAML_CPP_LIBRARIES}
+)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -106,14 +106,18 @@ if(BUILD_TESTING)
   ament_add_gmock(test_metadata_serialization
     test/rosbag2_storage/test_metadata_serialization.cpp)
   if(TARGET test_metadata_serialization)
-    target_link_libraries(test_metadata_serialization ${PROJECT_NAME})
-    ament_target_dependencies(test_metadata_serialization rosbag2_test_common)
+    target_link_libraries(test_metadata_serialization
+      ${PROJECT_NAME}
+      rosbag2_test_common::rosbag2_test_common
+    )
   endif()
 
   ament_add_gmock(test_storage_options
     test/rosbag2_storage/test_storage_options.cpp)
-  target_link_libraries(test_storage_options ${PROJECT_NAME})
-  ament_target_dependencies(test_storage_options rosbag2_test_common)
+  target_link_libraries(test_storage_options
+    ${PROJECT_NAME}
+    rosbag2_test_common::rosbag2_test_common
+  )
 endif()
 
 ament_package()

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(${PROJECT_NAME}
   pluginlib::pluginlib
   rcpputils::rcpputils
   rcutils::rcutils
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -38,11 +38,12 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_STORAGE_MCAP_BUILDING_DLL")
-ament_target_dependencies(${PROJECT_NAME}
-  mcap_vendor
-  pluginlib
-  rcutils
-  rosbag2_storage)
+target_link_libraries(${PROJECT_NAME}
+  mcap_vendor::mcap
+  pluginlib::pluginlib
+  rcutils::rcutils
+  rosbag2_storage::rosbag2_storage
+)
 
 set(MCAP_COMPILE_DEFS)
 # COMPATIBILITY(foxy) - 0.3.x is the Foxy release
@@ -102,8 +103,12 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gmock(test_mcap_storage test/rosbag2_storage_mcap/test_mcap_storage.cpp)
-  target_link_libraries(test_mcap_storage ${PROJECT_NAME})
-  ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_test_common std_msgs)
+  target_link_libraries(test_mcap_storage
+    ${PROJECT_NAME}
+    rosbag2_storage::rosbag2_storage
+    rosbag2_test_common::rosbag2_test_common
+    ${std_msgs_TARGETS}
+  )
   target_compile_definitions(test_mcap_storage PRIVATE ${MCAP_COMPILE_DEFS})
 
   ament_add_gmock(test_message_definition_cache test/rosbag2_storage_mcap/test_message_definition_cache.cpp)

--- a/rosbag2_storage_sqlite3/CMakeLists.txt
+++ b/rosbag2_storage_sqlite3/CMakeLists.txt
@@ -37,13 +37,14 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_storage_sqlite3/sqlite_storage.cpp
   src/rosbag2_storage_sqlite3/sqlite_statement_wrapper.cpp)
 
-ament_target_dependencies(${PROJECT_NAME}
-  pluginlib
-  rosbag2_storage
-  rcpputils
-  rcutils
-  SQLite3
-  yaml_cpp_vendor)
+target_link_libraries(${PROJECT_NAME}
+  pluginlib::pluginlib
+  rosbag2_storage::rosbag2_storage
+  rcpputils::rcpputils
+  rcutils::rcutils
+  SQLite::SQLite3
+  ${YAML_CPP_LIBRARIES}
+)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC
@@ -82,10 +83,11 @@ if(BUILD_TESTING)
 
   set(TEST_LINK_LIBRARIES
     ${PROJECT_NAME}
-    ${rosbag2_storage_LIBRARIES}
-    ${rcutils_LIBRARIES}
-    ${SQLite3_LIBRARIES}
-    ${pluginlib_LIBRARIES}
+    rosbag2_storage::rosbag2_storage
+    rosbag2_test_common::rosbag2_test_common
+    rcutils::rcutils
+    SQLite::SQLite3
+    pluginlib::pluginlib
   )
 
   ament_add_gmock(test_sqlite_wrapper
@@ -93,7 +95,6 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_sqlite_wrapper)
     target_link_libraries(test_sqlite_wrapper ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(test_sqlite_wrapper rosbag2_storage rosbag2_test_common)
   endif()
 
   ament_add_gmock(test_sqlite_storage
@@ -101,7 +102,6 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_sqlite_storage)
     target_link_libraries(test_sqlite_storage ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(test_sqlite_storage rosbag2_storage rosbag2_test_common)
   endif()
 endif()
 

--- a/rosbag2_storage_sqlite3/CMakeLists.txt
+++ b/rosbag2_storage_sqlite3/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(${PROJECT_NAME}
   rcpputils::rcpputils
   rcutils::rcutils
   SQLite::SQLite3
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/rosbag2_test_common/CMakeLists.txt
+++ b/rosbag2_test_common/CMakeLists.txt
@@ -28,7 +28,10 @@ add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(${PROJECT_NAME} INTERFACE rclcpp rcutils)
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  rclcpp::rclcpp
+  rcutils::rcutils
+)
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -98,8 +98,8 @@ if(BUILD_TESTING)
       rclcpp::rclcpp
       rosbag2_cpp::rosbag2_cpp
       rosbag2_storage::rosbag2_storage
-      rosbag2_storage_default_plugins::rosbag2_storage_default_plugins
       rosbag2_test_common::rosbag2_test_common
+      ${std_msgs_TARGETS}
     )
   endif()
 

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -45,14 +45,14 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     TIMEOUT 120)
   if(TARGET test_rosbag2_record_end_to_end)
-    ament_target_dependencies(test_rosbag2_record_end_to_end
-      rclcpp
-      rosbag2_compression
-      rosbag2_compression_zstd
-      rosbag2_storage
-      rosbag2_storage_default_plugins
-      rosbag2_test_common
-      test_msgs)
+    target_link_libraries(test_rosbag2_record_end_to_end
+      rclcpp::rclcpp
+      rosbag2_compression::rosbag2_compression
+      rosbag2_compression_zstd::rosbag2_compression_zstd
+      rosbag2_storage::rosbag2_storage
+      rosbag2_test_common::rosbag2_test_common
+      ${test_msgs_TARGETS}
+    )
     ament_add_test_label(test_rosbag2_record_end_to_end xfail)
   endif()
 
@@ -60,12 +60,12 @@ if(BUILD_TESTING)
     test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_rosbag2_play_end_to_end)
-    ament_target_dependencies(test_rosbag2_play_end_to_end
-      rclcpp
-      rosbag2_storage
-      rosbag2_storage_default_plugins
-      rosbag2_test_common
-      test_msgs)
+    target_link_libraries(test_rosbag2_play_end_to_end
+      rclcpp::rclcpp
+      rosbag2_storage::rosbag2_storage
+      rosbag2_test_common::rosbag2_test_common
+      ${test_msgs_TARGETS}
+    )
     ament_add_test_label(test_rosbag2_play_end_to_end xfail)
   endif()
 
@@ -73,9 +73,10 @@ if(BUILD_TESTING)
     test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_rosbag2_info_end_to_end)
-    ament_target_dependencies(test_rosbag2_info_end_to_end
-      rosbag2_storage
-      rosbag2_test_common)
+    target_link_libraries(test_rosbag2_info_end_to_end
+      rosbag2_storage::rosbag2_storage
+      rosbag2_test_common::rosbag2_test_common
+    )
     ament_add_test_label(test_rosbag2_info_end_to_end xfail)
   endif()
 
@@ -83,22 +84,23 @@ if(BUILD_TESTING)
     test/rosbag2_tests/test_converter.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_converter)
-    ament_target_dependencies(test_converter
-      rosbag2_cpp
-      rosbag2_test_common
-      test_msgs)
+    target_link_libraries(test_converter
+      rosbag2_cpp::rosbag2_cpp
+      rosbag2_test_common::rosbag2_test_common
+      ${test_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gmock(test_reindex
     test/rosbag2_tests/test_reindexer.cpp)
   if(TARGET test_reindex)
-    ament_target_dependencies(test_reindex
-      rclcpp
-      rosbag2_cpp
-      rosbag2_storage
-      rosbag2_storage_default_plugins
-      rosbag2_test_common
-      std_msgs)
+    target_link_libraries(test_reindex
+      rclcpp::rclcpp
+      rosbag2_cpp::rosbag2_cpp
+      rosbag2_storage::rosbag2_storage
+      rosbag2_storage_default_plugins::rosbag2_storage_default_plugins
+      rosbag2_test_common::rosbag2_test_common
+    )
   endif()
 
 
@@ -106,13 +108,13 @@ if(BUILD_TESTING)
     test/rosbag2_tests/test_rosbag2_cpp_api.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_rosbag2_cpp_api)
-    ament_target_dependencies(test_rosbag2_cpp_api
-      rclcpp
-      rosbag2_cpp
-      rosbag2_storage
-      rosbag2_storage_default_plugins
-      rosbag2_test_common
-      test_msgs)
+    target_link_libraries(test_rosbag2_cpp_api
+      rclcpp::rclcpp
+      rosbag2_cpp::rosbag2_cpp
+      rosbag2_storage::rosbag2_storage
+      rosbag2_test_common::rosbag2_test_common
+      ${test_msgs_TARGETS}
+    )
   endif()
 endif()
 

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(${PROJECT_NAME}
   rosbag2_storage::rosbag2_storage
   shared_queues_vendor::singleproducerconsumer
   shared_queues_vendor::concurrentqueue
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -51,18 +51,19 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-ament_target_dependencies(${PROJECT_NAME}
-  keyboard_handler
-  rcl
-  rclcpp
-  rcutils
-  rmw
-  rosbag2_compression
-  rosbag2_cpp
-  rosbag2_interfaces
-  rosbag2_storage
-  shared_queues_vendor
-  yaml_cpp_vendor
+target_link_libraries(${PROJECT_NAME}
+  keyboard_handler::keyboard_handler
+  rcl::rcl
+  rclcpp::rclcpp
+  rcutils::rcutils
+  rmw::rmw
+  rosbag2_compression::rosbag2_compression
+  rosbag2_cpp::rosbag2_cpp
+  ${rosbag2_interfaces_TARGETS}
+  rosbag2_storage::rosbag2_storage
+  shared_queues_vendor::singleproducerconsumer
+  shared_queues_vendor::concurrentqueue
+  ${YAML_CPP_LIBRARIES}
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -171,11 +172,11 @@ function(create_tests_for_rmw_implementation)
       LINK_LIBS rosbag2_transport
       AMENT_DEPS test_msgs rosbag2_test_common)
 
-    rosbag2_transport_add_gmock(test_burst
-      test/rosbag2_transport/test_burst.cpp
-      INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
-      LINK_LIBS rosbag2_transport
-      AMENT_DEPS test_msgs rosbag2_test_common)
+  rosbag2_transport_add_gmock(test_burst
+    test/rosbag2_transport/test_burst.cpp
+    INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
+    LINK_LIBS rosbag2_transport
+    AMENT_DEPS test_msgs rosbag2_test_common)
 
   rosbag2_transport_add_gmock(test_qos
     test/rosbag2_transport/test_qos.cpp
@@ -260,18 +261,19 @@ if(BUILD_TESTING)
     test/rosbag2_transport/test_topic_filter.cpp)
   target_include_directories(test_topic_filter PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>)
-  target_link_libraries(test_topic_filter rosbag2_transport)
+  target_link_libraries(test_topic_filter
+    ${PROJECT_NAME}
+  )
 
   ament_add_gmock(test_rewrite
     test/rosbag2_transport/test_rewrite.cpp)
-  target_link_libraries(test_rewrite ${PROJECT_NAME})
-  ament_target_dependencies(
-    test_rewrite
-    keyboard_handler
-    rcpputils
-    rosbag2_cpp
-    rosbag2_test_common
-    test_msgs
+  target_link_libraries(test_rewrite
+    ${PROJECT_NAME}
+    keyboard_handler::keyboard_handler
+    rcpputils::rcpputils
+    rosbag2_cpp::rosbag2_cpp
+    rosbag2_test_common::rosbag2_test_common
+    ${test_msgs_TARGTES}
   )
 endif()
 


### PR DESCRIPTION
Use `target_link_libraries` instead of `ament_target_dependencies` for modern cmake.

See discussion on https://github.com/ament/ament_cmake/issues/292 for context on this decision.

This method will be the new standard recommendation after merge of https://github.com/ros2/ros2_documentation/pull/2915