### PR TITLE
[iron] Add ROS_DISTRO metadata record to mcap file when opening for writing

### DIFF
--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -107,6 +107,7 @@ if(BUILD_TESTING)
   ament_add_gmock(test_mcap_storage test/rosbag2_storage_mcap/test_mcap_storage.cpp)
   target_link_libraries(test_mcap_storage
     ${PROJECT_NAME}
+    mcap_vendor::mcap
     rosbag2_storage::rosbag2_storage
     rosbag2_test_common::rosbag2_test_common
     ${std_msgs_TARGETS}

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -261,6 +261,7 @@ private:
   std::unique_ptr<mcap::McapWriter> mcap_writer_;
 
   bool has_read_summary_ = false;
+  bool has_added_ros_distro_metadata_ = false;
   rcutils_time_point_value_t last_read_time_point_ = 0;
   std::optional<mcap::RecordOffset> last_read_message_offset_;
   std::optional<mcap::RecordOffset> last_enqueued_message_offset_;
@@ -806,13 +807,13 @@ void MCAPStorage::update_metadata(const rosbag2_storage::BagMetadata & bag_metad
       "MCAP storage plugin does not support message compression, "
       "consider using chunk compression by setting `compression: 'Zstd'` in storage config");
   }
+  ensure_rosdistro_metadata_added();
 }
 #endif
 
 void MCAPStorage::ensure_rosdistro_metadata_added()
 {
-  static bool already_added = false;
-  if (!already_added) {
+  if (!has_added_ros_distro_metadata_) {
     mcap::Metadata metadata;
     metadata.name = "rosbag2";
     metadata.metadata = {{"ROS_DISTRO", rcpputils::get_env_var("ROS_DISTRO")}};
@@ -821,7 +822,7 @@ void MCAPStorage::ensure_rosdistro_metadata_added()
       OnProblem(status);
     }
   }
-  already_added = true;
+  has_added_ros_distro_metadata_ = true;
 }
 
 }  // namespace rosbag2_storage_plugins

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -206,12 +206,13 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
 
 TEST_F(TemporaryDirectoryFixture, mcap_contains_ros_distro)
 {
-  // const auto expected_file = rcpputils::fs::path(temporary_dir_path_) / "rosdistro_bag.mcap";
-  const auto expected_file = rcpputils::fs::path("rosdistro_bag.mcap");
+  // Guarantee env var set for mcap to use - in a full-build testing environment it may not be.
+  const std::string current_ros_distro = "rolling";
+  ASSERT_TRUE(rcpputils::set_env_var("ROS_DISTRO", current_ros_distro.c_str()));
+
+  const auto expected_file = rcpputils::fs::path(temporary_dir_path_) / "rosdistro_bag.mcap";
   const auto uri = rcpputils::fs::remove_extension(expected_file);
   const std::string storage_id = "mcap";
-  const std::string current_ros_distro = rcpputils::get_env_var("ROS_DISTRO");
-  ASSERT_FALSE(current_ros_distro.empty());
   std::string read_metadata_ros_distro = "";
 
   // Open writer to create no-data file and then delete the writer to close


### PR DESCRIPTION
Related to #1239
This is an API/ABI-stable patch to add some of the functionality from #1241 to Iron

Adds ROS_DISTRO metadata record to mcap storage file when opened for writing. `ros2 bag info` will not know about this information, but its presence in the file will be readable by other mcap-reading tools

When complete - will backport to Humble