### PR TITLE
Add python binding to close the SequentialWriter

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -97,6 +97,7 @@ PYBIND11_MODULE(_writer, m) {
       const rosbag2_storage::StorageOptions &, const rosbag2_cpp::ConverterOptions &
     >(&PyWriter::open))
   .def("write", &PyWriter::write)
+  .def("close", &PyWriter::close)
   .def("remove_topic", &PyWriter::remove_topic)
   .def(
     "create_topic",


### PR DESCRIPTION
Required to fix https://github.com/ros-visualization/rqt_bag/issues/127