### PR TITLE
Remove an incorrect TSA annotation.

### DIFF
--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -126,7 +126,7 @@ private:
   int get_last_rowid();
   int read_db_schema_version();
   uint64_t get_page_size() const;
-  uint64_t read_total_page_count_locked() const RCPPUTILS_TSA_GUARDED_BY(db_read_write_mutex_);
+  uint64_t read_total_page_count_locked() const;
 
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string, int>;

--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -126,7 +126,7 @@ private:
   int get_last_rowid();
   int read_db_schema_version();
   uint64_t get_page_size() const;
-  uint64_t read_total_page_count_locked() const;
+  uint64_t read_total_page_count_locked() const RCPPUTILS_TSA_REQUIRES(db_read_write_mutex_);
 
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string, int>;


### PR DESCRIPTION
read_total_page_count_locked is not protected by the mutex in question, so remove the annotation.

This fixes a warning when building under clang: https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1776/clang/new/source.5173c086-9b9f-4319-96c5-67a99529b3cd/#129 .

This is followup from #1516 .  @MichaelOrlov FYI