### PR TITLE
Fixes bag not closing properly (#1586)

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -160,9 +160,9 @@ void SequentialWriter::close()
     finalize_metadata();
     metadata_io_->write_metadata(base_folder_, metadata_);
   }
-
   storage_.reset();  // Necessary to ensure that the storage is destroyed before the factory
-  storage_factory_.reset();
+
+  topics_names_to_info_.clear();
 }
 
 void SequentialWriter::create_topic(const rosbag2_storage::TopicMetadata & topic_with_type)

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -61,7 +61,11 @@ SequentialWriter::SequentialWriter(
 
 SequentialWriter::~SequentialWriter()
 {
-  close();
+  // only close writer if bag is open to prevent overwrite
+  if(storage_)
+  {
+    close();
+  }
 }
 
 void SequentialWriter::init_metadata()
@@ -160,8 +164,9 @@ void SequentialWriter::close()
     finalize_metadata();
     metadata_io_->write_metadata(base_folder_, metadata_);
   }
-  storage_.reset();  // Necessary to ensure that the storage is destroyed before the factory
 
+  // destroy current storage object and clear active track map for topic metadata
+  storage_.reset();
   topics_names_to_info_.clear();
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -62,8 +62,7 @@ SequentialWriter::SequentialWriter(
 SequentialWriter::~SequentialWriter()
 {
   // only close writer if bag is open to prevent overwrite
-  if(storage_)
-  {
+  if (storage_) {
     close();
   }
 }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -43,8 +43,10 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
   serialization.serialize_message(&test_msg, &serialized_msg);
 
   auto rosbag_directory = rcpputils::fs::path("test_rosbag2_writer_api_bag");
+  auto rosbag_directory_next = rcpputils::fs::path("test_rosbag2_writer_api_bag_next");
   // in case the bag was previously not cleaned up
   rcpputils::fs::remove_all(rosbag_directory);
+  rcpputils::fs::remove_all(rosbag_directory_next);
 
   {
     rosbag2_cpp::Writer writer;
@@ -87,7 +89,14 @@ TEST(TestRosbag2CPPAPI, minimal_writer_example)
     // writing a non-serialized message
     writer.write(test_msg, "/a/ros2/message", rclcpp::Clock().now());
 
-    // close on scope exit
+    // close as prompted
+    writer.close();
+
+    writer.open(rosbag_directory_next.string());
+    writer.write(bag_message, "/my/other/topic", "test_msgs/msg/BasicTypes");
+
+    writer.close();
+
   }
 
   {


### PR DESCRIPTION
This PR fixes #1586.
Basically, destruction of the `storage_factory_` does not allow the writer to open another bag file after it got closed. I also don't think that it is necessary to destroy the factory in the first place as it does not get any data from the writer and its `unique` anyway. What did prevent the writer to work as expected was keeping track of existing topics in the map `topics_names_to_info_` but that can be easily cleared on close.

I don't know if the test is in the maintainers way of doing things, please let me know.