### PR TITLE
When using sim time, wait for /clock before beginning recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ In the same fashion, this auto discovery can be disabled with `--no-discovery`.
 If not further specified, `ros2 bag record` will create a new folder named to the current time stamp and stores all data within this folder.
 A user defined name can be given with `-o, --output`.
 
+#### Simulation time
+
+In ROS 2, "simulation time" refers to publishing a clock value on the `/clock` topic, instead of using the system clock to tell time.
+By passing `--use-sim-time` argument to `ros2 bag record`, we turn on this option for the recording node.
+Messages written to the bag will use the latest received value of `/clock` for the timestamp of the recorded message.
+
+Note: Until the first `/clock` message is received, the recorder will not write any messages.
+Before that message is received, the time is 0, which leads to a significant time jump once simulation time begins, making the bag essentially unplayable if messages are written first with time 0 and then time N from `/clock`.
+
 #### Splitting recorded bag files
 
 rosbag2 offers the capability to split bag files when they reach a maximum size or after a specified duration. By default rosbag2 will record all data into a single bag file, but this can be changed using the CLI options.

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -205,6 +205,11 @@ class RecordVerb(VerbExtension):
             except (InvalidQoSProfileException, ValueError) as e:
                 return print_error(str(e))
 
+        if args.use_sim_time and args.no_discovery:
+            return print_error(
+                '--use-sim-time and --no-discovery both set, but are incompatible settings. '
+                'The /clock topic needs to be discovered to record with sim time.')
+
         # Prepare custom_data dictionary
         custom_data = {}
         if args.custom_data:

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -129,7 +129,8 @@ class RecordVerb(VerbExtension):
             help='Start the recorder in a paused state.')
         parser.add_argument(
             '--use-sim-time', action='store_true', default=False,
-            help='Use simulation time.')
+            help='Use simulation time for message timestamps by subscribing to the /clock topic. '
+                 'Until first /clock message is received, no messages will be written to bag.')
         parser.add_argument(
             '--node-name', type=str, default='rosbag2_recorder',
             help='Specify the recorder node name. Default is %(default)s.')

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -372,6 +372,20 @@ bool RecorderImpl::is_paused()
 
 void RecorderImpl::topics_discovery()
 {
+  // If using sim time - wait until /clock topic received before even creating subscriptions
+  if (record_options_.use_sim_time) {
+    RCLCPP_INFO(
+      node->get_logger(),
+      "use_sim_time set, waiting for /clock before starting recording...");
+    while (rclcpp::ok() && stop_discovery_ == false) {
+      if (node->get_clock()->wait_until_started(record_options_.topic_polling_interval)) {
+        break;
+      }
+    }
+    if (node->get_clock()->started()) {
+      RCLCPP_INFO(node->get_logger(), "Sim time /clock found, starting recording.");
+    }
+  }
   while (rclcpp::ok() && stop_discovery_ == false) {
     auto topics_to_subscribe =
       get_requested_or_available_topics();

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -163,8 +163,8 @@ RecorderImpl::RecorderImpl(
 {
   if (record_options_.use_sim_time && record_options_.is_discovery_disabled) {
     throw std::runtime_error(
-      "use_sim_time and is_discovery_disabled both set, but are incompatible settings. "
-      "The /clock topic needs to be discovered to record with sim time.");
+            "use_sim_time and is_discovery_disabled both set, but are incompatible settings. "
+            "The /clock topic needs to be discovered to record with sim time.");
   }
 
   std::string key_str = enum_key_code_to_str(Recorder::kPauseResumeToggleKey);
@@ -311,9 +311,10 @@ void RecorderImpl::record()
 
   serialization_format_ = record_options_.rmw_serialization_format;
   RCLCPP_INFO(node->get_logger(), "Listening for topics...");
-  if (record_options_.is_discovery_disabled) {
+  if (!record_options_.use_sim_time) {
     subscribe_topics(get_requested_or_available_topics());
-  } else {
+  }
+  if (!record_options_.is_discovery_disabled) {
     discovery_future_ =
       std::async(std::launch::async, std::bind(&RecorderImpl::topics_discovery, this));
   }


### PR DESCRIPTION
Fixes https://github.com/ros2/rosbag2/issues/1276
Retry at #1354 after reverting

When using sim-time, check that `/clock` has actually been received before writing any messages into the bag, to avoid the time jump that then happens on first `/clock` message, given that initial messages are written with a timestamp of 0. 
This potentially drops some messages that it could have written, but is more correct, in that those messages are "out of time" and have no temporal standing in simulated time.