### PR TITLE
Fix the build with rmw_fastrtps_dynamic.

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -242,8 +242,11 @@ function(create_tests_for_rmw_implementation)
     ament_add_test_label(test_play_services__rmw_cyclonedds_cpp xfail)
   endif()
 
-  if(${rmw_implementation} MATCHES "rmw_fastrtps(.*)")
+  if(${rmw_implementation} MATCHES "rmw_fastrtps_cpp")
     ament_add_test_label(test_play_services__rmw_fastrtps_cpp xfail)
+  endif()
+  if(${rmw_implementation} MATCHES "rmw_fastrtps_dynamic_cpp")
+    ament_add_test_label(test_play_services__rmw_fastrtps_dynamic_cpp xfail)
   endif()
 endfunction()
 


### PR DESCRIPTION
When building with *only* rmw_fastrtps_dynamic, there is no test named "test_play_services__rmw_fastrtps_cpp" to mark as xfail.  Instead, it is called
"test_play_services__rmw_fastrtps_dynamic_cpp", so make sure to add a different xfail marking for that test.

This should fix the failing build at https://build.ros2.org/view/Rci/job/Rci__nightly-fastrtps-dynamic_ubuntu_jammy_amd64/