### PR TITLE
Disable false message about plugin not found on bag opening

### DIFF
--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -116,8 +116,9 @@ get_interface_instance(
     registered_classes.begin(),
     registered_classes.end(), storage_options.storage_id);
   if (class_exists == registered_classes.end()) {
-    ROSBAG2_STORAGE_LOG_WARN_STREAM(
-      "No storage plugin found with id '" << storage_options.storage_id << "'.");
+    // This should not print a warning, because it can be used by open_read_only twice,
+    // legitimately expecting to fail for READ_ONLY but succeed for READ_WRITE
+    // The extra output is misleading to end users.
     return nullptr;
   }
 


### PR DESCRIPTION
- Closes #1195 
The error about not found plugin was incorrectly reporting on bag open. Error happened because we are trying to open storage in read only mode first, although SQLite3 an MCAP plugins supports only read-write mode.

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>