### PR TITLE
Make sure to build_export_depend liblz4-dev.

### DIFF
--- a/liblz4_vendor/package.xml
+++ b/liblz4_vendor/package.xml
@@ -17,6 +17,9 @@
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
   <build_depend>liblz4-dev</build_depend>
+
+  <build_export_depend>liblz4-dev</build_export_depend>
+
   <exec_depend>liblz4</exec_depend>
 
   <export>


### PR DESCRIPTION
Otherwise downstream packages that depend on it won't install the package, and thus won't find the library.

@MichaelOrlov We need to break the freeze and land this on `rolling` so we can get `mcap_vendor` building on Rolling.