### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24 for mcap_vendor

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(ament_cmake REQUIRED)
 find_package(zstd_vendor REQUIRED)
 find_package(zstd REQUIRED)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 ## Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy for `mcap_vendor` CMakeLists.txt

> [This issue](https://github.com/ros2/rosbag2/pull/1084) is happening again.

Failing builds (for now):
* https://ci.ros2.org/job/ci_windows/18458/
* https://ci.ros2.org/view/packaging/job/packaging_windows/2696/


Running CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17808)](http://ci.ros2.org/job/ci_linux/17808/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=12373)](http://ci.ros2.org/job/ci_linux-aarch64/12373/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=18464)](http://ci.ros2.org/job/ci_windows/18464/)