### PR TITLE
Add /bigobj to MSVC compiles.

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # Windows supplies macros for min and max by default. We should only use min and max from stl
 if(WIN32)
   add_definitions(-DNOMINMAX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Currently when [building rosbag2_transport on Humble with Windows debug](https://ci.ros2.org/job/ci_windows/21027/), it fails with the following error:

```
C:\ci\ws\src\ros2\rosbag2\rosbag2_transport\test\rosbag2_transport\test_play.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj [C:\ci\ws\build\rosbag2_transport\test_play__rmw_connextdds.vcxproj]
```

The advice there is pretty explicit; adding in the `/bigobj` flag should fix the compilation.  We could alternatively fix this by splitting `test_play.cpp` into smaller pieces, but adding /bigobj is simpler.  We also do this in a couple of other places, like https://github.com/ros2/rviz/blob/b30838530c1aee8f6ddcbd11db258fbd24e57935/rviz_default_plugins/CMakeLists.txt#L47 and https://github.com/ros2/system_tests/blob/2144c027383ff7c08c88c47aadaefcc701490d7c/test_communication/CMakeLists.txt#L16