### PR TITLE
add missing import otherwise it doesnt compile

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_info.cpp
+++ b/rosbag2_py/src/rosbag2_py/_info.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iostream>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
On AMD64 / debian bookworm

without this include the compilation fails
<details><summary>with the following error message</summary>

```
/opt/ros2_ws/src/ros2/rosbag2/rosbag2_py/src/rosbag2_py/_info.cpp: In member function ‘void rosbag2_py::Info::read_metadata_and_output_service_verbose(const std::string&, const std::string&)’:
/opt/ros2_ws/src/ros2/rosbag2/rosbag2_py/src/rosbag2_py/_info.cpp:63:10: error: ‘cout’ is not a member of ‘std’
   63 |     std::cout << format_bag_meta_data(metadata_info, true);
      |          ^~~~
/opt/ros2_ws/src/ros2/rosbag2/rosbag2_py/src/rosbag2_py/_info.cpp:24:1: note: ‘std::cout’ is defined in header ‘<iostream>’; did you forget to ‘#include <iostream>’?
   23 | #include "pybind11.hpp"
  +++ |+#include <iostream>
   24 | 
/opt/ros2_ws/src/ros2/rosbag2/rosbag2_py/src/rosbag2_py/_info.cpp:64:10: error: ‘cout’ is not a member of ‘std’
   64 |     std::cout << format_service_info(all_services_info) << std::endl;
      |          ^~~~
/opt/ros2_ws/src/ros2/rosbag2/rosbag2_py/src/rosbag2_py/_info.cpp:64:10: note: ‘std::cout’ is defined in header ‘<iostream>’; did you forget to ‘#include <iostream>’?
gmake[2]: *** [CMakeFiles/_info.dir/build.make:76: CMakeFiles/_info.dir/src/rosbag2_py/_info.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:308: CMakeFiles/_info.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

</details>