### PR TITLE
Switch rclpy to be an exec_depend in rosbag2_py.

### DIFF
--- a/rosbag2_py/package.xml
+++ b/rosbag2_py/package.xml
@@ -24,13 +24,13 @@
   <depend>rosbag2_storage</depend>
   <depend>rosbag2_transport</depend>
 
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>rpyutils</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rcl_interfaces</test_depend>
-  <test_depend>rclpy</test_depend>
   <test_depend>rosbag2_compression_zstd</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>
   <test_depend>rosbag2_test_common</test_depend>


### PR DESCRIPTION
That's because there is code in _storage.cpp
that imports rclpy.duration at runtime.

In particular, see https://github.com/ros2/rosbag2/blob/1bfe305cf3018fb59bc6571df303a919e7b4bd89/rosbag2_py/src/rosbag2_py/_storage.cpp#L37 and https://github.com/ros2/rosbag2/blob/1bfe305cf3018fb59bc6571df303a919e7b4bd89/rosbag2_py/src/rosbag2_py/_storage.cpp#L50