### PR TITLE
Remove rcpputils::fs dependency from rosbag2_cpp

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/reindexer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reindexer.hpp
@@ -23,12 +23,11 @@
 #ifndef ROSBAG2_CPP__REINDEXER_HPP_
 #define ROSBAG2_CPP__REINDEXER_HPP_
 
+#include <filesystem>
 #include <memory>
 #include <regex>
 #include <string>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/converter.hpp"
 #include "rosbag2_cpp/reader.hpp"
@@ -91,27 +90,27 @@ protected:
 
 private:
   std::string regex_bag_pattern_;
-  rcpputils::fs::path base_folder_;   // The folder that the bag files are in
+  std::filesystem::path base_folder_;   // The folder that the bag files are in
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
   void get_bag_files(
-    const rcpputils::fs::path & base_folder,
-    std::vector<rcpputils::fs::path> & output);
+    const std::filesystem::path & base_folder,
+    std::vector<std::filesystem::path> & output);
 
   // Prepares the metadata by setting initial values.
   void init_metadata(
-    const std::vector<rcpputils::fs::path> & files,
+    const std::vector<std::filesystem::path> & files,
     const rosbag2_storage::StorageOptions & storage_options);
 
   // Attempts to harvest metadata from all bag files, and aggregates the result
   void aggregate_metadata(
-    const std::vector<rcpputils::fs::path> & files,
+    const std::vector<std::filesystem::path> & files,
     const std::unique_ptr<rosbag2_cpp::readers::SequentialReader> & bag_reader,
     const rosbag2_storage::StorageOptions & storage_options);
 
   // Comparison function for std::sort with our filepath convention
   bool compare_relative_file(
-    const rcpputils::fs::path & first_path,
-    const rcpputils::fs::path & second_path);
+    const std::filesystem::path & first_path,
+    const std::filesystem::path & second_path);
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/info.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/info.cpp
@@ -14,11 +14,11 @@
 
 #include "rosbag2_cpp/info.hpp"
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
 
-#include "rcpputils/filesystem_helper.hpp"
 #include "rosbag2_storage/logging.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
