### PR TITLE
Gracefully handle SIGINT and SIGTERM in rosbag2 recorder

### DIFF
--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -80,6 +80,7 @@ def test_record_cancel(tmp_path, storage_id):
     metadata_io = rosbag2_py.MetadataIo()
     assert wait_for(lambda: metadata_io.metadata_file_exists(bag_path),
                     timeout=rclpy.duration.Duration(seconds=3))
+    record_thread.join()
 
     metadata = metadata_io.read_metadata(bag_path)
     assert(len(metadata.relative_file_paths))


### PR DESCRIPTION
- Followup from #1300 
- Relates #1213
- Relates #926 

- Call recorder->stop() and exec_->cancel() instead of rclcpp::shutdown in signal handlers.

Note: Will address Windows specific signals handling in a separate PR.