### PR TITLE
Add default initialization for CompressionOptions

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
@@ -62,7 +62,7 @@ struct CompressionOptions
   CompressionMode compression_mode{CompressionMode::NONE};
   uint64_t compression_queue_size{0};
   /// \brief // The number of compression threads
-  uint64_t compression_threads{5};
+  uint64_t compression_threads{0};
   /// \brief If set, the compression thread(s) will try to set the given priority for itself
   /// For Windows the valid values are: THREAD_PRIORITY_LOWEST, THREAD_PRIORITY_BELOW_NORMAL and
   /// THREAD_PRIORITY_NORMAL. For POSIX compatible OSes this is the "nice" value.

--- a/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/compression_options.hpp
@@ -58,11 +58,11 @@ ROSBAG2_COMPRESSION_PUBLIC std::string compression_mode_to_string(CompressionMod
  */
 struct CompressionOptions
 {
-  std::string compression_format;
-  CompressionMode compression_mode;
-  uint64_t compression_queue_size;
+  std::string compression_format{};
+  CompressionMode compression_mode{CompressionMode::NONE};
+  uint64_t compression_queue_size{0};
   /// \brief // The number of compression threads
-  uint64_t compression_threads;
+  uint64_t compression_threads{5};
   /// \brief If set, the compression thread(s) will try to set the given priority for itself
   /// For Windows the valid values are: THREAD_PRIORITY_LOWEST, THREAD_PRIORITY_BELOW_NORMAL and
   /// THREAD_PRIORITY_NORMAL. For POSIX compatible OSes this is the "nice" value.


### PR DESCRIPTION
This PR adds sane defaults for the `CompressionOptions` struct.
Sane defaults are important because the struct does not have a constructor and it is possible (and very easy) to use it without completely initializing it.

Another option would be to add a constructor and delete the default constructor, but that would not be backward compatible.






