### PR TITLE
Workaround for flaky test_play_services running with fastrtps

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -106,6 +106,12 @@ public:
     ASSERT_TRUE(cli_stop_->wait_for_service(service_wait_timeout_));
   }
 
+  void TearDown() override
+  {
+    // Gracefully stop player before calling rclcpp::shutdown() in destructor
+    player_->stop();
+  }
+
   /// Call a service client, and expect it to successfully return within a reasonable timeout
   template<typename Srv>
   typename Srv::Response::SharedPtr successful_call(


### PR DESCRIPTION
- Workaround for #1311 as described in the RCA here https://github.com/ros2/rosbag2/issues/1311#issuecomment-1528951469
- Gracefully stop player in TearDown() before calling rclcpp::shutdown() in destructor.