### PR TITLE
Update rosbag2_py stubs

### DIFF
--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -52,6 +52,7 @@ class RecordOptions:
     start_paused: bool
     topic_polling_interval: datetime.timedelta
     topic_qos_profile_overrides: dict
+    topic_types: List[str]
     topics: List[str]
     use_sim_time: bool
     def __init__(self) -> None: ...


### PR DESCRIPTION
Related to a recent change that added stub files https://github.com/ros2/rosbag2/pull/1569

PR above was not rebased to the latest rolling, which had [pybind11 changes](https://github.com/ros2/rosbag2/pull/1577/files#diff-c85fd024e7d68c762d60d25e2ba155bcc527f04c937ed09adc893ea241fdc61c), before merging. This caused a "race condition" - CI was green, but after rebasing it would fail. Seems, when making changes to rosbag2_py (pybind11), we need to make sure to rebase to latest rolling before merge.