### PR TITLE
Don't record sim-time messages before first /clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ In the same fashion, this auto discovery can be disabled with `--no-discovery`.
 If not further specified, `ros2 bag record` will create a new folder named to the current time stamp and stores all data within this folder.
 A user defined name can be given with `-o, --output`.
 
+#### Simulation time
+
+In ROS 2, "simulation time" refers to publishing a clock value on the `/clock` topic, instead of using the system clock to tell time.
+By passing `--use-sim-time` argument to `ros2 bag record`, we turn on this option for the recording node.
+Messages written to the bag will use the latest received value of `/clock` for the timestamp of the recorded message.
+
+Note: Until the first `/clock` message is received, the recorder will not write any messages.
+Before that message is received, the time is 0, which leads to a significant time jump once simulation time begins, making the bag essentially unplayable if messages are written first with time 0 and then time N from `/clock`.
+
 #### Splitting recorded bag files
 
 rosbag2 offers the capability to split bag files when they reach a maximum size or after a specified duration. By default rosbag2 will record all data into a single bag file, but this can be changed using the CLI options.

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -129,7 +129,8 @@ class RecordVerb(VerbExtension):
             help='Start the recorder in a paused state.')
         parser.add_argument(
             '--use-sim-time', action='store_true', default=False,
-            help='Use simulation time.')
+            help='Use simulation time for message timestamps by subscribing to the /clock topic. '
+                 'Until first /clock message is received, no messages will be written to bag.')
         parser.add_argument(
             '--node-name', type=str, default='rosbag2_recorder',
             help='Specify the recorder node name. Default is %(default)s.')

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -449,7 +449,11 @@ RecorderImpl::create_subscription(
     qos,
     [this, topic_name, topic_type](std::shared_ptr<const rclcpp::SerializedMessage> message) {
       if (!paused_.load()) {
-        writer_->write(message, topic_name, topic_type, node->get_clock()->now());
+        auto now = node->get_clock()->now();
+        // When using sim time, do not record messages before receiving first /clock
+        if (!(record_options_.use_sim_time && now.nanoseconds() == 0)) {
+          writer_->write(message, topic_name, topic_type, now);
+        }
       }
     });
   return subscription;


### PR DESCRIPTION
Fixes https://github.com/ros2/rosbag2/issues/1276

When using sim-time, check that `now != 0` before writing any messages into the bag, to avoid the time jump that then happens on first `/clock` message. This potentially drops some messages that it could have written, but is more correct, in that those messages are "out of time" and have no temporal standing in simulated time.