### PR TITLE
Fix a warning from python setuptools.

### DIFF
--- a/rosbag2_examples/rosbag2_examples_py/setup.cfg
+++ b/rosbag2_examples/rosbag2_examples_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rosbag2_examples_py
+script_dir=$base/lib/rosbag2_examples_py
 [install]
-install-scripts=$base/lib/rosbag2_examples_py
+install_scripts=$base/lib/rosbag2_examples_py


### PR DESCRIPTION
In particular, the 'script-dir' and 'install-scripts' keys are deprecated in favor of 'script_dir' and
'install_scripts', respectively.