### PR TITLE
Make some changes for newer versions of uncrustify.

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/logging.hpp
+++ b/rosbag2_compression/src/rosbag2_compression/logging.hpp
@@ -22,40 +22,44 @@
 
 #define ROSBAG2_COMPRESSION_PACKAGE_NAME "rosbag2_compression"
 
+// *INDENT-OFF*
+
 #define ROSBAG2_COMPRESSION_LOG_INFO(...) \
   RCUTILS_LOG_INFO_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_INFO_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_INFO_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_COMPRESSION_LOG_ERROR(...) \
   RCUTILS_LOG_ERROR_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_ERROR_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_COMPRESSION_LOG_WARN(...) \
   RCUTILS_LOG_WARN_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_LOG_WARN_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_WARN_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_WARN_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_COMPRESSION_LOG_DEBUG(...) \
   RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_COMPRESSION_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
+
+// *INDENT-ON*
 
 #endif  // ROSBAG2_COMPRESSION__LOGGING_HPP_

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -118,13 +118,15 @@ void SequentialCompressionWriter::compression_thread_fn()
     std::string file;
     {
       std::unique_lock<std::mutex> lock(compressor_queue_mutex_);
+      // *INDENT-OFF*
       compressor_condition_.wait(
         lock,
         [&] {
           return !compression_is_running_ ||
-          !compressor_message_queue_.empty() ||
-          !compressor_file_queue_.empty();
+                 !compressor_message_queue_.empty() ||
+                 !compressor_file_queue_.empty();
         });
+      // *INDENT-ON*
 
       if (!compressor_message_queue_.empty()) {
         message = compressor_message_queue_.front();
@@ -388,12 +390,14 @@ void SequentialCompressionWriter::write(
     if (compression_options_.compression_queue_size == 0u &&
       compressor_message_queue_.size() > compression_options_.compression_threads)
     {
+      // *INDENT-OFF*
       compressor_condition_.wait(
         lock,
         [&] {
           return !compression_is_running_ ||
-          compressor_message_queue_.size() <= compression_options_.compression_threads;
+                 compressor_message_queue_.size() <= compression_options_.compression_threads;
         });
+      // *INDENT-ON*
     }
 
     compressor_message_queue_.push(message);

--- a/rosbag2_compression_zstd/src/rosbag2_compression_zstd/logging.hpp
+++ b/rosbag2_compression_zstd/src/rosbag2_compression_zstd/logging.hpp
@@ -22,40 +22,44 @@
 
 #define ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME "rosbag2_compression_zstd"
 
+// *INDENT-OFF*
+
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_INFO(...) \
   RCUTILS_LOG_INFO_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_INFO_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_INFO_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_ERROR(...) \
   RCUTILS_LOG_ERROR_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_ERROR_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_WARN(...) \
   RCUTILS_LOG_WARN_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_WARN_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_WARN_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_WARN_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_DEBUG(...) \
   RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_COMPRESSION_ZSTD_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_COMPRESSION_ZSTD_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
+
+// *INDENT-ON*
 
 #endif  // ROSBAG2_COMPRESSION_ZSTD__LOGGING_HPP_

--- a/rosbag2_cpp/include/rosbag2_cpp/logging.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/logging.hpp
@@ -22,40 +22,44 @@
 
 #define ROSBAG2_CPP_PACKAGE_NAME "rosbag2_cpp"
 
+// *INDENT-OFF*
+
 #define ROSBAG2_CPP_LOG_INFO(...) \
   RCUTILS_LOG_INFO_NAMED(ROSBAG2_CPP_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_CPP_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_INFO_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_INFO_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_CPP_LOG_ERROR(...) \
   RCUTILS_LOG_ERROR_NAMED(ROSBAG2_CPP_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_CPP_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_ERROR_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_CPP_LOG_WARN(...) \
   RCUTILS_LOG_WARN_NAMED(ROSBAG2_CPP_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_CPP_LOG_WARN_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_WARN_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_WARN_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_CPP_LOG_DEBUG(...) \
   RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_CPP_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_CPP_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_CPP_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
+
+// *INDENT-ON*
 
 #endif  // ROSBAG2_CPP__LOGGING_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -369,12 +369,11 @@ TEST_F(
   fake_storage_size_ = 0;
   size_t written_messages = 0;
 
-  ON_CALL(
-    *storage_,
-    write(An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())).
-  WillByDefault(
-    [this, &written_messages]
-      (const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msgs)
+  using VectorSharedBagMessages =
+    std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>;
+
+  ON_CALL(*storage_, write(An<const VectorSharedBagMessages &>())).WillByDefault(
+    [this, &written_messages](const VectorSharedBagMessages & msgs)
     {
       written_messages += msgs.size();
       fake_storage_size_.fetch_add(static_cast<uint32_t>(msgs.size()));

--- a/rosbag2_storage/include/rosbag2_storage/logging.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/logging.hpp
@@ -22,40 +22,44 @@
 
 #define ROSBAG2_STORAGE_PACKAGE_NAME "rosbag2_storage"
 
+// *INDENT-OFF*
+
 #define ROSBAG2_STORAGE_LOG_INFO(...) \
   RCUTILS_LOG_INFO_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_INFO_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_INFO_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_LOG_ERROR(...) \
   RCUTILS_LOG_ERROR_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_ERROR_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_LOG_WARN(...) \
   RCUTILS_LOG_WARN_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_LOG_WARN_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_WARN_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_WARN_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_LOG_DEBUG(...) \
   RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_STORAGE_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
+
+// *INDENT-ON*
 
 #endif  // ROSBAG2_STORAGE__LOGGING_HPP_

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/logging.hpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/logging.hpp
@@ -22,44 +22,48 @@
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME "rosbag2_storage"
 
+// *INDENT-OFF*
+
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO(...) \
   RCUTILS_LOG_INFO_NAMED(ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_INFO_NAMED( \
-      ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_INFO_NAMED( \
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR(...) \
   RCUTILS_LOG_ERROR_NAMED(ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_ERROR_NAMED( \
-      ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_ERROR_NAMED( \
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_WARN(...) \
   RCUTILS_LOG_WARN_NAMED(ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_WARN_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_WARN_NAMED( \
-      ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_WARN_NAMED( \
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_DEBUG(...) \
   RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_DEBUG_NAMED( \
-      ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_DEBUG_NAMED( \
+    ROSBAG2_STORAGE_DEFAULT_PLUGINS_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
+
+// *INDENT-ON*
 
 #endif  // ROSBAG2_STORAGE_SQLITE3__LOGGING_HPP_

--- a/rosbag2_test_common/include/rosbag2_test_common/client_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/client_manager.hpp
@@ -43,6 +43,7 @@ public:
     enable_service_event_contents_(service_event_contents),
     enable_client_event_contents_(client_event_contents)
   {
+    // *INDENT-OFF*
     auto do_nothing_srv_callback =
       [this](const std::shared_ptr<rmw_request_id_t> request_header,
         const std::shared_ptr<typename ServiceT::Request> request,
@@ -53,6 +54,7 @@ public:
         (void)request;
         (void)response;
       };
+    // *INDENT-ON*
 
     service_ = create_service<ServiceT>(service_name_, do_nothing_srv_callback);
 

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -149,11 +149,13 @@ TEST_P(ReindexTestFixture, test_multiple_files) {
         target_metadata.topics_with_message_count.begin(),
         target_metadata.topics_with_message_count.end(),
         [&gen_topic](rosbag2_storage::TopicInformation & t) {
+          // *INDENT-OFF*
           return (t.topic_metadata.name == gen_topic.topic_metadata.name) &&
-          (t.message_count == gen_topic.message_count) &&
-          (t.topic_metadata.offered_qos_profiles ==
-          gen_topic.topic_metadata.offered_qos_profiles) &&
-          (t.topic_metadata.type == gen_topic.topic_metadata.type);
+                 (t.message_count == gen_topic.message_count) &&
+                 (t.topic_metadata.offered_qos_profiles ==
+                 gen_topic.topic_metadata.offered_qos_profiles) &&
+                 (t.topic_metadata.type == gen_topic.topic_metadata.type);
+          // *INDENT-ON*
         }
       ) != target_metadata.topics_with_message_count.end()
     );

--- a/rosbag2_transport/src/rosbag2_transport/logging.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/logging.hpp
@@ -22,40 +22,44 @@
 
 #define ROSBAG2_TRANSPORT_PACKAGE_NAME "ROSBAG2_TRANSPORT"
 
+// *INDENT-OFF*
+
 #define ROSBAG2_TRANSPORT_LOG_INFO(...) \
   RCUTILS_LOG_INFO_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_TRANSPORT_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_INFO_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_INFO_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_TRANSPORT_LOG_ERROR(...) \
   RCUTILS_LOG_ERROR_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_TRANSPORT_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_ERROR_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_ERROR_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_TRANSPORT_LOG_WARN(...) \
   RCUTILS_LOG_WARN_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_TRANSPORT_LOG_WARN_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_WARN_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_WARN_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
 
 #define ROSBAG2_TRANSPORT_LOG_DEBUG(...) \
   RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, __VA_ARGS__)
 
 #define ROSBAG2_TRANSPORT_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
+  std::stringstream __ss; \
+  __ss << args; \
+  RCUTILS_LOG_DEBUG_NAMED(ROSBAG2_TRANSPORT_PACKAGE_NAME, "%s", __ss.str().c_str()); \
 } while (0)
+
+// *INDENT-ON*
 
 #endif  // ROSBAG2_TRANSPORT__LOGGING_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -312,9 +312,11 @@ TEST_F(RecordIntegrationTestFixture, mixed_qos_subscribes) {
     std::chrono::seconds(5), recorder,
     [publisher_volatile, publisher_transient_local]() {
       // This test is a success if rosbag2 has connected to both publishers
+      // *INDENT-OFF*
       return
-      publisher_volatile->get_subscription_count() &&
-      publisher_transient_local->get_subscription_count();
+        publisher_volatile->get_subscription_count() &&
+        publisher_transient_local->get_subscription_count();
+      // *INDENT-ON*
     });
   ASSERT_TRUE(succeeded);
 }
@@ -358,11 +360,13 @@ TEST_F(RecordIntegrationTestFixture, duration_and_noncompatibility_policies_mixe
   bool succeeded = rosbag2_test_common::spin_and_wait_for(
     std::chrono::seconds(5), recorder,
     [publisher_history, publisher_lifespan, publisher_deadline, publisher_liveliness]() {
+      // *INDENT-OFF*
       return
-      publisher_history->get_subscription_count() &&
-      publisher_lifespan->get_subscription_count() &&
-      publisher_deadline->get_subscription_count() &&
-      publisher_liveliness->get_subscription_count();
+        publisher_history->get_subscription_count() &&
+        publisher_lifespan->get_subscription_count() &&
+        publisher_deadline->get_subscription_count() &&
+        publisher_liveliness->get_subscription_count();
+      // *INDENT-ON*
     });
   ASSERT_TRUE(succeeded);
 }


### PR DESCRIPTION
Uncrustify 0.78 is the new version in Ubuntu 24.04. It has some small differences in indentation compared to Uncrustify 0.72, which is what is in Ubuntu 22.04.

In this PR, we make the changes to match what Uncrustify 0.78 wants.  In most cases, I think this is a "better" indentation.

We also add in strategic use of "*INDENT-OFF*" comments, which instructs Uncrustify to not indent this particular section of code.  That is so that this will still pass the linters on Uncrustify 0.72 while Rolling is still on that version.

With this in place, we should get green CI on both Ubuntu 22.04 and 24.04.