### PR TITLE
Enable document generation using rosdoc2 for ament_python pkgs

### DIFF
--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -13,12 +13,10 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>
 
-  <depend>ros2cli</depend>
-  <depend>rosbag2_py</depend>
-  <depend>rosbag2_transport</depend>
-
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
+  <exec_depend>rosbag2_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -17,6 +17,9 @@
   <depend>rosbag2_py</depend>
   <depend>rosbag2_transport</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
Fix missing `exec_depends` in `package.xmls` and docstrings to generate documentation without any warnings using `autodoc`