### PR TITLE
Fix expectations for rosbag2 return code in rosbag2_performance_benchmarking

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/launch/benchmark_launch.py
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/launch/benchmark_launch.py
@@ -158,8 +158,8 @@ def _rosbag_proc_exited(event, context):
     """
     global _producer_idx, _result_writers, _rosbag_pid
 
-    # ROS2 bag returns 2 if terminated with SIGINT, which we expect here
-    if event.returncode != 2:
+    # ROS2 bag returns 0 if terminated with SIGINT, which we expect here
+    if event.returncode != 0:
         _rosbag_pid = None
         return [
             launch.actions.LogInfo(msg='Rosbag2 record error. Shutting down benchmark.'),

--- a/rosbag2_performance/rosbag2_performance_benchmarking/launch/benchmark_launch.py
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/launch/benchmark_launch.py
@@ -162,7 +162,8 @@ def _rosbag_proc_exited(event, context):
     if event.returncode != 0:
         _rosbag_pid = None
         return [
-            launch.actions.LogInfo(msg='Rosbag2 record error. Shutting down benchmark.'),
+            launch.actions.LogInfo(msg='Rosbag2 record error. Shutting down benchmark. '
+                                       'Return code = ' + str(event.returncode)),
             launch.actions.EmitEvent(
                 event=launch.events.Shutdown(
                     reason='Rosbag2 record error'


### PR DESCRIPTION
In the past we had return code 2 for rosbag2 when interrupting by CTRL+C.
Although we have changed  behavior and now returning 0 and seems forgotten to change expectation in `rosbag2_performance_benchmarking` package.