### PR TITLE
Add type_hash in MessageDefinition struct

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/fake_data.cpp
@@ -51,7 +51,8 @@ void write_sample_split_bag(
     "# documentation on all multiarrays.\n"
     "\n"
     "MultiArrayLayout  layout        # specification of data layout\n"
-    "byte[]            data          # array of data"
+    "byte[]            data          # array of data",
+    "type_hash1"
   });
   for (size_t i = 0; i < fake_messages.size(); i++) {
     if (i > 0 && (i % split_every == 0)) {

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -132,15 +132,17 @@ PYBIND11_MODULE(_storage, m) {
 
   pybind11::class_<rosbag2_storage::MessageDefinition>(m, "MessageDefinition")
   .def(
-    pybind11::init<std::string, std::string, std::string>(),
+    pybind11::init<std::string, std::string, std::string, std::string>(),
     pybind11::arg("topic_type"),
     pybind11::arg("encoding"),
-    pybind11::arg("encoded_message_definition"))
+    pybind11::arg("encoded_message_definition"),
+    pybind11::arg("type_hash"))
   .def_readwrite("topic_type", &rosbag2_storage::MessageDefinition::topic_type)
   .def_readwrite("encoding", &rosbag2_storage::MessageDefinition::encoding)
   .def_readwrite(
     "encoded_message_definition",
-    &rosbag2_storage::MessageDefinition::encoded_message_definition);
+    &rosbag2_storage::MessageDefinition::encoded_message_definition)
+  .def_readwrite("type_hash", &rosbag2_storage::MessageDefinition::type_hash);
 
   pybind11::class_<rosbag2_storage::TopicMetadata>(m, "TopicMetadata")
   .def(

--- a/rosbag2_storage/include/rosbag2_storage/message_definition.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/message_definition.hpp
@@ -35,21 +35,25 @@ struct MessageDefinition
   std::string encoding;
   /// @brief The full encoded message definition for this type.
   std::string encoded_message_definition;
+  /// @brief  REP-2011 type description hash if available for topic, "" otherwise.
+  std::string type_hash;
 
   /// @brief used when no message definition is available for a given topic type.
-  static MessageDefinition empty_message_definition_for(std::string topic_type)
+  static MessageDefinition empty_message_definition_for(const std::string & topic_type)
   {
     MessageDefinition self;
     self.topic_type = topic_type;
     self.encoding = "";
     self.encoded_message_definition = "";
+    self.type_hash = "";
     return self;
   }
 
   bool operator==(const MessageDefinition & rhs) const
   {
     return topic_type == rhs.topic_type && encoding == rhs.encoding &&
-           encoded_message_definition == rhs.encoded_message_definition;
+           encoded_message_definition == rhs.encoded_message_definition &&
+           type_hash == rhs.type_hash;
   }
 };
 

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -651,16 +651,14 @@ void MCAPStorage::get_all_message_definitions(
   definitions.clear();
   definitions.reserve(schema_map.size());
   for (const auto & [id, schema_ptr] : schema_map) {
-    std::string encoded_message_definition = "";
+    std::string encoded_message_definition;
     if (!schema_ptr->data.empty()) {
       encoded_message_definition = std::string(
         reinterpret_cast<const char *>(&(schema_ptr->data[0])), schema_ptr->data.size());
     }
-    definitions.push_back({
-      schema_ptr->name,
-      schema_ptr->encoding,
-      encoded_message_definition,
-    });
+    std::string type_hash;  // TODO(jrms): save and get type_hash in mcap schema
+    definitions.push_back(
+      {schema_ptr->name, schema_ptr->encoding, encoded_message_definition, type_hash});
   }
 }
 
@@ -764,6 +762,7 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic,
     const auto & full_text = message_definition.encoded_message_definition;
     schema.data.assign(reinterpret_cast<const std::byte *>(full_text.data()),
                        reinterpret_cast<const std::byte *>(full_text.data() + full_text.size()));
+    // TODO(jrms): save message_definition.type_hash in mcap schema
     mcap_writer_->addSchema(schema);
     schema_ids_.emplace(datatype, schema.id);
     schema_id = schema.id;

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -48,7 +48,7 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file)
   const std::string message_data = "Test Message 1";
   const std::string storage_id = "mcap";
   const rosbag2_storage::MessageDefinition definition = {"std_msgs/msg/String", "ros2msg",
-                                                         "string data"};
+                                                         "string data", ""};
   // COMPATIBILITY(foxy)
   // using verbose APIs for Foxy compatibility which did not yet provide plain-message API
   rclcpp::Serialization<std_msgs::msg::String> serialization;
@@ -144,7 +144,7 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
   const std::string storage_id = "mcap";
   const std::string config_path = _TEST_RESOURCES_DIR_PATH;
   const rosbag2_storage::MessageDefinition definition = {"std_msgs/msg/String", "ros2msg",
-                                                         "string data"};
+                                                         "string data", ""};
   rclcpp::Serialization<std_msgs::msg::String> serialization;
 
   {

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -197,7 +197,7 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
 
 TEST_F(StorageTestFixture, get_all_message_definitions_returns_the_correct_vector) {
   const rosbag2_storage::MessageDefinition msg_definition =
-  {"type1", "ros2msg", "string data"};
+  {"type1", "ros2msg", "string data", ""};
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadWriteInterface> writable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
@@ -225,9 +225,13 @@ TEST_F(StorageTestFixture, get_all_message_definitions_returns_the_correct_vecto
   readable_storage->get_all_message_definitions(msg_definitions);
 
   EXPECT_EQ(msg_definitions.size(), 1u);
-  EXPECT_THAT(msg_definitions, ElementsAreArray({msg_definition})) <<
-    msg_definition.topic_type << " " << msg_definition.encoding << " " <<
-    msg_definition.encoded_message_definition;
+  EXPECT_THAT(
+    msg_definitions,
+    ElementsAreArray(
+  {
+    rosbag2_storage::MessageDefinition{"type1", "ros2msg", "string data", "type_hash1"}
+  })) << msg_definition.topic_type << " " << msg_definition.encoding << " " <<
+    msg_definition.encoded_message_definition << " " << msg_definition.type_hash;
 }
 
 TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -84,9 +84,8 @@ public:
       rosbag2_storage::TopicMetadata topic;
       topic.name = "/test_topic";
       topic.type = "std_msgs/msg/String";
-      rosbag2_storage::MessageDefinition md;
-      md.topic_type = topic.type;
-      writer.create_topic(topic, md);
+      topic.type_description_hash = "type_hash_msg_string";
+      writer.create_topic(topic);
 
       std_msgs::msg::String msg;
       rclcpp::Time stamp;


### PR DESCRIPTION
Add `type_hash` in `MessageDefinition` struct

Just keep placeholder for future implementation when `type_hash` will be ready.

- There are will be possible situation when several publishers publishing on the same topic but with different version of the message definition. (e.g. maybe added or removed some field) We will be able to detect this situation when type_hash will be available.
- Also will be useful to detect discrepancy in message definitions versions when merging multiple bags. 

It will great to have ability to gracefully handle such situation.
To be able differentiate different version of the  message definitions  we will need to save `type_hash` as a separate filed in `MessageDefinition`

