### PR TITLE
Check existence of a file before passing it to the mcap reader

### DIFF
--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -14,6 +14,7 @@
 
 #include "rcpputils/thread_safety_annotations.hpp"
 #include "rcutils/logging_macros.h"
+#include "rcutils/strerror.h"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
@@ -336,7 +337,9 @@ void MCAPStorage::open_impl(const std::string & uri, const std::string & preset_
       relative_path_ = uri;
       input_ = std::make_unique<std::ifstream>(relative_path_, std::ios::binary);
       if (!input_->is_open()) {
-        throw std::runtime_error(std::strerror(errno));
+        char error_string[1024] = {};
+        rcutils_strerror(error_string, sizeof(error_string));
+        throw std::runtime_error(error_string);
       }
       data_source_ = std::make_unique<mcap::FileStreamReader>(*input_);
       mcap_reader_ = std::make_unique<mcap::McapReader>();

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -40,6 +40,7 @@
 #include <mcap/mcap.hpp>
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -334,6 +335,9 @@ void MCAPStorage::open_impl(const std::string & uri, const std::string & preset_
     case rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY: {
       relative_path_ = uri;
       input_ = std::make_unique<std::ifstream>(relative_path_, std::ios::binary);
+      if (!input_->is_open()) {
+        throw std::runtime_error(std::strerror(errno));
+      }
       data_source_ = std::make_unique<mcap::FileStreamReader>(*input_);
       mcap_reader_ = std::make_unique<mcap::McapReader>();
       auto status = mcap_reader_->open(*data_source_);


### PR DESCRIPTION
…mcap::FileStreamReader in order to avoid this assertion: failing https://github.com/foxglove/mcap/blob/9d73125e50121c1eeb2ceb9d13db51ff923b0420/cpp/mcap/include/mcap/reader.inl#L90

This is an issue if you happen to run rosbag build in debug mode (in which assertions are enabled). As it is the behavior of debug and release mode is inconsistent as in debug mode the assertion is raised and in release mode an exception is raised.

