### PR TITLE
DRAFT: Add message definition to TopicMetadata

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/bag_metadata.hpp
@@ -29,7 +29,7 @@ namespace rosbag2_storage
 struct TopicInformation
 {
   TopicMetadata topic_metadata;
-  size_t message_count;
+  size_t message_count{0};
 };
 
 struct FileInformation
@@ -42,7 +42,7 @@ struct FileInformation
 
 struct BagMetadata
 {
-  int version = 6;  // upgrade this number when changing the content of the struct
+  int version = 7;  // upgrade this number when changing the content of the struct
   uint64_t bag_size = 0;  // Will not be serialized
   std::string storage_identifier;
   std::vector<std::string> relative_file_paths;

--- a/rosbag2_storage/include/rosbag2_storage/message_definition.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/message_definition.hpp
@@ -35,8 +35,11 @@ struct MessageDefinition
   std::string type_hash;
   /// @brief The full encoded message definition for this type.
   std::string encoded_message_definition;
-  enum class Encoding
+
+  enum class Encoding : uint8_t
   {
+    /// \brief Default value
+    Unknown = 0,
     /// @brief concatenated `.msg` files for this message definition and all dependent types.
     ConcatenatedMsg,
     /// @brief concatenated `.idl` files for this message definition and all dependent types.
@@ -45,8 +48,13 @@ struct MessageDefinition
   /// @brief The encoding technique used in `encoded_message_definition`.
   ///
   /// See docs/message_definition_encoding.md for details of each encoding.
-  Encoding encoding;
+  Encoding encoding{Encoding::Unknown};
 
+  bool operator==(const MessageDefinition & rhs) const
+  {
+    return rhs.encoding == encoding && rhs.name == name && rhs.type_hash == type_hash &&
+           rhs.encoded_message_definition == encoded_message_definition;
+  }
   /// @brief returns the name of the encoding technique as a string.
   std::string encoding_name() const
   {
@@ -56,8 +64,22 @@ struct MessageDefinition
       case Encoding::ConcatenatedMsg:
         return "ros2msg";
       default:
-        assert(false);
+        return "unknown";
     }
+  }
+
+  /// @brief returns the Encoding enum value corresponding to the encoding string
+  Encoding encoding_from_string(const std::string & encoding_str) const
+  {
+    Encoding encoding_value{Encoding::ConcatenatedMsg};
+    if (encoding_str == "ros2msg") {
+      encoding_value = Encoding::ConcatenatedMsg;
+    } else if (encoding_str == "ros2idl") {
+      encoding_value = Encoding::ConcatenatedIdl;
+    } else {
+      encoding_value = Encoding::Unknown;
+    }
+    return encoding_value;
   }
 };
 

--- a/rosbag2_storage/include/rosbag2_storage/topic_metadata.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/topic_metadata.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_STORAGE__TOPIC_METADATA_HPP_
 
 #include <string>
+#include "rosbag2_storage/message_definition.hpp"
 
 namespace rosbag2_storage
 {
@@ -27,12 +28,13 @@ struct TopicMetadata
   std::string serialization_format;
   // Serialized std::vector<rclcpp::QoS> as a YAML string
   std::string offered_qos_profiles;
-  // type hash, retrieved from subscription QoS metadata
-  std::string type_hash;
+  rosbag2_storage::MessageDefinition message_definition;
 
   bool operator==(const rosbag2_storage::TopicMetadata & rhs) const
   {
-    return name == rhs.name && type == rhs.type && serialization_format == rhs.serialization_format;
+    return name == rhs.name && type == rhs.type &&
+           serialization_format == rhs.serialization_format &&
+           message_definition == rhs.message_definition;
   }
 };
 

--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -124,6 +124,9 @@ private:
   RCPPUTILS_TSA_REQUIRES(database_write_mutex_);
   int get_last_rowid();
   int read_db_schema_version();
