### PR TITLE
Skip messages from 0 timestamp while --use_sim_time

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -325,7 +325,12 @@ Recorder::create_subscription(
     qos,
     [this, topic_name, topic_type](std::shared_ptr<rclcpp::SerializedMessage> message) {
       if (!paused_.load()) {
-        writer_->write(message, topic_name, topic_type, this->get_clock()->now());
+        auto time = this->get_clock()->now();
+        bool time_is_zero = time.nanoseconds() == 0 && time.seconds() == 0;
+        if (record_options_.use_sim_time && time_is_zero) {
+          return;
+        }
+        writer_->write(message, topic_name, topic_type, time);
       }
     });
   return subscription;


### PR DESCRIPTION
Fix for #1276 
Implements discussed solution as only viable.
Skip all messages with timestamp 0.0 if recording with --use_sim_time