### PR TITLE
Bugfix for incorrect playback rate changes when pressing buttons

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -1061,12 +1061,12 @@ void PlayerImpl::add_keyboard_callbacks()
   );
   add_key_callback(
     play_options_.increase_rate_key,
-    [this]() {owner_->set_rate(get_rate() * 1.1);},
+    [this]() {owner_->set_rate(get_rate() + 0.1);},
     "Increase Rate 10%"
   );
   add_key_callback(
     play_options_.decrease_rate_key,
-    [this]() {owner_->set_rate(get_rate() * 0.9);},
+    [this]() {owner_->set_rate(get_rate() - 0.1);},
     "Decrease Rate 10%"
   );
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
@@ -157,8 +157,14 @@ TEST_F(RosBag2PlayTestFixture, test_keyboard_controls)
   keyboard_handler->simulate_key_press(play_options_.pause_resume_toggle_key);
   EXPECT_THAT(player->is_paused(), true);
 
-  keyboard_handler->simulate_key_press(play_options_.increase_rate_key);
+  EXPECT_DOUBLE_EQ(player->get_rate(), 1.0);
   keyboard_handler->simulate_key_press(play_options_.decrease_rate_key);
+  // Each increase/decrease shall change playback rate value by 10%
+  EXPECT_DOUBLE_EQ(player->get_rate(), 0.9);
+  keyboard_handler->simulate_key_press(play_options_.increase_rate_key);
+  EXPECT_DOUBLE_EQ(player->get_rate(), 1.0);
+  keyboard_handler->simulate_key_press(play_options_.increase_rate_key);
+  EXPECT_DOUBLE_EQ(player->get_rate(), 1.1);
 
   // start playback asynchronously in a separate thread
   player->play();
@@ -175,7 +181,7 @@ TEST_F(RosBag2PlayTestFixture, test_keyboard_controls)
   EXPECT_THAT(player->num_paused, 1);
   EXPECT_THAT(player->num_resumed, 1);
   EXPECT_THAT(player->num_played_next, 1);
-  EXPECT_THAT(player->num_set_rate, 2);
+  EXPECT_THAT(player->num_set_rate, 3);
 }
 
 TEST_F(RecordIntegrationTestFixture, test_keyboard_controls)


### PR DESCRIPTION
- Closes https://github.com/ros2/rosbag2/issues/1210

- Playback rate expected to be changed by 10% with each increase/decrease step.
- Use +0.1 and -0.1 in decrease/increase rate formula instead of multiply by factor of the 1.1 and 0.9 respectively.