### PR TITLE
DRAFT: Add message_definition to create_topic(..) API

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -88,7 +88,9 @@ public:
    * \param topic_with_type name and type identifier of topic to be created
    * \throws runtime_error if the Writer is not open.
    */
-  void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type) override;
+  void create_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    const rosbag2_storage::MessageDefinition & message_definition) override;
 
   /**
    * Remove a new topic in the underlying storage.

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -221,10 +221,11 @@ void SequentialCompressionWriter::close()
 }
 
 void SequentialCompressionWriter::create_topic(
-  const rosbag2_storage::TopicMetadata & topic_with_type)
+  const rosbag2_storage::TopicMetadata & topic_with_type,
+  const rosbag2_storage::MessageDefinition & message_definition)
 {
   std::lock_guard<std::recursive_mutex> lock(storage_mutex_);
-  SequentialWriter::create_topic(topic_with_type);
+  SequentialWriter::create_topic(topic_with_type, message_definition);
 }
 
 void SequentialCompressionWriter::register_message_definition(

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
@@ -35,7 +35,9 @@ public:
     void(const rosbag2_storage::StorageOptions &, rosbag2_storage::storage_interfaces::IOFlag));
   MOCK_METHOD1(update_metadata, void(const rosbag2_storage::BagMetadata &));
   MOCK_METHOD1(register_message_definition, void(const rosbag2_storage::MessageDefinition &));
-  MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
+  MOCK_METHOD2(
+    create_topic, void(const rosbag2_storage::TopicMetadata &,
+    const rosbag2_storage::MessageDefinition &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(set_read_order, bool(const rosbag2_storage::ReadOrder &));
   MOCK_METHOD0(has_next, bool());

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -54,7 +54,7 @@ public:
     rcpputils::fs::remove_all(tmp_dir_);
     storage_options_.uri = tmp_dir_.string();
     topic_with_type_ = rosbag2_storage::TopicMetadata{
-      "topic", "test_msgs/BasicTypes", storage_serialization_format_, ""};
+      "topic", "test_msgs/BasicTypes", storage_serialization_format_, "", "type_hash"};
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type_};
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type_.name;

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -243,7 +243,7 @@ TEST_F(SequentialCompressionWriterTest, writer_creates_correct_metadata_relative
 
   tmp_dir_storage_options_.max_bagfile_size = 1;
   writer_->open(tmp_dir_storage_options_);
-  writer_->create_topic({test_topic_name, test_topic_type, "", ""});
+  writer_->create_topic({test_topic_name, test_topic_type, "", "", "type_hash"}, {});
 
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = test_topic_name;
@@ -285,7 +285,7 @@ TEST_F(SequentialCompressionWriterTest, writer_call_metadata_update_on_open_and_
 
   EXPECT_CALL(*storage_, update_metadata(_)).Times(2);
   writer_->open(tmp_dir_storage_options_);
-  writer_->create_topic({test_topic_name, test_topic_type, "", ""});
+  writer_->create_topic({test_topic_name, test_topic_type, "", "", "type_hash"}, {});
 
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = test_topic_name;
@@ -323,7 +323,7 @@ TEST_F(SequentialCompressionWriterTest, writer_call_metadata_update_on_bag_split
 
   EXPECT_CALL(*storage_, update_metadata(_)).Times(4);
   writer_->open(tmp_dir_storage_options_);
-  writer_->create_topic({test_topic_name, test_topic_type, "", ""});
+  writer_->create_topic({test_topic_name, test_topic_type, "", "", "type_hash"}, {});
 
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = test_topic_name;
@@ -370,7 +370,7 @@ TEST_P(SequentialCompressionWriterTest, writer_writes_with_compression_queue_siz
   initializeWriter(compression_options);
 
   writer_->open(tmp_dir_storage_options_);
-  writer_->create_topic({test_topic_name, test_topic_type, "", ""});
+  writer_->create_topic({test_topic_name, test_topic_type, "", "", "type_hash"}, {});
 
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = test_topic_name;

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -104,7 +104,9 @@ public:
    * \param topic_with_type name and type identifier of topic to be created
    * \throws runtime_error if the Writer is not open.
    */
