### PR TITLE
mcap_vendor: download MCAP source via tarball

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -27,8 +27,8 @@ endif()
 macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
-    GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG 801c4ae3f34b23e9a27eb34b88ab7a0180d4b40f # v0.8.0
+    URL https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.8.0.tar.gz
+    URL_HASH SHA1=b44637791da2c9c1cec61a3ba6994f1ef63a228c # v0.8.0
   )
   fetchcontent_makeavailable(mcap)
 


### PR DESCRIPTION
Relating to #1200 in humble - this makes `mcap_vendor` build faster and also removes the need for source-builders to have git LFS properly configured.