### PR TITLE
Remove rcpputils::fs dependencies from rosbag2_storages

### DIFF
--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
@@ -43,7 +42,6 @@ target_include_directories(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
   pluginlib::pluginlib
-  rcpputils::rcpputils
   rcutils::rcutils
   yaml-cpp
 )

--- a/rosbag2_storage/package.xml
+++ b/rosbag2_storage/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>pluginlib</depend>
-  <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <depend>yaml_cpp_vendor</depend>
 

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -55,7 +55,7 @@ BagMetadata MetadataIo::read_metadata(const std::string & uri)
 
 std::string MetadataIo::get_metadata_file_name(const std::string & uri)
 {
-  std::string metadata_file = (std::filesystem::path(uri) / metadata_filename).string();
+  std::string metadata_file = (std::filesystem::path(uri) / metadata_filename).generic_string();
 
   return metadata_file;
 }

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -14,11 +14,10 @@
 
 #include "rosbag2_storage/metadata_io.hpp"
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rcutils/filesystem.h"
 
@@ -56,14 +55,14 @@ BagMetadata MetadataIo::read_metadata(const std::string & uri)
 
 std::string MetadataIo::get_metadata_file_name(const std::string & uri)
 {
-  std::string metadata_file = (rcpputils::fs::path(uri) / metadata_filename).string();
+  std::string metadata_file = (std::filesystem::path(uri) / metadata_filename).string();
 
   return metadata_file;
 }
 
 bool MetadataIo::metadata_file_exists(const std::string & uri)
 {
-  return rcpputils::fs::exists(rcpputils::fs::path(get_metadata_file_name(uri)));
+  return std::filesystem::exists(std::filesystem::path(get_metadata_file_name(uri)));
 }
 
 std::string MetadataIo::serialize_metadata(const BagMetadata & metadata)

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -90,7 +90,6 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
-  find_package(rcpputils REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   find_package(std_msgs REQUIRED)
 

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -22,7 +22,6 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>rcpputils</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -14,7 +14,6 @@
 
 #include "rclcpp/serialization.hpp"
 #include "rclcpp/serialized_message.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/logging_macros.h"
 #include "rosbag2_storage/storage_factory.hpp"
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
@@ -25,6 +24,7 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 
@@ -58,7 +58,7 @@ public:
     if (nullptr == rw_storage) {
       rosbag2_storage::StorageFactory factory;
       rosbag2_storage::StorageOptions options;
-      auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
+      auto uri = std::filesystem::path(temporary_dir_path_) / "bag";
       options.uri = uri.string();
       options.storage_id = "mcap";
       rw_storage = factory.open_read_write(options);
@@ -88,8 +88,8 @@ bool operator==(const TopicInformation & lhs, const TopicInformation & rhs)
 TEST_F(McapStorageTestFixture, can_store_and_read_metadata_correctly)
 {
   const std::string storage_id = "mcap";
-  auto uri = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
-  auto expected_bag = rcpputils::fs::path(temporary_dir_path_) / "rosbag.mcap";
+  auto uri = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
+  auto expected_bag = std::filesystem::path(temporary_dir_path_) / "rosbag.mcap";
   const rosbag2_storage::MessageDefinition definition = {"std_msgs/msg/String", "ros2msg",
                                                          "string data", ""};
 
@@ -161,8 +161,8 @@ TEST_F(McapStorageTestFixture, can_store_and_read_metadata_correctly)
 
 TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file)
 {
-  auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
-  auto expected_bag = rcpputils::fs::path(temporary_dir_path_) / "bag.mcap";
+  auto uri = std::filesystem::path(temporary_dir_path_) / "bag";
+  auto expected_bag = std::filesystem::path(temporary_dir_path_) / "bag.mcap";
   const int64_t timestamp_nanos = 100;  // arbitrary value
   rcutils_time_point_value_t time_stamp{timestamp_nanos};
   const std::string topic_name = "test_topic";
@@ -211,7 +211,7 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file)
     serialized_bag_msg->topic_name = topic_name;
     writer->write(serialized_bag_msg);
   }
-  EXPECT_TRUE(expected_bag.is_regular_file());
+  EXPECT_TRUE(std::filesystem::is_regular_file(expected_bag));
   {
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
     rosbag2_storage::StorageOptions options;
@@ -255,8 +255,8 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file)
 // This test disabled on Foxy since StorageOptions doesn't have storage_config_uri field on it
 TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
 {
-  auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
-  auto expected_bag = rcpputils::fs::path(temporary_dir_path_) / "bag.mcap";
+  auto uri = std::filesystem::path(temporary_dir_path_) / "bag";
+  auto expected_bag = std::filesystem::path(temporary_dir_path_) / "bag.mcap";
   const int64_t timestamp_nanos = 100;  // arbitrary value
   rcutils_time_point_value_t time_stamp{timestamp_nanos};
   const std::string topic_name = "test_topic";
@@ -298,7 +298,7 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
     serialized_bag_msg->topic_name = topic_name;
     writer->write(serialized_bag_msg);
     writer->write(serialized_bag_msg);
-    EXPECT_TRUE(expected_bag.is_regular_file());
+    EXPECT_TRUE(std::filesystem::is_regular_file(expected_bag));
   }
   {
     rosbag2_storage::StorageOptions options;

--- a/rosbag2_storage_sqlite3/CMakeLists.txt
+++ b/rosbag2_storage_sqlite3/CMakeLists.txt
@@ -6,9 +6,9 @@ if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
 endif()
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -19,8 +19,9 @@
 #include <atomic>
 #include <chrono>
 #include <cstring>
-#include <iostream>
+#include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -28,7 +29,6 @@
 #include <vector>
 
 #include "rcpputils/env.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
@@ -192,7 +192,7 @@ void SqliteStorage::open(
     relative_path_ = storage_options.uri + FILE_EXTENSION;
 
     // READ_WRITE requires the DB to not exist.
-    if (rcpputils::fs::path(relative_path_).exists()) {
+    if (std::filesystem::exists(std::filesystem::path(relative_path_))) {
       throw std::runtime_error(
               "Failed to create bag: File '" + relative_path_ + "' already exists!");
     }
@@ -200,7 +200,7 @@ void SqliteStorage::open(
     relative_path_ = storage_options.uri;
 
     // APPEND and READ_ONLY require the DB to exist
-    if (!rcpputils::fs::path(relative_path_).exists()) {
+    if (!std::filesystem::exists(std::filesystem::path(relative_path_))) {
       throw std::runtime_error(
               "Failed to read from bag: File '" + relative_path_ + "' does not exist!");
     }
@@ -401,9 +401,9 @@ void SqliteStorage::get_all_message_definitions(
 
 uint64_t SqliteStorage::get_bagfile_size() const
 {
-  const auto bag_path = rcpputils::fs::path{get_relative_file_path()};
+  const auto bag_path = std::filesystem::path{get_relative_file_path()};
 
-  return bag_path.exists() ? bag_path.file_size() : 0u;
+  return std::filesystem::exists(bag_path) ? std::filesystem::file_size(bag_path) : 0u;
 }
 
 void SqliteStorage::initialize()

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -27,8 +28,6 @@
 #include <utility>
 #include <vector>
 #include <unordered_map>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rcutils/logging_macros.h"
 #include "rcutils/snprintf.h"
@@ -99,7 +98,7 @@ public:
     if (nullptr == writable_storage) {
       writable_storage = std::make_shared<rosbag2_storage_plugins::SqliteStorage>();
 
-      auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+      auto db_file = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
 
       writable_storage->open({db_file, plugin_id_});
     }
@@ -128,11 +127,11 @@ public:
       std::tuple<std::string, int64_t, std::string, std::string, std::string>
     > & messages)
   {
-    auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+    auto db_file = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
     std::string relative_path = db_file + ".db3";
 
     // READ_WRITE requires the DB to not exist.
-    if (rcpputils::fs::path(relative_path).exists()) {
+    if (std::filesystem::exists(std::filesystem::path(relative_path))) {
       throw std::runtime_error(
               "Failed to create bag: File '" + relative_path + "' already exists!");
     }
@@ -203,11 +202,11 @@ public:
 
   void create_new_db3_file_with_schema_version_2()
   {
-    auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+    auto db_file = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
     std::string relative_path = db_file + ".db3";
 
     // READ_WRITE requires the DB to not exist.
-    if (rcpputils::fs::path(relative_path).exists()) {
+    if (std::filesystem::exists(std::filesystem::path(relative_path))) {
       throw std::runtime_error(
               "Failed to create bag: File '" + relative_path + "' already exists!");
     }
@@ -251,7 +250,7 @@ public:
     std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
       std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-    auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+    auto db_file = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
 
     readable_storage->open(
       {db_file, plugin_id_},
@@ -269,7 +268,7 @@ public:
     const std::string & config_yaml,
     const std::string & plugin_id)
   {
-    auto temp_dir = rcpputils::fs::path(temporary_dir_path_);
+    auto temp_dir = std::filesystem::path(temporary_dir_path_);
     const auto storage_uri = (temp_dir / "rosbag").string();
     const auto yaml_config = (temp_dir / "sqlite_config.yaml").string();
 

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <limits>
 #include <memory>
 #include <string>
@@ -23,8 +24,6 @@
 #include <vector>
 
 #include "rcpputils/env.hpp"
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rcutils/snprintf.h"
 
@@ -87,7 +86,7 @@ TEST_F(StorageTestFixture, has_next_return_false_if_there_are_no_more_messages) 
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
   readable_storage->open({db_filename, kPluginID});
 
   EXPECT_TRUE(readable_storage->has_next());
@@ -107,7 +106,7 @@ TEST_F(StorageTestFixture, get_next_returns_messages_in_timestamp_order) {
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
   readable_storage->open({db_filename, kPluginID});
 
   EXPECT_TRUE(readable_storage->has_next());
@@ -130,7 +129,7 @@ TEST_F(StorageTestFixture, read_next_returns_filtered_messages) {
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
   readable_storage->open({db_filename, kPluginID});
 
   rosbag2_storage::StorageFilter storage_filter;
@@ -171,7 +170,7 @@ TEST_F(StorageTestFixture, get_all_topics_and_types_returns_the_correct_vector) 
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
   // extension is omitted since storage is being created; io_flag = READ_WRITE
-  const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+  const auto read_write_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
 
   writable_storage->open({read_write_filename, kPluginID});
   writable_storage->create_topic({"topic1", "type1", "rmw1", "qos_profile1", "type_hash1"}, {});
@@ -202,7 +201,7 @@ TEST_F(StorageTestFixture, get_all_message_definitions_returns_the_correct_vecto
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
   // extension is omitted since storage is being created; io_flag = READ_WRITE
-  const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+  const auto read_write_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
 
   writable_storage->open({read_write_filename, kPluginID});
   writable_storage->create_topic(
@@ -236,7 +235,7 @@ TEST_F(StorageTestFixture, get_all_message_definitions_returns_the_correct_vecto
 
 TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
   auto writable_storage = std::make_shared<rosbag2_storage_plugins::SqliteStorage>();
-  auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+  auto read_write_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
   writable_storage->open({read_write_filename, kPluginID});
   writable_storage->create_topic({"topic1", "type1", "rmw1", "qos_profile1", "type_hash1"}, {});
   writable_storage->create_topic({"topic2", "type2", "rmw2", "qos_profile2", "type_hash2"}, {});
@@ -254,7 +253,7 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct) {
   write_messages_to_sqlite(messages, writable_storage);
 
   const auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  const auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  const auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
 
   readable_storage->open(
     {db_filename, kPluginID},
@@ -293,7 +292,7 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_for_prefoxy_db_sc
   write_messages_to_sqlite_in_pre_foxy_format(messages);
 
   const auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  const auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  const auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
 
   readable_storage->open(
     {db_filename, kPluginID},
@@ -344,7 +343,7 @@ TEST_F(StorageTestFixture, get_db_schema_version_returns_correct_value) {
   auto writable_storage = std::make_shared<rosbag2_storage_plugins::SqliteStorage>();
   EXPECT_EQ(writable_storage->get_db_schema_version(), -1);
 
-  auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+  auto db_file = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
   writable_storage->open({db_file, plugin_id_});
 
   EXPECT_GE(writable_storage->get_db_schema_version(), 3);
@@ -352,7 +351,7 @@ TEST_F(StorageTestFixture, get_db_schema_version_returns_correct_value) {
 
 TEST_F(StorageTestFixture, metadata_ros_distro_returns_correct_value) {
   auto writable_storage = std::make_shared<rosbag2_storage_plugins::SqliteStorage>();
-  auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+  auto db_file = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
   writable_storage->open({db_file, plugin_id_});
 
   std::string current_ros_distro = rcpputils::get_env_var("ROS_DISTRO");
@@ -366,7 +365,7 @@ TEST_F(StorageTestFixture, check_backward_compatibility_with_schema_version_2) {
 
   EXPECT_EQ(readable_storage->get_db_schema_version(), -1);
 
-  auto db_file = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  auto db_file = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
   readable_storage->open(
     {db_file, plugin_id_},
     rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
@@ -379,7 +378,7 @@ TEST_F(StorageTestFixture, get_metadata_returns_correct_struct_if_no_messages) {
   write_messages_to_sqlite({});
 
   const auto readable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
-  const auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  const auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
 
   readable_storage->open(
     {db_filename, kPluginID},
@@ -402,7 +401,7 @@ TEST_F(StorageTestFixture, remove_topics_and_types_returns_the_empty_vector) {
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
   // extension is omitted since storage is created; io_flag = READ_WRITE
-  const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+  const auto read_write_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
 
   writable_storage->open({read_write_filename, kPluginID});
   writable_storage->create_topic({"topic1", "type1", "rmw1", "", "hash"}, {});
@@ -433,7 +432,7 @@ TEST_F(StorageTestFixture, get_relative_file_path_returns_db_name_with_ext) {
   // check that storage::get_relative_file_path returns the relative path to the sqlite3 db
   // and that uri is handled properly when storage::open is called with different io_flags
   // READ_WRITE expects uri to not end in extension
-  const auto read_write_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag").string();
+  const auto read_write_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag").string();
   const auto storage_filename = read_write_filename + ".db3";
   const auto read_write_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
   read_write_storage->open(
@@ -493,7 +492,7 @@ TEST_F(StorageTestFixture, storage_preset_profile_applies_over_defaults) {
   // Check that "resilient" values override default optimized ones
   const auto writable_storage = std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto temp_dir = rcpputils::fs::path(temporary_dir_path_);
+  auto temp_dir = std::filesystem::path(temporary_dir_path_);
   const auto storage_uri = (temp_dir / "rosbag").string();
   rosbag2_storage::StorageOptions options{storage_uri, kPluginID, 0, 0, 0, "", ""};
 
@@ -562,7 +561,7 @@ TEST_F(StorageTestFixture, read_next_returns_filtered_messages_regex) {
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
   readable_storage->open({db_filename, kPluginID});
 
   rosbag2_storage::StorageFilter storage_filter;
@@ -608,7 +607,7 @@ TEST_F(StorageTestFixture, read_next_returns_filtered_messages_topics_regex_to_e
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = (rcpputils::fs::path(temporary_dir_path_) / "rosbag.db3").string();
+  auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").string();
   readable_storage->open({db_filename, kPluginID});
 
   rosbag2_storage::StorageFilter storage_filter;

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_wrapper.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_wrapper.cpp
@@ -14,11 +14,10 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rcutils/types.h"
 
@@ -34,7 +33,7 @@ public:
   SqliteWrapperTestFixture()
   : StorageTestFixture(),
     db_(
-      (rcpputils::fs::path(temporary_dir_path_) / "test.db3").string(),
+      (std::filesystem::path(temporary_dir_path_) / "test.db3").string(),
       rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE)
   {}
 


### PR DESCRIPTION
Because the package will be no longer available. https://github.com/ros2/rcpputils/issues/164

This operation was carried out with the following simple rules.
1. Replace rcpputils::fs::path class to std::filesystem::path class.
2. Replace rcpputils::fs::path::exists function to std::filesystem::exists function.
3. Replace rcpputils::fs::path::string function to std::filesystem::path::generic_string function.

I will create several PRs for the same operation for other rosbag2 packages.