### PR TITLE
Add recorder stop() API

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -89,6 +89,11 @@ public:
     const ConverterOptions & converter_options = ConverterOptions());
 
   /**
+   * \brief Close the current bag file and write metadata.yaml file
+   */
+  void close();
+
+  /**
    * Create a new topic in the underlying storage. Needs to be called for every topic used within
    * a message which is passed to write(...).
    *

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -65,6 +65,11 @@ void Writer::open(
   writer_impl_->open(storage_options, converter_options);
 }
 
+void Writer::close()
+{
+  writer_impl_->close();
+}
+
 void Writer::create_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
 {
   std::lock_guard<std::mutex> writer_lock(writer_mutex_);

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -85,6 +85,11 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   void record();
 
+  /// @brief Stopping recording and closing writer.
+  /// The record() can be called again after stop().
+  ROSBAG2_TRANSPORT_PUBLIC
+  void stop();
+
   ROSBAG2_TRANSPORT_PUBLIC
   const std::unordered_set<std::string> &
   topics_using_fallback_qos() const;

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -85,8 +85,9 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   void record();
 
-  /// @brief Stopping recording and closing writer.
-  /// The record() can be called again after stop().
+  /// @brief Stopping recording.
+  /// @details The stop() is opposite to the record() operation. It will stop recording, dump
+  /// all buffers to the disk and close writer. The record() can be called again after stop().
   ROSBAG2_TRANSPORT_PUBLIC
   void stop();
 
@@ -101,7 +102,8 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   const rosbag2_cpp::Writer & get_writer_handle();
 
-  /// Pause the recording.
+  /// @brief Pause the recording.
+  /// @details Will keep writer open and skip messages upon arrival on subscriptions.
   ROSBAG2_TRANSPORT_PUBLIC
   void pause();
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -182,12 +182,19 @@ RecorderImpl::RecorderImpl(
 RecorderImpl::~RecorderImpl()
 {
   keyboard_handler_->delete_key_press_callback(toggle_paused_key_callback_handle_);
+  stop();
+}
+
+
+void RecorderImpl::stop()
+{
   stop_discovery_ = true;
   if (discovery_future_.valid()) {
     discovery_future_.wait();
   }
-
+  paused_ = true;
   subscriptions_.clear();
+  writer_->close();  // Call writer->close() to finalize current bag file and write metadata
 
   {
     std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
@@ -199,13 +206,9 @@ RecorderImpl::~RecorderImpl()
   }
 }
 
-void RecorderImpl::stop()
-{
-  writer_->close();
-}
-
 void RecorderImpl::record()
 {
+  paused_ = record_options_.start_paused;
   topic_qos_profile_overrides_ = record_options_.topic_qos_profile_overrides;
   if (record_options_.rmw_serialization_format.empty()) {
     throw std::runtime_error("No serialization format specified!");

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -57,6 +57,10 @@ public:
 
   void record();
 
+  /// @brief Stopping recording and closing writer.
+  /// The record() can be called again after stop().
+  void stop();
+
   const rosbag2_cpp::Writer & get_writer_handle();
 
   /// Pause the recording.
@@ -193,6 +197,11 @@ RecorderImpl::~RecorderImpl()
   if (event_publisher_thread_.joinable()) {
     event_publisher_thread_.join();
   }
+}
+
+void RecorderImpl::stop()
+{
+  writer_->close();
 }
 
 void RecorderImpl::record()
@@ -615,10 +624,14 @@ Recorder::Recorder(
 Recorder::~Recorder()
 {}
 
-void
-Recorder::record()
+void Recorder::record()
 {
   pimpl_->record();
+}
+
+void Recorder::stop()
+{
+  pimpl_->stop();
 }
 
 const std::unordered_set<std::string> &

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -33,9 +33,13 @@ public:
     snapshot_mode_ = storage_options.snapshot_mode;
     (void) storage_options;
     (void) converter_options;
+    writer_close_called_ = false;
   }
 
-  void close() override {}
+  void close() override
+  {
+    writer_close_called_ = true;
+  }
 
   void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type) override
   {
@@ -131,6 +135,11 @@ public:
     return max_messages_per_file_;
   }
 
+  bool closed_was_called() const
+  {
+    return writer_close_called_;
+  }
+
 private:
   std::unordered_map<
     std::string,
@@ -144,6 +153,7 @@ private:
   rosbag2_cpp::bag_events::EventCallbackManager callback_manager_;
   size_t file_number_ = 0;
   size_t max_messages_per_file_ = 0;
+  bool writer_close_called_{false};
 };
 
 #endif  // ROSBAG2_TRANSPORT__MOCK_SEQUENTIAL_WRITER_HPP_


### PR DESCRIPTION
- Relates  #1213
- Replaces #1216

- Expose Writer::close() as public API and add Recorder::stop() API to be able to use in future for gracefully handle SIGINT and SIGTERM and send bagsplit() or bagclose() event from Recorder::stop() API.