### PR TITLE
Fix for false negative tests in rosbag2_py

### DIFF
--- a/rosbag2_py/test/common.py
+++ b/rosbag2_py/test/common.py
@@ -51,4 +51,4 @@ def wait_for(
         if clock.now() - start > timeout:
             return False
         time.sleep(sleep_time)
-        return True
+    return True

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -84,6 +84,6 @@ def test_record_cancel(tmp_path, storage_id):
 
     metadata = metadata_io.read_metadata(bag_path)
     assert len(metadata.relative_file_paths)
-    storage_path = Path(metadata.relative_file_paths[0])
+    storage_path = Path(bag_path + '/' + metadata.relative_file_paths[0])
     assert wait_for(lambda: storage_path.is_file(),
                     timeout=rclpy.duration.Duration(seconds=3))

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import datetime
-from pathlib import Path
 import threading
 
 from common import get_rosbag_options, wait_for
@@ -44,8 +43,8 @@ def test_options_qos_conversion():
 
 @pytest.mark.parametrize('storage_id', TESTED_STORAGE_IDS)
 def test_record_cancel(tmp_path, storage_id):
-    bag_path = str(tmp_path / 'test_record_cancel')
-    storage_options, converter_options = get_rosbag_options(bag_path, storage_id)
+    bag_path = tmp_path / 'test_record_cancel'
+    storage_options, converter_options = get_rosbag_options(str(bag_path), storage_id)
 
     recorder = rosbag2_py.Recorder()
 
@@ -78,12 +77,12 @@ def test_record_cancel(tmp_path, storage_id):
     recorder.cancel()
 
     metadata_io = rosbag2_py.MetadataIo()
-    assert wait_for(lambda: metadata_io.metadata_file_exists(bag_path),
+    assert wait_for(lambda: metadata_io.metadata_file_exists(str(bag_path)),
                     timeout=rclpy.duration.Duration(seconds=3))
     record_thread.join()
 
-    metadata = metadata_io.read_metadata(bag_path)
+    metadata = metadata_io.read_metadata(str(bag_path))
     assert len(metadata.relative_file_paths)
-    storage_path = Path(bag_path + '/' + metadata.relative_file_paths[0])
+    storage_path = bag_path / metadata.relative_file_paths[0]
     assert wait_for(lambda: storage_path.is_file(),
                     timeout=rclpy.duration.Duration(seconds=3))


### PR DESCRIPTION
-  wait_for(condition: Callable, timout) was incorrectly returning True after the first iteration even if condition was false.