### PR TITLE
Gracefully handle CTRL+C and CTR+Break events on Windows

### DIFF
--- a/ros2bag/test/test_record.py
+++ b/ros2bag/test/test_record.py
@@ -53,13 +53,10 @@ class TestRecord(unittest.TestCase):
 
     def test_output(self, record_all_process, proc_output):
         proc_output.assertWaitFor(
-            'Listening for topics...',
+            "Subscribed to topic '/events/write_split'",
             process=record_all_process
         )
-        proc_output.assertWaitFor(
-            "Subscribed to topic '/rosout'",
-            process=record_all_process
-        )
+        proc_output.assertWaitFor('Recording...', process=record_all_process)
 
 
 @launch_testing.post_shutdown_test()

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -84,7 +84,7 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_basic'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_output = 'Listening for topics...'
+        expected_output = 'Recording...'
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_output in output,
@@ -99,7 +99,7 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_output = 'Listening for topics...'
+        expected_output = 'Recording...'
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_output in output,

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -31,6 +31,11 @@
 
 #include "./pybind11.hpp"
 
+#ifdef _WIN32
+#include <windows.h>
+#include <iostream>
+#endif
+
 namespace py = pybind11;
 typedef std::unordered_map<std::string, rclcpp::QoS> QoSMap;
 
@@ -132,7 +137,49 @@ class Player
 public:
   Player()
   {
-    rclcpp::init(0, nullptr);
+    auto init_options = rclcpp::InitOptions();
+    init_options.shutdown_on_signal = false;
+    rclcpp::init(0, nullptr, init_options, rclcpp::SignalHandlerOptions::None);
+    std::signal(
+      SIGTERM, [](int /* signal */) {
+        rclcpp::shutdown();
+      });
+    std::signal(
+      SIGINT, [](int /* signal */) {
+        rclcpp::shutdown();
+      });
+#ifdef _WIN32
+    // According to the
+    // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/signal?view=msvc-170
+    // SIGINT is not supported for any Win32 application. When a CTRL+C interrupt occurs,
+    // Win32 operating systems generate a new thread to specifically handle that interrupt.
+    // Therefore, need to use native Windows control event handler as analog for the SIGINT.
+
+    // Enable default CTRL+C handler first. This is workaround and needed for the cases when
+    // process created with CREATE_NEW_PROCESS_GROUP flag. Without it, installing custom Ctrl+C
+    // handler will not work.
+    if (!SetConsoleCtrlHandler(nullptr, false)) {
+      std::cerr << "Rosbag2 player error: Failed to enable default CTL+C handler. \n";
+    }
+    // Installing our own control handler
+    auto CtrlHandler = [](DWORD fdwCtrlType) -> BOOL {
+        switch (fdwCtrlType) {
+          case CTRL_C_EVENT:
+          case CTRL_BREAK_EVENT:
+          case CTRL_CLOSE_EVENT:
+            rclcpp::shutdown();
+            return TRUE;
+          case CTRL_SHUTDOWN_EVENT:
+            rclcpp::shutdown();
+            return FALSE;
+          default:
+            return FALSE;
+        }
+      };
+    if (!SetConsoleCtrlHandler(CtrlHandler, TRUE)) {
+      std::cerr << "Rosbag2 player error: Could not set control handler.\n";
+    }
+#endif  // #ifdef _WIN32
   }
 
   virtual ~Player()
@@ -158,7 +205,7 @@ public:
     player->wait_for_playback_to_finish();
 
     exec.cancel();
-    spin_thread.join();
+    if (spin_thread.joinable()) {spin_thread.join();}
   }
 
   void burst(
@@ -180,7 +227,8 @@ public:
     player->burst(num_messages);
 
     exec.cancel();
-    spin_thread.join();
+    if (spin_thread.joinable()) {spin_thread.join();}
+    if (play_thread.joinable()) {play_thread.join();}
   }
 };
 
@@ -210,6 +258,39 @@ public:
       SIGINT, [](int /* signal */) {
         rosbag2_py::Recorder::cancel();
       });
