### PR TITLE
[Iron] (pre-backport #1337) Change subscriptions from GenericSubscripton to SubscriptionBase

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -96,7 +96,7 @@ public:
   topics_using_fallback_qos() const;
 
   ROSBAG2_TRANSPORT_PUBLIC
-  const std::unordered_map<std::string, std::shared_ptr<rclcpp::GenericSubscription>> &
+  const std::unordered_map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> &
   subscriptions() const;
 
   ROSBAG2_TRANSPORT_PUBLIC

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -83,7 +83,7 @@ public:
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::RecordOptions record_options_;
   std::atomic<bool> stop_discovery_;
-  std::unordered_map<std::string, std::shared_ptr<rclcpp::GenericSubscription>> subscriptions_;
+  std::unordered_map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> subscriptions_;
 
 private:
   void topics_discovery();
@@ -643,7 +643,7 @@ Recorder::topics_using_fallback_qos() const
   return pimpl_->topics_warned_about_incompatibility_;
 }
 
-const std::unordered_map<std::string, std::shared_ptr<rclcpp::GenericSubscription>> &
+const std::unordered_map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> &
 Recorder::subscriptions() const
 {
   return pimpl_->subscriptions_;


### PR DESCRIPTION
Pre-backports #1337

Fixing API for new features that will be coming in below the API layer in future Iron syncs