### PR TITLE
update converter namespace

### DIFF
--- a/docs/converter_plugin_development.md
+++ b/docs/converter_plugin_development.md
@@ -11,7 +11,7 @@ Rosbag2 is shipped with a default converter plugin to convert between ROS 2 mess
 ## Writing converter plugins for both serialization and deserialization
 
 Most converter plugins are used to convert between a custom serialization format in both directions, i.e. serialization and deserialization.
-To write a plugin `MyConverter` supporting conversion to and from a custom serialization format, implement the interface `rosbag2::converter_interfaces::SerializationFormatConverter`.
+To write a plugin `MyConverter` supporting conversion to and from a custom serialization format, implement the interface `rosbag2_cpp::converter_interfaces::SerializationFormatConverter`.
 
 The plugin interface provides two functions: 
 
@@ -23,7 +23,7 @@ Add the following lines in the `my_converter.cpp`:
 
 ```
 #include "pluginlib/class_list_macros.hpp"
-PLUGINLIB_EXPORT_CLASS(MyConverter, rosbag2::converter_interfaces::SerializationFormatConverter)
+PLUGINLIB_EXPORT_CLASS(MyConverter, rosbag2_cpp::converter_interfaces::SerializationFormatConverter)
 ```
 
 Furthermore, we need some meta-information in the form of a `plugin_description.xml` file.
@@ -33,7 +33,7 @@ In the case of `MyConverter` this would look like:
   <class
     name="my_storage_format_converter"
     type="MyConverter"
-    base_class_type="rosbag2::converter_interfaces::SerializationFormatConverter"
+    base_class_type="rosbag2_cpp::converter_interfaces::SerializationFormatConverter"
   >
     <description>This is a converter plugin for my storage format.</description>
   </class>
@@ -44,10 +44,10 @@ It **must** have the format `<rmw storage format>_converter` as described in the
 
 In addition, in the `CMakeLists.txt` the `plugin_description.xml` file needs to be added to the index to be found at runtime:
 ```
-pluginlib_export_plugin_description_file(rosbag2 plugin_description.xml)
+pluginlib_export_plugin_description_file(rosbag2_cpp plugin_description.xml)
 ```
 
-The first argument `rosbag2` denotes the ament index key we add our plugin to (this will always be `rosbag2` for converter plugins), while the second argument is the path to the plugin description file.
+The first argument `rosbag2_cpp` denotes the ament index key we add our plugin to (this will always be `rosbag2_cpp` for converter plugins), while the second argument is the path to the plugin description file.
 
 ## Writing converter plugins for only serialization or deserialization
 
@@ -55,9 +55,9 @@ It is possible to write a plugin which only supports converting to OR from a cus
 For example, the default plugin for legacy ROS1 rosbags  supports only conversion from a ROS 1 to a ROS 2 message format (deserialization), since rosbag2 is not intended to be used to write rosbags in the old format.
 When a similar use case applies, it is possible to provide a plugin which supports only one direction (serialization or deserialization).
 
-In order to write a plugin `MyDeserializer` supporting conversion from a custom serialization format, implement the interface `rosbag2::converter_interfaces::SerializationFormatDeserializer.
+In order to write a plugin `MyDeserializer` supporting conversion from a custom serialization format, implement the interface `rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer.
 This interface only provides the `deserialize` method mentioned above.
-Similarly, there exists a `rosbag2::converter_interfaces::SerializationFormatSerializer` for serialization plugins.
+Similarly, there exists a `rosbag2_cpp::converter_interfaces::SerializationFormatSerializer` for serialization plugins.
 
 ## How to choose conversion at runtime
 


### PR DESCRIPTION
The converter development guide says that the converter plugins should be in the `rosbag2` namespace, but they are actually in the `rosbag2_cpp` namespace.