@@ -30,8 +30,8 @@ namespace rosbag2_cpp
 rosbag2_storage::BagMetadata Info::read_metadata(
   const std::string & uri, const std::string & storage_id)
 {
-  const rcpputils::fs::path bag_path{uri};
-  if (!bag_path.exists()) {
+  const std::filesystem::path bag_path{uri};
+  if (!std::filesystem::exists(bag_path)) {
     throw std::runtime_error("Bag path " + uri + " does not exist.");
   }
 
@@ -40,7 +40,7 @@ rosbag2_storage::BagMetadata Info::read_metadata(
     return metadata_io.read_metadata(uri);
   }
 
-  if (bag_path.is_directory()) {
+  if (std::filesystem::is_directory(bag_path)) {
     throw std::runtime_error("Could not find metadata in bag directory " + uri);
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -19,7 +20,6 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/logging.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
@@ -34,23 +34,23 @@ namespace details
 std::vector<std::string> resolve_relative_paths(
   const std::string & base_folder, std::vector<std::string> relative_files, const int version = 4)
 {
-  auto base_path = rcpputils::fs::path(base_folder);
+  auto base_path = std::filesystem::path(base_folder);
   if (version < 4) {
     // In older rosbags (version <=3) relative files are prefixed with the rosbag folder name
-    base_path = rcpputils::fs::path(base_folder).parent_path();
+    base_path = std::filesystem::path(base_folder).parent_path();
   }
 
   rcpputils::require_true(
-    base_path.exists(), "base folder does not exist: " + base_folder);
+    std::filesystem::exists(base_path), "base folder does not exist: " + base_folder);
   rcpputils::require_true(
-    base_path.is_directory(), "base folder has to be a directory: " + base_folder);
+    std::filesystem::is_directory(base_path), "base folder has to be a directory: " + base_folder);
 
   for (auto & file : relative_files) {
-    auto path = rcpputils::fs::path(file);
+    auto path = std::filesystem::path(file);
     if (path.is_absolute()) {
       continue;
     }
-    file = (base_path / path).string();
+    file = (base_path / path).generic_string();
   }
 
   return relative_files;
@@ -307,7 +307,7 @@ std::string SequentialReader::get_current_file() const
 std::string SequentialReader::get_current_uri() const
 {
   auto current_file = get_current_file();
-  auto current_uri = rcpputils::fs::remove_extension(current_file);
+  auto current_uri = std::filesystem::path(current_file).stem();
   return current_uri.string();
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -14,12 +14,11 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/writer.hpp"
@@ -62,8 +61,8 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_2) 
 
   {
     std::ofstream fout {
-      (rcpputils::fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
-      .string()};
+      (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+      .generic_string()};
     fout << bagfile;
   }
 
@@ -144,8 +143,8 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_6) 
 
   {
     std::ofstream fout {
-      (rcpputils::fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
-      .string()};
+      (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+      .generic_string()};
     fout << bagfile;
   }
 
@@ -234,8 +233,8 @@ TEST_P(
     "  compression_mode: \"FILE\"\n");
 
   std::ofstream fout {
-    (rcpputils::fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
-    .string()};
+    (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+    .generic_string()};
   fout << bagfile;
   fout.close();
 
@@ -287,13 +286,13 @@ TEST_P(
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, info_for_standalone_bagfile) {
   const auto storage_id = GetParam();
-  const auto bag_path = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  const auto bag_path = std::filesystem::path(temporary_dir_path_) / "bag";
   {
     // Create an empty bag with default storage
     rosbag2_cpp::Writer writer;
     rosbag2_storage::StorageOptions storage_options;
     storage_options.storage_id = storage_id;
-    storage_options.uri = bag_path.string();
+    storage_options.uri = bag_path.generic_string();
     writer.open(storage_options);
     test_msgs::msg::BasicTypes msg;
     writer.write(msg, "testtopic", rclcpp::Time{});

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -14,12 +14,11 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
@@ -41,10 +40,10 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
-    storage_uri_(rcpputils::fs::temp_directory_path().string()),
+    storage_uri_(std::filesystem::temp_directory_path().generic_string()),
     relative_path_1_("some_relative_path_1"),
     relative_path_2_("some_relative_path_2"),
-    absolute_path_1_((rcpputils::fs::path(storage_uri_) / "some/folder").string()),
+    absolute_path_1_((std::filesystem::path(storage_uri_) / "some/folder").generic_string()),
     default_storage_options_({storage_uri_, ""})
   {}
 
@@ -108,7 +107,7 @@ public:
   {
     relative_path_1_ = "rosbag_name/some_relative_path_1";
     relative_path_2_ = "rosbag_name/some_relative_path_2";
-    absolute_path_1_ = (rcpputils::fs::path(storage_uri_) / "some/folder").string();
+    absolute_path_1_ = (std::filesystem::path(storage_uri_) / "some/folder").generic_string();
   }
 
   rosbag2_storage::BagMetadata get_metadata() const override
@@ -138,11 +137,11 @@ TEST_F(MultifileReaderTest, has_next_reads_next_file)
     reader_->get_implementation_handle());
 
   auto resolved_relative_path_1 =
-    (rcpputils::fs::path(storage_uri_) / relative_path_1_).string();
+    (std::filesystem::path(storage_uri_) / relative_path_1_).generic_string();
   auto resolved_relative_path_2 =
-    (rcpputils::fs::path(storage_uri_) / relative_path_2_).string();
+    (std::filesystem::path(storage_uri_) / relative_path_2_).generic_string();
   auto resolved_absolute_path_1 =
-    rcpputils::fs::path(absolute_path_1_).string();
+    std::filesystem::path(absolute_path_1_).generic_string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->read_next();  // calls has_next false then true
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);
@@ -170,11 +169,11 @@ TEST_F(MultifileReaderTestVersion3, has_next_reads_next_file_version3)
 
   // Legacy version <=3 have a parent_path() prefixed in the relative files
   auto resolved_relative_path_1 =
-    (rcpputils::fs::path(storage_uri_).parent_path() / relative_path_1_).string();
+    (std::filesystem::path(storage_uri_).parent_path() / relative_path_1_).generic_string();
   auto resolved_relative_path_2 =
-    (rcpputils::fs::path(storage_uri_).parent_path() / relative_path_2_).string();
+    (std::filesystem::path(storage_uri_).parent_path() / relative_path_2_).generic_string();
   auto resolved_absolute_path_1 =
-    rcpputils::fs::path(absolute_path_1_).string();
+    std::filesystem::path(absolute_path_1_).generic_string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->read_next();  // calls has_next false then true
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -14,12 +14,11 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
 #include "rosbag2_cpp/reader.hpp"
@@ -52,7 +51,7 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
-    storage_uri_(rcpputils::fs::temp_directory_path().string()),
+    storage_uri_(std::filesystem::temp_directory_path().generic_string()),
     default_storage_options_({storage_uri_, "mock_storage"})
   {
     rosbag2_storage::TopicMetadata topic_with_type;
@@ -66,12 +65,13 @@ public:
     message->topic_name = topic_with_type.name;
 
     relative_file_path_ =
-      (rcpputils::fs::path(storage_uri_) / "some/folder").string();
+      (std::filesystem::path(storage_uri_) / "some/folder").generic_string();
     auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
     bag_file_1_path_ = relative_file_path_ / "bag_file1";
     bag_file_2_path_ = relative_file_path_ / "bag_file2";
-    metadata_.relative_file_paths = {bag_file_1_path_.string(), bag_file_2_path_.string()};
+    metadata_.relative_file_paths =
+    {bag_file_1_path_.generic_string(), bag_file_2_path_.generic_string()};
     metadata_.version = 4;
     metadata_.topics_with_message_count.push_back({{topic_with_type}, 6});
     metadata_.storage_identifier = "mock_storage";
@@ -121,9 +121,9 @@ public:
   std::string storage_serialization_format_;
   std::string storage_uri_;
   rosbag2_storage::BagMetadata metadata_;
-  rcpputils::fs::path relative_file_path_;
-  rcpputils::fs::path bag_file_1_path_;
-  rcpputils::fs::path bag_file_2_path_;
+  std::filesystem::path relative_file_path_;
+  std::filesystem::path bag_file_1_path_;
+  std::filesystem::path bag_file_2_path_;
   rosbag2_storage::StorageOptions default_storage_options_;
   size_t num_next_ = 0;
 };
@@ -223,25 +223,25 @@ TEST_F(SequentialReaderTest, next_file_calls_callback) {
 }
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, reader_accepts_bare_file) {
-  const auto bag_path = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  const auto bag_path = std::filesystem::path(temporary_dir_path_) / "bag";
   const auto storage_id = GetParam();
 
   {
     // Create an empty bag with default storage
     rosbag2_cpp::Writer writer;
     rosbag2_storage::StorageOptions options;
-    options.uri = bag_path.string();
+    options.uri = bag_path.generic_string();
     options.storage_id = storage_id;
     writer.open(options);
     test_msgs::msg::BasicTypes msg;
     writer.write(msg, "testtopic", rclcpp::Time{});
   }
   rosbag2_storage::MetadataIo metadata_io;
-  auto metadata = metadata_io.read_metadata(bag_path.string());
+  auto metadata = metadata_io.read_metadata(bag_path.generic_string());
   auto first_storage = bag_path / metadata.relative_file_paths[0];
 
   rosbag2_cpp::Reader reader;
-  EXPECT_NO_THROW(reader.open(first_storage.string()));
+  EXPECT_NO_THROW(reader.open(first_storage.generic_string()));
   EXPECT_TRUE(reader.has_next());
   EXPECT_THAT(reader.get_metadata().topics_with_message_count, SizeIs(1));
 }
@@ -258,7 +258,8 @@ class ReadOrderTest : public ParametrizedTemporaryDirectoryFixture
 public:
   ReadOrderTest()
   {
-    storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "ordertest").string();
+    storage_options.uri =
+      (std::filesystem::path(temporary_dir_path_) / "ordertest").generic_string();
     storage_options.storage_id = GetParam();
     write_sample_split_bag(storage_options, fake_messages, split_every);
   }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -14,13 +14,12 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
 #include "rosbag2_cpp/writer.hpp"
@@ -54,8 +53,8 @@ public:
     storage_options_ = rosbag2_storage::StorageOptions{};
     storage_options_.uri = "uri";
 
-    rcpputils::fs::path dir(storage_options_.uri);
-    rcpputils::fs::remove_all(dir);
+    std::filesystem::path dir(storage_options_.uri);
+    std::filesystem::remove_all(dir);
 
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(
       DoAll(
@@ -77,8 +76,8 @@ public:
 
   ~SequentialWriterTest() override
   {
-    rcpputils::fs::path dir(storage_options_.uri);
-    rcpputils::fs::remove_all(dir);
+    std::filesystem::path dir(storage_options_.uri);
+    std::filesystem::remove_all(dir);
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
@@ -637,8 +636,9 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
   }
 
   ASSERT_TRUE(callback_called);
-  auto expected_closed = rcpputils::fs::path(storage_options_.uri) / (storage_options_.uri + "_0");
-  EXPECT_EQ(closed_file, expected_closed.string());
+  auto expected_closed = std::filesystem::path(storage_options_.uri) /
+    (storage_options_.uri + "_0");
+  EXPECT_EQ(closed_file, expected_closed.generic_string());
   EXPECT_EQ(opened_file, fake_storage_uri_);
 }
 
@@ -697,8 +697,9 @@ TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
   writer_->close();
 
   ASSERT_TRUE(callback_called);
-  auto expected_closed = rcpputils::fs::path(storage_options_.uri) / (storage_options_.uri + "_0");
-  EXPECT_EQ(closed_file, expected_closed.string());
+  auto expected_closed = std::filesystem::path(storage_options_.uri) /
+    (storage_options_.uri + "_0");
+  EXPECT_EQ(closed_file, expected_closed.generic_string());
   EXPECT_TRUE(opened_file.empty());
 }
 
@@ -712,7 +713,8 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, split_bag_metadata_has_full_durati
     {600, 6}
   };
   rosbag2_storage::StorageOptions storage_options;
-  storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "split_duration_bag").string();
+  storage_options.uri =
+    (std::filesystem::path(temporary_dir_path_) / "split_duration_bag").generic_string();
   storage_options.storage_id = GetParam();
   write_sample_split_bag(storage_options, fake_messages, 3);
 


### PR DESCRIPTION
Sequential PRs from https://github.com/ros2/rosbag2/pull/1474

This PR and #1474 are independent of each other.
So, whenever they can be merged, and do not need to care about the order.