### PR TITLE
Add topic_name option to info verb

### DIFF
--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -23,7 +23,7 @@ class InfoVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):  # noqa: D102
         add_standard_reader_args(parser)
         parser.add_argument(
-            '-q', '--quiet', action='store_true',
+            '-t', '--topic_name', action='store_true',
             help='Only display topic names.'
         )
 

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -21,6 +21,7 @@ class InfoVerb(VerbExtension):
     """Print information about a bag to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
+        add_standard_reader_args(parser)
         parser.add_argument(
             '-q', '--quiet', action='store_true',
             help='Only display topic names.'

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -23,13 +23,13 @@ class InfoVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):  # noqa: D102
         add_standard_reader_args(parser)
         parser.add_argument(
-            '-t', '--topic_name', action='store_true',
+            '-t', '--topic-name', action='store_true',
             help='Only display topic names.'
         )
 
     def main(self, *, args):  # noqa: D102
         m = Info().read_metadata(args.bag_path, args.storage)
-        if args.quiet:
+        if args.topic_name:
             for topic_info in m.topics_with_message_count:
                 print(topic_info.topic_metadata.name)
         else:

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -21,8 +21,15 @@ class InfoVerb(VerbExtension):
     """Print information about a bag to the screen."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        add_standard_reader_args(parser)
+        parser.add_argument(
+            '-q', '--quiet', action='store_true',
+            help='Only display topic names.'
+        )
 
     def main(self, *, args):  # noqa: D102
         m = Info().read_metadata(args.bag_path, args.storage)
-        print(m)
+        if args.quiet:
+            for topic_info in m.topics_with_message_count:
+                print(topic_info.topic_metadata.name)
+        else:
+            print(m)

--- a/ros2bag/test/test_info.py
+++ b/ros2bag/test/test_info.py
@@ -20,6 +20,7 @@ from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 import launch_testing
 import launch_testing.actions
+from launch_testing.tools.text import normalize_lineseps
 
 import pytest
 
@@ -78,7 +79,7 @@ class TestRos2BagInfo(unittest.TestCase):
         arguments = ['info', bag_path.as_posix()]
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_shutdown(timeout=5)
-        assert bag_command.output == EXPECTED_OUTPUT, \
+        assert normalize_lineseps(bag_command.output) == EXPECTED_OUTPUT, \
             'ros2bag CLI did not produce the expected output'
 
     def test_info_with_topic_name_option(self):
@@ -87,5 +88,5 @@ class TestRos2BagInfo(unittest.TestCase):
         arguments = ['info', '--topic-name', bag_path.as_posix()]
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_shutdown(timeout=5)
-        assert bag_command.output == EXPECTED_TOPIC_NAME_OUTPUT, \
+        assert normalize_lineseps(bag_command.output) == EXPECTED_TOPIC_NAME_OUTPUT, \
             'ros2bag CLI did not produce the expected output'

--- a/ros2bag/test/test_info.py
+++ b/ros2bag/test/test_info.py
@@ -73,15 +73,6 @@ class TestRos2BagInfo(unittest.TestCase):
                 yield pkg_command
         cls.launch_bag_command = launch_bag_command
 
-    def test_info_with_no_options(self):
-        """Test the output with no options."""
-        bag_path = RESOURCES_PATH / 'empty_bag'
-        arguments = ['info', bag_path.as_posix()]
-        with self.launch_bag_command(arguments=arguments) as bag_command:
-            bag_command.wait_for_shutdown(timeout=5)
-        assert normalize_lineseps(bag_command.output) == EXPECTED_OUTPUT, \
-            'ros2bag CLI did not produce the expected output'
-
     def test_info_with_topic_name_option(self):
         """Test the output with --topic-name options."""
         bag_path = RESOURCES_PATH / 'empty_bag'