+
+#ifdef _WIN32
+    // According to the
+    // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/signal?view=msvc-170
+    // SIGINT is not supported for any Win32 application. When a CTRL+C interrupt occurs,
+    // Win32 operating systems generate a new thread to specifically handle that interrupt.
+    // Therefore, need to use native Windows control event handler as analog for the SIGINT.
+
+    // Enable default CTRL+C handler first. This is workaround and needed for the cases when
+    // process created with CREATE_NEW_PROCESS_GROUP flag. Without it, installing custom Ctrl+C
+    // handler will not work.
+    if (!SetConsoleCtrlHandler(nullptr, false)) {
+      std::cerr << "Rosbag2 recorder error: Failed to enable default CTL+C handler.\n";
+    }
+    // Installing our own control handler
+    auto CtrlHandler = [](DWORD fdwCtrlType) -> BOOL {
+        switch (fdwCtrlType) {
+          case CTRL_C_EVENT:
+          case CTRL_BREAK_EVENT:
+          case CTRL_CLOSE_EVENT:
+            rosbag2_py::Recorder::cancel();
+            return TRUE;
+          case CTRL_SHUTDOWN_EVENT:
+            rosbag2_py::Recorder::cancel();
+            return TRUE;
+          default:
+            return FALSE;
+        }
+      };
+    if (!SetConsoleCtrlHandler(CtrlHandler, TRUE)) {
+      std::cerr << "Rosbag2 recorder error: Could not set control handler.\n";
+    }
+#endif  // #ifdef _WIN32
 
     try {
       exit_ = false;
@@ -251,6 +332,13 @@ public:
       if (old_sigint_handler != SIG_ERR) {
         std::signal(SIGTERM, old_sigint_handler);
       }
+#ifdef _WIN32
+      // Remove CtrlHandler from ConsoleCtrl handlers
+      SetConsoleCtrlHandler(CtrlHandler, FALSE);
+      if (!SetConsoleCtrlHandler(nullptr, false)) {
+        std::cerr << "Rosbag2 recorder error: Failed to enable default CTL+C handler.\n";
+      }
+#endif  // #ifdef _WIN32
       throw;
     }
     // Return old signal handlers
@@ -260,6 +348,13 @@ public:
     if (old_sigint_handler != SIG_ERR) {
       std::signal(SIGTERM, old_sigint_handler);
     }
+#ifdef _WIN32
+    // Remove CtrlHandler from ConsoleCtrl handlers
+    SetConsoleCtrlHandler(CtrlHandler, FALSE);
+    if (!SetConsoleCtrlHandler(nullptr, false)) {
+      std::cerr << "Rosbag2 recorder error: Failed to enable default CTL+C handler.\n";
+    }
+#endif  // #ifdef _WIN32
   }
 
   static void cancel()

