### PR TITLE
Use RMW methods to initialize endpoint info

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_qos.cpp
@@ -152,16 +152,15 @@ public:
 
   rclcpp::TopicEndpointInfo make_endpoint(const rclcpp::QoS & qos)
   {
-    rcl_topic_endpoint_info_t endpoint_info {
-      "some_node_name",
-      "some_node_namespace",
-      "some_topic_type",
-      RMW_ENDPOINT_PUBLISHER,
-      {0},
-      qos.get_rmw_qos_profile(),
-    };
-
-    return rclcpp::TopicEndpointInfo(endpoint_info);
+    auto allocator = rcutils_get_default_allocator();
+    rcl_topic_endpoint_info_t info = rmw_get_zero_initialized_topic_endpoint_info();
+    rcl_ret_t ret = rmw_topic_endpoint_info_set_node_name(&info, "some_node_name", &allocator);
+    ret |= rmw_topic_endpoint_info_set_node_namespace(&info, "some_node_namespace", &allocator);
+    ret |= rmw_topic_endpoint_info_set_topic_type(&info, "some_topic_type", &allocator);
+    ret |= rmw_topic_endpoint_info_set_endpoint_type(&info, RMW_ENDPOINT_PUBLISHER);
+    ret |= rmw_topic_endpoint_info_set_qos_profile(&info, &qos.get_rmw_qos_profile());
+    EXPECT_EQ(ret, RCL_RET_OK);
+    return rclcpp::TopicEndpointInfo(info);
   }
 
   void add_endpoint(const rclcpp::QoS & qos)


### PR DESCRIPTION
Instead of brace initializer to guard against upcoming struct change - new member in the middle (unrelated to this test) will make the initializer incorrect.

See https://github.com/ros2/rmw/pull/348