### PR TITLE
Add node name to the Read(Write)SplitEvent message

### DIFF
--- a/rosbag2_interfaces/msg/ReadSplitEvent.msg
+++ b/rosbag2_interfaces/msg/ReadSplitEvent.msg
@@ -1,4 +1,8 @@
 # The full path of the file that was finished and closed
 string closed_file
+
 # The full path of the new file that was opened to continue playback
 string opened_file
+
+# The fully qualified node name of the event sender
+string node_name

--- a/rosbag2_interfaces/msg/WriteSplitEvent.msg
+++ b/rosbag2_interfaces/msg/WriteSplitEvent.msg
@@ -1,4 +1,8 @@
 # The full path of the file that was finished and closed
 string closed_file
+
 # The full path of the new file that was created to continue recording
 string opened_file
+
+# The fully qualified node name of the event sender
+string node_name

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -1176,6 +1176,7 @@ void PlayerImpl::prepare_publishers()
       auto message = rosbag2_interfaces::msg::ReadSplitEvent();
       message.closed_file = info.closed_file;
       message.opened_file = info.opened_file;
+      message.node_name = owner_->get_fully_qualified_name();
       split_event_pub_->publish(message);
     };
   reader_->add_event_callbacks(callbacks);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -373,6 +373,7 @@ void RecorderImpl::event_publisher_thread_main()
       auto message = rosbag2_interfaces::msg::WriteSplitEvent();
       message.closed_file = bag_split_info_.closed_file;
       message.opened_file = bag_split_info_.opened_file;
+      message.node_name = node->get_fully_qualified_name();
       try {
         split_event_pub_->publish(message);
       } catch (const std::exception & e) {


### PR DESCRIPTION
- Rationale: 
When running multiple instances of the rosbag2 recorder or player there are no way to know from what instance arrived notification about files split event. With node name in event message we will be able to identify instance of the recorder or player from which event arrived.