### PR TITLE
Update to use yaml-cpp version 0.8.0.

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -75,9 +75,7 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/reindexer.cpp
   src/rosbag2_cpp/service_utils.cpp)
 
-target_link_libraries(${PROJECT_NAME}
-  PUBLIC
-  ament_index_cpp::ament_index_cpp
+target_link_libraries(${PROJECT_NAME} PUBLIC
   pluginlib::pluginlib
   rclcpp::rclcpp
   rcpputils::rcpputils
@@ -87,8 +85,11 @@ target_link_libraries(${PROJECT_NAME}
   rosbag2_storage::rosbag2_storage
   rosidl_runtime_c::rosidl_runtime_c
   rosidl_runtime_cpp::rosidl_runtime_cpp
-  rosidl_typesupport_cpp::rosidl_typesupport_cpp
   rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  ament_index_cpp::ament_index_cpp
+  rosidl_typesupport_cpp::rosidl_typesupport_cpp
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -122,12 +123,13 @@ ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   pluginlib
   rclcpp
+  rcpputils
+  rcutils
   rmw
   rmw_implementation
   rosbag2_storage
   rosidl_runtime_c
   rosidl_runtime_cpp
-  rosidl_typesupport_cpp
   rosidl_typesupport_introspection_cpp
 )
 
@@ -164,7 +166,7 @@ if(BUILD_TESTING)
     test/rosbag2_cpp/test_typesupport_helpers.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_typesupport_helpers)
-    target_link_libraries(test_typesupport_helpers ${PROJECT_NAME})
+    target_link_libraries(test_typesupport_helpers ${PROJECT_NAME} ament_index_cpp::ament_index_cpp rosidl_typesupport_cpp::rosidl_typesupport_cpp)
   endif()
 
   ament_add_gmock(test_info

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -166,7 +166,11 @@ if(BUILD_TESTING)
     test/rosbag2_cpp/test_typesupport_helpers.cpp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   if(TARGET test_typesupport_helpers)
-    target_link_libraries(test_typesupport_helpers ${PROJECT_NAME} ament_index_cpp::ament_index_cpp rosidl_typesupport_cpp::rosidl_typesupport_cpp)
+    target_link_libraries(test_typesupport_helpers
+      ${PROJECT_NAME}
+      ament_index_cpp::ament_index_cpp
+      rosidl_typesupport_cpp::rosidl_typesupport_cpp
+    )
   endif()
 
   ament_add_gmock(test_info

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -28,12 +28,13 @@ find_package(rmw REQUIRED)
 find_package(rosbag2_performance_benchmarking_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
-  add_executable(writer_benchmark
-    src/config_utils.cpp
-    src/result_utils.cpp
-    src/writer_benchmark.cpp
-    src/msg_utils/helpers.cpp)
+add_executable(writer_benchmark
+  src/config_utils.cpp
+  src/result_utils.cpp
+  src/writer_benchmark.cpp
+  src/msg_utils/helpers.cpp)
 
 add_executable(benchmark_publishers
   src/benchmark_publishers.cpp
@@ -52,7 +53,7 @@ target_link_libraries(writer_benchmark
   rosbag2_compression::rosbag2_compression
   rosbag2_cpp::rosbag2_cpp
   rosbag2_storage::rosbag2_storage
-  yaml-cpp
+  yaml-cpp::yaml-cpp
 )
 
 target_link_libraries(benchmark_publishers

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(rcutils REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 add_library(
   ${PROJECT_NAME}
@@ -43,12 +44,14 @@ target_include_directories(${PROJECT_NAME}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-target_link_libraries(${PROJECT_NAME}
-  pluginlib::pluginlib
+target_link_libraries(${PROJECT_NAME} PUBLIC
   rcutils::rcutils
   rclcpp::rclcpp
   rmw::rmw
-  yaml-cpp
+  yaml-cpp::yaml-cpp
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  pluginlib::pluginlib
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -73,7 +76,7 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
 
-ament_export_dependencies(pluginlib yaml_cpp_vendor rclcpp rmw)
+ament_export_dependencies(rclcpp rcutils rmw yaml-cpp yaml_cpp_vendor)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -87,7 +90,7 @@ if(BUILD_TESTING)
     SHARED
     test/rosbag2_storage/test_plugin.cpp
     test/rosbag2_storage/test_read_only_plugin.cpp)
-  target_link_libraries(test_plugin ${PROJECT_NAME})
+  target_link_libraries(test_plugin ${PROJECT_NAME} pluginlib::pluginlib)
   install(
     TARGETS test_plugin
     ARCHIVE DESTINATION lib
@@ -128,7 +131,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_qos
     ${PROJECT_NAME}
     rosbag2_test_common::rosbag2_test_common
-    yaml-cpp
+    yaml-cpp::yaml-cpp
   )
 endif()
 

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -28,6 +28,8 @@ find_package(mcap_vendor REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 ament_python_install_package(ros2bag_mcap_cli)
 
@@ -40,11 +42,12 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_STORAGE_MCAP_BUILDING_DLL")
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   mcap_vendor::mcap
   pluginlib::pluginlib
   rcutils::rcutils
   rosbag2_storage::rosbag2_storage
+  yaml-cpp::yaml-cpp
 )
 
 set(MCAP_COMPILE_DEFS)
@@ -109,6 +112,7 @@ if(BUILD_TESTING)
     rosbag2_storage::rosbag2_storage
     rosbag2_test_common::rosbag2_test_common
     ${std_msgs_TARGETS}
+    yaml-cpp::yaml-cpp
   )
   target_compile_definitions(test_mcap_storage PRIVATE ${MCAP_COMPILE_DEFS})
 
@@ -117,6 +121,5 @@ endif()
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})
-ament_export_dependencies(mcap_vendor pluginlib rosbag2_storage rcutils)
 
 ament_package()

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -17,6 +17,7 @@
   <depend>pluginlib</depend>
   <depend>rcutils</depend>
   <depend>rosbag2_storage</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/rosbag2_storage_sqlite3/CMakeLists.txt
+++ b/rosbag2_storage_sqlite3/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(rosbag2_storage REQUIRED)
 find_package(sqlite3_vendor REQUIRED)
 find_package(SQLite3 REQUIRED)  # provided by sqlite3_vendor
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 ament_python_install_package(ros2bag_sqlite3_cli)
 
@@ -38,13 +39,15 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_storage_sqlite3/sqlite_storage.cpp
   src/rosbag2_storage_sqlite3/sqlite_statement_wrapper.cpp)
 
-target_link_libraries(${PROJECT_NAME}
-  pluginlib::pluginlib
+target_link_libraries(${PROJECT_NAME} PUBLIC
   rosbag2_storage::rosbag2_storage
   rcpputils::rcpputils
   rcutils::rcutils
   SQLite::SQLite3
-  yaml-cpp
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  pluginlib::pluginlib
+  yaml-cpp::yaml-cpp
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -87,8 +90,6 @@ if(BUILD_TESTING)
     rosbag2_storage::rosbag2_storage
     rosbag2_test_common::rosbag2_test_common
     rcutils::rcutils
-    SQLite::SQLite3
-    pluginlib::pluginlib
   )
 
   ament_add_gmock(test_sqlite_wrapper

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(rosbag2_storage REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(shared_queues_vendor REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_transport/bag_rewrite.cpp
@@ -67,7 +68,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   rmw::rmw
   rosbag2_compression::rosbag2_compression
   shared_queues_vendor::singleproducerconsumer
-  yaml-cpp
+  yaml-cpp::yaml-cpp
 )
 
 rclcpp_components_register_node(


### PR DESCRIPTION
In yaml-cpp 0.8.0, they updated to use a proper CMake target, i.e. yaml-cpp::yaml-cpp.  Update that here as well since we are updating our vendor to 0.8.0.

While I was in here, I did a bunch of cleanup to make fewer symbols externally visible.

Let me know if you want me to split the cleanups out into a separate PR; I'm happy to do that.

Depends on https://github.com/ros2/yaml_cpp_vendor/pull/48 , so should not be merged before that one.
