### PR TITLE
Fix missing cstdint include when compiling with GCC13

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_STORAGE__STORAGE_OPTIONS_HPP_
 #define ROSBAG2_STORAGE__STORAGE_OPTIONS_HPP_
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
Fixes https://github.com/ros2/rosbag2/issues/1379