### PR TITLE
Stop inheriting from std::iterator.

### DIFF
--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_statement_wrapper.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_statement_wrapper.hpp
@@ -53,9 +53,15 @@ public:
   {
 public:
     using RowType = std::tuple<Columns ...>;
-    class Iterator : public std::iterator<std::input_iterator_tag, RowType>
+    class Iterator
     {
 public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = RowType;
+      using difference_type = std::ptrdiff_t;
+      using pointer = RowType *;
+      using reference = RowType &;
+
       static const int POSITION_END = -1;
       Iterator(std::shared_ptr<SqliteStatementWrapper> statement, int position)
       : statement_(statement), next_row_idx_(position), cached_row_idx_(POSITION_END - 1)


### PR DESCRIPTION
In C++17, inheriting from std::iterator has been
deprecated: https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/

Here, switch away from inheriting and just define the interface ourselves (which is the current recommended best practice).

This removes some warning when building with gcc 13.1.1