--- a/rosbag2_test_common/CMakeLists.txt
+++ b/rosbag2_test_common/CMakeLists.txt
@@ -42,8 +42,26 @@ install(
   DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  find_package(rcpputils REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  add_executable(loop_with_ctrl_c_handler test/rosbag2_test_common/loop_with_ctrl_c_handler.cpp)
+  install(
+      TARGETS loop_with_ctrl_c_handler
+      EXPORT export_loop_with_ctrl_c_handler
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+  )
+
+  ament_add_gmock(test_process_execution_helpers
+    test/rosbag2_test_common/test_process_execution_helpers.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if(TARGET test_process_execution_helpers)
+    target_link_libraries(test_process_execution_helpers ${PROJECT_NAME})
+  endif()
 endif()
 
 ament_python_install_package(${PROJECT_NAME})

--- a/rosbag2_test_common/package.xml
+++ b/rosbag2_test_common/package.xml
@@ -23,6 +23,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rcpputils</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosbag2_test_common/test/rosbag2_test_common/loop_with_ctrl_c_handler.cpp
+++ b/rosbag2_test_common/test/rosbag2_test_common/loop_with_ctrl_c_handler.cpp
@@ -1,0 +1,78 @@
+// Copyright 2023 Apex.AI, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdio>
+#include <iostream>
+#include <thread>
+
+#ifdef _WIN32
+#include <windows.h>
+int main(void)
+{
+  // Enable default CTRL+C handler first. This is workaround and needed for the cases when
+  // process created with CREATE_NEW_PROCESS_GROUP flag. Without it, installing custom Ctrl+C
+  // handler will not work.
+  if (!SetConsoleCtrlHandler(nullptr, false)) {
+    std::cerr << "Error: Failed to enable default CTL+C handler. \n";
+  }
+
+  static std::atomic_bool running = true;
+  // Installing our own control handler
+  auto CtrlHandler = [](DWORD fdwCtrlType) -> BOOL {
+      switch (fdwCtrlType) {
+        case CTRL_C_EVENT:
+          printf("Ctrl-C event\n");
+          running = false;
+          return TRUE;
+        default:
+          return FALSE;
+      }
+    };
+  if (!SetConsoleCtrlHandler(CtrlHandler, TRUE)) {
+    std::cerr << "\nError. Can't install SIGINT handler\n";
+    return EXIT_FAILURE;
+  } else {
+    std::cout << "\nWaiting in a loop for CTRL+C event\n";
+    std::cout.flush();
+    while (running) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    }
+  }
+  return EXIT_SUCCESS;
+}
+#else
+#include <csignal>
+
+int main()
+{
+  auto old_sigint_handler = std::signal(
+    SIGINT, [](int /* signal */) {
+      printf("Ctrl-C event\n");
+      exit(EXIT_SUCCESS);
+    });
+
+  if (old_sigint_handler != SIG_ERR) {
+    std::cout << "\nWaiting in a loop for CTRL+C event\n";
+    std::cout.flush();
+    while (1) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    }
+  } else {
+    std::cerr << "\nError. Can't install SIGINT handler\n";
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+#endif

--- a/rosbag2_test_common/test/rosbag2_test_common/test_process_execution_helpers.cpp
+++ b/rosbag2_test_common/test/rosbag2_test_common/test_process_execution_helpers.cpp
@@ -1,0 +1,44 @@
+// Copyright 2023 Apex.AI, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "rosbag2_test_common/process_execution_helpers.hpp"
+#include "rcpputils/scope_exit.hpp"
+
+class ProcessExecutionHelpersTest : public ::testing::Test
+{
+public:
+  ProcessExecutionHelpersTest() = default;
+};
+
+TEST_F(ProcessExecutionHelpersTest, ctrl_c_event_can_be_send_and_received) {
+  testing::internal::CaptureStdout();
+  auto process_id = start_execution("loop_with_ctrl_c_handler");
+  auto cleanup_process_handle = rcpputils::make_scope_exit(
+    [process_id]() {
+      stop_execution(process_id);
+    });
+
+  // Sleep for 1 second to yield CPU resources to the newly spawned process, to make sure that
+  // signal handlers has been installed.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  std::string test_output = testing::internal::GetCapturedStdout();
+  EXPECT_THAT(test_output, HasSubstr("Waiting in a loop for CTRL+C event"));
+
+  // Send SIGINT to child process and check exit code
+  stop_execution(process_id, SIGINT);
+  cleanup_process_handle.cancel();
+}

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -126,7 +126,7 @@ public:
       std::this_thread::sleep_for(50ms);
     }
     ASSERT_EQ(metadata_io.metadata_file_exists(bag_path), true)
-      << "Could not find metadata file.";
+      << "Could not find " << bag_path << " metadata file.";
   }
 
   void wait_for_storage_file(std::chrono::duration<float> timeout = std::chrono::seconds(10))
@@ -179,44 +179,6 @@ public:
         return topic_name == tm.name;
       });
     return topic_it->serialization_format;
