### PR TITLE
Fix the description of paramter '--topics' for play

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -50,7 +50,7 @@ class PlayVerb(VerbExtension):
             help='rate at which to play back messages. Valid range > 0.0.')
         parser.add_argument(
             '--topics', type=str, default=[], nargs='+',
-            help='List of topics to replay, separated by space. At least one topic is specified.')
+            help='topics to replay, separated by space. At least one topic needs to be specified.')
         parser.add_argument(
             '-e', '--regex', default='',
             help='filter topics by regular expression to replay, separated by space. If none '

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -50,7 +50,7 @@ class PlayVerb(VerbExtension):
             help='rate at which to play back messages. Valid range > 0.0.')
         parser.add_argument(
             '--topics', type=str, default=[], nargs='+',
-            help='topics to replay, separated by space. At least one topic needs to be specified.')
+            help='Space-delimited list of topics to play.')
         parser.add_argument(
             '-e', '--regex', default='',
             help='filter topics by regular expression to replay, separated by space. If none '

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -50,8 +50,7 @@ class PlayVerb(VerbExtension):
             help='rate at which to play back messages. Valid range > 0.0.')
         parser.add_argument(
             '--topics', type=str, default=[], nargs='+',
-            help='topics to replay, separated by space. If none specified, all topics will be '
-                 'replayed.')
+            help='List of topics to replay, separated by space. At least one topic is specified.')
         parser.add_argument(
             '-e', '--regex', default='',
             help='filter topics by regular expression to replay, separated by space. If none '


### PR DESCRIPTION
https://github.com/ros2/rosbag2/blob/744cdf0420189b4435b9c8b2839899b1b80d23f5/ros2bag/ros2bag/verb/play.py#L51-L54

`nargs='+'` means that at least one topic is needed.   
But current description of this parameter means that no topic can be acceptable. 