### PR TITLE
Use std::filesystem instead of rcpputils::fs

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -14,6 +14,7 @@
 
 #include "rosbag2_compression/sequential_compression_reader.hpp"
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -21,11 +22,12 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/compression_options.hpp"
 
 #include "logging.hpp"
+
+namespace fs = std::filesystem;
 
 namespace rosbag2_compression
 {
@@ -67,17 +69,17 @@ void SequentialCompressionReader::preprocess_current_file()
      * Because we have no way to check whether the bag was written correctly,
      * check for the existence of the prefixed file as a fallback.
      */
-    const rcpputils::fs::path base{base_folder_};
-    const rcpputils::fs::path relative{get_current_file()};
+    const fs::path base{base_folder_};
+    const fs::path relative{get_current_file()};
     const auto resolved = base / relative;
-    if (!resolved.exists()) {
+    if (!fs::exists(resolved)) {
       const auto base_stripped = relative.filename();
       const auto resolved_stripped = base / base_stripped;
       ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
         "Unable to find specified bagfile " << resolved.string() <<
           ". Falling back to checking for " << resolved_stripped.string());
       rcpputils::require_true(
-        resolved_stripped.exists(),
+        fs::exists(resolved_stripped),
         "Unable to resolve relative file path either as a V3 or V4 relative path");
       *current_file_iterator_ = resolved_stripped.string();
     }

--- a/rosbag2_compression/test/rosbag2_compression/fake_decompressor.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/fake_decompressor.cpp
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <string>
 
 #include "pluginlib/class_list_macros.hpp"
 
-#include "rcpputils/filesystem_helper.hpp"
-
 #include "fake_decompressor.hpp"
+
+namespace fs = std::filesystem;
 
 std::string FakeDecompressor::decompress_uri(const std::string & uri)
 {
-  auto uri_path = rcpputils::fs::path{uri};
-  const auto decompressed_path = rcpputils::fs::remove_extension(uri_path);
-  return decompressed_path.string();
+  auto uri_path = fs::path{uri};
+  const auto decompressed_path = uri_path.replace_extension();
+  return decompressed_path.generic_string();
 }
 
 void FakeDecompressor::decompress_serialized_bag_message(

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_reader.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -21,7 +22,6 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/sequential_compression_reader.hpp"
 
@@ -37,6 +37,8 @@
 
 using namespace testing;  // NOLINT
 
+namespace fs = std::filesystem;
+
 static constexpr const char * DefaultTestCompressor = "fake_comp";
 
 class SequentialCompressionReaderTest : public Test
@@ -48,10 +50,10 @@ public:
     converter_factory_{std::make_shared<StrictMock<MockConverterFactory>>()},
     metadata_io_{std::make_unique<NiceMock<MockMetadataIo>>()},
     storage_serialization_format_{"rmw1_format"},
-    tmp_dir_{rcpputils::fs::temp_directory_path() / bag_name_},
+    tmp_dir_{fs::temp_directory_path() / bag_name_},
     converter_options_{"", storage_serialization_format_}
   {
-    rcpputils::fs::remove_all(tmp_dir_);
+    fs::remove_all(tmp_dir_);
     storage_options_.uri = tmp_dir_.string();
     topic_with_type_ = rosbag2_storage::TopicMetadata{
       0U, "topic", "test_msgs/BasicTypes", storage_serialization_format_, {}, ""};
@@ -92,7 +94,7 @@ public:
   void initialize_dummy_storage_files()
   {
     // Initialize some dummy files so that they can be found
-    rcpputils::fs::create_directories(tmp_dir_);
+    fs::create_directories(tmp_dir_);
     for (auto relative : metadata_.relative_file_paths) {
       std::ofstream output((tmp_dir_ / relative).string());
       output << "Fake storage data" << std::endl;
@@ -104,9 +106,9 @@ public:
     auto decompressor = std::make_unique<NiceMock<MockDecompressor>>();
     ON_CALL(*decompressor, decompress_uri).WillByDefault(
       [](auto uri) {
-        auto path = rcpputils::fs::path(uri);
-        EXPECT_TRUE(path.exists());
-        return rcpputils::fs::remove_extension(path).string();
+        auto path = fs::path(uri);
+        EXPECT_TRUE(fs::exists(path));
+        return path.replace_extension().generic_string();
       });
     auto compression_factory = std::make_unique<NiceMock<MockCompressionFactory>>();
     ON_CALL(*compression_factory, create_decompressor(_))
@@ -126,7 +128,7 @@ public:
   std::string storage_serialization_format_;
   rosbag2_storage::TopicMetadata topic_with_type_;
   const std::string bag_name_ = "SequentialCompressionReaderTest";
-  rcpputils::fs::path tmp_dir_;
+  fs::path tmp_dir_;
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_storage::BagMetadata metadata_;
   rosbag2_cpp::ConverterOptions converter_options_;
@@ -254,7 +256,7 @@ TEST_F(SequentialCompressionReaderTest, throws_on_incorrect_filenames)
 {
   for (auto & relative_file_path : metadata_.relative_file_paths) {
     relative_file_path = (
-      rcpputils::fs::path(bag_name_) / (relative_file_path + ".something")).string();
+      fs::path(bag_name_) / (relative_file_path + ".something")).string();
   }
   auto reader = create_reader();
   EXPECT_THROW(reader->open(storage_options_, converter_options_), std::invalid_argument);
@@ -264,7 +266,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames)
 {
   // By prefixing the bag name, this imitates the V3 filename logic
   for (auto & relative_file_path : metadata_.relative_file_paths) {
-    relative_file_path = (rcpputils::fs::path(bag_name_) / relative_file_path).string();
+    relative_file_path = (fs::path(bag_name_) / relative_file_path).string();
   }
   auto reader = create_reader();
 
@@ -278,7 +280,7 @@ TEST_F(SequentialCompressionReaderTest, can_find_prefixed_filenames_in_renamed_b
   // was recorded using V3 logic, then the directory was moved to be a new name - this is the
   // use case the V4 relative path logic was intended to fix
   for (auto & relative_file_path : metadata_.relative_file_paths) {
-    relative_file_path = (rcpputils::fs::path("OtherBagName") / relative_file_path).string();
+    relative_file_path = (fs::path("OtherBagName") / relative_file_path).string();
   }
   auto reader = create_reader();
 

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -21,7 +22,6 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/compression_options.hpp"
 #include "rosbag2_compression/sequential_compression_writer.hpp"
@@ -47,6 +47,8 @@
 
 using namespace testing;  // NOLINT
 
+namespace fs = std::filesystem;
+
 static constexpr const char * DefaultTestCompressor = "fake_comp";
 
 class SequentialCompressionWriterTest : public TestWithParam<uint64_t>
@@ -57,12 +59,12 @@ public:
     storage_{std::make_shared<NiceMock<MockStorage>>()},
     converter_factory_{std::make_shared<StrictMock<MockConverterFactory>>()},
     metadata_io_{std::make_unique<NiceMock<MockMetadataIo>>()},
-    tmp_dir_{rcpputils::fs::temp_directory_path() / "SequentialCompressionWriterTest"},
+    tmp_dir_{fs::temp_directory_path() / "SequentialCompressionWriterTest"},
     tmp_dir_storage_options_{},
     serialization_format_{"rmw_format"}
   {
     tmp_dir_storage_options_.uri = tmp_dir_.string();
-    rcpputils::fs::remove_all(tmp_dir_);
+    fs::remove_all(tmp_dir_);
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(Return(storage_));
     EXPECT_CALL(*storage_factory_, open_read_write(_)).Times(AtLeast(0));
     // intercept the metadata write so we can analyze it.
@@ -79,7 +81,7 @@ public:
 
   ~SequentialCompressionWriterTest() override
   {
-    rcpputils::fs::remove_all(tmp_dir_);
+    fs::remove_all(tmp_dir_);
   }
 
   void initializeFakeFileStorage()
@@ -139,7 +141,7 @@ public:
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<MockMetadataIo> metadata_io_;
 
-  rcpputils::fs::path tmp_dir_;
+  fs::path tmp_dir_;
   rosbag2_storage::StorageOptions tmp_dir_storage_options_;
   rosbag2_storage::BagMetadata intercepted_write_metadata_;
   std::vector<rosbag2_storage::BagMetadata> v_intercepted_update_metadata_;
@@ -212,7 +214,7 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_on_supported_compression_f
     kDefaultCompressionQueueThreadsPriority};
   initializeWriter(compression_options);
 
-  auto tmp_dir = rcpputils::fs::temp_directory_path() / "path_not_empty";
+  auto tmp_dir = fs::temp_directory_path() / "path_not_empty";
   auto storage_options = rosbag2_storage::StorageOptions();
   storage_options.uri = tmp_dir.string();
 

--- a/rosbag2_compression_zstd/CMakeLists.txt
+++ b/rosbag2_compression_zstd/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(rcpputils REQUIRED)
 find_package(rosbag2_compression REQUIRED)
 find_package(zstd_vendor REQUIRED)
 find_package(zstd REQUIRED)
@@ -37,7 +36,6 @@ target_include_directories(${PROJECT_NAME}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 target_link_libraries(${PROJECT_NAME}
-  rcpputils::rcpputils
   rosbag2_compression::rosbag2_compression
   zstd::zstd
 )
@@ -63,7 +61,7 @@ ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})
 
 # order matters here, first vendor, then zstd
-ament_export_dependencies(rcpputils rosbag2_compression zstd_vendor zstd)
+ament_export_dependencies(rosbag2_compression zstd_vendor zstd)
 
 
 if(BUILD_TESTING)

--- a/rosbag2_compression_zstd/package.xml
+++ b/rosbag2_compression_zstd/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>pluginlib</depend>
-  <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <depend>rosbag2_compression</depend>
   <depend>zstd_vendor</depend>

--- a/rosbag2_compression_zstd/src/rosbag2_compression_zstd/compression_utils.hpp
+++ b/rosbag2_compression_zstd/src/rosbag2_compression_zstd/compression_utils.hpp
@@ -23,8 +23,7 @@
 #include <vector>
 
 #include "logging.hpp"
-
-#include "rcpputils/filesystem_helper.hpp"
+#include "rcutils/types/rcutils_ret.h"
 
 namespace rosbag2_compression_zstd
 {

--- a/rosbag2_compression_zstd/src/rosbag2_compression_zstd/zstd_compressor.cpp
+++ b/rosbag2_compression_zstd/src/rosbag2_compression_zstd/zstd_compressor.cpp
@@ -19,8 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "rcpputils/filesystem_helper.hpp"
-
 #include "compression_utils.hpp"
 #include "rosbag2_compression_zstd/zstd_compressor.hpp"
 #include "rosbag2_storage/ros_helper.hpp"

--- a/rosbag2_compression_zstd/src/rosbag2_compression_zstd/zstd_decompressor.cpp
+++ b/rosbag2_compression_zstd/src/rosbag2_compression_zstd/zstd_decompressor.cpp
@@ -15,14 +15,15 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <filesystem>
 #include <sstream>
 #include <string>
 #include <vector>
 
-#include "rcpputils/filesystem_helper.hpp"
-
 #include "compression_utils.hpp"
 #include "rosbag2_compression_zstd/zstd_decompressor.hpp"
+
+namespace fs = std::filesystem;
 
 namespace rosbag2_compression_zstd
 {
@@ -45,8 +46,8 @@ ZstdDecompressor::~ZstdDecompressor()
 std::string ZstdDecompressor::decompress_uri(const std::string & uri)
 {
   const auto start = std::chrono::high_resolution_clock::now();
-  const auto uri_path = rcpputils::fs::path{uri};
-  const auto decompressed_uri = rcpputils::fs::remove_extension(uri_path).string();
+  auto uri_path = fs::path{uri};
+  auto decompressed_uri = uri_path.replace_extension().generic_string();
 
   std::ifstream input(uri, std::ios::in | std::ios::binary);
   if (!input.is_open()) {

--- a/rosbag2_compression_zstd/test/rosbag2_compression_zstd/test_zstd_compressor.cpp
+++ b/rosbag2_compression_zstd/test/rosbag2_compression_zstd/test_zstd_compressor.cpp
@@ -14,14 +14,14 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression_zstd/zstd_compressor.hpp"
 #include "rosbag2_compression_zstd/zstd_decompressor.hpp"
@@ -31,6 +31,8 @@
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 
 #include "gmock/gmock.h"
+
+namespace fs = std::filesystem;
 
 namespace
 {
@@ -134,62 +136,63 @@ protected:
 
 TEST_F(CompressionHelperFixture, zstd_compress_file_uri)
 {
-  const auto uri = (rcpputils::fs::path(temporary_dir_path_) / "file1.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file1.txt").string();
   create_garbage_file(uri);
 
-  ASSERT_TRUE(rcpputils::fs::exists(uri)) <<
+  ASSERT_TRUE(fs::exists(uri)) <<
     "Expected uncompressed URI: \"" << uri << "\" to exist.";
 
   auto zstd_compressor = rosbag2_compression_zstd::ZstdCompressor{};
   const auto compressed_uri = zstd_compressor.compress_uri(uri);
 
-  ASSERT_TRUE(rcpputils::fs::exists(compressed_uri)) <<
+  ASSERT_TRUE(fs::exists(compressed_uri)) <<
     "Expected compressed URI: \"" << compressed_uri << "\" to exist.";
 
   const auto expected_compressed_uri = uri + "." + zstd_compressor.get_compression_identifier();
-  const auto uncompressed_file_size = rcpputils::fs::file_size(rcpputils::fs::path{uri});
-  const auto compressed_file_size = rcpputils::fs::file_size(rcpputils::fs::path{compressed_uri});
+  const auto uncompressed_file_size = fs::file_size(fs::path(uri));
+  const auto compressed_file_size =
+    fs::file_size(fs::path{compressed_uri});
 
   EXPECT_NE(compressed_uri, uri);
   EXPECT_EQ(compressed_uri, expected_compressed_uri);
   EXPECT_LT(compressed_file_size, uncompressed_file_size);
   EXPECT_GT(compressed_file_size, 0u);
-  EXPECT_TRUE(rcpputils::fs::exists(compressed_uri)) <<
+  EXPECT_TRUE(fs::exists(compressed_uri)) <<
     "Expected compressed path: \"" << compressed_uri << "\" to exist!";
 }
 
 TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
 {
-  const auto uri = (rcpputils::fs::path(temporary_dir_path_) / "file1.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file1.txt").string();
   create_garbage_file(uri);
 
-  const auto initial_file_path = rcpputils::fs::path{uri};
+  const auto initial_file_path = fs::path{uri};
 
-  ASSERT_TRUE(initial_file_path.exists()) <<
+  ASSERT_TRUE(fs::exists(initial_file_path)) <<
     "Expected initial file: \"" << initial_file_path.string() <<
     "\" to exist.";
 
-  const auto initial_file_size = initial_file_path.file_size();
+  const auto initial_file_size = fs::file_size(initial_file_path);
 
   auto zstd_compressor = rosbag2_compression_zstd::ZstdCompressor{};
   const auto compressed_uri = zstd_compressor.compress_uri(uri);
 
   // The test is invalid if the initial file is not deleted
-  ASSERT_TRUE(rcpputils::fs::remove(initial_file_path)) <<
+  ASSERT_TRUE(fs::remove(initial_file_path)) <<
     "Removal of \"" << initial_file_path.string() <<
     "\" failed! The remaining tests require \"" <<
     initial_file_path.string() << "\" to be deleted!";
 
   auto zstd_decompressor = rosbag2_compression_zstd::ZstdDecompressor{};
   const auto decompressed_uri = zstd_decompressor.decompress_uri(compressed_uri);
-  const auto decompressed_file_path = rcpputils::fs::path{decompressed_uri};
+  const auto decompressed_file_path = fs::path{decompressed_uri};
   const auto expected_decompressed_uri = uri;
 
-  ASSERT_TRUE(decompressed_file_path.exists()) <<
+  ASSERT_TRUE(fs::exists(decompressed_file_path)) <<
     "Expected decompressed file: \"" << decompressed_file_path.string() <<
     "\" to exist.";
 
-  const auto decompressed_file_size = decompressed_file_path.file_size();
+  const auto decompressed_file_size = fs::file_size(decompressed_file_path);
 
   EXPECT_NE(compressed_uri, uri);
   EXPECT_NE(decompressed_uri, compressed_uri);
@@ -199,15 +202,15 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
 
 TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
 {
-  const auto uri = (rcpputils::fs::path(temporary_dir_path_) / "file2.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file2.txt").string();
   create_garbage_file(uri);
 
-  const auto initial_file_path = rcpputils::fs::path{uri};
-  ASSERT_TRUE(initial_file_path.exists()) <<
+  const auto initial_file_path = fs::path{uri};
+  ASSERT_TRUE(fs::exists(initial_file_path)) <<
     "Expected initial file: \"" << uri << "\" to exist!";
 
   const auto initial_data = read_file(uri);
-  const auto initial_file_size = initial_file_path.file_size();
+  const auto initial_file_size = fs::file_size(initial_file_path);
 
   EXPECT_EQ(
     initial_data.size() * sizeof(decltype(initial_data)::value_type),
@@ -216,7 +219,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
   auto compressor = rosbag2_compression_zstd::ZstdCompressor{};
   const auto compressed_uri = compressor.compress_uri(uri);
 
-  ASSERT_TRUE(rcpputils::fs::exists(compressed_uri)) <<
+  ASSERT_TRUE(fs::exists(compressed_uri)) <<
     "Expected compressed file: \"" << compressed_uri << "\" to exist!";
 
   ASSERT_EQ(0, std::remove(uri.c_str())) <<
@@ -225,16 +228,16 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
 
   auto decompressor = rosbag2_compression_zstd::ZstdDecompressor{};
   const auto decompressed_uri = decompressor.decompress_uri(compressed_uri);
-  const auto decompressed_file_path = rcpputils::fs::path{decompressed_uri};
+  const auto decompressed_file_path = fs::path{decompressed_uri};
 
-  ASSERT_TRUE(decompressed_file_path.exists()) <<
+  ASSERT_TRUE(fs::exists(decompressed_file_path)) <<
     "Decompressed file: \"" << decompressed_file_path.string() << "\" must exist!";
 
   EXPECT_EQ(uri, decompressed_uri) <<
     "Expected decompressed file name to be same as initial!";
 
   const auto decompressed_data = read_file(decompressed_uri);
-  const auto decompressed_file_size = decompressed_file_path.file_size();
+  const auto decompressed_file_size = fs::file_size(decompressed_file_path);
 
   EXPECT_EQ(
     decompressed_data.size() * sizeof(decltype(initial_data)::value_type),
@@ -249,7 +252,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
 
 TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_file)
 {
-  const auto uri = (rcpputils::fs::path(temporary_dir_path_) / "file3.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file3.txt").string();
   create_garbage_file(uri);
 
   auto decompressor = rosbag2_compression_zstd::ZstdDecompressor{};
@@ -259,7 +262,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_file)
 
 TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_uri)
 {
-  const auto bad_uri = (rcpputils::fs::path(temporary_dir_path_) / "bad_uri.txt").string();
+  const auto bad_uri = (fs::path(temporary_dir_path_) / "bad_uri.txt").string();
   auto decompressor = rosbag2_compression_zstd::ZstdDecompressor{};
 
   EXPECT_THROW(decompressor.decompress_uri(bad_uri), std::runtime_error) <<

--- a/rosbag2_compression_zstd/test/rosbag2_compression_zstd/test_zstd_compressor.cpp
+++ b/rosbag2_compression_zstd/test/rosbag2_compression_zstd/test_zstd_compressor.cpp
@@ -136,7 +136,7 @@ protected:
 
 TEST_F(CompressionHelperFixture, zstd_compress_file_uri)
 {
-  const auto uri = (fs::path(temporary_dir_path_) / "file1.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file1.txt").generic_string();
   create_garbage_file(uri);
 
   ASSERT_TRUE(fs::exists(uri)) <<
@@ -163,13 +163,13 @@ TEST_F(CompressionHelperFixture, zstd_compress_file_uri)
 
 TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
 {
-  const auto uri = (fs::path(temporary_dir_path_) / "file1.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file1.txt").generic_string();
   create_garbage_file(uri);
 
   const auto initial_file_path = fs::path{uri};
 
   ASSERT_TRUE(fs::exists(initial_file_path)) <<
-    "Expected initial file: \"" << initial_file_path.string() <<
+    "Expected initial file: \"" << initial_file_path.generic_string() <<
     "\" to exist.";
 
   const auto initial_file_size = fs::file_size(initial_file_path);
@@ -179,9 +179,9 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
 
   // The test is invalid if the initial file is not deleted
   ASSERT_TRUE(fs::remove(initial_file_path)) <<
-    "Removal of \"" << initial_file_path.string() <<
+    "Removal of \"" << initial_file_path.generic_string() <<
     "\" failed! The remaining tests require \"" <<
-    initial_file_path.string() << "\" to be deleted!";
+    initial_file_path.generic_string() << "\" to be deleted!";
 
   auto zstd_decompressor = rosbag2_compression_zstd::ZstdDecompressor{};
   const auto decompressed_uri = zstd_decompressor.decompress_uri(compressed_uri);
@@ -189,7 +189,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
   const auto expected_decompressed_uri = uri;
 
   ASSERT_TRUE(fs::exists(decompressed_file_path)) <<
-    "Expected decompressed file: \"" << decompressed_file_path.string() <<
+    "Expected decompressed file: \"" << decompressed_file_path.generic_string() <<
     "\" to exist.";
 
   const auto decompressed_file_size = fs::file_size(decompressed_file_path);
@@ -202,7 +202,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_uri)
 
 TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
 {
-  const auto uri = (fs::path(temporary_dir_path_) / "file2.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file2.txt").generic_string();
   create_garbage_file(uri);
 
   const auto initial_file_path = fs::path{uri};
@@ -231,7 +231,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
   const auto decompressed_file_path = fs::path{decompressed_uri};
 
   ASSERT_TRUE(fs::exists(decompressed_file_path)) <<
-    "Decompressed file: \"" << decompressed_file_path.string() << "\" must exist!";
+    "Decompressed file: \"" << decompressed_file_path.generic_string() << "\" must exist!";
 
   EXPECT_EQ(uri, decompressed_uri) <<
     "Expected decompressed file name to be same as initial!";
@@ -252,7 +252,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_file_contents)
 
 TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_file)
 {
-  const auto uri = (fs::path(temporary_dir_path_) / "file3.txt").string();
+  const auto uri = (fs::path(temporary_dir_path_) / "file3.txt").generic_string();
   create_garbage_file(uri);
 
   auto decompressor = rosbag2_compression_zstd::ZstdDecompressor{};
@@ -262,7 +262,7 @@ TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_file)
 
 TEST_F(CompressionHelperFixture, zstd_decompress_fails_on_bad_uri)
 {
-  const auto bad_uri = (fs::path(temporary_dir_path_) / "bad_uri.txt").string();
+  const auto bad_uri = (fs::path(temporary_dir_path_) / "bad_uri.txt").generic_string();
   auto decompressor = rosbag2_compression_zstd::ZstdDecompressor{};
 
   EXPECT_THROW(decompressor.decompress_uri(bad_uri), std::runtime_error) <<

--- a/rosbag2_cpp/include/rosbag2_cpp/reindexer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reindexer.hpp
@@ -23,12 +23,11 @@
 #ifndef ROSBAG2_CPP__REINDEXER_HPP_
 #define ROSBAG2_CPP__REINDEXER_HPP_
 
+#include <filesystem>
 #include <memory>
 #include <regex>
 #include <string>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/converter.hpp"
 #include "rosbag2_cpp/reader.hpp"
@@ -91,27 +90,27 @@ protected:
 
 private:
   std::string regex_bag_pattern_;
-  rcpputils::fs::path base_folder_;   // The folder that the bag files are in
+  std::filesystem::path base_folder_;   // The folder that the bag files are in
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
   void get_bag_files(
-    const rcpputils::fs::path & base_folder,
-    std::vector<rcpputils::fs::path> & output);
+    const std::filesystem::path & base_folder,
+    std::vector<std::filesystem::path> & output);
 
   // Prepares the metadata by setting initial values.
   void init_metadata(
-    const std::vector<rcpputils::fs::path> & files,
+    const std::vector<std::filesystem::path> & files,
     const rosbag2_storage::StorageOptions & storage_options);
 
   // Attempts to harvest metadata from all bag files, and aggregates the result
   void aggregate_metadata(
-    const std::vector<rcpputils::fs::path> & files,
+    const std::vector<std::filesystem::path> & files,
     const std::unique_ptr<rosbag2_cpp::readers::SequentialReader> & bag_reader,
     const rosbag2_storage::StorageOptions & storage_options);
 
   // Comparison function for std::sort with our filepath convention
   bool compare_relative_file(
-    const rcpputils::fs::path & first_path,
-    const rcpputils::fs::path & second_path);
+    const std::filesystem::path & first_path,
+    const std::filesystem::path & second_path);
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/info.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/info.cpp
@@ -22,12 +22,13 @@
 
 #include "rmw/rmw.h"
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 #include "service_msgs/msg/service_event_info.hpp"
 
 #include "rosbag2_cpp/service_utils.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
+
+namespace fs = std::filesystem;
 
 namespace rosbag2_cpp
 {
@@ -35,8 +36,8 @@ namespace rosbag2_cpp
 rosbag2_storage::BagMetadata Info::read_metadata(
   const std::string & uri, const std::string & storage_id)
 {
-  const std::filesystem::path bag_path{uri};
-  if (!std::filesystem::exists(bag_path)) {
+  const fs::path bag_path{uri};
+  if (!fs::exists(bag_path)) {
     throw std::runtime_error("Bag path " + uri + " does not exist.");
   }
 
@@ -45,7 +46,7 @@ rosbag2_storage::BagMetadata Info::read_metadata(
     return metadata_io.read_metadata(uri);
   }
 
-  if (std::filesystem::is_directory(bag_path)) {
+  if (fs::is_directory(bag_path)) {
     throw std::runtime_error("Could not find metadata in bag directory " + uri);
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/info.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/info.cpp
@@ -14,6 +14,7 @@
 
 #include "rosbag2_cpp/info.hpp"
 
+#include <filesystem>
 #include <unordered_map>
 #include <unordered_set>
 #include <stdexcept>
@@ -34,8 +35,8 @@ namespace rosbag2_cpp
 rosbag2_storage::BagMetadata Info::read_metadata(
   const std::string & uri, const std::string & storage_id)
 {
-  const rcpputils::fs::path bag_path{uri};
-  if (!bag_path.exists()) {
+  const std::filesystem::path bag_path{uri};
+  if (!std::filesystem::exists(bag_path)) {
     throw std::runtime_error("Bag path " + uri + " does not exist.");
   }
 
@@ -44,7 +45,7 @@ rosbag2_storage::BagMetadata Info::read_metadata(
     return metadata_io.read_metadata(uri);
   }
 
-  if (bag_path.is_directory()) {
+  if (std::filesystem::is_directory(bag_path)) {
     throw std::runtime_error("Could not find metadata in bag directory " + uri);
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -24,6 +24,7 @@
 #include "rosbag2_cpp/logging.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
 
+namespace fs = std::filesystem;
 
 namespace rosbag2_cpp
 {
@@ -34,19 +35,19 @@ namespace details
 std::vector<std::string> resolve_relative_paths(
   const std::string & base_folder, std::vector<std::string> relative_files, const int version = 4)
 {
-  auto base_path = std::filesystem::path(base_folder);
+  auto base_path = fs::path(base_folder);
   if (version < 4) {
     // In older rosbags (version <=3) relative files are prefixed with the rosbag folder name
-    base_path = std::filesystem::path(base_folder).parent_path();
+    base_path = fs::path(base_folder).parent_path();
   }
 
   rcpputils::require_true(
-    std::filesystem::exists(base_path), "base folder does not exist: " + base_folder);
+    fs::exists(base_path), "base folder does not exist: " + base_folder);
   rcpputils::require_true(
-    std::filesystem::is_directory(base_path), "base folder has to be a directory: " + base_folder);
+    fs::is_directory(base_path), "base folder has to be a directory: " + base_folder);
 
   for (auto & file : relative_files) {
-    auto path = std::filesystem::path(file);
+    auto path = fs::path(file);
     if (path.is_absolute()) {
       continue;
     }
@@ -307,8 +308,8 @@ std::string SequentialReader::get_current_file() const
 std::string SequentialReader::get_current_uri() const
 {
   auto current_file = get_current_file();
-  auto current_uri = std::filesystem::path(current_file).stem();
-  return current_uri.string();
+  auto current_uri = fs::path(current_file).stem();
+  return current_uri.generic_string();
 }
 
 void SequentialReader::check_topics_serialization_formats(

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -19,7 +20,6 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/logging.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
@@ -34,23 +34,23 @@ namespace details
 std::vector<std::string> resolve_relative_paths(
   const std::string & base_folder, std::vector<std::string> relative_files, const int version = 4)
 {
-  auto base_path = rcpputils::fs::path(base_folder);
+  auto base_path = std::filesystem::path(base_folder);
   if (version < 4) {
     // In older rosbags (version <=3) relative files are prefixed with the rosbag folder name
-    base_path = rcpputils::fs::path(base_folder).parent_path();
+    base_path = std::filesystem::path(base_folder).parent_path();
   }
 
   rcpputils::require_true(
-    base_path.exists(), "base folder does not exist: " + base_folder);
+    std::filesystem::exists(base_path), "base folder does not exist: " + base_folder);
   rcpputils::require_true(
-    base_path.is_directory(), "base folder has to be a directory: " + base_folder);
+    std::filesystem::is_directory(base_path), "base folder has to be a directory: " + base_folder);
 
   for (auto & file : relative_files) {
-    auto path = rcpputils::fs::path(file);
+    auto path = std::filesystem::path(file);
     if (path.is_absolute()) {
       continue;
     }
-    file = (base_path / path).string();
+    file = (base_path / path).generic_string();
   }
 
   return relative_files;
@@ -307,7 +307,7 @@ std::string SequentialReader::get_current_file() const
 std::string SequentialReader::get_current_uri() const
 {
   auto current_file = get_current_file();
-  auto current_uri = rcpputils::fs::remove_extension(current_file);
+  auto current_uri = std::filesystem::path(current_file).stem();
   return current_uri.string();
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -34,6 +34,8 @@
 #include "rosbag2_storage/default_storage_id.hpp"
 #include "rosbag2_storage/storage_options.hpp"
 
+namespace fs = std::filesystem;
+
 namespace rosbag2_cpp
 {
 namespace writers
@@ -43,7 +45,7 @@ namespace
 {
 std::string strip_parent_path(const std::string & relative_path)
 {
-  return std::filesystem::path(relative_path).filename().generic_string();
+  return fs::path(relative_path).filename().generic_string();
 }
 }  // namespace
 
@@ -107,15 +109,15 @@ void SequentialWriter::open(
     converter_ = std::make_unique<Converter>(converter_options, converter_factory_);
   }
 
-  std::filesystem::path storage_path(storage_options.uri);
-  if (std::filesystem::is_directory(storage_path)) {
+  fs::path storage_path(storage_options.uri);
+  if (fs::is_directory(storage_path)) {
     std::stringstream error;
     error << "Bag directory already exists (" << storage_path.string() <<
       "), can't overwrite existing bag";
     throw std::runtime_error{error.str()};
   }
 
-  bool dir_created = std::filesystem::create_directories(storage_path);
+  bool dir_created = fs::create_directories(storage_path);
   if (!dir_created) {
     std::stringstream error;
     error << "Failed to create bag directory (" << storage_path.string() << ").";
@@ -287,10 +289,10 @@ std::string SequentialWriter::format_storage_uri(
   // The name of the folder needs to be queried in case
   // SequentialWriter is opened with a relative path.
   std::stringstream storage_file_name;
-  storage_file_name << std::filesystem::path(base_folder).filename().generic_string() << "_" <<
+  storage_file_name << fs::path(base_folder).filename().generic_string() << "_" <<
     storage_count;
 
-  return (std::filesystem::path(base_folder) / storage_file_name.str()).generic_string();
+  return (fs::path(base_folder) / storage_file_name.str()).generic_string();
 }
 
 void SequentialWriter::switch_to_next_storage()
@@ -469,10 +471,10 @@ void SequentialWriter::finalize_metadata()
   metadata_.bag_size = 0;
 
   for (const auto & path : metadata_.relative_file_paths) {
-    const auto bag_path = std::filesystem::path{path};
+    const auto bag_path = fs::path{path};
 
-    if (std::filesystem::exists(bag_path)) {
-      metadata_.bag_size += std::filesystem::file_size(bag_path);
+    if (fs::exists(bag_path)) {
+      metadata_.bag_size += fs::file_size(bag_path);
     }
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -25,7 +26,6 @@
 #include <vector>
 
 #include "rcpputils/env.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/logging.hpp"
@@ -43,7 +43,7 @@ namespace
 {
 std::string strip_parent_path(const std::string & relative_path)
 {
-  return rcpputils::fs::path(relative_path).filename().string();
+  return std::filesystem::path(relative_path).filename().generic_string();
 }
 }  // namespace
 
@@ -107,15 +107,15 @@ void SequentialWriter::open(
     converter_ = std::make_unique<Converter>(converter_options, converter_factory_);
   }
 
-  rcpputils::fs::path storage_path(storage_options.uri);
-  if (storage_path.is_directory()) {
+  std::filesystem::path storage_path(storage_options.uri);
+  if (std::filesystem::is_directory(storage_path)) {
     std::stringstream error;
     error << "Bag directory already exists (" << storage_path.string() <<
       "), can't overwrite existing bag";
     throw std::runtime_error{error.str()};
   }
 
-  bool dir_created = rcpputils::fs::create_directories(storage_path);
+  bool dir_created = std::filesystem::create_directories(storage_path);
   if (!dir_created) {
     std::stringstream error;
     error << "Failed to create bag directory (" << storage_path.string() << ").";
@@ -287,9 +287,10 @@ std::string SequentialWriter::format_storage_uri(
   // The name of the folder needs to be queried in case
   // SequentialWriter is opened with a relative path.
   std::stringstream storage_file_name;
-  storage_file_name << rcpputils::fs::path(base_folder).filename().string() << "_" << storage_count;
+  storage_file_name << std::filesystem::path(base_folder).filename().generic_string() << "_" <<
+    storage_count;
 
-  return (rcpputils::fs::path(base_folder) / storage_file_name.str()).string();
+  return (std::filesystem::path(base_folder) / storage_file_name.str()).generic_string();
 }
 
 void SequentialWriter::switch_to_next_storage()
@@ -468,10 +469,10 @@ void SequentialWriter::finalize_metadata()
   metadata_.bag_size = 0;
 
   for (const auto & path : metadata_.relative_file_paths) {
-    const auto bag_path = rcpputils::fs::path{path};
+    const auto bag_path = std::filesystem::path{path};
 
-    if (bag_path.exists()) {
-      metadata_.bag_size += bag_path.file_size();
+    if (std::filesystem::exists(bag_path)) {
+      metadata_.bag_size += std::filesystem::file_size(bag_path);
     }
   }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -14,12 +14,11 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/writer.hpp"
@@ -62,8 +61,8 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_2) 
 
   {
     std::ofstream fout {
-      (rcpputils::fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
-      .string()};
+      (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+      .generic_string()};
     fout << bagfile;
   }
 
@@ -150,8 +149,8 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_6) 
 
   {
     std::ofstream fout {
-      (rcpputils::fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
-      .string()};
+      (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+      .generic_string()};
     fout << bagfile;
   }
 
@@ -240,8 +239,8 @@ TEST_P(
     "  compression_mode: \"FILE\"\n");
 
   std::ofstream fout {
-    (rcpputils::fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
-    .string()};
+    (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+    .generic_string()};
   fout << bagfile;
   fout.close();
 
@@ -293,13 +292,13 @@ TEST_P(
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, info_for_standalone_bagfile) {
   const auto storage_id = GetParam();
-  const auto bag_path = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  const auto bag_path = std::filesystem::path(temporary_dir_path_) / "bag";
   {
     // Create an empty bag with default storage
     rosbag2_cpp::Writer writer;
     rosbag2_storage::StorageOptions storage_options;
     storage_options.storage_id = storage_id;
-    storage_options.uri = bag_path.string();
+    storage_options.uri = bag_path.generic_string();
     writer.open(storage_options);
     test_msgs::msg::BasicTypes msg;
     writer.write(msg, "testtopic", rclcpp::Time{});

--- a/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_info.cpp
@@ -33,6 +33,7 @@
 
 using namespace ::testing;  // NOLINT
 using rosbag2_test_common::ParametrizedTemporaryDirectoryFixture;
+namespace fs = std::filesystem;
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_2) {
   const auto expected_storage_id = GetParam();
@@ -61,7 +62,7 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_2) 
 
   {
     std::ofstream fout {
-      (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+      (fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
       .generic_string()};
     fout << bagfile;
   }
@@ -149,7 +150,7 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, read_metadata_supports_version_6) 
 
   {
     std::ofstream fout {
-      (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+      (fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
       .generic_string()};
     fout << bagfile;
   }
@@ -239,7 +240,7 @@ TEST_P(
     "  compression_mode: \"FILE\"\n");
 
   std::ofstream fout {
-    (std::filesystem::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
+    (fs::path(temporary_dir_path_) / rosbag2_storage::MetadataIo::metadata_filename)
     .generic_string()};
   fout << bagfile;
   fout.close();
@@ -292,7 +293,7 @@ TEST_P(
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, info_for_standalone_bagfile) {
   const auto storage_id = GetParam();
-  const auto bag_path = std::filesystem::path(temporary_dir_path_) / "bag";
+  const auto bag_path = fs::path(temporary_dir_path_) / "bag";
   {
     // Create an empty bag with default storage
     rosbag2_cpp::Writer writer;

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -32,6 +32,7 @@
 #include "mock_storage_factory.hpp"
 
 using namespace testing;  // NOLINT
+namespace fs = std::filesystem;
 
 class MultifileReaderTest : public Test
 {
@@ -40,10 +41,10 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
-    storage_uri_(std::filesystem::temp_directory_path().generic_string()),
+    storage_uri_(fs::temp_directory_path().generic_string()),
     relative_path_1_("some_relative_path_1"),
     relative_path_2_("some_relative_path_2"),
-    absolute_path_1_((std::filesystem::path(storage_uri_) / "some/folder").generic_string()),
+    absolute_path_1_((fs::path(storage_uri_) / "some/folder").generic_string()),
     default_storage_options_({storage_uri_, ""})
   {}
 
@@ -107,7 +108,7 @@ public:
   {
     relative_path_1_ = "rosbag_name/some_relative_path_1";
     relative_path_2_ = "rosbag_name/some_relative_path_2";
-    absolute_path_1_ = (std::filesystem::path(storage_uri_) / "some/folder").generic_string();
+    absolute_path_1_ = (fs::path(storage_uri_) / "some/folder").generic_string();
   }
 
   rosbag2_storage::BagMetadata get_metadata() const override
@@ -137,11 +138,11 @@ TEST_F(MultifileReaderTest, has_next_reads_next_file)
     reader_->get_implementation_handle());
 
   auto resolved_relative_path_1 =
-    (std::filesystem::path(storage_uri_) / relative_path_1_).generic_string();
+    (fs::path(storage_uri_) / relative_path_1_).generic_string();
   auto resolved_relative_path_2 =
-    (std::filesystem::path(storage_uri_) / relative_path_2_).generic_string();
+    (fs::path(storage_uri_) / relative_path_2_).generic_string();
   auto resolved_absolute_path_1 =
-    std::filesystem::path(absolute_path_1_).generic_string();
+    fs::path(absolute_path_1_).generic_string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->read_next();  // calls has_next false then true
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);
@@ -169,11 +170,11 @@ TEST_F(MultifileReaderTestVersion3, has_next_reads_next_file_version3)
 
   // Legacy version <=3 have a parent_path() prefixed in the relative files
   auto resolved_relative_path_1 =
-    (std::filesystem::path(storage_uri_).parent_path() / relative_path_1_).generic_string();
+    (fs::path(storage_uri_).parent_path() / relative_path_1_).generic_string();
   auto resolved_relative_path_2 =
-    (std::filesystem::path(storage_uri_).parent_path() / relative_path_2_).generic_string();
+    (fs::path(storage_uri_).parent_path() / relative_path_2_).generic_string();
   auto resolved_absolute_path_1 =
-    std::filesystem::path(absolute_path_1_).generic_string();
+    fs::path(absolute_path_1_).generic_string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->read_next();  // calls has_next false then true
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_multifile_reader.cpp
@@ -14,12 +14,11 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
@@ -41,10 +40,10 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
-    storage_uri_(rcpputils::fs::temp_directory_path().string()),
+    storage_uri_(std::filesystem::temp_directory_path().generic_string()),
     relative_path_1_("some_relative_path_1"),
     relative_path_2_("some_relative_path_2"),
-    absolute_path_1_((rcpputils::fs::path(storage_uri_) / "some/folder").string()),
+    absolute_path_1_((std::filesystem::path(storage_uri_) / "some/folder").generic_string()),
     default_storage_options_({storage_uri_, ""})
   {}
 
@@ -108,7 +107,7 @@ public:
   {
     relative_path_1_ = "rosbag_name/some_relative_path_1";
     relative_path_2_ = "rosbag_name/some_relative_path_2";
-    absolute_path_1_ = (rcpputils::fs::path(storage_uri_) / "some/folder").string();
+    absolute_path_1_ = (std::filesystem::path(storage_uri_) / "some/folder").generic_string();
   }
 
   rosbag2_storage::BagMetadata get_metadata() const override
@@ -138,11 +137,11 @@ TEST_F(MultifileReaderTest, has_next_reads_next_file)
     reader_->get_implementation_handle());
 
   auto resolved_relative_path_1 =
-    (rcpputils::fs::path(storage_uri_) / relative_path_1_).string();
+    (std::filesystem::path(storage_uri_) / relative_path_1_).generic_string();
   auto resolved_relative_path_2 =
-    (rcpputils::fs::path(storage_uri_) / relative_path_2_).string();
+    (std::filesystem::path(storage_uri_) / relative_path_2_).generic_string();
   auto resolved_absolute_path_1 =
-    rcpputils::fs::path(absolute_path_1_).string();
+    std::filesystem::path(absolute_path_1_).generic_string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->read_next();  // calls has_next false then true
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);
@@ -170,11 +169,11 @@ TEST_F(MultifileReaderTestVersion3, has_next_reads_next_file_version3)
 
   // Legacy version <=3 have a parent_path() prefixed in the relative files
   auto resolved_relative_path_1 =
-    (rcpputils::fs::path(storage_uri_).parent_path() / relative_path_1_).string();
+    (std::filesystem::path(storage_uri_).parent_path() / relative_path_1_).generic_string();
   auto resolved_relative_path_2 =
-    (rcpputils::fs::path(storage_uri_).parent_path() / relative_path_2_).string();
+    (std::filesystem::path(storage_uri_).parent_path() / relative_path_2_).generic_string();
   auto resolved_absolute_path_1 =
-    rcpputils::fs::path(absolute_path_1_).string();
+    std::filesystem::path(absolute_path_1_).generic_string();
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_1);
   reader_->read_next();  // calls has_next false then true
   EXPECT_EQ(sr.get_current_file(), resolved_relative_path_2);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -221,8 +221,8 @@ TEST_F(SequentialReaderTest, next_file_calls_callback) {
   reader_->read_next();
 
   ASSERT_TRUE(callback_called);
-  EXPECT_EQ(closed_file, bag_file_1_path_.string());
-  EXPECT_EQ(opened_file, bag_file_2_path_.string());
+  EXPECT_EQ(closed_file, bag_file_1_path_.generic_string());
+  EXPECT_EQ(opened_file, bag_file_2_path_.generic_string());
 }
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, reader_accepts_bare_file) {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -43,6 +43,7 @@
 
 using namespace testing;  // NOLINT
 using rosbag2_test_common::ParametrizedTemporaryDirectoryFixture;
+namespace fs = std::filesystem;
 
 class SequentialReaderTest : public Test
 {
@@ -51,7 +52,7 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
-    storage_uri_(std::filesystem::temp_directory_path().generic_string()),
+    storage_uri_(fs::temp_directory_path().generic_string()),
     default_storage_options_({storage_uri_, "mock_storage"})
   {
     rosbag2_storage::TopicMetadata topic_with_type;
@@ -65,13 +66,15 @@ public:
     message->topic_name = topic_with_type.name;
 
     relative_file_path_ =
-      (std::filesystem::path(storage_uri_) / "some/folder").generic_string();
+      (fs::path(storage_uri_) / "some/folder").generic_string();
     auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
     bag_file_1_path_ = relative_file_path_ / "bag_file1";
     bag_file_2_path_ = relative_file_path_ / "bag_file2";
-    metadata_.relative_file_paths =
-    {bag_file_1_path_.generic_string(), bag_file_2_path_.generic_string()};
+    metadata_.relative_file_paths = {
+      bag_file_1_path_.generic_string(),
+      bag_file_2_path_.generic_string()
+    };
     metadata_.version = 4;
     metadata_.topics_with_message_count.push_back({{topic_with_type}, 6});
     metadata_.storage_identifier = "mock_storage";
@@ -121,9 +124,9 @@ public:
   std::string storage_serialization_format_;
   std::string storage_uri_;
   rosbag2_storage::BagMetadata metadata_;
-  std::filesystem::path relative_file_path_;
-  std::filesystem::path bag_file_1_path_;
-  std::filesystem::path bag_file_2_path_;
+  fs::path relative_file_path_;
+  fs::path bag_file_1_path_;
+  fs::path bag_file_2_path_;
   rosbag2_storage::StorageOptions default_storage_options_;
   size_t num_next_ = 0;
 };
@@ -223,7 +226,7 @@ TEST_F(SequentialReaderTest, next_file_calls_callback) {
 }
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, reader_accepts_bare_file) {
-  const auto bag_path = std::filesystem::path(temporary_dir_path_) / "bag";
+  const auto bag_path = fs::path(temporary_dir_path_) / "bag";
   const auto storage_id = GetParam();
 
   {
@@ -259,7 +262,7 @@ public:
   ReadOrderTest()
   {
     storage_options.uri =
-      (std::filesystem::path(temporary_dir_path_) / "ordertest").generic_string();
+      (fs::path(temporary_dir_path_) / "ordertest").generic_string();
     storage_options.storage_id = GetParam();
     write_sample_split_bag(storage_options, fake_messages, split_every);
   }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -14,12 +14,11 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
 #include "rosbag2_cpp/reader.hpp"
@@ -52,7 +51,7 @@ public:
   : storage_(std::make_shared<NiceMock<MockStorage>>()),
     converter_factory_(std::make_shared<StrictMock<MockConverterFactory>>()),
     storage_serialization_format_("rmw1_format"),
-    storage_uri_(rcpputils::fs::temp_directory_path().string()),
+    storage_uri_(std::filesystem::temp_directory_path().generic_string()),
     default_storage_options_({storage_uri_, "mock_storage"})
   {
     rosbag2_storage::TopicMetadata topic_with_type;
@@ -66,12 +65,13 @@ public:
     message->topic_name = topic_with_type.name;
 
     relative_file_path_ =
-      (rcpputils::fs::path(storage_uri_) / "some/folder").string();
+      (std::filesystem::path(storage_uri_) / "some/folder").generic_string();
     auto storage_factory = std::make_unique<StrictMock<MockStorageFactory>>();
     auto metadata_io = std::make_unique<NiceMock<MockMetadataIo>>();
     bag_file_1_path_ = relative_file_path_ / "bag_file1";
     bag_file_2_path_ = relative_file_path_ / "bag_file2";
-    metadata_.relative_file_paths = {bag_file_1_path_.string(), bag_file_2_path_.string()};
+    metadata_.relative_file_paths =
+    {bag_file_1_path_.generic_string(), bag_file_2_path_.generic_string()};
     metadata_.version = 4;
     metadata_.topics_with_message_count.push_back({{topic_with_type}, 6});
     metadata_.storage_identifier = "mock_storage";
@@ -121,9 +121,9 @@ public:
   std::string storage_serialization_format_;
   std::string storage_uri_;
   rosbag2_storage::BagMetadata metadata_;
-  rcpputils::fs::path relative_file_path_;
-  rcpputils::fs::path bag_file_1_path_;
-  rcpputils::fs::path bag_file_2_path_;
+  std::filesystem::path relative_file_path_;
+  std::filesystem::path bag_file_1_path_;
+  std::filesystem::path bag_file_2_path_;
   rosbag2_storage::StorageOptions default_storage_options_;
   size_t num_next_ = 0;
 };
@@ -223,25 +223,25 @@ TEST_F(SequentialReaderTest, next_file_calls_callback) {
 }
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, reader_accepts_bare_file) {
-  const auto bag_path = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  const auto bag_path = std::filesystem::path(temporary_dir_path_) / "bag";
   const auto storage_id = GetParam();
 
   {
     // Create an empty bag with default storage
     rosbag2_cpp::Writer writer;
     rosbag2_storage::StorageOptions options;
-    options.uri = bag_path.string();
+    options.uri = bag_path.generic_string();
     options.storage_id = storage_id;
     writer.open(options);
     test_msgs::msg::BasicTypes msg;
     writer.write(msg, "testtopic", rclcpp::Time{});
   }
   rosbag2_storage::MetadataIo metadata_io;
-  auto metadata = metadata_io.read_metadata(bag_path.string());
+  auto metadata = metadata_io.read_metadata(bag_path.generic_string());
   auto first_storage = bag_path / metadata.relative_file_paths[0];
 
   rosbag2_cpp::Reader reader;
-  EXPECT_NO_THROW(reader.open(first_storage.string()));
+  EXPECT_NO_THROW(reader.open(first_storage.generic_string()));
   EXPECT_TRUE(reader.has_next());
   EXPECT_THAT(reader.get_metadata().topics_with_message_count, SizeIs(1));
 }
@@ -258,7 +258,8 @@ class ReadOrderTest : public ParametrizedTemporaryDirectoryFixture
 public:
   ReadOrderTest()
   {
-    storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "ordertest").string();
+    storage_options.uri =
+      (std::filesystem::path(temporary_dir_path_) / "ordertest").generic_string();
     storage_options.storage_id = GetParam();
     write_sample_split_bag(storage_options, fake_messages, split_every);
   }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -14,13 +14,12 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
 #include "rosbag2_cpp/writer.hpp"
@@ -54,8 +53,8 @@ public:
     storage_options_ = rosbag2_storage::StorageOptions{};
     storage_options_.uri = "uri";
 
-    rcpputils::fs::path dir(storage_options_.uri);
-    rcpputils::fs::remove_all(dir);
+    std::filesystem::path dir(storage_options_.uri);
+    std::filesystem::remove_all(dir);
 
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(
       DoAll(
@@ -77,8 +76,8 @@ public:
 
   ~SequentialWriterTest() override
   {
-    rcpputils::fs::path dir(storage_options_.uri);
-    rcpputils::fs::remove_all(dir);
+    std::filesystem::path dir(storage_options_.uri);
+    std::filesystem::remove_all(dir);
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
@@ -637,8 +636,9 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
   }
 
   ASSERT_TRUE(callback_called);
-  auto expected_closed = rcpputils::fs::path(storage_options_.uri) / (storage_options_.uri + "_0");
-  EXPECT_EQ(closed_file, expected_closed.string());
+  auto expected_closed = std::filesystem::path(storage_options_.uri) /
+    (storage_options_.uri + "_0");
+  EXPECT_EQ(closed_file, expected_closed.generic_string());
   EXPECT_EQ(opened_file, fake_storage_uri_);
 }
 
@@ -697,8 +697,9 @@ TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
   writer_->close();
 
   ASSERT_TRUE(callback_called);
-  auto expected_closed = rcpputils::fs::path(storage_options_.uri) / (storage_options_.uri + "_0");
-  EXPECT_EQ(closed_file, expected_closed.string());
+  auto expected_closed = std::filesystem::path(storage_options_.uri) /
+    (storage_options_.uri + "_0");
+  EXPECT_EQ(closed_file, expected_closed.generic_string());
   EXPECT_TRUE(opened_file.empty());
 }
 
@@ -712,7 +713,8 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, split_bag_metadata_has_full_durati
     {600, 6}
   };
   rosbag2_storage::StorageOptions storage_options;
-  storage_options.uri = (rcpputils::fs::path(temporary_dir_path_) / "split_duration_bag").string();
+  storage_options.uri =
+    (std::filesystem::path(temporary_dir_path_) / "split_duration_bag").generic_string();
   storage_options.storage_id = GetParam();
   write_sample_split_bag(storage_options, fake_messages, 3);
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -40,6 +40,7 @@
 
 using namespace testing;  // NOLINT
 using rosbag2_test_common::ParametrizedTemporaryDirectoryFixture;
+namespace fs = std::filesystem;
 
 class SequentialWriterTest : public Test
 {
@@ -53,8 +54,8 @@ public:
     storage_options_ = rosbag2_storage::StorageOptions{};
     storage_options_.uri = "uri";
 
-    std::filesystem::path dir(storage_options_.uri);
-    std::filesystem::remove_all(dir);
+    fs::path dir(storage_options_.uri);
+    fs::remove_all(dir);
 
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(
       DoAll(
@@ -76,8 +77,8 @@ public:
 
   ~SequentialWriterTest() override
   {
-    std::filesystem::path dir(storage_options_.uri);
-    std::filesystem::remove_all(dir);
+    fs::path dir(storage_options_.uri);
+    fs::remove_all(dir);
   }
 
   std::unique_ptr<StrictMock<MockStorageFactory>> storage_factory_;
@@ -636,7 +637,7 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
   }
 
   ASSERT_TRUE(callback_called);
-  auto expected_closed = std::filesystem::path(storage_options_.uri) /
+  auto expected_closed = fs::path(storage_options_.uri) /
     (storage_options_.uri + "_0");
   EXPECT_EQ(closed_file, expected_closed.generic_string());
   EXPECT_EQ(opened_file, fake_storage_uri_);
@@ -697,7 +698,7 @@ TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
   writer_->close();
 
   ASSERT_TRUE(callback_called);
-  auto expected_closed = std::filesystem::path(storage_options_.uri) /
+  auto expected_closed = fs::path(storage_options_.uri) /
     (storage_options_.uri + "_0");
   EXPECT_EQ(closed_file, expected_closed.generic_string());
   EXPECT_TRUE(opened_file.empty());
@@ -714,7 +715,7 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, split_bag_metadata_has_full_durati
   };
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri =
-    (std::filesystem::path(temporary_dir_path_) / "split_duration_bag").generic_string();
+    (fs::path(temporary_dir_path_) / "split_duration_bag").generic_string();
   storage_options.storage_id = GetParam();
   write_sample_split_bag(storage_options, fake_messages, 3);
 

--- a/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/metadata_io.cpp
@@ -24,6 +24,8 @@
 #include "rosbag2_storage/topic_metadata.hpp"
 #include "rosbag2_storage/yaml.hpp"
 
+namespace fs = std::filesystem;
+
 namespace rosbag2_storage
 {
 
@@ -55,14 +57,14 @@ BagMetadata MetadataIo::read_metadata(const std::string & uri)
 
 std::string MetadataIo::get_metadata_file_name(const std::string & uri)
 {
-  std::string metadata_file = (std::filesystem::path(uri) / metadata_filename).generic_string();
+  std::string metadata_file = (fs::path(uri) / metadata_filename).generic_string();
 
   return metadata_file;
 }
 
 bool MetadataIo::metadata_file_exists(const std::string & uri)
 {
-  return std::filesystem::exists(std::filesystem::path(get_metadata_file_name(uri)));
+  return fs::exists(fs::path(get_metadata_file_name(uri)));
 }
 
 std::string MetadataIo::serialize_metadata(const BagMetadata & metadata)

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -17,7 +17,6 @@
 
 #include <gmock/gmock.h>
 
-#include <filesystem>
 #include <string>
 
 #include "rcpputils/filesystem_helper.hpp"
@@ -37,7 +36,7 @@ public:
 
   ~TemporaryDirectoryFixture() override
   {
-    std::filesystem::remove_all(std::filesystem::path(temporary_dir_path_));
+    rcpputils::fs::remove_all(rcpputils::fs::path(temporary_dir_path_));
   }
 
   std::string temporary_dir_path_;

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -20,6 +20,8 @@
 #include <filesystem>
 #include <string>
 
+#include "rcpputils/filesystem_helper.hpp"
+
 using namespace ::testing;  // NOLINT
 
 namespace rosbag2_test_common
@@ -30,7 +32,7 @@ class TemporaryDirectoryFixture : public Test
 public:
   TemporaryDirectoryFixture()
   {
-    temporary_dir_path_ = std::filesystem::temp_directory_path().generic_string();
+    temporary_dir_path_ = rcpputils::fs::create_temp_directory("tmp_test_dir_").string();
   }
 
   ~TemporaryDirectoryFixture() override

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -17,9 +17,8 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <string>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 using namespace ::testing;  // NOLINT
 
@@ -31,12 +30,12 @@ class TemporaryDirectoryFixture : public Test
 public:
   TemporaryDirectoryFixture()
   {
-    temporary_dir_path_ = rcpputils::fs::create_temp_directory("tmp_test_dir_").string();
+    temporary_dir_path_ = std::filesystem::temp_directory_path().generic_string();
   }
 
   ~TemporaryDirectoryFixture() override
   {
-    rcpputils::fs::remove_all(rcpputils::fs::path(temporary_dir_path_));
+    std::filesystem::remove_all(std::filesystem::path(temporary_dir_path_));
   }
 
   std::string temporary_dir_path_;

--- a/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
+++ b/rosbag2_tests/test/rosbag2_tests/record_fixture.hpp
@@ -17,13 +17,12 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <future>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -50,12 +49,12 @@ public:
   void SetUp() override
   {
     auto bag_name = get_test_name() + "_" + GetParam();
-    root_bag_path_ = rcpputils::fs::path(temporary_dir_path_) / bag_name;
+    root_bag_path_ = std::filesystem::path(temporary_dir_path_) / bag_name;
 
     // Clean up potentially leftover bag files.
     // There may be leftovers if the system reallocates a temp directory
     // used by a previous test execution and the test did not have a clean exit.
-    rcpputils::fs::remove_all(root_bag_path_);
+    std::filesystem::remove_all(root_bag_path_);
   }
 
   static void SetUpTestCase()
@@ -65,7 +64,7 @@ public:
 
   void TearDown() override
   {
-    rcpputils::fs::remove_all(root_bag_path_);
+    std::filesystem::remove_all(root_bag_path_);
   }
 
   static void TearDownTestCase()
@@ -75,7 +74,8 @@ public:
 
   std::string get_base_record_command() const
   {
-    return "ros2 bag record --storage " + GetParam() + " --output " + root_bag_path_.string();
+    return "ros2 bag record --storage " + GetParam() + " --output " +
+           root_bag_path_.generic_string();
   }
 
   std::string get_test_name() const
@@ -95,20 +95,20 @@ public:
     return bag_file_name.str();
   }
 
-  rcpputils::fs::path get_compressed_bag_file_path(int split_index)
+  std::filesystem::path get_compressed_bag_file_path(int split_index)
   {
-    return rcpputils::fs::path(get_bag_file_path(split_index).string() + ".zstd");
+    return std::filesystem::path(get_bag_file_path(split_index).generic_string() + ".zstd");
   }
 
-  rcpputils::fs::path get_bag_file_path(int split_index)
+  std::filesystem::path get_bag_file_path(int split_index)
   {
     return root_bag_path_ / get_relative_bag_file_path(split_index);
   }
 
-  rcpputils::fs::path get_relative_bag_file_path(int split_index)
+  std::filesystem::path get_relative_bag_file_path(int split_index)
   {
     const auto storage_id = GetParam();
-    return rcpputils::fs::path(
+    return std::filesystem::path(
       rosbag2_test_common::bag_filename_for_storage_id(
         get_bag_file_name(split_index), storage_id));
   }
@@ -117,7 +117,7 @@ public:
   {
     rosbag2_storage::MetadataIo metadata_io;
     const auto start_time = std::chrono::steady_clock::now();
-    const auto bag_path = root_bag_path_.string();
+    const auto bag_path = root_bag_path_.generic_string();
 
     while (std::chrono::steady_clock::now() - start_time < timeout && rclcpp::ok()) {
       if (metadata_io.metadata_file_exists(bag_path)) {
@@ -134,13 +134,13 @@ public:
     const auto storage_path = get_bag_file_path(0);
     const auto start_time = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - start_time < timeout && rclcpp::ok()) {
-      if (storage_path.exists()) {
+      if (std::filesystem::exists(storage_path)) {
         return;
       }
       std::this_thread::sleep_for(50ms);  // wait a bit to not query constantly
     }
-    ASSERT_EQ(storage_path.exists(), true)
-      << "Could not find storage file: \"" << storage_path.string() << "\"";
+    ASSERT_EQ(std::filesystem::exists(storage_path), true)
+      << "Could not find storage file: \"" << storage_path.generic_string() << "\"";
   }
 
   template<typename MessageT>
@@ -157,7 +157,7 @@ public:
       reader = std::make_unique<rosbag2_cpp::Reader>(
         std::make_unique<rosbag2_compression::SequentialCompressionReader>());
     }
-    reader->open(root_bag_path_.string());
+    reader->open(root_bag_path_.generic_string());
     reader->set_filter(filter);
 
     auto messages = std::vector<std::shared_ptr<MessageT>>{};
@@ -171,7 +171,7 @@ public:
   std::string get_serialization_format_for_topic(const std::string & topic_name)
   {
     auto reader = rosbag2_cpp::Reader{};
-    reader.open(root_bag_path_.string());
+    reader.open(root_bag_path_.generic_string());
     auto topics_and_types = reader.get_all_topics_and_types();
     auto topic_it = std::find_if(
       topics_and_types.begin(), topics_and_types.end(),
@@ -192,15 +192,15 @@ public:
     rosbag2_storage::BagMetadata metadata{};
     metadata.storage_identifier = rosbag2_storage::get_default_storage_id();
     for (int i = 0; i <= expected_splits; i++) {
-      rcpputils::fs::path bag_file_path;
+      std::filesystem::path bag_file_path;
       if (!compression_format.empty()) {
         bag_file_path = get_bag_file_path(i);
       } else {
         bag_file_path = get_compressed_bag_file_path(i);
       }
 
-      if (rcpputils::fs::exists(bag_file_path)) {
-        metadata.relative_file_paths.push_back(bag_file_path.string());
+      if (std::filesystem::exists(bag_file_path)) {
+        metadata.relative_file_paths.push_back(bag_file_path.generic_string());
       }
     }
     metadata.duration = std::chrono::nanoseconds(0);
@@ -211,7 +211,7 @@ public:
     metadata.compression_format = compression_format;
 
     rosbag2_storage::MetadataIo metadata_io;
-    metadata_io.write_metadata(root_bag_path_.string(), metadata);
+    metadata_io.write_metadata(root_bag_path_.generic_string(), metadata);
   #else
     (void)expected_splits;
     (void)compression_format;
@@ -220,7 +220,7 @@ public:
   }
 
   // relative path to the root of the bag file.
-  rcpputils::fs::path root_bag_path_;
+  std::filesystem::path root_bag_path_;
 
   MemoryManagement memory_management_;
 };

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -23,6 +23,7 @@
 #include <gmock/gmock.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
@@ -30,7 +31,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rcpputils/asserts.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
 #include "rosbag2_cpp/reindexer.hpp"
@@ -56,12 +56,12 @@ public:
   void SetUp() override
   {
     auto bag_name = get_test_name() + "_" + GetParam();
-    root_bag_path_ = rcpputils::fs::path(temporary_dir_path_) / bag_name;
+    root_bag_path_ = std::filesystem::path(temporary_dir_path_) / bag_name;
   }
 
   void TearDown() override
   {
-    rcpputils::fs::remove_all(root_bag_path_);
+    std::filesystem::remove_all(root_bag_path_);
   }
 
   std::string get_test_name() const
@@ -104,11 +104,11 @@ public:
     }
 
     rosbag2_storage::MetadataIo metadata_io;
-    original_metadata_ = metadata_io.read_metadata(root_bag_path_.string());
-    rcpputils::fs::remove(root_bag_path_ / "metadata.yaml");
+    original_metadata_ = metadata_io.read_metadata(root_bag_path_.generic_string());
+    std::filesystem::remove(root_bag_path_ / "metadata.yaml");
   }
 
-  rcpputils::fs::path root_bag_path_;
+  std::filesystem::path root_bag_path_;
   rosbag2_storage::BagMetadata original_metadata_;
 };
 

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -49,6 +49,7 @@
 using namespace testing;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
 
+namespace fs = std::filesystem;
 
 class ReindexTestFixture : public ParametrizedTemporaryDirectoryFixture
 {
@@ -56,12 +57,12 @@ public:
   void SetUp() override
   {
     auto bag_name = get_test_name() + "_" + GetParam();
-    root_bag_path_ = std::filesystem::path(temporary_dir_path_) / bag_name;
+    root_bag_path_ = fs::path(temporary_dir_path_) / bag_name;
   }
 
   void TearDown() override
   {
-    std::filesystem::remove_all(root_bag_path_);
+    fs::remove_all(root_bag_path_);
   }
 
   std::string get_test_name() const
@@ -105,10 +106,10 @@ public:
 
     rosbag2_storage::MetadataIo metadata_io;
     original_metadata_ = metadata_io.read_metadata(root_bag_path_.generic_string());
-    std::filesystem::remove(root_bag_path_ / "metadata.yaml");
+    fs::remove(root_bag_path_ / "metadata.yaml");
   }
 
-  std::filesystem::path root_bag_path_;
+  fs::path root_bag_path_;
   rosbag2_storage::BagMetadata original_metadata_;
 };
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -36,6 +36,8 @@
 
 using namespace ::testing;  // NOLINT
 
+namespace fs = std::filesystem;
+
 class TestRosbag2CPPAPI : public Test, public WithParamInterface<std::string>
 {};
 
@@ -49,9 +51,9 @@ TEST_P(TestRosbag2CPPAPI, minimal_writer_example)
   rclcpp::Serialization<TestMsgT> serialization;
   serialization.serialize_message(&test_msg, &serialized_msg);
 
-  auto rosbag_directory = std::filesystem::path("test_rosbag2_writer_api_bag");
+  auto rosbag_directory = fs::path("test_rosbag2_writer_api_bag");
   // in case the bag was previously not cleaned up
-  std::filesystem::remove_all(rosbag_directory);
+  fs::remove_all(rosbag_directory);
 
   {
     rosbag2_cpp::Writer writer;
@@ -137,7 +139,7 @@ TEST_P(TestRosbag2CPPAPI, minimal_writer_example)
   }
 
   // remove the rosbag again after the test
-  EXPECT_TRUE(std::filesystem::remove_all(rosbag_directory));
+  EXPECT_TRUE(fs::remove_all(rosbag_directory));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,7 +23,6 @@
 #include "rclcpp/serialization.hpp"
 #include "rclcpp/serialized_message.hpp"
 
-#include "rcpputils/filesystem_helper.hpp"
 #include "rcutils/time.h"
 
 #include "rosbag2_cpp/reader.hpp"
@@ -49,9 +49,9 @@ TEST_P(TestRosbag2CPPAPI, minimal_writer_example)
   rclcpp::Serialization<TestMsgT> serialization;
   serialization.serialize_message(&test_msg, &serialized_msg);
 
-  auto rosbag_directory = rcpputils::fs::path("test_rosbag2_writer_api_bag");
+  auto rosbag_directory = std::filesystem::path("test_rosbag2_writer_api_bag");
   // in case the bag was previously not cleaned up
-  rcpputils::fs::remove_all(rosbag_directory);
+  std::filesystem::remove_all(rosbag_directory);
 
   {
     rosbag2_cpp::Writer writer;
@@ -137,7 +137,7 @@ TEST_P(TestRosbag2CPPAPI, minimal_writer_example)
   }
 
   // remove the rosbag again after the test
-  EXPECT_TRUE(rcpputils::fs::remove_all(rosbag_directory));
+  EXPECT_TRUE(std::filesystem::remove_all(rosbag_directory));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -33,6 +33,8 @@
 #include "test_msgs/msg/basic_types.hpp"
 #include "test_msgs/srv/basic_types.hpp"
 
+namespace fs = std::filesystem;
+
 class SequentialWriterForTest : public rosbag2_cpp::writers::SequentialWriter
 {
 public:
@@ -53,17 +55,17 @@ public:
   void SetUp() override
   {
     auto bag_name = get_test_name() + "_" + GetParam();
-    root_bag_path_ = std::filesystem::path(temporary_dir_path_) / bag_name;
+    root_bag_path_ = fs::path(temporary_dir_path_) / bag_name;
 
     // Clean up potentially leftover bag files.
     // There may be leftovers if the system reallocates a temp directory
     // used by a previous test execution and the test did not have a clean exit.
-    std::filesystem::remove_all(root_bag_path_);
+    fs::remove_all(root_bag_path_);
   }
 
   void TearDown() override
   {
-    std::filesystem::remove_all(root_bag_path_);
+    fs::remove_all(root_bag_path_);
   }
 
   static void SetUpTestCase()
@@ -143,7 +145,7 @@ public:
   }
 
   // relative path to the root of the bag file.
-  std::filesystem::path root_bag_path_;
+  fs::path root_bag_path_;
   std::future<void> node_spinner_future_;
   std::atomic_bool exit_from_node_spinner_{false};
 };

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -15,10 +15,9 @@
 #include <gmock/gmock.h>
 
 #include <cstdlib>
+#include <filesystem>
 #include <string>
 #include <thread>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_test_common/process_execution_helpers.hpp"
 #include "rosbag2_test_common/tested_storage_ids.hpp"
@@ -31,7 +30,7 @@ public:
   InfoEndToEndTestFixture()
   {
     // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
-    bags_path_ = (rcpputils::fs::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).string();
+    bags_path_ = (std::filesystem::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).generic_string();
   }
 
   std::string bags_path_;

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -24,13 +24,15 @@
 
 using namespace ::testing;  // NOLINT
 
+namespace fs = std::filesystem;
+
 class InfoEndToEndTestFixture : public Test, public WithParamInterface<std::string>
 {
 public:
   InfoEndToEndTestFixture()
   {
     // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
-    bags_path_ = (std::filesystem::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).generic_string();
+    bags_path_ = (fs::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).generic_string();
   }
 
   std::string bags_path_;

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -32,6 +32,8 @@
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
 
+namespace fs = std::filesystem;
+
 class PlayEndToEndTestFixture : public Test, public WithParamInterface<std::string>
 {
 public:
@@ -43,7 +45,7 @@ public:
       .durability(rclcpp::DurabilityPolicy::TransientLocal))
   {
     // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
-    bags_path_ = (std::filesystem::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).generic_string();
+    bags_path_ = (fs::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).generic_string();
     sub_ = std::make_unique<SubscriptionManager>();
     client_node_ = std::make_shared<rclcpp::Node>("test_record_client");
     cli_resume_ = client_node_->create_client<Resume>("/rosbag2_player/resume");

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 
 #include <cstdlib>
+#include <filesystem>
 #include <future>
 #include <memory>
 #include <string>
@@ -42,7 +43,7 @@ public:
       .durability(rclcpp::DurabilityPolicy::TransientLocal))
   {
     // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
-    bags_path_ = (rcpputils::fs::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).string();
+    bags_path_ = (std::filesystem::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).generic_string();
     sub_ = std::make_unique<SubscriptionManager>();
     client_node_ = std::make_shared<rclcpp::Node>("test_record_client");
     cli_resume_ = client_node_->create_client<Resume>("/rosbag2_player/resume");

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -29,6 +29,8 @@
 
 #include "record_fixture.hpp"
 
+namespace fs = std::filesystem;
+
 namespace
 {
 /**
@@ -95,7 +97,7 @@ TEST_P(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
 
   const auto compressed_bag_file_path = get_compressed_bag_file_path(0);
 
-  ASSERT_TRUE(std::filesystem::exists(compressed_bag_file_path)) <<
+  ASSERT_TRUE(fs::exists(compressed_bag_file_path)) <<
     "Expected compressed bag file path: \"" <<
     compressed_bag_file_path.generic_string() << "\" to exist!";
 
@@ -107,7 +109,7 @@ TEST_P(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
 
   ASSERT_EQ(decompressed_uri, bag_path) <<
     "Expected decompressed URI to be same as uncompressed bag file path!";
-  ASSERT_TRUE(std::filesystem::exists(bag_path)) <<
+  ASSERT_TRUE(fs::exists(bag_path)) <<
     "Expected decompressed first bag file to exist!";
 
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>(
@@ -320,11 +322,11 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 
   // Don't include the last bagfile since it won't be full
   for (int i = 0; i < actual_splits - 1; ++i) {
-    const auto bagfile_path = root_bag_path_ / std::filesystem::path{metadata.files[i].path};
-    ASSERT_TRUE(std::filesystem::exists(bagfile_path)) <<
+    const auto bagfile_path = root_bag_path_ / fs::path{metadata.files[i].path};
+    ASSERT_TRUE(fs::exists(bagfile_path)) <<
       "Expected bag file: \"" << bagfile_path.generic_string() << "\" to exist.";
 
-    const auto actual_split_size = static_cast<int>(std::filesystem::file_size(bagfile_path));
+    const auto actual_split_size = static_cast<int>(fs::file_size(bagfile_path));
     // Actual size is guaranteed to be >= bagfile_split size
     EXPECT_LT(bagfile_split_size, actual_split_size);
   }
@@ -369,13 +371,13 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
 
   // Check that there's only 1 bagfile and that it exists.
   ASSERT_EQ(1u, metadata.files.size());
-  const auto bagfile_path = root_bag_path_ / std::filesystem::path{metadata.files[0].path};
-  ASSERT_TRUE(std::filesystem::exists(bagfile_path)) <<
+  const auto bagfile_path = root_bag_path_ / fs::path{metadata.files[0].path};
+  ASSERT_TRUE(fs::exists(bagfile_path)) <<
     "Expected bag file: \"" << bagfile_path.generic_string() << "\" to exist.";
 
   // Check that the next bagfile does not exist.
   const auto next_bag_file = get_bag_file_path(1);
-  EXPECT_FALSE(std::filesystem::exists(next_bag_file)) << "Expected next bag file: \"" <<
+  EXPECT_FALSE(fs::exists(next_bag_file)) << "Expected next bag file: \"" <<
     next_bag_file.generic_string() << "\" to not exist!";
 }
 
@@ -420,8 +422,8 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   ASSERT_GE(metadata.relative_file_paths.size(), 1u) << "Bagfile never split!";
 
   for (const auto & file : metadata.files) {
-    auto path = root_bag_path_ / std::filesystem::path(file.path);
-    EXPECT_TRUE(std::filesystem::exists(path));
+    auto path = root_bag_path_ / fs::path(file.path);
+    EXPECT_TRUE(fs::exists(path));
   }
 }
 
@@ -465,8 +467,8 @@ TEST_P(RecordFixture, record_end_to_end_with_duration_splitting_splits_bagfile) 
   const auto metadata = metadata_io.read_metadata(root_bag_path_.generic_string());
 
   for (const auto & file : metadata.files) {
-    auto path = root_bag_path_ / std::filesystem::path(file.path);
-    EXPECT_TRUE(std::filesystem::exists(path));
+    auto path = root_bag_path_ / fs::path(file.path);
+    EXPECT_TRUE(fs::exists(path));
   }
 }
 
@@ -512,9 +514,9 @@ TEST_P(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
   const auto metadata = metadata_io.read_metadata(root_bag_path_.generic_string());
 
   for (const auto & path : metadata.relative_file_paths) {
-    const auto file_path = root_bag_path_ / std::filesystem::path{path};
+    const auto file_path = root_bag_path_ / fs::path{path};
 
-    EXPECT_TRUE(std::filesystem::exists(file_path)) << "File: \"" <<
+    EXPECT_TRUE(fs::exists(file_path)) << "File: \"" <<
       file_path.generic_string() << "\" does not exist!";
     EXPECT_EQ(file_path.extension().generic_string(), ".zstd") << "File :\"" <<
       file_path.generic_string() << "\" does not have proper \".zstd\" extension!";

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -14,14 +14,13 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <unordered_set>
 
 #include "rclcpp/rclcpp.hpp"
-#include "rcpputils/filesystem_helper.hpp"
 #include "rcpputils/scope_exit.hpp"
-#include "rcutils/filesystem.h"
 #include "rosbag2_compression_zstd/zstd_decompressor.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_test_common/publication_manager.hpp"
@@ -96,18 +95,19 @@ TEST_P(RecordFixture, record_end_to_end_test_with_zstd_file_compression) {
 
   const auto compressed_bag_file_path = get_compressed_bag_file_path(0);
 
-  ASSERT_TRUE(compressed_bag_file_path.exists()) <<
+  ASSERT_TRUE(std::filesystem::exists(compressed_bag_file_path)) <<
     "Expected compressed bag file path: \"" <<
-    compressed_bag_file_path.string() << "\" to exist!";
+    compressed_bag_file_path.generic_string() << "\" to exist!";
 
   rosbag2_compression_zstd::ZstdDecompressor decompressor;
 
-  const auto decompressed_uri = decompressor.decompress_uri(compressed_bag_file_path.string());
-  const auto bag_path = get_bag_file_path(0).string();
+  const auto decompressed_uri = decompressor.decompress_uri(
+    compressed_bag_file_path.generic_string());
+  const auto bag_path = get_bag_file_path(0).generic_string();
 
   ASSERT_EQ(decompressed_uri, bag_path) <<
     "Expected decompressed URI to be same as uncompressed bag file path!";
-  ASSERT_TRUE(rcpputils::fs::exists(bag_path)) <<
+  ASSERT_TRUE(std::filesystem::exists(bag_path)) <<
     "Expected decompressed first bag file to exist!";
 
   auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>(
@@ -258,7 +258,7 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_metadata_contains_all_top
 
   wait_for_metadata();
   rosbag2_storage::MetadataIo metadataIo;
-  const auto metadata = metadataIo.read_metadata(root_bag_path_.string());
+  const auto metadata = metadataIo.read_metadata(root_bag_path_.generic_string());
   // Verify at least 2 topics are in the metadata.
   // There may be more if the test system is noisy.
   EXPECT_GT(metadata.topics_with_message_count.size(), 1u);
@@ -310,7 +310,7 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   finalize_metadata_kludge(expected_splits);
   wait_for_metadata();
   rosbag2_storage::MetadataIo metadata_io;
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.generic_string());
   const auto actual_splits = static_cast<int>(metadata.files.size());
 
   // TODO(zmichaels11): Support reliable sync-to-disk for more accurate splits.
@@ -320,11 +320,11 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
 
   // Don't include the last bagfile since it won't be full
   for (int i = 0; i < actual_splits - 1; ++i) {
-    const auto bagfile_path = root_bag_path_ / rcpputils::fs::path{metadata.files[i].path};
-    ASSERT_TRUE(bagfile_path.exists()) <<
-      "Expected bag file: \"" << bagfile_path.string() << "\" to exist.";
+    const auto bagfile_path = root_bag_path_ / std::filesystem::path{metadata.files[i].path};
+    ASSERT_TRUE(std::filesystem::exists(bagfile_path)) <<
+      "Expected bag file: \"" << bagfile_path.generic_string() << "\" to exist.";
 
-    const auto actual_split_size = static_cast<int>(bagfile_path.file_size());
+    const auto actual_split_size = static_cast<int>(std::filesystem::file_size(bagfile_path));
     // Actual size is guaranteed to be >= bagfile_split size
     EXPECT_LT(bagfile_split_size, actual_split_size);
   }
@@ -365,18 +365,18 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_max_size_not_reached) {
   finalize_metadata_kludge();
   wait_for_metadata();
   rosbag2_storage::MetadataIo metadata_io;
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.generic_string());
 
   // Check that there's only 1 bagfile and that it exists.
   ASSERT_EQ(1u, metadata.files.size());
-  const auto bagfile_path = root_bag_path_ / rcpputils::fs::path{metadata.files[0].path};
-  ASSERT_TRUE(bagfile_path.exists()) <<
-    "Expected bag file: \"" << bagfile_path.string() << "\" to exist.";
+  const auto bagfile_path = root_bag_path_ / std::filesystem::path{metadata.files[0].path};
+  ASSERT_TRUE(std::filesystem::exists(bagfile_path)) <<
+    "Expected bag file: \"" << bagfile_path.generic_string() << "\" to exist.";
 
   // Check that the next bagfile does not exist.
   const auto next_bag_file = get_bag_file_path(1);
-  EXPECT_FALSE(next_bag_file.exists()) << "Expected next bag file: \"" <<
-    next_bag_file.string() << "\" to not exist!";
+  EXPECT_FALSE(std::filesystem::exists(next_bag_file)) << "Expected next bag file: \"" <<
+    next_bag_file.generic_string() << "\" to not exist!";
 }
 
 TEST_P(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
@@ -415,13 +415,13 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_splits_bagfile) {
   wait_for_metadata();
   finalize_metadata_kludge(expected_splits);
   rosbag2_storage::MetadataIo metadata_io;
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.generic_string());
 
   ASSERT_GE(metadata.relative_file_paths.size(), 1u) << "Bagfile never split!";
 
   for (const auto & file : metadata.files) {
-    auto path = root_bag_path_ / rcpputils::fs::path(file.path);
-    EXPECT_TRUE(rcpputils::fs::exists(path));
+    auto path = root_bag_path_ / std::filesystem::path(file.path);
+    EXPECT_TRUE(std::filesystem::exists(path));
   }
 }
 
@@ -462,11 +462,11 @@ TEST_P(RecordFixture, record_end_to_end_with_duration_splitting_splits_bagfile) 
   finalize_metadata_kludge();
   wait_for_metadata();
   rosbag2_storage::MetadataIo metadata_io;
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.generic_string());
 
   for (const auto & file : metadata.files) {
-    auto path = root_bag_path_ / rcpputils::fs::path(file.path);
-    EXPECT_TRUE(rcpputils::fs::exists(path));
+    auto path = root_bag_path_ / std::filesystem::path(file.path);
+    EXPECT_TRUE(std::filesystem::exists(path));
   }
 }
 
@@ -509,15 +509,15 @@ TEST_P(RecordFixture, record_end_to_end_test_with_zstd_file_compression_compress
   finalize_metadata_kludge(expected_splits);
   wait_for_metadata();
   rosbag2_storage::MetadataIo metadata_io;
-  const auto metadata = metadata_io.read_metadata(root_bag_path_.string());
+  const auto metadata = metadata_io.read_metadata(root_bag_path_.generic_string());
 
   for (const auto & path : metadata.relative_file_paths) {
-    const auto file_path = root_bag_path_ / rcpputils::fs::path{path};
+    const auto file_path = root_bag_path_ / std::filesystem::path{path};
 
-    EXPECT_TRUE(file_path.exists()) << "File: \"" <<
-      file_path.string() << "\" does not exist!";
-    EXPECT_EQ(file_path.extension().string(), ".zstd") << "File :\"" <<
-      file_path.string() << "\" does not have proper \".zstd\" extension!";
+    EXPECT_TRUE(std::filesystem::exists(file_path)) << "File: \"" <<
+      file_path.generic_string() << "\" does not exist!";
+    EXPECT_EQ(file_path.extension().generic_string(), ".zstd") << "File :\"" <<
+      file_path.generic_string() << "\" does not have proper \".zstd\" extension!";
   }
 }
 
@@ -645,7 +645,7 @@ TEST_P(RecordFixture, rosbag2_record_and_play_multiple_topics_with_filter) {
   auto sub_future = sub->spin_subscriptions();
 
   std::stringstream command_play;
-  command_play << "ros2 bag play " << root_bag_path_.string() << " --topics " <<
+  command_play << "ros2 bag play " << root_bag_path_.generic_string() << " --topics " <<
     second_topic_name;
 
   int exit_code = execute_and_wait_until_completion(command_play.str(), ".");

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_storage_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_storage_api.cpp
@@ -29,6 +29,8 @@ using namespace std::chrono_literals;  // NOLINT
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
 
+namespace fs = std::filesystem;
+
 class Rosbag2StorageAPITests : public rosbag2_test_common::ParametrizedTemporaryDirectoryFixture
 {
 public:
@@ -40,17 +42,17 @@ public:
   void SetUp() override
   {
     auto bag_name = get_test_name() + "_" + GetParam();
-    root_bag_path_ = std::filesystem::path(temporary_dir_path_) / bag_name;
+    root_bag_path_ = fs::path(temporary_dir_path_) / bag_name;
 
     // Clean up potentially leftover bag files.
     // There may be leftovers if the system reallocates a temp directory
     // used by a previous test execution and the test did not have a clean exit.
-    std::filesystem::remove_all(root_bag_path_);
+    fs::remove_all(root_bag_path_);
   }
 
   void TearDown() override
   {
-    std::filesystem::remove_all(root_bag_path_);
+    fs::remove_all(root_bag_path_);
   }
 
   static std::string get_test_name()
@@ -111,14 +113,14 @@ public:
     }
   }
 
-  std::filesystem::path root_bag_path_;
+  fs::path root_bag_path_;
   std::unique_ptr<MemoryManagement> memory_management_;
 };
 
 TEST_P(Rosbag2StorageAPITests, get_bagfile_size_read_write_interface)
 {
   const std::string FILE_EXTENSION = (GetParam() == "mcap") ? ".mcap" : ".db3";
-  std::filesystem::path full_bagfile_path = root_bag_path_;
+  fs::path full_bagfile_path = root_bag_path_;
   full_bagfile_path.replace_extension(FILE_EXTENSION);
 
   rosbag2_storage::StorageFactory factory{};
@@ -136,7 +138,7 @@ TEST_P(Rosbag2StorageAPITests, get_bagfile_size_read_write_interface)
   rw_storage->write(serialized_messages);
   uint64_t storage_bagfile_size = rw_storage->get_bagfile_size();
 
-  size_t fs_bagfile_size = std::filesystem::file_size(full_bagfile_path);
+  size_t fs_bagfile_size = fs::file_size(full_bagfile_path);
   auto tolerance = static_cast<size_t>(fs_bagfile_size * 0.001);  // tolerance = 0.1%
 
   size_t filesize_difference =
@@ -150,7 +152,7 @@ TEST_P(Rosbag2StorageAPITests, get_bagfile_size_read_write_interface)
   rw_storage->write(serialized_messages);
   storage_bagfile_size = rw_storage->get_bagfile_size();
 
-  fs_bagfile_size = std::filesystem::file_size(full_bagfile_path);
+  fs_bagfile_size = fs::file_size(full_bagfile_path);
   tolerance = static_cast<size_t>(fs_bagfile_size * 0.001);  // tolerance = 0.1%
 
   filesize_difference =

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_player.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_player.cpp
@@ -31,6 +31,8 @@
 using namespace std::chrono_literals;  // NOLINT
 using namespace ::testing;  // NOLINT
 
+namespace fs = std::filesystem;
+
 class ComposablePlayerTests
   : public ::testing::Test, public WithParamInterface<std::string>
 {
@@ -128,7 +130,7 @@ TEST_P(ComposablePlayerTests, player_can_parse_parameters_from_file) {
     "play.qos_profile_overrides_path",
     _SRC_RESOURCES_DIR_PATH "/qos_profile_overrides.yaml");
   opts.append_parameter_override("storage.storage_id", GetParam());
-  const std::string uri_str = (std::filesystem::path(
+  const std::string uri_str = (fs::path(
       _SRC_RESOURCES_DIR_PATH) / GetParam() / "test_bag_for_seek").generic_string();
   opts.append_parameter_override("storage.uri", uri_str);
 
@@ -181,7 +183,7 @@ TEST_P(ComposablePlayerIntegrationTests, player_can_automatically_play_file_afte
   load_node_request->package_name = "rosbag2_transport";
   load_node_request->plugin_name = "rosbag2_transport::Player";
 
-  const std::string uri_str = (std::filesystem::path(
+  const std::string uri_str = (fs::path(
       _SRC_RESOURCES_DIR_PATH) / GetParam() / "test_bag_for_seek").generic_string();
   rclcpp::Parameter uri("storage.uri", rclcpp::ParameterValue(uri_str));
   rclcpp::Parameter start_paused("play.start_paused", rclcpp::ParameterValue(true));

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
@@ -30,6 +30,8 @@ using namespace std::chrono_literals;  // NOLINT
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
 
+namespace fs = std::filesystem;
+
 class ComposableRecorderIntegrationTests : public CompositionManagerTestFixture
 {
 public:
@@ -41,15 +43,15 @@ public:
     return bag_file_name.str();
   }
 
-  std::filesystem::path get_bag_file_path(int split_index)
+  fs::path get_bag_file_path(int split_index)
   {
     return root_bag_path_ / get_relative_bag_file_path(split_index);
   }
 
-  std::filesystem::path get_relative_bag_file_path(int split_index) const
+  fs::path get_relative_bag_file_path(int split_index) const
   {
     const auto storage_id = GetParam();
-    return std::filesystem::path(
+    return fs::path(
       rosbag2_test_common::bag_filename_for_storage_id(get_bag_file_name(split_index), storage_id));
   }
 
@@ -74,12 +76,12 @@ public:
     const auto storage_path = get_bag_file_path(0);
     const auto start_time = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - start_time < timeout && rclcpp::ok()) {
-      if (std::filesystem::exists(storage_path)) {
+      if (fs::exists(storage_path)) {
         return;
       }
       std::this_thread::sleep_for(50ms);  // wait a bit to not query constantly
     }
-    ASSERT_EQ(std::filesystem::exists(storage_path), true)
+    ASSERT_EQ(fs::exists(storage_path), true)
       << "Could not find storage file: \"" << storage_path.generic_string() << "\"";
   }
 
@@ -113,18 +115,18 @@ public:
   {
     rclcpp::init(0, nullptr);
     auto bag_name = get_test_name() + "_" + GetParam();
-    root_bag_path_ = std::filesystem::path(temporary_dir_path_) / bag_name;
+    root_bag_path_ = fs::path(temporary_dir_path_) / bag_name;
 
     // Clean up potentially leftover bag files.
     // There may be leftovers if the system reallocates a temp directory
     // used by a previous test execution and the test did not have a clean exit.
-    std::filesystem::remove_all(root_bag_path_);
+    fs::remove_all(root_bag_path_);
   }
 
   void TearDown() override
   {
     rclcpp::shutdown();
-    std::filesystem::remove_all(root_bag_path_);
+    fs::remove_all(root_bag_path_);
   }
 
   std::string get_test_name() const
@@ -136,7 +138,7 @@ public:
     return test_name;
   }
 
-  std::filesystem::path root_bag_path_;
+  fs::path root_bag_path_;
 };
 
 class MockComposableRecorder : public rosbag2_transport::Recorder

--- a/rosbag2_transport/test/rosbag2_transport/test_load_composable_components.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_load_composable_components.cpp
@@ -19,6 +19,8 @@
 
 using namespace std::chrono_literals;  // NOLINT
 
+namespace fs = std::filesystem;
+
 TEST_P(CompositionManagerTestFixture, test_load_play_component)
 {
   std::string path{_SRC_RESOURCES_DIR_PATH "/player_node_params.yaml"};
@@ -34,7 +36,7 @@ TEST_P(CompositionManagerTestFixture, test_load_play_component)
   rclcpp::Parameter qos_profile_overrides_path("play.qos_profile_overrides_path",
     rclcpp::ParameterValue(_SRC_RESOURCES_DIR_PATH "/qos_profile_overrides.yaml"));
 
-  const std::string uri_str = (std::filesystem::path(
+  const std::string uri_str = (fs::path(
       _SRC_RESOURCES_DIR_PATH) / GetParam() / "test_bag_for_seek").generic_string();
   rclcpp::Parameter uri("storage.uri", rclcpp::ParameterValue(uri_str));
   rclcpp::Parameter storage_id("storage.storage_id", GetParam());

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 
 #include <chrono>
+#include <filesystem>
 #include <future>
 #include <memory>
 #include <string>
@@ -33,6 +34,8 @@ using namespace ::testing;  // NOLINT
 using namespace rosbag2_transport;  // NOLINT
 using namespace rosbag2_test_common;  // NOLINT
 
+namespace fs = std::filesystem;
+
 class RosBag2PlaySeekTestFixture
   : public RosBag2PlayTestFixture,
   public WithParamInterface<std::string>
@@ -44,8 +47,8 @@ public:
     topic_types_ = std::vector<rosbag2_storage::TopicMetadata>{
       {1u, "topic1", "test_msgs/BasicTypes", rmw_get_serialization_format(), {}, ""}};
 
-    const rcpputils::fs::path base{_SRC_RESOURCES_DIR_PATH};
-    const rcpputils::fs::path bag_path = base / GetParam() / "test_bag_for_seek";
+    const fs::path base{_SRC_RESOURCES_DIR_PATH};
+    const fs::path bag_path = base / GetParam() / "test_bag_for_seek";
 
     storage_options_ = rosbag2_storage::StorageOptions({bag_path.string(), "", 0, 0, 0});
     play_options_.read_ahead_queue_size = 2;


### PR DESCRIPTION
Based on PRs https://github.com/ros2/rosbag2/pull/1478 and https://github.com/ros2/rosbag2/pull/1479

Use std::filesystem instead of rcpputils::fs (https://github.com/ros2/rcpputils/issues/164) in all packages of rosbag2.

~~The only place where it is still used is TemporaryDirectoryFixture in https://github.com/ros2/rosbag2/blob/1564687de2d10d5bce32dcb9b38ec5c9239416a4/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp#L34~~

~~Because there is no alternative in the standard library~~
