### PR TITLE
Fix uninitialized value pointed out by clang static analysis.

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_type_description_hash.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_type_description_hash.cpp
@@ -60,6 +60,7 @@ rclcpp::TopicEndpointInfo make_info(rosidl_type_hash_t hash)
   info.node_name = "node_name";
   info.node_namespace = "node_namespace";
   info.endpoint_type = RMW_ENDPOINT_INVALID;
+  info.qos_profile = rmw_qos_profile_default;
   return rclcpp::TopicEndpointInfo(info);
 }
 


### PR DESCRIPTION
When constructing rclcpp::TopicEndpointInfo from an rcl_topic_endpoint_info_t, one of the fields it uses is the 'qos_profile'.  But this particular test was forgetting to initialize that field, leading to access of uninitialized data.  Just set it to default here.