### PR TITLE
Refine root cause of the `unpaused_sleep_returns_true` test failure

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -165,6 +165,8 @@ TEST_F(TimeControllerClockTest, unpaused_sleep_returns_true)
     sleep_result = clock.sleep_until(sleep_until_timestamp);
   }
   auto end = std::chrono::steady_clock::now();
+  EXPECT_FALSE(clock.is_paused());
+  EXPECT_TRUE(rclcpp::ok());
   EXPECT_TRUE(end - start < std::chrono::milliseconds(1200));
   EXPECT_TRUE(end - start >= std::chrono::seconds(1));
   EXPECT_TRUE(sleep_result);


### PR DESCRIPTION
- Follow up to the failure in https://ci.ros2.org/job/ci_windows/19597/