### PR TITLE
Add option to disable recorder keyboard controls

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -152,6 +152,9 @@ class RecordVerb(VerbExtension):
                  'about one second of total recorded data volume. '
                  'If the value specified is 0, then every message is directly written to disk.')
         parser.add_argument(
+            '--disable-keyboard-controls', action='store_true', default=False,
+            help='disables keyboard controls for recorder')
+        parser.add_argument(
             '--start-paused', action='store_true', default=False,
             help='Start the recorder in a paused state.')
         parser.add_argument(
@@ -293,9 +296,12 @@ class RecordVerb(VerbExtension):
         )
         record_options = RecordOptions()
         record_options.all_topics = args.all_topics or args.all
+        record_options.all_services = args.all_services or args.all
         record_options.is_discovery_disabled = args.no_discovery
         record_options.topics = args.topics
         record_options.topic_types = args.topic_types
+        # Convert service name to service event topic name
+        record_options.services = convert_service_to_service_event_topic(args.services)
         record_options.exclude_topic_types = args.exclude_topic_types
         record_options.rmw_serialization_format = args.serialization_format
         record_options.topic_polling_interval = datetime.timedelta(
@@ -316,10 +322,7 @@ class RecordVerb(VerbExtension):
         record_options.start_paused = args.start_paused
         record_options.ignore_leaf_topics = args.ignore_leaf_topics
         record_options.use_sim_time = args.use_sim_time
-        record_options.all_services = args.all_services or args.all
-
-        # Convert service name to service event topic name
-        record_options.services = convert_service_to_service_event_topic(args.services)
+        record_options.disable_keyboard_controls = args.disable_keyboard_controls
 
         recorder = Recorder()
 

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -44,6 +44,7 @@ class RecordOptions:
     compression_mode: str
     compression_queue_size: int
     compression_threads: int
+    disable_keyboard_controls: bool
     exclude_regex: str
     exclude_service_events: List[str]
     exclude_topic_types: List[str]

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -55,6 +55,7 @@ public:
   bool ignore_leaf_topics = false;
   bool start_paused = false;
   bool use_sim_time = false;
+  bool disable_keyboard_controls = false;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -333,6 +333,9 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
 
   record_options.start_paused = node.declare_parameter<bool>("record.start_paused", false);
 
+  record_options.disable_keyboard_controls =
+    node.declare_parameter<bool>("record.disable_keyboard_controls", false);
+
   record_options.use_sim_time = node.get_parameter("use_sim_time").get_value<bool>();
 
   if (record_options.use_sim_time && record_options.is_discovery_disabled) {

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -51,6 +51,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
     record_options.topic_qos_profile_overrides);
   node["include_hidden_topics"] = record_options.include_hidden_topics;
   node["include_unpublished_topics"] = record_options.include_unpublished_topics;
+  node["disable_keyboard_controls"] = record_options.disable_keyboard_controls;
   return node;
 }
 
@@ -97,6 +98,9 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<bool>(
     node, "include_unpublished_topics",
     record_options.include_unpublished_topics);
+  optional_assign<bool>(
+    node, "disable_keyboard_controls",
+    record_options.disable_keyboard_controls);
   return true;
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -752,12 +752,7 @@ Recorder::Recorder(
 
   std::shared_ptr<KeyboardHandler> keyboard_handler;
   if (!record_options.disable_keyboard_controls) {
-  #ifndef _WIN32
-    keyboard_handler = std::make_shared<KeyboardHandler>(false);
-  #else
-    // We don't have signal handler option in constructor for windows version
-    keyboard_handler = std::shared_ptr<KeyboardHandler>(new KeyboardHandler());
-  #endif
+    keyboard_handler = std::make_shared<KeyboardHandler>();
   }
 
   auto writer = std::make_unique<rosbag2_cpp::Writer>();
@@ -776,12 +771,7 @@ Recorder::Recorder(
   const rclcpp::NodeOptions & node_options)
 : Recorder(
     std::move(writer),
-#ifndef _WIN32
-    std::make_shared<KeyboardHandler>(false),
-#else
-    // We don't have signal handler option in constructor for windows version
-    std::shared_ptr<KeyboardHandler>(new KeyboardHandler()),
-#endif
+    record_options.disable_keyboard_controls ? nullptr : std::make_shared<KeyboardHandler>(),
     storage_options,
     record_options,
     node_name,
@@ -799,7 +789,7 @@ Recorder::Recorder(
     .start_parameter_event_publisher(false)
     .append_parameter_override("use_sim_time", record_options.use_sim_time)),
   pimpl_(std::make_unique<RecorderImpl>(
-      this, std::move(writer), keyboard_handler,
+      this, std::move(writer), std::move(keyboard_handler),
       storage_options, record_options))
 {}
 

--- a/rosbag2_transport/test/resources/recorder_node_params.yaml
+++ b/rosbag2_transport/test/resources/recorder_node_params.yaml
@@ -30,6 +30,7 @@ recorder_params_node:
       include_unpublished_topics: true
       ignore_leaf_topics: false
       start_paused: false
+      disable_keyboard_controls: true
 
     storage:
       uri: "path/to/some_bag"

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_player.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_player.cpp
@@ -170,6 +170,7 @@ TEST_P(ComposablePlayerTests, player_can_parse_parameters_from_file) {
   EXPECT_DOUBLE_EQ(play_options.playback_duration.seconds(), -1.0);
   EXPECT_EQ(play_options.playback_until_timestamp, -2500000000LL);
   EXPECT_EQ(play_options.start_offset, 999999999);
+  EXPECT_EQ(play_options.disable_keyboard_controls, true);
   EXPECT_EQ(play_options.wait_acked_timeout, -999999999);
   EXPECT_EQ(play_options.disable_loan_message, false);
   EXPECT_EQ(play_options.publish_service_requests, false);

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
@@ -245,6 +245,7 @@ TEST_P(ComposableRecorderTests, recorder_can_parse_parameters_from_file) {
   EXPECT_EQ(record_options.include_unpublished_topics, true);
   EXPECT_EQ(record_options.ignore_leaf_topics, false);
   EXPECT_EQ(record_options.start_paused, false);
+  EXPECT_EQ(record_options.disable_keyboard_controls, true);
   EXPECT_EQ(record_options.use_sim_time, false);
 
   EXPECT_EQ(storage_options.uri, root_bag_path_.generic_string());


### PR DESCRIPTION
Currently only the Player node has an option to disable the keyboard control. This PR adds the same feature to the Recorder node.

When I instantiate the Recorder within C++ as a node and directly run it with e.g. a SingleThreaded executor, it messes up my terminal to the point that I can no longer read the output and need to reset the terminal. Very annoying. Also, I don't want to see output about allowed keystrokes in my log files. This output may have made sense when the recorder was only run from the CLI, but now that the Recorder is a bona-fide composable node, the logging is unwanted.

It turns out that already instantiating (not just using) a KeyboardHandler messes up my terminal, so this PR avoids creating a KeyboardHandler altogether when record_options.disable_keyboard_controls is true.

