### PR TITLE
fix: use size_t instead of uint64_t in play_options YAML converter

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/play_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/play_options.cpp
@@ -62,9 +62,7 @@ Node convert<rosbag2_transport::PlayOptions>::encode(
 bool convert<rosbag2_transport::PlayOptions>::decode(
   const Node & node, rosbag2_transport::PlayOptions & play_options)
 {
-  optional_assign<decltype(play_options.read_ahead_queue_size)>(
-    node, "read_ahead_queue_size",
-    play_options.read_ahead_queue_size);
+  optional_assign<size_t>(node, "read_ahead_queue_size", play_options.read_ahead_queue_size);
   optional_assign<std::string>(node, "node_prefix", play_options.node_prefix);
   optional_assign<float>(node, "rate", play_options.rate);
   optional_assign<std::vector<std::string>>(

--- a/rosbag2_transport/src/rosbag2_transport/play_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/play_options.cpp
@@ -62,7 +62,9 @@ Node convert<rosbag2_transport::PlayOptions>::encode(
 bool convert<rosbag2_transport::PlayOptions>::decode(
   const Node & node, rosbag2_transport::PlayOptions & play_options)
 {
-  optional_assign<uint64_t>(node, "read_ahead_queue_size", play_options.read_ahead_queue_size);
+  optional_assign<decltype(play_options.read_ahead_queue_size)>(
+    node, "read_ahead_queue_size",
+    play_options.read_ahead_queue_size);
   optional_assign<std::string>(node, "node_prefix", play_options.node_prefix);
   optional_assign<float>(node, "rate", play_options.rate);
   optional_assign<std::vector<std::string>>(


### PR DESCRIPTION
- avoid build error on apple silicon below.
```
/Users/daisuke/workspace/rolling/src/ros2/rosbag2/rosbag2_transport/src/rosbag2_transport/play_options.cpp:65:3: error: no matching function for call to 'optional_assign'
  optional_assign<uint64_t>(node, "read_ahead_queue_size", play_options.read_ahead_queue_size);
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/Users/daisuke/workspace/rolling/install/rosbag2_storage/include/rosbag2_storage/rosbag2_storage/yaml.hpp:42:6: note: candidate function template not viable: no known conversion from 'size_t' (aka 'unsigned long') to 'unsigned long long &' for 3rd argument
void optional_assign(const Node & node, std::string field, T & assign_to)
     ^
1 error generated.                                        
make[2]: *** [CMakeFiles/rosbag2_transport.dir/src/rosbag2_transport/play_options.cpp.o] Error 1
make[1]: *** [CMakeFiles/rosbag2_transport.dir/all] Error 2
make: *** [all] Error 2
--- stderr: rosbag2_transport                             
/Users/daisuke/workspace/rolling/src/ros2/rosbag2/rosbag2_transport/src/rosbag2_transport/play_options.cpp:65:3: error: no matching function for call to 'optional_assign'
  optional_assign<uint64_t>(node, "read_ahead_queue_size", play_options.read_ahead_queue_size);
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/Users/daisuke/workspace/rolling/install/rosbag2_storage/include/rosbag2_storage/rosbag2_storage/yaml.hpp:42:6: note: candidate function template not viable: no known conversion from 'size_t' (aka 'unsigned long') to 'unsigned long long &' for 3rd argument
void optional_assign(const Node & node, std::string field, T & assign_to)
     ^
1 error generated.
make[2]: *** [CMakeFiles/rosbag2_transport.dir/src/rosbag2_transport/play_options.cpp.o] Error 1
make[1]: *** [CMakeFiles/rosbag2_transport.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< rosbag2_transport [4.53s, exited with code 2]
```