### PR TITLE
Rewrite TimeControllerClockTest.unpaused_sleep_returns_true to be correct

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_time_controller_clock.cpp
@@ -146,7 +146,7 @@ TEST_F(TimeControllerClockTest, is_paused)
 
 TEST_F(TimeControllerClockTest, unpaused_sleep_returns_true)
 {
-  const float error_ratio = 1.2;
+  const float error_ratio = 1.2f;
   const std::chrono::nanoseconds test_timeout{RCUTILS_S_TO_NS(2)};
   const std::chrono::nanoseconds sleep_duration{RCUTILS_S_TO_NS(1)};
   rosbag2_cpp::TimeControllerClock clock(ros_start_time);


### PR DESCRIPTION
Closes https://github.com/ros2/rosbag2/issues/1282
Related to #1012, #1290, #1367

The original test was written such that it requested a 100ns sleep. With such a short time it was either impossible or extremely unlikely to experience a spurious wakeup, so the unlooped condition never failed. When #1012 attempted an improvement, it added a 1s sleep (10 million times longer), making the chance of spurious wakeup much more likely. However, its loop condition checked for `rclcpp::ok()` which is always false in this test, so the loop was never entered. The outcome was that test failure was made far more likely.

This rewrites the test to have a correct spurious wakeup check loop with reasonable timeout. It should remove the flakiness from the CI builds. If so, it is purely a test change and can be easily backported to live distros.