### PR TITLE
Fix a clang warning about uninitialized variable.

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_type_description_hash.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_type_description_hash.cpp
@@ -59,6 +59,7 @@ rclcpp::TopicEndpointInfo make_info(rosidl_type_hash_t hash)
   info.topic_type = "topic_type";
   info.node_name = "node_name";
   info.node_namespace = "node_namespace";
+  info.endpoint_type = RMW_ENDPOINT_INVALID;
   return rclcpp::TopicEndpointInfo(info);
 }
 


### PR DESCRIPTION
In the tests for the type description hash, we were forgetting to initialize the endpoint_type, which is necessary when constructing an rclcpp::TopicEndpointInfo object.  Just set it to INVALID here, as we don't care whether this is a publisher or subscriber.