### PR TITLE
Add python3-yaml as a dependency

### DIFF
--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -14,6 +14,7 @@
   <license>Apache License 2.0</license>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>rosbag2_py</exec_depend>


### PR DESCRIPTION
Verbs such as `ros2 bag play` import the Python yaml package. This package is probably present in most ROS installations, but in some minimalist ones (e.g. built with the Nix package manager), it can be missing. In that case `ros2 bag play` fails with errors like the following:

    Failed to load entry point 'play': No module named 'yaml'
    Traceback (most recent call last):
      File "/nix/store/yg2iwwv9i4dann0mjjxcqsi0hrc8h1ix-python3.10-ros-humble-ros2cli-0.18.7-r1/bin/.ros2-wrapped", line 34, in <module>
        sys.exit(load_entry_point('ros2cli==0.18.7', 'console_scripts', 'ros2')())
      File "/nix/store/yg2iwwv9i4dann0mjjxcqsi0hrc8h1ix-python3.10-ros-humble-ros2cli-0.18.7-r1/lib/python3.10/site-packages/ros2cli/cli.py", line 50, in main
        add_subparsers_on_demand(
      File "/nix/store/yg2iwwv9i4dann0mjjxcqsi0hrc8h1ix-python3.10-ros-humble-ros2cli-0.18.7-r1/lib/python3.10/site-packages/ros2cli/command/__init__.py", line 250, in add_subparsers_on_demand
        extension.add_arguments(
      File "/nix/store/k0bvhnx4zm851bxfyz65ggpl0f1zjmx5-python3.10-ros-humble-ros2bag-0.15.8-r1/lib/python3.10/site-packages/ros2bag/command/bag.py", line 26, in add_arguments
        add_subparsers_on_demand(
      File "/nix/store/yg2iwwv9i4dann0mjjxcqsi0hrc8h1ix-python3.10-ros-humble-ros2cli-0.18.7-r1/lib/python3.10/site-packages/ros2cli/command/__init__.py", line 237, in add_subparsers_on_demand
        extension = command_extensions[name]
    KeyError: 'play'

Here, we add the dependency to package.xml to ensure that the Python yaml package is always available.