### PR TITLE
Allow for definitions from srvs, as long as the .msg file can be found

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -191,7 +191,9 @@ if(BUILD_TESTING)
   ament_add_gmock(test_local_message_definition_source
     test/rosbag2_cpp/test_local_message_definition_source.cpp)
   if(TARGET test_local_message_definition_source)
-    target_link_libraries(test_local_message_definition_source ${PROJECT_NAME})
+    target_link_libraries(test_local_message_definition_source
+      ${PROJECT_NAME}
+      ${rosbag2_test_msgdefs_TARGETS})
   endif()
 
   ament_add_gmock(test_message_cache

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -29,7 +29,6 @@
 
 namespace rosbag2_cpp
 {
-
 /// A type name did not match expectations, so a definition could not be looked for.
 class TypenameNotUnderstoodError : public std::exception
 {
@@ -46,9 +45,6 @@ public:
     return name_.c_str();
   }
 };
-
-// Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar)
-static const std::regex PACKAGE_TYPENAME_REGEX{R"(^([a-zA-Z0-9_]+)/(?:msg/)?([a-zA-Z0-9_]+)$)"};
 
 // Match field types from .msg definitions ("foo_msgs/Bar" in "foo_msgs/Bar[] bar")
 static const std::regex MSG_FIELD_TYPE_REGEX{R"((?:^|\n)\s*([a-zA-Z0-9_/]+)(?:\[[^\]]*\])?\s+)"};
@@ -160,13 +156,30 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
     return it->second;
   }
   std::smatch match;
-  const auto topic_type = definition_identifier.topic_type();
-  if (!std::regex_match(topic_type, match, PACKAGE_TYPENAME_REGEX)) {
-    throw TypenameNotUnderstoodError(topic_type);
+  const std::string topic_type = definition_identifier.topic_type();
+
+  static const std::string valid_first_chars{"a-zA-Z"};
+  static const std::string valid_nonfirst_chars{"a-zA-Z0-9_"};
+  static const std::string ros_name = "[" + valid_first_chars + "][" + valid_nonfirst_chars + "]*";
+  const std::regex no_namespace_regex{"^(" + ros_name + ")/(" + ros_name + ")$"};
+  const std::regex with_namespace_regex{
+    "^(" + ros_name + ")/(" + ros_name + ")/(" + ros_name + ")$"};
+
+  std::string package_name, namespace_name, type_name;
+  if (std::regex_match(topic_type, match, no_namespace_regex)) {
+    package_name = match[1];
+    namespace_name = "msg";
+    type_name = match[2];
+  } else if (std::regex_match(topic_type, match, with_namespace_regex)) {
+    package_name = match[1];
+    namespace_name = match[2];
+    type_name = match[3];
+  } else {
+    throw std::invalid_argument("Invalid topic_type: " + topic_type);
   }
-  std::string package = match[1];
-  std::string share_dir = ament_index_cpp::get_package_share_directory(package);
-  std::ifstream file{share_dir + "/msg/" + match[2].str() +
+
+  std::string share_dir = ament_index_cpp::get_package_share_directory(package_name);
+  std::ifstream file{share_dir + "/" + namespace_name + "/" + type_name +
     extension_for_format(definition_identifier.format())};
   if (!file.good()) {
     throw DefinitionNotFoundError(definition_identifier.topic_type());
@@ -175,7 +188,7 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   std::string contents{std::istreambuf_iterator(file), {}};
   const MessageSpec & spec = msg_specs_by_definition_identifier_.emplace(
     definition_identifier,
-    MessageSpec(definition_identifier.format(), std::move(contents), package)).first->second;
+    MessageSpec(definition_identifier.format(), std::move(contents), package_name)).first->second;
 
   // "References and pointers to data stored in the container are only invalidated by erasing that
   // element, even when the corresponding iterator is invalidated."

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -29,6 +29,7 @@
 
 namespace rosbag2_cpp
 {
+
 /// A type name did not match expectations, so a definition could not be looked for.
 class TypenameNotUnderstoodError : public std::exception
 {

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -175,10 +175,11 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   std::string type_name = match[3];
 
   std::string share_dir = ament_index_cpp::get_package_share_directory(package_name);
-  std::ifstream file{share_dir + "/" + namespace_name + "/" + type_name +
-    extension_for_format(definition_identifier.format())};
+  std::string filename = share_dir + "/" + namespace_name + "/" +
+                         type_name + extension_for_format(definition_identifier.format());
+  std::ifstream file{filename};
   if (!file.good()) {
-    throw DefinitionNotFoundError(definition_identifier.topic_type());
+    throw DefinitionNotFoundError(filename);
   }
 
   std::string contents{std::istreambuf_iterator(file), {}};

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -132,7 +132,7 @@ TEST(test_local_message_definition_source, no_crash_on_bad_name)
   rosbag2_storage::MessageDefinition result;
   ASSERT_NO_THROW(
   {
-    result = source.get_full_text("rosbag2_test_msgdefs/srv/BasicSrv_Request");
+    result = source.get_full_text("rosbag2_test_msgdefs/action/BasicAction_SetGoal_Request");
   });
   ASSERT_EQ(result.encoding, "unknown");
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -136,3 +136,19 @@ TEST(test_local_message_definition_source, no_crash_on_bad_name)
   });
   ASSERT_EQ(result.encoding, "unknown");
 }
+
+TEST(test_local_message_definition_source, get_service_message_definitions)
+{
+  LocalMessageDefinitionSource source;
+  auto result = source.get_full_text("rosbag2_test_msgdefs/srv/BasicSrv_Request");
+  ASSERT_EQ(result.encoding, "ros2msg");
+  ASSERT_EQ(
+    result.encoded_message_definition,
+    "string req\n");
+
+  result = source.get_full_text("rosbag2_test_msgdefs/srv/BasicSrv_Response");
+  ASSERT_EQ(result.encoding, "ros2msg");
+  ASSERT_EQ(
+    result.encoded_message_definition,
+    "\nstring resp\n");
+}

--- a/rosbag2_test_msgdefs/CMakeLists.txt
+++ b/rosbag2_test_msgdefs/CMakeLists.txt
@@ -15,6 +15,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ComplexMsg.msg"
   "msg/ComplexMsgDependsOnIdl.msg"
   "srv/BasicSrv.srv"
+  "action/BasicAction.action"
   ADD_LINTER_TESTS
 )
 

--- a/rosbag2_test_msgdefs/action/BasicAction.action
+++ b/rosbag2_test_msgdefs/action/BasicAction.action
@@ -1,0 +1,5 @@
+string goal
+---
+string result
+---
+string feedback


### PR DESCRIPTION
Fixes #1336

Changes message source scraping to allow for `package/namespace/typename` where `namespace != "msg"`. For srvs the rest of the existing logic is fine - because the adapter outputs `.msg` files we could use. For actions, however, no such "implicit subinterfaces" have files produced, we may need to get a little more clever - there are even subinterfaces that are not included in the adapted `.idl`...