### PR TITLE
Link and compile against rosbag2_storage_mcap: Fixed issue 1492

### DIFF
--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -87,11 +87,6 @@ install(
   RUNTIME DESTINATION bin
 )
 
-install(
-  DIRECTORY include/
-  DESTINATION include/${PROJECT_NAME}
-)
-
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
@@ -124,6 +119,5 @@ endif()
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(mcap_vendor pluginlib rosbag2_storage rcutils)
-ament_export_include_directories("include/${PROJECT_NAME}")
 
 ament_package()

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -87,6 +87,11 @@ install(
   RUNTIME DESTINATION bin
 )
 
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
@@ -118,6 +123,7 @@ endif()
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})
-ament_export_dependencies(rosbag2_storage rcutils)
+ament_export_dependencies(mcap_vendor pluginlib rosbag2_storage rcutils)
+ament_export_include_directories("include/${PROJECT_NAME}")
 
 ament_package()


### PR DESCRIPTION
Fixed issue https://github.com/ros2/rosbag2/issues/1492

How to test it 
```sh
rm -rf /tmp/colcon-example && mkdir /tmp/colcon-example && cd /tmp/colcon-example
mkdir -p src/example

cat > src/example/CMakeLists.txt <<'EOF'
cmake_minimum_required(VERSION 3.14)
project(example)

find_package(ament_cmake REQUIRED)
find_package(rosbag2_storage_mcap REQUIRED)

file(WRITE empty.cc "")
add_library(${PROJECT_NAME} SHARED empty.cc)

target_link_libraries(${PROJECT_NAME} rosbag2_storage_mcap::rosbag2_storage_mcap)

ament_package()
EOF

cat > src/example/package.xml <<'EOF'
<?xml version="1.0"?>
<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
<package format="3">
  <name>example</name>
  <version>0.0.1</version>
  <description>thing</description>
  <maintainer email="meh@nowhere.com">Meh</maintainer>
  <license>Apache-2.0</license>
  <buildtool_depend>ament_cmake</buildtool_depend>
  <depend>rosbag2_storage_map</depend>
  <export>
    <build_type>ament_cmake</build_type>
  </export>
</package>
EOF

source /opt/ros/humble/setup.bash
colcon build
```

FYI @EricCousineau-TRI 