### PR TITLE
Fix for flaky `TimeControllerClockTest::unpaused_sleep_returns_true`

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -53,6 +53,15 @@ public:
   virtual rcutils_time_point_value_t now() const = 0;
 
   /**
+   * @brief Convert an arbitrary ROSTime to a SteadyTime, based on the current reference snapshot.
+   * @param ros_time - time point in ROSTime
+   * @return time point in steady clock i.e. std::chrono::steady_clock
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual std::chrono::steady_clock::time_point
+  ros_to_steady(rcutils_time_point_value_t ros_time) const = 0;
+
+  /**
    * Try to sleep (non-busy) the current thread until the provided time is reached - according to this Clock
    *
    * Return true if the time has been reached, false if it was not successfully reached after sleeping

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -60,6 +60,15 @@ public:
   rcutils_time_point_value_t now() const override;
 
   /**
+   * @brief Convert an arbitrary ROSTime to a SteadyTime, based on the current reference snapshot.
+   * @param ros_time - time point in ROSTime
+   * @return time point in steady clock i.e. std::chrono::steady_clock
+   */
+  ROSBAG2_CPP_PUBLIC
+  std::chrono::steady_clock::time_point
+  ros_to_steady(rcutils_time_point_value_t ros_time) const override;
+
+  /**
    * Try to sleep (non-busy) the current thread until the provided time is reached - according to this Clock
    *
    * Return true if the time has been reached, false if it was not successfully reached after sleeping

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -166,6 +166,16 @@ rcutils_time_point_value_t TimeControllerClock::now() const
   return impl_->ros_now();
 }
 
+/// @brief Convert an arbitrary ROSTime to a SteadyTime, based on the current reference snapshot.
+/// @param ros_time - time point in ROSTime
+/// @return time point in steady clock i.e. std::chrono::steady_clock
+std::chrono::steady_clock::time_point
+TimeControllerClock::ros_to_steady(rcutils_time_point_value_t ros_time) const
+{
+  std::lock_guard<std::mutex> lock(impl_->state_mutex);
+  return impl_->ros_to_steady(ros_time);
+}
+
 bool TimeControllerClock::sleep_until(rcutils_time_point_value_t until)
 {
   {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -153,8 +153,9 @@ TEST_F(TimeControllerClockTest, unpaused_sleep_returns_true)
   clock.pause();
   clock.resume();
 
-  auto sleep_until_timestamp = clock.now() + RCUTILS_S_TO_NS(1);
-  auto start = std::chrono::steady_clock::now();
+  auto ros_time_now = clock.now();
+  auto sleep_until_timestamp = ros_time_now + RCUTILS_S_TO_NS(1);
+  auto start = clock.ros_to_steady(ros_time_now);
   bool sleep_result = clock.sleep_until(sleep_until_timestamp);
   // clock.sleep_until can spuriously wake up and return false.
   // Check it until true and use a timeout to avoid a hang


### PR DESCRIPTION
- Closes https://github.com/ros2/rosbag2/issues/1282
- Addressing failure on nightly job https://ci.ros2.org/view/nightly/job/nightly_win_rep/2955/testReport/(root)/projectroot/test_time_controller_clock/
It was a problem in test since we were not able to properly get the same time source for `now()` for measuring start point and delay for `sleep_until(timepoint)` API.
- Brought up `ros_to_steady(timepoint)` API in `TimeControllerClock` class from inner implementation layer to be able to transform `TimeControllerClock::now()` in to the steady clock domain.