+  std::string serialize_msg_definition(const rosbag2_storage::MessageDefinition & msg_definition);
+  rosbag2_storage::MessageDefinition
+  deserialize_msg_definition(const std::string & serialized_msg_definition);
 
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string, int>;

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -532,7 +532,7 @@ void SqliteStorage::fill_topics_and_types()
 
   for (auto result : query_results) {
     all_topics_and_types_.push_back(
-      {std::get<0>(result), std::get<1>(result), std::get<2>(result), ""});
+      {std::get<0>(result), std::get<1>(result), std::get<2>(result), "", {}});
   }
 }
 
@@ -577,7 +577,7 @@ void SqliteStorage::read_metadata()
     for (auto result : query_results) {
       metadata_.topics_with_message_count.push_back(
         {
-          {std::get<0>(result), std::get<1>(result), std::get<2>(result), std::get<6>(result)},
+          {std::get<0>(result), std::get<1>(result), std::get<2>(result), std::get<6>(result), {}},
           static_cast<size_t>(std::get<3>(result))
         });
 
@@ -599,7 +599,7 @@ void SqliteStorage::read_metadata()
     for (auto result : query_results) {
       metadata_.topics_with_message_count.push_back(
         {
-          {std::get<0>(result), std::get<1>(result), std::get<2>(result), ""},
+          {std::get<0>(result), std::get<1>(result), std::get<2>(result), "", {}},
           static_cast<size_t>(std::get<3>(result))
         });
 
@@ -705,6 +705,22 @@ int SqliteStorage::read_db_schema_version()
   }
 
   return schema_version;
+}
+
+std::string
+SqliteStorage::serialize_msg_definition(const rosbag2_storage::MessageDefinition & msg_definition)
+{
+  auto node = YAML::convert<rosbag2_storage::MessageDefinition>().encode(msg_definition);
+  std::stringstream out;
+  out << node;
+  return out.str();
+}
+
+rosbag2_storage::MessageDefinition
+SqliteStorage::deserialize_msg_definition(const std::string & serialized_msg_definition)
+{
+  YAML::Node yaml = YAML::Load(serialized_msg_definition);
+  return yaml.as<rosbag2_storage::MessageDefinition>();
 }
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
@@ -110,7 +110,7 @@ public:
       std::string topic_name = std::get<2>(msg);
       std::string type_name = std::get<3>(msg);
       std::string rmw_format = std::get<4>(msg);
-      rw_storage.create_topic({topic_name, type_name, rmw_format, ""});
+      rw_storage.create_topic({topic_name, type_name, rmw_format, "", {}});
       auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
       bag_message->serialized_data = make_serialized_message(std::get<0>(msg));
       bag_message->time_stamp = std::get<1>(msg);

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -174,8 +174,8 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
   const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
 
   writable_storage->open({read_write_filename, kPluginID});
-  writable_storage->create_topic({"topic1", "type1", "rmw1", ""});
-  writable_storage->create_topic({"topic2", "type2", "rmw2", ""});
+  writable_storage->create_topic({"topic1", "type1", "rmw1", "", {}});
+  writable_storage->create_topic({"topic2", "type2", "rmw2", "", {}});
 
   const auto read_only_filename = writable_storage->get_relative_file_path();
 
@@ -190,8 +190,8 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
   EXPECT_THAT(
     topics_and_types, ElementsAreArray(
   {
-    rosbag2_storage::TopicMetadata{"topic1", "type1", "rmw1", ""},
-    rosbag2_storage::TopicMetadata{"topic2", "type2", "rmw2", ""}
+    rosbag2_storage::TopicMetadata{"topic1", "type1", "rmw1", "", {}},
+    rosbag2_storage::TopicMetadata{"topic2", "type2", "rmw2", "", {}}
   }));
 }
 
