### PR TITLE
[foxy] Fix YAML_CPP_DLL warnings on Windows

### DIFF
--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -26,7 +26,9 @@
 
 #ifdef _WIN32
 // This is necessary because of a bug in yaml-cpp's cmake
+#ifndef YAML_CPP_DLL
 #define YAML_CPP_DLL
+#endif
 // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
 # pragma warning(push)
 # pragma warning(disable:4251)

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -25,7 +25,7 @@
   #ifdef _WIN32
     // This is necessary because of a bug in yaml-cpp's cmake
     #ifndef YAML_CPP_DLL
-    #define YAML_CPP_DLL
+      #define YAML_CPP_DLL
     #endif
     // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
     #pragma warning(push)

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -24,7 +24,9 @@
   // COMPATIBILITY(foxy, galactic) - this block is available in rosbag2_storage/yaml.hpp in H
   #ifdef _WIN32
     // This is necessary because of a bug in yaml-cpp's cmake
+    #ifndef YAML_CPP_DLL
     #define YAML_CPP_DLL
+    #endif
     // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
     #pragma warning(push)
     #pragma warning(disable : 4251)

--- a/rosbag2_transport/src/rosbag2_transport/qos.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/qos.hpp
@@ -23,7 +23,9 @@
 
 #ifdef _WIN32
 // This is necessary because of a bug in yaml-cpp's cmake
+#ifndef YAML_CPP_DLL
 #define YAML_CPP_DLL
+#endif
 // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
 # pragma warning(push)
 # pragma warning(disable:4251)

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -33,7 +33,9 @@
 
 #ifdef _WIN32
 // This is necessary because of a bug in yaml-cpp's cmake
+#ifndef YAML_CPP_DLL
 #define YAML_CPP_DLL
+#endif
 // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
 # pragma warning(push)
 # pragma warning(disable:4251)


### PR DESCRIPTION
Add simple preprocessor checks to avoid redefining the macro to quiet the preexisting Windows warnings.

For an example see https://ci.ros2.org/job/ci_windows/19550/

Related to https://github.com/ros2/rosidl/pull/745