### PR TITLE
Add BagSplitInfo service call on bag close

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/bag_events.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/bag_events.hpp
@@ -166,6 +166,14 @@ public:
   }
 
   /**
+   * \brief Delete all callbacks
+   */
+  void delete_all_callbacks()
+  {
+    callbacks_.clear();
+  }
+
+  /**
    * \brief Execute all callbacks registered for the given event.
    *
    * The provided information value is passed to each callback by copy.


### PR DESCRIPTION
- Replaces #1216
- Relates #1418 
- Note: The `BagSplitInfo::opened_file` will have an empty string to indicate that it was "bag close" and not bag split event.