--- a/ros2bag/test/test_info.py
+++ b/ros2bag/test/test_info.py
@@ -58,7 +58,10 @@ class TestRos2BagInfo(unittest.TestCase):
         def launch_bag_command(self, arguments, **kwargs):
             pkg_command_action = ExecuteProcess(
                 cmd=['ros2', 'bag', *arguments],
-                additional_env={'PYTHONUNBUFFERED': '1'},
+                additional_env={
+                    'PYTHONUNBUFFERED': '1',
+                    'TZ': 'UTC',
+                },
                 name='ros2bag-cli',
                 output='screen',
                 **kwargs

--- a/ros2bag/test/test_info.py
+++ b/ros2bag/test/test_info.py
@@ -1,0 +1,88 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+from pathlib import Path
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+import launch_testing
+import launch_testing.actions
+
+import pytest
+
+
+RESOURCES_PATH = Path(__file__).parent / 'resources'
+EXPECTED_OUTPUT = """
+Files:             empty_bag_0.db3
+Bag size:          49.1 KiB
+Storage id:        sqlite3
+Duration:          0.0s
+Start:             Apr 12 2262 08:47:16.854 (9223372036.854)
+End:               Apr 12 2262 08:47:16.854 (9223372036.854)
+Messages:          0
+Topic information: Topic: /parameter_events | Type: rcl_interfaces/msg/ParameterEvent \
+| Count: 0 | Serialization Format: cdr
+                   Topic: /rosout | Type: rcl_interfaces/msg/Log \
+| Count: 0 | Serialization Format: cdr
+
+"""
+EXPECTED_TOPIC_NAME_OUTPUT = """/parameter_events
+/rosout
+"""
+
+
+@pytest.mark.rostest
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    return LaunchDescription([launch_testing.actions.ReadyToTest()])
+
+
+class TestRos2BagInfo(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls, launch_service, proc_info, proc_output):
+        @contextlib.contextmanager
+        def launch_bag_command(self, arguments, **kwargs):
+            pkg_command_action = ExecuteProcess(
+                cmd=['ros2', 'bag', *arguments],
+                additional_env={'PYTHONUNBUFFERED': '1'},
+                name='ros2bag-cli',
+                output='screen',
+                **kwargs
+            )
+            with launch_testing.tools.launch_process(
+                    launch_service, pkg_command_action, proc_info, proc_output
+            ) as pkg_command:
+                yield pkg_command
+        cls.launch_bag_command = launch_bag_command
+
+    def test_info_with_no_options(self):
+        """Test the output with no options."""
+        bag_path = RESOURCES_PATH / 'empty_bag'
+        arguments = ['info', bag_path.as_posix()]
+        with self.launch_bag_command(arguments=arguments) as bag_command:
+            bag_command.wait_for_shutdown(timeout=5)
+        assert bag_command.output == EXPECTED_OUTPUT, \
+            'ros2bag CLI did not produce the expected output'
+
+    def test_info_with_topic_name_option(self):
+        """Test the output with --topic-name options."""
+        bag_path = RESOURCES_PATH / 'empty_bag'
+        arguments = ['info', '--topic-name', bag_path.as_posix()]
+        with self.launch_bag_command(arguments=arguments) as bag_command:
+            bag_command.wait_for_shutdown(timeout=5)
+        assert bag_command.output == EXPECTED_TOPIC_NAME_OUTPUT, \
+            'ros2bag CLI did not produce the expected output'

--- a/ros2bag/test/test_info.py
+++ b/ros2bag/test/test_info.py
@@ -26,21 +26,7 @@ import pytest
 
 
 RESOURCES_PATH = Path(__file__).parent / 'resources'
-EXPECTED_OUTPUT = """
-Files:             empty_bag_0.db3
-Bag size:          49.1 KiB
-Storage id:        sqlite3
-Duration:          0.0s
-Start:             Apr 11 2262 23:47:16.854 (9223372036.854)
-End:               Apr 11 2262 23:47:16.854 (9223372036.854)
-Messages:          0
-Topic information: Topic: /parameter_events | Type: rcl_interfaces/msg/ParameterEvent \
-| Count: 0 | Serialization Format: cdr
-                   Topic: /rosout | Type: rcl_interfaces/msg/Log \
-| Count: 0 | Serialization Format: cdr
-
-"""
-EXPECTED_TOPIC_NAME_OUTPUT = """/parameter_events
+EXPECTED_OUTPUT = """/parameter_events
 /rosout
 """
 
@@ -79,5 +65,5 @@ class TestRos2BagInfo(unittest.TestCase):
         arguments = ['info', '--topic-name', bag_path.as_posix()]
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_shutdown(timeout=5)
-        assert normalize_lineseps(bag_command.output) == EXPECTED_TOPIC_NAME_OUTPUT, \
+        assert normalize_lineseps(bag_command.output) == EXPECTED_OUTPUT, \
             'ros2bag CLI did not produce the expected output'

--- a/ros2bag/test/test_info.py
+++ b/ros2bag/test/test_info.py
@@ -30,8 +30,8 @@ Files:             empty_bag_0.db3
 Bag size:          49.1 KiB
 Storage id:        sqlite3
 Duration:          0.0s
-Start:             Apr 12 2262 08:47:16.854 (9223372036.854)
-End:               Apr 12 2262 08:47:16.854 (9223372036.854)
+Start:             Apr 11 2262 23:47:16.854 (9223372036.854)
+End:               Apr 11 2262 23:47:16.854 (9223372036.854)
 Messages:          0
 Topic information: Topic: /parameter_events | Type: rcl_interfaces/msg/ParameterEvent \
 | Count: 0 | Serialization Format: cdr


### PR DESCRIPTION
In some use cases we may want to get a list of topic names. For this reason I have added the quiet option to a info verb.

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>