### PR TITLE
Skip install when not building rosbag2_performance_benchmarking

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosbag2_performance_benchmarking)
 
+if (NOT BUILD_ROSBAG2_BENCHMARKS)
+  return()
+endif()
+
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -12,83 +16,81 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-if(BUILD_ROSBAG2_BENCHMARKS)
-  find_package(rclcpp REQUIRED)
-  find_package(rcutils REQUIRED)
-  find_package(rosbag2_compression REQUIRED)
-  find_package(rosbag2_cpp REQUIRED)
-  find_package(rosbag2_storage REQUIRED)
-  find_package(rmw REQUIRED)
-  find_package(rosbag2_performance_benchmarking_msgs REQUIRED)
-  find_package(sensor_msgs REQUIRED)
-  find_package(yaml_cpp_vendor REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(rosbag2_compression REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
+find_package(rosbag2_storage REQUIRED)
+find_package(rmw REQUIRED)
+find_package(rosbag2_performance_benchmarking_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 
-  add_executable(writer_benchmark
-    src/config_utils.cpp
-    src/result_utils.cpp
-    src/writer_benchmark.cpp)
+add_executable(writer_benchmark
+  src/config_utils.cpp
+  src/result_utils.cpp
+  src/writer_benchmark.cpp)
 
-  add_executable(benchmark_publishers
-    src/benchmark_publishers.cpp
-    src/config_utils.cpp
-    src/msg_utils/helpers.cpp)
+add_executable(benchmark_publishers
+  src/benchmark_publishers.cpp
+  src/config_utils.cpp
+  src/msg_utils/helpers.cpp)
 
-  add_executable(results_writer
-    src/config_utils.cpp
-    src/result_utils.cpp
-    src/results_writer.cpp)
+add_executable(results_writer
+  src/config_utils.cpp
+  src/result_utils.cpp
+  src/results_writer.cpp)
 
-  ament_target_dependencies(writer_benchmark
-    rclcpp
-    rosbag2_performance_benchmarking_msgs
-    sensor_msgs
-    rosbag2_compression
-    rosbag2_cpp
-    rosbag2_storage
-    yaml_cpp_vendor
-  )
+ament_target_dependencies(writer_benchmark
+  rclcpp
+  rosbag2_performance_benchmarking_msgs
+  sensor_msgs
+  rosbag2_compression
+  rosbag2_cpp
+  rosbag2_storage
+  yaml_cpp_vendor
+)
 
-  ament_target_dependencies(benchmark_publishers
-    rclcpp
-    rosbag2_storage
-    rosbag2_performance_benchmarking_msgs
-    sensor_msgs
-    yaml_cpp_vendor
-  )
+ament_target_dependencies(benchmark_publishers
+  rclcpp
+  rosbag2_storage
+  rosbag2_performance_benchmarking_msgs
+  sensor_msgs
+  yaml_cpp_vendor
+)
 
-  ament_target_dependencies(results_writer
-    rclcpp
-    rosbag2_storage
-  )
+ament_target_dependencies(results_writer
+  rclcpp
+  rosbag2_storage
+)
 
-  target_include_directories(writer_benchmark
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  )
+target_include_directories(writer_benchmark
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
 
-  target_include_directories(benchmark_publishers
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  )
+target_include_directories(benchmark_publishers
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
 
-  target_include_directories(results_writer
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  )
+target_include_directories(results_writer
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
 
-  install(TARGETS writer_benchmark benchmark_publishers results_writer
-    DESTINATION lib/${PROJECT_NAME})
+install(TARGETS writer_benchmark benchmark_publishers results_writer
+  DESTINATION lib/${PROJECT_NAME})
 
-  install(DIRECTORY
-    launch
-    config
-    DESTINATION share/${PROJECT_NAME}
-  )
+install(DIRECTORY
+  launch
+  config
+  DESTINATION share/${PROJECT_NAME}
+)
 
-  if(BUILD_TESTING)
-    find_package(ament_lint_auto REQUIRED)
-    ament_lint_auto_find_test_dependencies()
-  endif()
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package()

--- a/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CMakeLists.txt
@@ -2,15 +2,17 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosbag2_performance_benchmarking_msgs)
 
-if(BUILD_ROSBAG2_BENCHMARKS)
-  find_package(ament_cmake REQUIRED)
-  find_package(rosidl_default_generators REQUIRED)
-
-  rosidl_generate_interfaces(${PROJECT_NAME}
-    "msg/ByteArray.msg"
-    DEPENDENCIES
-  )
-
-  ament_export_dependencies(rosidl_default_runtime)
-  ament_package()
+if(NOT BUILD_ROSBAG2_BENCHMARKS)
+  return()
 endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/ByteArray.msg"
+  DEPENDENCIES
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()


### PR DESCRIPTION
This fixes a bug where `rosbag2_performance_benchmarking` gets installed to the ament resource index when it's not built, and that causes rosdep to fail to find `rosbag2_performance_benchmarking_msgs`.

Example:
```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies (ROS distro is not set. Make sure `ROS_DISTRO` environment variable is set, or use `--rosdistro` option to specify the distro, e.g. `--rosdistro indigo`):
rosbag2_performance_benchmarking: Cannot locate rosdep definition for [rosbag2_performance_benchmarking_msgs]
```

The problem is the `ament_package()` call is still run when `rosbag2_performance_benchmarking` is not built, however it's dependency `rosbag2_performance_benchmarking_msgs` does not run `ament_package()`. This causes rosdep to think `rosbag2_performance_benchmarking` is installed and needs it's dependencies, but the dependency `rosbag2_performance_benchmarking_msgs` can't be found.

I fixed it by inverting the logic and putting it at the top of the file with a `return()` statement to make sure none of the logic is run when skipping this package.