### PR TITLE
Add simple bag player examples

### DIFF
--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -20,14 +20,13 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(example_interfaces REQUIRED)
 
 add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
 target_link_libraries(simple_bag_recorder
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
-  ${std_msgs_TARGETS}
+  ${example_interfaces_TARGETS}
 )
 
 install(TARGETS
@@ -63,7 +62,7 @@ add_executable(simple_bag_reader src/simple_bag_reader.cpp)
 target_link_libraries(simple_bag_reader
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
-  ${std_msgs_TARGETS}
+  ${example_interfaces_TARGETS}
 )
 
 install(TARGETS

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -58,15 +58,15 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-add_executable(simple_bag_player src/simple_bag_player.cpp)
-target_link_libraries(simple_bag_player
+add_executable(simple_bag_reader src/simple_bag_reader.cpp)
+target_link_libraries(simple_bag_reader
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
   ${example_interfaces_TARGETS}
 )
 
 install(TARGETS
-  simple_bag_player
+  simple_bag_reader
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -21,12 +21,13 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(example_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 
 add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
 target_link_libraries(simple_bag_recorder
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
-  ${example_interfaces_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 install(TARGETS
@@ -62,7 +63,7 @@ add_executable(simple_bag_player src/simple_bag_player.cpp)
 target_link_libraries(simple_bag_player
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
-  ${example_interfaces_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 install(TARGETS

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -20,13 +20,14 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(example_interfaces REQUIRED)
 
 add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
 target_link_libraries(simple_bag_recorder
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
-  ${example_interfaces_TARGETS}
+  ${std_msgs_TARGETS}
 )
 
 install(TARGETS
@@ -55,6 +56,18 @@ target_link_libraries(data_generator_executable
 
 install(TARGETS
   data_generator_executable
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(simple_bag_reader src/simple_bag_reader.cpp)
+target_link_libraries(simple_bag_reader
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  ${std_msgs_TARGETS}
+)
+
+install(TARGETS
+  simple_bag_reader
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -58,15 +58,15 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-add_executable(simple_bag_reader src/simple_bag_reader.cpp)
-target_link_libraries(simple_bag_reader
+add_executable(simple_bag_player src/simple_bag_player.cpp)
+target_link_libraries(simple_bag_player
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
   ${example_interfaces_TARGETS}
 )
 
 install(TARGETS
-  simple_bag_reader
+  simple_bag_player
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rosbag2_examples/rosbag2_examples_cpp/package.xml
+++ b/rosbag2_examples/rosbag2_examples_cpp/package.xml
@@ -13,6 +13,7 @@
 
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>
+  <depend>std_msgs</depend>
   <depend>example_interfaces</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rosbag2_examples/rosbag2_examples_cpp/package.xml
+++ b/rosbag2_examples/rosbag2_examples_cpp/package.xml
@@ -14,6 +14,7 @@
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>
   <depend>example_interfaces</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_examples/rosbag2_examples_cpp/package.xml
+++ b/rosbag2_examples/rosbag2_examples_cpp/package.xml
@@ -13,7 +13,6 @@
 
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>
-  <depend>std_msgs</depend>
   <depend>example_interfaces</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -34,7 +34,7 @@ public:
 
     timer_ = this->create_wall_timer(
       100ms,
-      [this](){return this->timer_callback();}
+      [this]() {return this->timer_callback();}
     );
 
     reader_.open(bag_filename);

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -7,7 +7,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/serialization.hpp"
 #include "rosbag2_cpp/reader.hpp"
-#include "example_interfaces/msg/string.hpp"
+#include "std_msgs/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
@@ -17,7 +17,7 @@ class SimpleBagPlayer : public rclcpp::Node
     SimpleBagPlayer(const std::string & bag_filename)
     : Node("playback_node")
     {
-      publisher_ = this->create_publisher<example_interfaces::msg::String>("chatter", 10);
+      publisher_ = this->create_publisher<std_msgs::msg::String>("chatter", 10);
 
       timer_ = this->create_wall_timer(100ms,
           [this](){return this->timer_callback();}
@@ -37,7 +37,7 @@ class SimpleBagPlayer : public rclcpp::Node
         }
 
         rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
-        example_interfaces::msg::String::SharedPtr ros_msg = std::make_shared<example_interfaces::msg::String>();
+        std_msgs::msg::String::SharedPtr ros_msg = std::make_shared<std_msgs::msg::String>();
 
         serialization_.deserialize_message(&serialized_msg, ros_msg.get());
 
@@ -49,9 +49,9 @@ class SimpleBagPlayer : public rclcpp::Node
     }
 
     rclcpp::TimerBase::SharedPtr timer_;
-    rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr publisher_;
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
 
-    rclcpp::Serialization<example_interfaces::msg::String> serialization_;
+    rclcpp::Serialization<std_msgs::msg::String> serialization_;
     rosbag2_cpp::Reader reader_;
 };
 

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -30,12 +30,15 @@ public:
   explicit SimpleBagPlayer(const std::string & bag_filename)
   : Node("simple_bag_player")
   {
+    declare_parameter("edit", false);
+    message_needs_to_be_edit_before_send_ = get_parameter("edit").as_bool();
+
     publisher_ = this->create_publisher<std_msgs::msg::String>("chatter", 10);
 
     // ignore timestamp and publish at a fixed rate (10 Hz).
     timer_ = this->create_wall_timer(
       100ms,
-      [this]() {return this->timer_callback();}
+      [this]() {this->timer_callback();}
     );
 
     reader_.open(bag_filename);
@@ -73,12 +76,12 @@ private:
   rclcpp::Serialization<std_msgs::msg::String> serialization_;
   rosbag2_cpp::Reader reader_;
 
-  bool message_needs_to_be_edit_before_send_ {true};
+  bool message_needs_to_be_edit_before_send_;
 };
 
 int main(int argc, char ** argv)
 {
-  if (argc != 2) {
+  if (argc < 2) {
     std::cerr << "Usage: " << argv[0] << " <bag>" << std::endl;
     return 1;
   }

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -51,13 +51,20 @@ private:
         continue;
       }
 
-      rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
-      std_msgs::msg::String::SharedPtr ros_msg = std::make_shared<std_msgs::msg::String>();
+      if (message_needs_to_be_edit_before_send_)
+      {
+        rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
+        std_msgs::msg::String::SharedPtr ros_msg = std::make_shared<std_msgs::msg::String>();
 
-      serialization_.deserialize_message(&serialized_msg, ros_msg.get());
-
-      publisher_->publish(*ros_msg);
-      std::cout << ros_msg->data << "\n";
+        serialization_.deserialize_message(&serialized_msg, ros_msg.get());
+        ros_msg->data += "[edited]";
+        publisher_->publish(*ros_msg);
+        std::cout << ros_msg->data << "\n";
+      }
+      else
+      {
+        publisher_->publish(*msg->serialized_data);
+      }
 
       break;
     }
@@ -68,6 +75,8 @@ private:
 
   rclcpp::Serialization<std_msgs::msg::String> serialization_;
   rosbag2_cpp::Reader reader_;
+
+  bool message_needs_to_be_edit_before_send_ {true};
 };
 
 int main(int argc, char ** argv)

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -28,10 +28,11 @@ class SimpleBagPlayer : public rclcpp::Node
 {
 public:
   explicit SimpleBagPlayer(const std::string & bag_filename)
-  : Node("playback_node")
+  : Node("simple_bag_player")
   {
     publisher_ = this->create_publisher<std_msgs::msg::String>("chatter", 10);
 
+    // ignore timestamp and publish at a fixed rate (10 Hz).
     timer_ = this->create_wall_timer(
       100ms,
       [this]() {return this->timer_callback();}

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -51,8 +51,7 @@ private:
         continue;
       }
 
-      if (message_needs_to_be_edit_before_send_)
-      {
+      if (message_needs_to_be_edit_before_send_) {
         rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
         std_msgs::msg::String::SharedPtr ros_msg = std::make_shared<std_msgs::msg::String>();
 
@@ -60,9 +59,7 @@ private:
         ros_msg->data += "[edited]";
         publisher_->publish(*ros_msg);
         std::cout << ros_msg->data << "\n";
-      }
-      else
-      {
+      } else {
         publisher_->publish(*msg->serialized_data);
       }
 

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -11,10 +11,10 @@
 
 using namespace std::chrono_literals;
 
-class PlaybackNode : public rclcpp::Node
+class SimpleBagPlayer : public rclcpp::Node
 {
   public:
-    PlaybackNode(const std::string & bag_filename)
+    SimpleBagPlayer(const std::string & bag_filename)
     : Node("playback_node")
     {
       publisher_ = this->create_publisher<example_interfaces::msg::String>("chatter", 10);
@@ -63,7 +63,7 @@ int main(int argc, char ** argv)
   }
 
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<PlaybackNode>(argv[1]));
+  rclcpp::spin(std::make_shared<SimpleBagPlayer>(argv[1]));
   rclcpp::shutdown();
 
   return 0;

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_player.cpp
@@ -6,6 +6,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/serialization.hpp"
+#include "rosbag2_storage/qos.hpp"
 #include "rosbag2_cpp/reader.hpp"
 #include "example_interfaces/msg/string.hpp"
 
@@ -17,13 +18,19 @@ class PlaybackNode : public rclcpp::Node
     PlaybackNode(const std::string & bag_filename)
     : Node("playback_node")
     {
-      publisher_ = this->create_publisher<example_interfaces::msg::String>("chatter", 10);
+      reader_.open(bag_filename);
+
+      auto topics = reader_.get_all_topics_and_types();
+
+      for (const auto & topic : topics) {
+        if (topic.name == TOPIC_NAME) {
+          publisher_ = create_generic_publisher(topic.name, topic.type, rosbag2_storage::Rosbag2QoS{});
+        }
+      }
 
       timer_ = this->create_wall_timer(100ms,
           [this](){return this->timer_callback();}
       );
-
-      reader_.open(bag_filename);
     }
 
   private:
@@ -31,28 +38,21 @@ class PlaybackNode : public rclcpp::Node
     {
       while (reader_.has_next()) {
         rosbag2_storage::SerializedBagMessageSharedPtr msg = reader_.read_next();
-
-        if (msg->topic_name != "chatter") {
+        if (msg->topic_name != TOPIC_NAME) {
           continue;
         }
-
-        rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
-        example_interfaces::msg::String::SharedPtr ros_msg = std::make_shared<example_interfaces::msg::String>();
-
-        serialization_.deserialize_message(&serialized_msg, ros_msg.get());
-
-        publisher_->publish(*ros_msg);
-        std::cout << ros_msg->data << "\n";
+        publisher_->publish(rclcpp::SerializedMessage(*msg->serialized_data));
 
         break;
       }
     }
 
     rclcpp::TimerBase::SharedPtr timer_;
-    rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr publisher_;
+    std::shared_ptr<rclcpp::GenericPublisher> publisher_;
 
-    rclcpp::Serialization<example_interfaces::msg::String> serialization_;
     rosbag2_cpp::Reader reader_;
+
+    const std::string TOPIC_NAME {"chatter"};
 };
 
 int main(int argc, char ** argv)

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_reader.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_reader.cpp
@@ -7,7 +7,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/serialization.hpp"
 #include "rosbag2_cpp/reader.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
@@ -17,7 +17,7 @@ class PlaybackNode : public rclcpp::Node
     PlaybackNode(const std::string & bag_filename)
     : Node("playback_node")
     {
-      publisher_ = this->create_publisher<std_msgs::msg::String>("chatter", 10);
+      publisher_ = this->create_publisher<example_interfaces::msg::String>("chatter", 10);
 
       timer_ = this->create_wall_timer(100ms,
           [this](){return this->timer_callback();}
@@ -32,12 +32,12 @@ class PlaybackNode : public rclcpp::Node
       while (reader_.has_next()) {
         rosbag2_storage::SerializedBagMessageSharedPtr msg = reader_.read_next();
 
-        if (msg->topic_name != "/turtle1/pose") {
+        if (msg->topic_name != "/chatter") {
           continue;
         }
 
         rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
-        std_msgs::msg::String::SharedPtr ros_msg = std::make_shared<std_msgs::msg::String>();
+        example_interfaces::msg::String::SharedPtr ros_msg = std::make_shared<example_interfaces::msg::String>();
 
         serialization_.deserialize_message(&serialized_msg, ros_msg.get());
 
@@ -49,9 +49,9 @@ class PlaybackNode : public rclcpp::Node
     }
 
     rclcpp::TimerBase::SharedPtr timer_;
-    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+    rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr publisher_;
 
-    rclcpp::Serialization<std_msgs::msg::String> serialization_;
+    rclcpp::Serialization<example_interfaces::msg::String> serialization_;
     rosbag2_cpp::Reader reader_;
 };
 

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_reader.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_reader.cpp
@@ -32,7 +32,7 @@ class PlaybackNode : public rclcpp::Node
       while (reader_.has_next()) {
         rosbag2_storage::SerializedBagMessageSharedPtr msg = reader_.read_next();
 
-        if (msg->topic_name != "/chatter") {
+        if (msg->topic_name != "chatter") {
           continue;
         }
 

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_reader.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_reader.cpp
@@ -1,0 +1,70 @@
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/serialization.hpp"
+#include "rosbag2_cpp/reader.hpp"
+#include "std_msgs/msg/string.hpp"
+
+using namespace std::chrono_literals;
+
+class PlaybackNode : public rclcpp::Node
+{
+  public:
+    PlaybackNode(const std::string & bag_filename)
+    : Node("playback_node")
+    {
+      publisher_ = this->create_publisher<std_msgs::msg::String>("chatter", 10);
+
+      timer_ = this->create_wall_timer(100ms,
+          [this](){return this->timer_callback();}
+      );
+
+      reader_.open(bag_filename);
+    }
+
+  private:
+    void timer_callback()
+    {
+      while (reader_.has_next()) {
+        rosbag2_storage::SerializedBagMessageSharedPtr msg = reader_.read_next();
+
+        if (msg->topic_name != "/turtle1/pose") {
+          continue;
+        }
+
+        rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
+        std_msgs::msg::String::SharedPtr ros_msg = std::make_shared<std_msgs::msg::String>();
+
+        serialization_.deserialize_message(&serialized_msg, ros_msg.get());
+
+        publisher_->publish(*ros_msg);
+        std::cout << ros_msg->data << "\n";
+
+        break;
+      }
+    }
+
+    rclcpp::TimerBase::SharedPtr timer_;
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+
+    rclcpp::Serialization<std_msgs::msg::String> serialization_;
+    rosbag2_cpp::Reader reader_;
+};
+
+int main(int argc, char ** argv)
+{
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <bag>" << std::endl;
+    return 1;
+  }
+
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<PlaybackNode>(argv[1]));
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
@@ -27,6 +27,9 @@ public:
   SimpleBagRecorder()
   : Node("simple_bag_recorder")
   {
+    declare_parameter("edit", false);
+    message_needs_to_be_edit_before_write_ = get_parameter("edit").as_bool();
+
     writer_ = std::make_unique<rosbag2_cpp::Writer>();
 
     writer_->open("my_bag");
@@ -61,7 +64,7 @@ private:
   rclcpp::Serialization<std_msgs::msg::String> serialization_;
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
 
-  bool message_needs_to_be_edit_before_write_ {true};
+  bool message_needs_to_be_edit_before_write_;
 };
 
 int main(int argc, char * argv[])

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
@@ -51,8 +51,8 @@ private:
   {
     rclcpp::Time time_stamp = this->now();
     msg->data += "[edited]";
-    rclcpp::SerializedMessage serialized_msg;
-    serialization_.serialize_message(msg.get(), &serialized_msg);
+    auto serialized_msg = std::make_shared<rclcpp::SerializedMessage>();
+    serialization_.serialize_message(msg.get(), serialized_msg.get());
     writer_->write(serialized_msg, "chatter", "std_msgs/msg/String", time_stamp);
   }
 

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-#include "example_interfaces/msg/string.hpp"
+#include "std_msgs/msg/string.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "rosbag2_cpp/writer.hpp"
@@ -31,7 +31,7 @@ public:
 
     writer_->open("my_bag");
 
-    subscription_ = create_subscription<example_interfaces::msg::String>(
+    subscription_ = create_subscription<std_msgs::msg::String>(
       "chatter", 10, std::bind(&SimpleBagRecorder::topic_callback, this, _1));
   }
 
@@ -39,10 +39,10 @@ private:
   void topic_callback(std::shared_ptr<rclcpp::SerializedMessage> msg) const
   {
     rclcpp::Time time_stamp = this->now();
-    writer_->write(msg, "chatter", "example_interfaces/msg/String", time_stamp);
+    writer_->write(msg, "chatter", "std_msgs/msg/String", time_stamp);
   }
 
-  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr subscription_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
 };
 

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "rosbag2_cpp/writer.hpp"
@@ -31,7 +31,7 @@ public:
 
     writer_->open("my_bag");
 
-    subscription_ = create_subscription<std_msgs::msg::String>(
+    subscription_ = create_subscription<example_interfaces::msg::String>(
       "chatter", 10, std::bind(&SimpleBagRecorder::topic_callback, this, _1));
   }
 
@@ -39,10 +39,10 @@ private:
   void topic_callback(std::shared_ptr<rclcpp::SerializedMessage> msg) const
   {
     rclcpp::Time time_stamp = this->now();
-    writer_->write(msg, "chatter", "std_msgs/msg/String", time_stamp);
+    writer_->write(msg, "chatter", "example_interfaces/msg/String", time_stamp);
   }
 
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr subscription_;
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
 };
 

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
@@ -34,7 +34,8 @@ class SimpleBagPlayer(Node):
         self.publisher = self.create_publisher(String, 'chatter', 10)
         # ignore timestamp and publish at a fixed rate (10 Hz).
         self.timer = self.create_timer(0.1, self.timer_callback)
-        self.message_needs_to_be_edit_before_send_ = True
+        self.declare_parameter("edit", False)
+        self.message_needs_to_be_edit_before_send_ = self.get_parameter("edit").get_parameter_value().bool_value
 
     def timer_callback(self):
         while self.reader.has_next():

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
@@ -34,15 +34,21 @@ class SimpleBagPlayer(Node):
         self.publisher = self.create_publisher(String, 'chatter', 10)
         # ignore timestamp and publish at a fixed rate (10 Hz).
         self.timer = self.create_timer(0.1, self.timer_callback)
+        self.message_needs_to_be_edit_before_send_ = True
 
     def timer_callback(self):
         while self.reader.has_next():
             msg = self.reader.read_next()
             if msg[0] != 'chatter':
                 continue
-            ros_msg = deserialize_message(msg[1], String)
-            self.publisher.publish(ros_msg)
-            self.get_logger().info(ros_msg.data)
+
+            if self.message_needs_to_be_edit_before_send_:
+                ros_msg = deserialize_message(msg[1], String)
+                ros_msg.data += '[edited]'
+                self.publisher.publish(ros_msg)
+                self.get_logger().info(ros_msg.data)
+            else:
+                self.publisher.publish(msg[1])
 
 
 def main(args=None):

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
@@ -1,0 +1,55 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import rclpy
+from rclpy.node import Node
+from rclpy.serialization import deserialize_message
+import rosbag2_py
+from std_msgs.msg import String
+
+
+class SimpleBagPlayer(Node):
+
+    def __init__(self, bag_filename):
+        super().__init__('simple_bag_player')
+        self.reader = rosbag2_py.SequentialReader()
+        storage_options = rosbag2_py._storage.StorageOptions(
+            uri='my_bag',
+            storage_id='sqlite3')
+        converter_options = rosbag2_py._storage.ConverterOptions('', '')
+        self.reader.open(storage_options, converter_options)
+
+        self.publisher = self.create_publisher(String, 'chatter', 10)
+        self.timer = self.create_timer(0.1, self.timer_callback)
+
+    def timer_callback(self):
+        while self.reader.has_next():
+            msg = self.reader.read_next()
+            if msg[0] != 'chatter':
+                continue
+            ros_msg = deserialize_message(msg[1], String)
+            self.publisher.publish(ros_msg)
+            self.get_logger().info(ros_msg.data)
+
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    sbr = SimpleBagPlayer(sys.argv[1])
+    rclpy.spin(sbr)
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ class SimpleBagPlayer(Node):
         self.reader.open(storage_options, converter_options)
 
         self.publisher = self.create_publisher(String, 'chatter', 10)
+        # ignore timestamp and publish at a fixed rate (10 Hz).
         self.timer = self.create_timer(0.1, self.timer_callback)
 
     def timer_callback(self):

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
@@ -25,7 +25,7 @@ class SimpleBagPlayer(Node):
         super().__init__('simple_bag_player')
         self.reader = rosbag2_py.SequentialReader()
         storage_options = rosbag2_py._storage.StorageOptions(
-            uri='my_bag',
+            uri=bag_filename,
             storage_id='sqlite3')
         converter_options = rosbag2_py._storage.ConverterOptions('', '')
         self.reader.open(storage_options, converter_options)

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_player.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
+
 import rclpy
 from rclpy.node import Node
 from rclpy.serialization import deserialize_message
@@ -41,7 +42,6 @@ class SimpleBagPlayer(Node):
             ros_msg = deserialize_message(msg[1], String)
             self.publisher.publish(ros_msg)
             self.get_logger().info(ros_msg.data)
-
 
 
 def main(args=None):

--- a/rosbag2_examples/rosbag2_examples_py/setup.py
+++ b/rosbag2_examples/rosbag2_examples_py/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'simple_bag_recorder = rosbag2_examples_py.simple_bag_recorder:main',
+            'simple_bag_player = rosbag2_examples_py.simple_bag_player:main',
             'data_generator_node = rosbag2_examples_py.data_generator_node:main',
             'data_generator_executable = rosbag2_examples_py.data_generator_executable:main',
         ],


### PR DESCRIPTION
Fixes #1449.

Added simple bag player examples in cpp and Python. I also tried to read or write bag files without specifying topic types. However, it became too complicated and was no longer a "simple" example, so I decided not to push the changes.