### PR TITLE
[humble] Backport close() to rosbag2_cpp::writer to humble

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -211,6 +211,11 @@ public:
    */
   void add_event_callbacks(bag_events::WriterEventCallbacks & callbacks);
 
+  /**
+   * \brief Close the current bag file and write metadata.yaml file
+   */
+  void close();
+
 private:
   std::mutex writer_mutex_;
   std::unique_ptr<rosbag2_cpp::writer_interfaces::BaseWriterInterface> writer_impl_;

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -188,4 +188,9 @@ void Writer::add_event_callbacks(bag_events::WriterEventCallbacks & callbacks)
   writer_impl_->add_event_callbacks(callbacks);
 }
 
+void Writer::close()
+{
+  writer_impl_->close();
+}
+
 }  // namespace rosbag2_cpp


### PR DESCRIPTION
Ported the close functionality from rolling to humble