-  void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type);
+  void create_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    const rosbag2_storage::MessageDefinition & message_definition);
 
   /**
    * Trigger a snapshot when snapshot mode is enabled.

--- a/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
@@ -45,7 +45,9 @@ public:
   virtual void register_message_definition(
     const rosbag2_storage::MessageDefinition & message_definition) = 0;
 
-  virtual void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type) = 0;
+  virtual void create_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    const rosbag2_storage::MessageDefinition & message_definition) = 0;
 
   virtual void remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type) = 0;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -100,7 +100,9 @@ public:
    * \param topic_with_type name and type identifier of topic to be created
    * \throws runtime_error if the Writer is not open.
    */
-  void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type) override;
+  void create_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    const rosbag2_storage::MessageDefinition & message_definition) override;
 
   /**
    * Remove a new topic in the underlying storage.

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -73,10 +73,12 @@ void Writer::register_message_definition(
   writer_impl_->register_message_definition(message_definition);
 }
 
-void Writer::create_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
+void Writer::create_topic(
+  const rosbag2_storage::TopicMetadata & topic_with_type,
+  const rosbag2_storage::MessageDefinition & message_definition)
 {
   std::lock_guard<std::mutex> writer_lock(writer_mutex_);
-  writer_impl_->create_topic(topic_with_type);
+  writer_impl_->create_topic(topic_with_type, message_definition);
 }
 
 void Writer::remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
@@ -118,10 +120,10 @@ void Writer::write(
   tm.name = topic_name;
   tm.type = type_name;
   tm.serialization_format = serialization_format;
-  rosbag2_storage::MessageDefinition md;
+  rosbag2_storage::MessageDefinition md;  // TODO(morlov) We need either add message difinition
+  // to the upper level API or figure out how to get it here. This is actually an open question
   md.name = type_name;
-  register_message_definition(md);
-  create_topic(tm);
+  create_topic(tm, md);
   write(message);
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -193,7 +193,9 @@ void SequentialWriter::register_message_definition(
   // TODO(james-rms) something with converters
 }
 
-void SequentialWriter::create_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
+void SequentialWriter::create_topic(
+  const rosbag2_storage::TopicMetadata & topic_with_type,
+  const rosbag2_storage::MessageDefinition & message_definition)
 {
   if (topics_names_to_info_.find(topic_with_type.name) !=
     topics_names_to_info_.end())
@@ -224,7 +226,7 @@ void SequentialWriter::create_topic(const rosbag2_storage::TopicMetadata & topic
     throw std::runtime_error(errmsg.str());
   }
 
-  storage_->create_topic(topic_with_type);
+  storage_->create_topic(topic_with_type, message_definition);
 
   if (converter_) {
     converter_->add_topic(topic_with_type.name, topic_with_type.type);
@@ -287,12 +289,14 @@ void SequentialWriter::switch_to_next_storage()
 
     throw std::runtime_error(errmsg.str());
   }
-  // re-register all message definitions and topics since we rolled over to a new bag file.
-  for (const auto & message_definition : type_names_to_message_definitions_) {
-    storage_->register_message_definition(message_definition.second);
-  }
+//  // re-register all message definitions and topics since we rolled over to a new bag file.
+//  for (const auto & message_definition : type_names_to_message_definitions_) {
+//    storage_->register_message_definition(message_definition.second);
+//  }
+
   for (const auto & topic : topics_names_to_info_) {
-    storage_->create_topic(topic.second.topic_metadata);
+    auto const & md = type_names_to_message_definitions_[topic.first];
+    storage_->create_topic(topic.second.topic_metadata, md);
   }
 
   if (use_cache_) {

--- a/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
@@ -53,6 +53,20 @@ void write_sample_split_bag(
     "test_msgs/msg/ByteMultiArray",
     "cdr",
     ""
+  },
+  {
+    "test_msgs/msg/ByteMultiArray",
+    "RIHS01_bb56995ece1d87b157e740239fd7e92ed7c60c6326dfec09577dd5234359abe3",
+    "# This was originally provided as an example message.\n"
+    "# It is deprecated as of Foxy\n"
+    "# It is recommended to create your own semantically meaningful message.\n"
+    "\n"
+    "# Please look at the MultiArrayLayout message definition for\n"
+    "# documentation on all multiarrays.\n"
+    "\n"
+    "MultiArrayLayout  layout        # specification of data layout\n"
+    "byte[]            data          # array of data",
+    rosbag2_storage::MessageDefinition::Encoding::ConcatenatedMsg
   });
   for (size_t i = 0; i < fake_messages.size(); i++) {
     if (i > 0 && (i % split_every == 0)) {

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
@@ -36,7 +36,9 @@ public:
     void(const rosbag2_storage::StorageOptions &, rosbag2_storage::storage_interfaces::IOFlag));
   MOCK_METHOD1(update_metadata, void(const rosbag2_storage::BagMetadata &));
   MOCK_METHOD1(register_message_definition, void(const rosbag2_storage::MessageDefinition &));
-  MOCK_METHOD1(create_topic, void(const rosbag2_storage::TopicMetadata &));
+  MOCK_METHOD2(
+    create_topic, void(const rosbag2_storage::TopicMetadata &,
+    const rosbag2_storage::MessageDefinition &));
   MOCK_METHOD1(remove_topic, void(const rosbag2_storage::TopicMetadata &));
   MOCK_METHOD1(set_read_order, bool(const rosbag2_storage::ReadOrder &));
   MOCK_METHOD0(has_next, bool());

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -53,7 +53,7 @@ public:
     auto metadata = get_metadata();
 
     auto topic_with_type = rosbag2_storage::TopicMetadata{
-      "topic", "test_msgs/BasicTypes", storage_serialization_format_, ""};
+      "topic", "test_msgs/BasicTypes", storage_serialization_format_, "", "type_hash"};
     auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
     metadata.topics_with_message_count.push_back({topic_with_type, 10});
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -130,7 +130,7 @@ TEST_F(
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = "test_topic";
   writer_->open(storage_options_, {input_format, storage_serialization_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
   writer_->write(message);
 }
 
@@ -147,7 +147,7 @@ TEST_F(SequentialWriterTest, write_does_not_use_converters_if_input_and_output_f
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = "test_topic";
   writer_->open(storage_options_, {storage_serialization_format, storage_serialization_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
   writer_->write(message);
 }
 
@@ -175,7 +175,7 @@ TEST_F(SequentialWriterTest, sequantial_writer_call_metadata_update_on_open_and_
 
   std::string rmw_format = "rmw_format";
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({test_topic_name, test_topic_type, "", ""});
+  writer_->create_topic({test_topic_name, test_topic_type, "", "", "type_hash"}, {});
 
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = test_topic_name;
@@ -204,7 +204,7 @@ TEST_F(SequentialWriterTest, sequantial_writer_call_metadata_update_on_bag_split
 
   std::string rmw_format = "rmw_format";
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({test_topic_name, test_topic_type, "", ""});
+  writer_->create_topic({test_topic_name, test_topic_type, "", ""}, {});
 
   auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   message->topic_name = test_topic_name;
@@ -283,7 +283,7 @@ TEST_F(SequentialWriterTest, bagfile_size_is_checked_on_every_write) {
   storage_options_.max_bagfile_size = max_bagfile_size;
 
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
 
   for (auto i = 0; i < counter; ++i) {
     writer_->write(message);
@@ -333,7 +333,7 @@ TEST_F(SequentialWriterTest, writer_splits_when_storage_bagfile_size_gt_max_bagf
   storage_options_.max_bagfile_size = max_bagfile_size;
 
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
 
   for (auto i = 0; i < message_count; ++i) {
     writer_->write(message);
@@ -411,7 +411,7 @@ TEST_F(
   storage_options_.snapshot_mode = false;
 
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
 
   auto timeout = std::chrono::seconds(2);
   for (auto i = 1u; i < message_count; ++i) {
@@ -491,7 +491,7 @@ TEST_F(SequentialWriterTest, do_not_use_cache_if_cache_size_is_zero) {
   storage_options_.max_cache_size = max_cache_size;
 
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
 
   for (auto i = 0u; i < counter; ++i) {
     writer_->write(message);
@@ -525,7 +525,7 @@ TEST_F(SequentialWriterTest, snapshot_mode_write_on_trigger)
     msg_content.c_str(), msg_length);
 
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
 
   for (auto i = 0u; i < 100; ++i) {
     writer_->write(message);
@@ -561,7 +561,7 @@ TEST_F(SequentialWriterTest, snapshot_mode_not_triggered_no_storage_write)
     msg_content.c_str(), msg_length);
 
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
 
   for (auto i = 0u; i < 100; ++i) {
     writer_->write(message);
@@ -630,7 +630,7 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
   writer_->add_event_callbacks(callbacks);
 
   writer_->open(storage_options_, {"rmw_format", "rmw_format"});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", "", "type_hash"}, {});
 
   for (auto i = 0; i < message_count; ++i) {
     writer_->write(message);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
@@ -56,7 +56,8 @@ TEST_F(StorageWithoutMetadataFileTest, open_uses_storage_id_from_storage_options
       "topic",
       "test_msgs/BasicTypes",
       kRmwFormat,
-      ""
+      "",
+      "type_hash"
     };
 
     auto topic_information = rosbag2_storage::TopicInformation{

--- a/rosbag2_examples/rosbag2_examples_cpp/src/data_generator_executable.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/data_generator_executable.cpp
@@ -38,7 +38,7 @@ int main(int, char **)
     "example_interfaces/msg/Int32",
     rmw_get_serialization_format(),
     ""
-  });
+  }, {});
 
   rclcpp::Clock clock;
   rclcpp::Time time_stamp = clock.now();

--- a/rosbag2_examples/rosbag2_examples_cpp/src/data_generator_node.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/data_generator_node.cpp
@@ -39,7 +39,7 @@ public:
       "example_interfaces/msg/Int32",
       rmw_get_serialization_format(),
       ""
-    });
+    }, {});
 
     timer_ = create_wall_timer(1s, std::bind(&DataGenerator::timer_callback, this));
   }

--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
@@ -195,7 +195,7 @@ void WriterBenchmark::create_writer()
     // TODO(adamdbrw) - replace with something more general if needed
     topic.type = "rosbag2_performance_benchmarking_msgs/msg/ByteArray";
     topic.serialization_format = serialization_format;
-    writer_->create_topic(topic);
+    writer_->create_topic(topic, {});
   }
 }
 

--- a/rosbag2_py/test/test_sequential_writer.py
+++ b/rosbag2_py/test/test_sequential_writer.py
@@ -37,7 +37,7 @@ def create_topic(writer, topic_name, topic_type, serialization_format='cdr'):
     topic = rosbag2_py.TopicMetadata(name=topic_name, type=topic_type,
                                      serialization_format=serialization_format)
 
-    writer.create_topic(topic)
+    writer.create_topic(topic, {})
 
 
 @pytest.mark.parametrize('storage_id', TESTED_STORAGE_IDS)

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -44,7 +44,9 @@ public:
   virtual void register_message_definition(
     const rosbag2_storage::MessageDefinition & message_definition) = 0;
 
-  virtual void create_topic(const TopicMetadata & topic) = 0;
+  virtual void create_topic(
+    const TopicMetadata & topic,
+    const rosbag2_storage::MessageDefinition & message_definition) = 0;
 
   virtual void remove_topic(const TopicMetadata & topic) = 0;
 };

--- a/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_metadata_serialization.cpp
@@ -54,8 +54,12 @@ TEST_F(MetadataFixture, test_writing_and_reading_yaml)
   metadata.starting_time =
     std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(1000000));
   metadata.message_count = 50;
-  metadata.topics_with_message_count.push_back({{"topic1", "type1", "rmw1", "qos1"}, 100});
-  metadata.topics_with_message_count.push_back({{"topic2", "type2", "rmw2", "qos2"}, 200});
+  metadata.topics_with_message_count.push_back(
+  {
+    {"topic1", "type1", "rmw1", "qos1", "type_hash"}, 100});
+  metadata.topics_with_message_count.push_back(
+  {
+    {"topic2", "type2", "rmw2", "qos2", "type_hash"}, 200});
 
   metadata_io_->write_metadata(temporary_dir_path_, metadata);
   auto read_metadata = metadata_io_->read_metadata(temporary_dir_path_);

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -75,9 +75,12 @@ void TestPlugin::register_message_definition(
   std::cout << "Registered message definition for type " << message_definition.name << ".\n";
 }
 
-void TestPlugin::create_topic(const rosbag2_storage::TopicMetadata & topic)
+void TestPlugin::create_topic(
+  const rosbag2_storage::TopicMetadata & topic,
+  const rosbag2_storage::MessageDefinition & message_definition)
 {
-  std::cout << "Created topic with name =" << topic.name << " and type =" << topic.type << ".\n";
+  std::cout << "Created topic with name =" << topic.name << ", type =" << topic.type <<
+    " and type_hash=" << message_definition.type_hash << ".\n";
 }
 
 void TestPlugin::remove_topic(const rosbag2_storage::TopicMetadata & topic)

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -37,7 +37,9 @@ public:
 
   void register_message_definition(const rosbag2_storage::MessageDefinition & topic) override;
 
-  void create_topic(const rosbag2_storage::TopicMetadata & topic) override;
+  void create_topic(
+    const rosbag2_storage::TopicMetadata & topic,
+    const rosbag2_storage::MessageDefinition & message_definition) override;
 
   void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
 

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -60,7 +60,7 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file)
 #else
     auto writer = factory.open_read_write(uri.string(), storage_id);
 #endif
-    writer->create_topic(topic_metadata);
+    writer->create_topic(topic_metadata, {});
 
     auto serialized_msg = std::make_shared<rclcpp::SerializedMessage>();
     serialization.serialize_message(&msg, serialized_msg.get());
@@ -127,7 +127,7 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
 
     rosbag2_storage::StorageFactory factory;
     auto writer = factory.open_read_write(options);
-    writer->create_topic(topic_metadata);
+    writer->create_topic(topic_metadata, {});
 
     auto serialized_msg = std::make_shared<rclcpp::SerializedMessage>();
     serialization.serialize_message(&msg, serialized_msg.get());

--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -62,7 +62,9 @@ public:
   void register_message_definition(const rosbag2_storage::MessageDefinition & message_definition)
   override;
 
-  void create_topic(const rosbag2_storage::TopicMetadata & topic) override;
+  void create_topic(
+    const rosbag2_storage::TopicMetadata & topic,
+    const rosbag2_storage::MessageDefinition & message_definition) override;
 
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message) override;
 

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -425,7 +425,9 @@ void SqliteStorage::register_message_definition(const rosbag2_storage::MessageDe
   // Do nothing
 }
 
-void SqliteStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
+void SqliteStorage::create_topic(
+  const rosbag2_storage::TopicMetadata & topic,
+  const rosbag2_storage::MessageDefinition & message_definition)
 {
   std::lock_guard<std::mutex> db_lock(database_write_mutex_);
   if (topics_.find(topic.name) == std::end(topics_)) {
@@ -532,7 +534,7 @@ void SqliteStorage::fill_topics_and_types()
 
   for (auto result : query_results) {
     all_topics_and_types_.push_back(
-      {std::get<0>(result), std::get<1>(result), std::get<2>(result), ""});
+      {std::get<0>(result), std::get<1>(result), std::get<2>(result), "", "type_hash"});
   }
 }
 

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
@@ -110,7 +110,7 @@ public:
       std::string topic_name = std::get<2>(msg);
       std::string type_name = std::get<3>(msg);
       std::string rmw_format = std::get<4>(msg);
-      rw_storage.create_topic({topic_name, type_name, rmw_format, ""});
+      rw_storage.create_topic({topic_name, type_name, rmw_format, "", "type_hash"}, {});
       auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
       bag_message->serialized_data = make_serialized_message(std::get<0>(msg));
       bag_message->time_stamp = std::get<1>(msg);

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -174,8 +174,8 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
   const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
 
   writable_storage->open({read_write_filename, kPluginID});
-  writable_storage->create_topic({"topic1", "type1", "rmw1", ""});
-  writable_storage->create_topic({"topic2", "type2", "rmw2", ""});
+  writable_storage->create_topic({"topic1", "type1", "rmw1", "", "type_hash"}, {});
+  writable_storage->create_topic({"topic2", "type2", "rmw2", "", "type_hash"}, {});
 
   const auto read_only_filename = writable_storage->get_relative_file_path();
 
@@ -190,8 +190,8 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
   EXPECT_THAT(
     topics_and_types, ElementsAreArray(
   {
-    rosbag2_storage::TopicMetadata{"topic1", "type1", "rmw1", ""},
-    rosbag2_storage::TopicMetadata{"topic2", "type2", "rmw2", ""}
+    rosbag2_storage::TopicMetadata{"topic1", "type1", "rmw1", "", "type_hash"},
+    rosbag2_storage::TopicMetadata{"topic2", "type2", "rmw2", "", "type_hash"}
   }));
 }
 
@@ -222,9 +222,9 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
     metadata.topics_with_message_count, ElementsAreArray(
   {
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic1", "type1", "rmw_format", ""}, 2u},
+        "topic1", "type1", "rmw_format", "", "type_hash"}, 2u},
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic2", "type2", "rmw_format", ""}, 1u}
+        "topic2", "type2", "rmw_format", "", "type_hash"}, 1u}
   }));
   EXPECT_THAT(metadata.message_count, Eq(3u));
   EXPECT_THAT(
@@ -261,9 +261,9 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_for_prefoxy_db_sc
     metadata.topics_with_message_count, ElementsAreArray(
   {
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic1", "type1", "rmw_format", ""}, 2u},
+        "topic1", "type1", "rmw_format", "", "type_hash"}, 2u},
     rosbag2_storage::TopicInformation{rosbag2_storage::TopicMetadata{
-        "topic2", "type2", "rmw_format", ""}, 1u}
+        "topic2", "type2", "rmw_format", "", "type_hash"}, 1u}
   }));
   EXPECT_THAT(metadata.message_count, Eq(3u));
   EXPECT_THAT(
@@ -365,8 +365,8 @@ TEST_F(StorageTestFixture, remove_topics_and_types_returns_the_empty_vector) {
   const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
 
   writable_storage->open({read_write_filename, kPluginID});
-  writable_storage->create_topic({"topic1", "type1", "rmw1", ""});
-  writable_storage->remove_topic({"topic1", "type1", "rmw1", ""});
+  writable_storage->create_topic({"topic1", "type1", "rmw1", "", "type_hash"}, {});
+  writable_storage->remove_topic({"topic1", "type1", "rmw1", "", "type_hash"});
 
   const auto read_only_filename = writable_storage->get_relative_file_path();
 

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -39,6 +39,7 @@
 #include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
+#include "rosbag2_storage/message_definition.hpp"
 
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 #include "rosbag2_test_common/tested_storage_ids.hpp"
@@ -83,7 +84,9 @@ public:
       rosbag2_storage::TopicMetadata topic;
       topic.name = "/test_topic";
       topic.type = "std_msgs/msg/String";
-      writer.create_topic(topic);
+      rosbag2_storage::MessageDefinition md;
+      md.name = topic.name;
+      writer.create_topic(topic, md);
 
       std_msgs::msg::String msg;
       rclcpp::Time stamp;

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -70,7 +70,7 @@ TEST_P(TestRosbag2CPPAPI, minimal_writer_example)
     tm.name = "/my/test/topic";
     tm.type = "test_msgs/msg/BasicTypes";
     tm.serialization_format = "cdr";
-    writer.create_topic(tm);
+    writer.create_topic(tm, {});
 
     bag_message->topic_name = tm.name;
     bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(

--- a/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
@@ -122,7 +122,8 @@ setup_topic_filtering(
       std::stringstream qos_profiles;
       qos_profiles << input_topics_qos_profiles[topic_name];
       topic_metadata.offered_qos_profiles = qos_profiles.str();
-      writer->create_topic(topic_metadata);
+      // TODO(morlov:) Get message definition for topic from input storage
+      writer->create_topic(topic_metadata, {});
 
       filtered_outputs.try_emplace(topic_name);
       filtered_outputs[topic_name].push_back(writer.get());

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -341,8 +341,8 @@ void Recorder::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   // callback for subscription we are calling writer_->write(bag_message); and it could happened
   // that callback called before we reached out the line: writer_->create_topic(topic)
   auto message_definition = message_definition_cache_.get_full_text(topic.type);
-  writer_->register_message_definition(message_definition);
-  writer_->create_topic(topic);
+//  writer_->register_message_definition(message_definition);
+  writer_->create_topic(topic, message_definition);
 
   Rosbag2QoS subscription_qos{subscription_qos_for_topic(topic.name)};
   auto subscription = create_subscription(topic.name, topic.type, subscription_qos);

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -39,7 +39,9 @@ public:
 
   void register_message_definition(const rosbag2_storage::MessageDefinition &) override {}
 
-  void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type) override
+  void create_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    const rosbag2_storage::MessageDefinition & message_definition) override
   {
     topics_.emplace(topic_with_type.name, topic_with_type);
   }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -84,7 +84,7 @@ public:
       std::make_unique<rosbag2_cpp::writers::SequentialWriter>();
 
     writer->open(storage_options_, converter_options);
-    writer->create_topic(topic_types_[0]);
+    writer->create_topic(topic_types_[0], {});
 
     for (auto const & message : messages) {
       writer->write(message);


### PR DESCRIPTION
The purpose of this PR is to prototype option for adding message_definition on upper layer

- Also added dummy initializers for `type_hash` in TopicMetadata to address compile time warnings.