### PR TITLE
[humble] Don't crash when type definition cannot be found, and find srv defs if available

### DIFF
--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
@@ -29,6 +29,7 @@ enum struct Format
 {
   IDL,
   MSG,
+  UNKNOWN,
 };
 
 struct MessageSpec

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -725,10 +725,18 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
     schema.name = datatype;
     try {
       auto [format, full_text] = msgdef_cache_.get_full_text(datatype);
-      if (format == rosbag2_storage_mcap::internal::Format::MSG) {
-        schema.encoding = "ros2msg";
-      } else {
-        schema.encoding = "ros2idl";
+      switch (format) {
+        case rosbag2_storage_mcap::internal::Format::UNKNOWN:
+          schema.encoding = "unknown";
+          break;
+        case rosbag2_storage_mcap::internal::Format::MSG:
+          schema.encoding = "ros2msg";
+          break;
+        case rosbag2_storage_mcap::internal::Format::IDL:
+          schema.encoding = "ros2idl";
+          break;
+        default:
+          throw std::runtime_error("switch is not exhaustive");
       }
       schema.data.assign(reinterpret_cast<const std::byte *>(full_text.data()),
                          reinterpret_cast<const std::byte *>(full_text.data() + full_text.size()));

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -32,7 +32,6 @@
 
 namespace rosbag2_storage_mcap::internal
 {
-
 /// A type name did not match expectations, so a definition could not be looked for.
 class TypenameNotUnderstoodError : public std::exception
 {

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
@@ -124,3 +124,26 @@ module rosbag2_storage_mcap_testdata {
 };
 )r");
 }
+
+TEST(test_local_message_definition_source, no_crash_on_bad_name)
+{
+  MessageDefinitionCache source;
+  std::pair<Format, std::string> result;
+  ASSERT_NO_THROW({
+    result =
+      source.get_full_text("rosbag2_storage_mcap_testdata/action/BasicAction_SetGoal_Request");
+  });
+  ASSERT_EQ(result.first, rosbag2_storage_mcap::internal::Format::UNKNOWN);
+}
+
+TEST(test_message_definition_cache, get_service_message_definitions)
+{
+  MessageDefinitionCache source;
+  auto result = source.get_full_text("rosbag2_storage_mcap_testdata/srv/BasicSrv_Request");
+  ASSERT_EQ(result.first, rosbag2_storage_mcap::internal::Format::MSG);
+  ASSERT_EQ(result.second, "string req\n");
+
+  result = source.get_full_text("rosbag2_storage_mcap_testdata/srv/BasicSrv_Response");
+  ASSERT_EQ(result.first, rosbag2_storage_mcap::internal::Format::MSG);
+  ASSERT_EQ(result.second, "\nstring resp\n");
+}

--- a/rosbag2_storage_mcap_testdata/CMakeLists.txt
+++ b/rosbag2_storage_mcap_testdata/CMakeLists.txt
@@ -14,6 +14,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/BasicMsg.msg"
   "msg/ComplexMsg.msg"
   "msg/ComplexMsgDependsOnIdl.msg"
+  "srv/BasicSrv.srv"
+  "action/BasicAction.action"
   ADD_LINTER_TESTS
 )
 

--- a/rosbag2_storage_mcap_testdata/action/BasicAction.action
+++ b/rosbag2_storage_mcap_testdata/action/BasicAction.action
@@ -1,0 +1,5 @@
+string goal
+---
+string result
+---
+string feedback

--- a/rosbag2_storage_mcap_testdata/package.xml
+++ b/rosbag2_storage_mcap_testdata/package.xml
@@ -12,6 +12,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <depend>action_msgs</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rosbag2_storage_mcap_testdata/srv/BasicSrv.srv
+++ b/rosbag2_storage_mcap_testdata/srv/BasicSrv.srv
@@ -1,0 +1,3 @@
+string req
+---
+string resp


### PR DESCRIPTION
Part of https://github.com/ros2/rosbag2/issues/1336
Manual Humble backport of https://github.com/ros2/rosbag2/pull/1350 and https://github.com/ros2/rosbag2/pull/1341 combined

Required significant manual changes because the class in question is located in `rosbag2_storage_mcap`, which slightly different function signatures and a different linter configuration.