-  }
-
-  void finalize_metadata_kludge(
-    int expected_splits = 0,
-    const std::string & compression_format = "",
-    const std::string & compression_mode = "")
-  {
-    // TODO(ros-tooling): Find out how to correctly send a Ctrl-C signal on Windows
-    // This is necessary as the process is killed hard on Windows and doesn't write a metadata file
-  #ifdef _WIN32
-    rosbag2_storage::BagMetadata metadata{};
-    metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
-    for (int i = 0; i <= expected_splits; i++) {
-      rcpputils::fs::path bag_file_path;
-      if (!compression_format.empty()) {
-        bag_file_path = get_bag_file_path(i);
-      } else {
-        bag_file_path = get_compressed_bag_file_path(i);
-      }
-
-      if (rcpputils::fs::exists(bag_file_path)) {
-        metadata.relative_file_paths.push_back(bag_file_path.string());
-      }
-    }
-    metadata.duration = std::chrono::nanoseconds(0);
-    metadata.starting_time =
-      std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds(0));
-    metadata.message_count = 0;
-    metadata.compression_mode = compression_mode;
-    metadata.compression_format = compression_format;
-
-    rosbag2_storage::MetadataIo metadata_io;
-    metadata_io.write_metadata(root_bag_path_.string(), metadata);
-  #else
-    (void)expected_splits;
-    (void)compression_format;
-    (void)compression_mode;
-  #endif
   }
 
   // relative path to the root of the bag file.

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -271,7 +271,6 @@ TEST_P(PlayEndToEndTestFixture, play_filters_by_topic) {
   }
 }
 
-#ifndef _WIN32
 TEST_P(PlayEndToEndTestFixture, play_end_to_end_exits_gracefully_on_sigint) {
   sub_->add_subscription<test_msgs::msg::BasicTypes>("/test_topic", 3, sub_qos_);
   sub_->add_subscription<test_msgs::msg::Arrays>("/array_topic", 2, sub_qos_);
@@ -293,7 +292,6 @@ TEST_P(PlayEndToEndTestFixture, play_end_to_end_exits_gracefully_on_sigint) {
   stop_execution(process_id, SIGINT);
   cleanup_process_handle.cancel();
 }
-#endif  // #ifndef _WIN32
 
 INSTANTIATE_TEST_SUITE_P(
   TestPlayEndToEnd,

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_transport_test_fixture.hpp
@@ -26,11 +26,6 @@
 #include "rosbag2_cpp/types.hpp"
 #include "rosbag2_cpp/writer.hpp"
 
-#ifdef _WIN32
-# include <direct.h>
-# include <Windows.h>
-#endif
-
 #include "rosbag2_storage/storage_options.hpp"
 
 #include "rosbag2_transport/play_options.hpp"


### PR DESCRIPTION
- Add handler for the native Windows `CTRL_C_EVENT`, `CTRL_BREAK_EVENT` and `CTRL_CLOSE_EVENT` in rosbag2 recorder and player.
- Map SIGINT signal to the native Windows `CTRL_C_EVENT` in the `stop_execution(handle, signum)` version for Windows to be able correctly use start and stop execution routines from unit tests.
- Uses `CREATE_NEW_PROCESS_GROUP` when creating new process in process execution helper functions to be able to properly send native Windows `CTRL_C_EVENT` to the newly spawned child process.
- Creates new process suspended and resumes it after adding to the newly created job. To avoid a potential race condition where a newly created process starts a subprocess before we've called `AssignProcessToJobObject();`
- Enable integration tests that were disabled for Windows due to the incorrect sending and handling of the SIGINT event.
- Got rid of the `finalize_metadata_kludge(..)` helper function.

- ~~Depends from #1301~~
- Relates #927 
- Closes #926
- Closes #1326
- Closes #1270

**Note:** 
According to the https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/signal?view=msvc-170
> SIGINT is not supported for any Win32 application. When a CTRL+C interrupt occurs, Win32 operating systems generate a new thread to specifically handle that interrupt.

> The SIGILL and SIGTERM signals aren't generated under Windows. They're included for ANSI compatibility. Therefore, you can set signal handlers for these signals by using signal, and you can also explicitly generate these signals by calling [raise](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/raise?view=msvc-170).

The `CTRL_CLOSE_EVENT` is an analog of the `SIGTERM` from POSIX. Windows sends `CTRL_CLOSE_EVENT`
to all processes attached to a console when the user closes the console (either by clicking Close on the console window's window menu, or by clicking the End Task button command from Task Manager).
Although according to the https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent the
`GenerateConsoleCtrlEvent(..)` doesn't support sending `CTRL_CLOSE_EVENT`. There is no way to directly send `CTRL_CLOSE_EVENT` to the process in the same console application.
Therefore, added `SIGTERM` to the unsupported events in the `stop_execution(process_handle, signum)` API.

- **Update:** Removed dependencies from #1301 and rebased on top of the latest Rolling to be able to move forward with this PR and easily backport it to the Iron and Humble.