### PR TITLE
Fix warning from ClassLoader in sequential compression reader and writer

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_reader.hpp
@@ -84,10 +84,10 @@ private:
    */
   void setup_decompression();
 
-  std::shared_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};
   rosbag2_compression::CompressionMode compression_mode_{
     rosbag2_compression::CompressionMode::NONE};
   std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
+  std::shared_ptr<rosbag2_compression::BaseDecompressorInterface> decompressor_{};
 
   rosbag2_storage::StorageOptions storage_options_;
 };

--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -181,8 +181,8 @@ protected:
   virtual void stop_compressor_threads();
 
 private:
-  std::shared_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};
   std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
+  std::shared_ptr<rosbag2_compression::BaseCompressorInterface> compressor_{};
   std::mutex compressor_queue_mutex_;
   std::queue<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>
   compressor_message_queue_ RCPPUTILS_TSA_GUARDED_BY(compressor_queue_mutex_);


### PR DESCRIPTION
- Fix for warning messages "Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap!"
- Relates to #1278 

RCA:
It was incorrect order of objects destruction.
First should be destructed child objects produced by `compression_factory` such as `compressor` and `decompressor` since inside `compression_factory` destructor will be called ClassLoader destructor which will generate such warning.