@@ -222,9 +222,9 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
     metadata.topics_with_message_count, ElementsAreArray(
   {
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic1", "type1", "rmw_format", ""}, 2u},
+        "topic1", "type1", "rmw_format", "", {}}, 2u},
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic2", "type2", "rmw_format", ""}, 1u}
+        "topic2", "type2", "rmw_format", "", {}}, 1u}
   }));
   EXPECT_THAT(metadata.message_count, Eq(3u));
   EXPECT_THAT(
@@ -261,9 +261,9 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_for_prefoxy_db_sc
     metadata.topics_with_message_count, ElementsAreArray(
   {
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic1", "type1", "rmw_format", ""}, 2u},
+        "topic1", "type1", "rmw_format", "", {}}, 2u},
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic2", "type2", "rmw_format", ""}, 1u}
+        "topic2", "type2", "rmw_format", "", {}}, 1u}
   }));
   EXPECT_THAT(metadata.message_count, Eq(3u));
   EXPECT_THAT(
@@ -365,8 +365,8 @@ TEST_F(StorageTestFixture, remove_topics_and_types_returns_the_empty_vector) {
   const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
 
   writable_storage->open({read_write_filename, kPluginID});
-  writable_storage->create_topic({"topic1", "type1", "rmw1", ""});
-  writable_storage->remove_topic({"topic1", "type1", "rmw1", ""});
+  writable_storage->create_topic({"topic1", "type1", "rmw1", "", {}});
+  writable_storage->remove_topic({"topic1", "type1", "rmw1", "", {}});
 
   const auto read_only_filename = writable_storage->get_relative_file_path();
 

--- a/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
@@ -83,6 +83,7 @@ setup_topic_filtering(
   std::map<std::string, std::vector<std::string>> input_topics;
   std::unordered_map<std::string, YAML::Node> input_topics_qos_profiles;
   std::unordered_map<std::string, std::string> input_topics_serialization_format;
+  std::unordered_map<std::string, rosbag2_storage::MessageDefinition> input_topics_msg_definition;
 
   for (const auto & input_bag : input_bags) {
     auto bag_topics_and_types = input_bag->get_all_topics_and_types();
@@ -91,6 +92,7 @@ setup_topic_filtering(
       input_topics.try_emplace(topic_name);
       input_topics[topic_name].push_back(topic_metadata.type);
       input_topics_serialization_format[topic_name] = topic_metadata.serialization_format;
+      input_topics_msg_definition[topic_name] = topic_metadata.message_definition;
 
       // Gather all offered qos profiles from all inputs
       input_topics_qos_profiles.try_emplace(topic_name);
@@ -122,6 +124,7 @@ setup_topic_filtering(
       std::stringstream qos_profiles;
       qos_profiles << input_topics_qos_profiles[topic_name];
       topic_metadata.offered_qos_profiles = qos_profiles.str();
+      topic_metadata.message_definition = input_topics_msg_definition[topic_name];
       writer->create_topic(topic_metadata);
 
       filtered_outputs.try_emplace(topic_name);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -330,7 +330,8 @@ void Recorder::subscribe_topics(
         topic_with_type.first,
         topic_with_type.second,
         serialization_format_,
-        serialized_offered_qos_profiles_for_topic(topic_with_type.first)
+        serialized_offered_qos_profiles_for_topic(topic_with_type.first),
+        message_definition_cache_.get_full_text(topic_with_type.second)
       });
   }
 }
@@ -340,8 +341,6 @@ void Recorder::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   // Need to create topic in writer before we are trying to create subscription. Since in
   // callback for subscription we are calling writer_->write(bag_message); and it could happened
   // that callback called before we reached out the line: writer_->create_topic(topic)
-  auto message_definition = message_definition_cache_.get_full_text(topic.type);
-  writer_->register_message_definition(message_definition);
   writer_->create_topic(topic);
 
   Rosbag2QoS subscription_qos{subscription_qos_for_topic(topic.name)};


### PR DESCRIPTION
Intention of this PR is to prototype one of the possible solution of how to pass `message_definition` to the storage and read it back for bag rewriter.