### PR TITLE
Give proper log message for `--start-paused`

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -343,7 +343,13 @@ void RecorderImpl::record()
     discovery_future_ =
       std::async(std::launch::async, std::bind(&RecorderImpl::topics_discovery, this));
   }
-  RCLCPP_INFO(node->get_logger(), "Recording...");
+  if (record_options_.start_paused) {
+    RCLCPP_INFO(
+      node->get_logger(), "Wait for recording: Press %s to start.",
+      enum_key_code_to_str(Recorder::kPauseResumeToggleKey).c_str());
+  } else {
+    RCLCPP_INFO(node->get_logger(), "Recording...");
+  }
 }
 
 void RecorderImpl::event_publisher_thread_main()


### PR DESCRIPTION
Hi! I found it confusing that the last log message in the command line with  `--start-paused` is `Recording...`, because it doesn't.

> $ ros2 bag record --start-paused /joint_states
> [INFO] [1705052632.344791542] [rosbag2_recorder]: Press SPACE for pausing/resuming
> [INFO] [1705052632.349059100] [rosbag2_recorder]: Event publisher thread: Starting
> [INFO] [1705052632.349059491] [rosbag2_recorder]: Listening for topics...
> [INFO] [1705052632.353240795] [rosbag2_recorder]: Subscribed to topic '/joint_states'
> [INFO] [1705052632.353331326] [rosbag2_recorder]: Recording...
> [INFO] [1705052632.353794917] [rosbag2_recorder]: All requested topics are subscribed. Stopping discovery...

In this case I propose something like
> [INFO] [1705052619.854131527] [rosbag2_recorder]: Wait for recording: Press SPACE to start.