### PR TITLE
Fix for failing test_sequential_compression_writer tests

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -72,6 +72,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
+  find_package(test_msgs REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   add_library(fake_plugin SHARED

--- a/rosbag2_compression/package.xml
+++ b/rosbag2_compression/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
+  <test_depend>test_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
- Relates #1265
- Tests was failing because `ament_index_cpp::get_package_share_directory(package)` was not able to find `test_msgs` packages in install folder.