### PR TITLE
Updated zstd to 1.5.5

### DIFF
--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -5,13 +5,13 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
-# We need at least VERSION 1.4.8, version check is done in Findzstd.cmake
-find_package(zstd 1.4.8 QUIET)
+# We need at least VERSION 1.5.5, version check is done in Findzstd.cmake
+find_package(zstd 1.5.5 QUIET)
 
 ament_vendor(zstd_vendor
   SATISFIED ${zstd_FOUND}
   VCS_URL https://github.com/facebook/zstd.git
-  VCS_VERSION v1.4.8
+  VCS_VERSION v1.5.5
   SOURCE_SUBDIR build/cmake
   CMAKE_ARGS
     -DZSTD_BUILD_STATIC:BOOL=OFF

--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -17,6 +17,7 @@ ament_vendor(zstd_vendor
     -DZSTD_BUILD_STATIC:BOOL=OFF
     -DZSTD_BUILD_SHARED:BOOL=ON
     -DZSTD_BUILD_PROGRAMS:BOOL=OFF
+    PATCHES patches
 )
 
 install(DIRECTORY cmake DESTINATION share/${PROJECT_NAME})

--- a/zstd_vendor/patches/.gitattributes
+++ b/zstd_vendor/patches/.gitattributes
@@ -1,0 +1,1 @@
+*.patch text eol=lf

--- a/zstd_vendor/patches/0001-zstd-compiler-warning.patch
+++ b/zstd_vendor/patches/0001-zstd-compiler-warning.patch
@@ -5,11 +5,11 @@ index 57be832b..94efc253 100644
 @@ -3545,8 +3545,8 @@ static size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDs
  unsigned ZBUFFv04_isError(size_t errorCode) { return ERR_isError(errorCode); }
  const char* ZBUFFv04_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
- 
+
 -size_t ZBUFFv04_recommendedDInSize()  { return BLOCKSIZE + 3; }
 -size_t ZBUFFv04_recommendedDOutSize() { return BLOCKSIZE; }
 +size_t ZBUFFv04_recommendedDInSize(void)  { return BLOCKSIZE + 3; }
 +size_t ZBUFFv04_recommendedDOutSize(void) { return BLOCKSIZE; }
- 
- 
- 
+
+
+

--- a/zstd_vendor/patches/0001-zstd-compiler-warning.patch
+++ b/zstd_vendor/patches/0001-zstd-compiler-warning.patch
@@ -1,12 +1,15 @@
-diff --git a/lib/compress/zstd_compress_superblock.c b/lib/compress/zstd_compress_superblock.c
-index e23e619e..4a244f5c 100644
---- a/lib/compress/zstd_compress_superblock.c
-+++ b/lib/compress/zstd_compress_superblock.c
-@@ -410,6 +410,7 @@ static size_t ZSTD_seqDecompressedSize(seqStore_t const* seqStore, const seqDef*
-     const seqDef* sp = sstart;
-     size_t matchLengthSum = 0;
-     size_t litLengthSum = 0;
-+    (void) litLengthSum;
-     while (send-sp > 0) {
-         ZSTD_sequenceLength const seqLen = ZSTD_getSequenceLength(seqStore, sp);
-         litLengthSum += seqLen.litLength;
+diff --git a/lib/legacy/zstd_v04.c b/lib/legacy/zstd_v04.c
+index 57be832b..94efc253 100644
+--- a/lib/legacy/zstd_v04.c
++++ b/lib/legacy/zstd_v04.c
+@@ -3545,8 +3545,8 @@ static size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDs
+ unsigned ZBUFFv04_isError(size_t errorCode) { return ERR_isError(errorCode); }
+ const char* ZBUFFv04_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
+
+-size_t ZBUFFv04_recommendedDInSize()  { return BLOCKSIZE + 3; }
+-size_t ZBUFFv04_recommendedDOutSize() { return BLOCKSIZE; }
++size_t ZBUFFv04_recommendedDInSize(void)  { return BLOCKSIZE + 3; }
++size_t ZBUFFv04_recommendedDOutSize(void) { return BLOCKSIZE; }
+
+
+

--- a/zstd_vendor/patches/0001-zstd-compiler-warning.patch
+++ b/zstd_vendor/patches/0001-zstd-compiler-warning.patch
@@ -5,11 +5,11 @@ index 57be832b..94efc253 100644
 @@ -3545,8 +3545,8 @@ static size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDs
  unsigned ZBUFFv04_isError(size_t errorCode) { return ERR_isError(errorCode); }
  const char* ZBUFFv04_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
-
+ 
 -size_t ZBUFFv04_recommendedDInSize()  { return BLOCKSIZE + 3; }
 -size_t ZBUFFv04_recommendedDOutSize() { return BLOCKSIZE; }
 +size_t ZBUFFv04_recommendedDInSize(void)  { return BLOCKSIZE + 3; }
 +size_t ZBUFFv04_recommendedDOutSize(void) { return BLOCKSIZE; }
-
-
-
+ 
+ 
+ 

--- a/zstd_vendor/patches/0001-zstd-compiler-warning.patch
+++ b/zstd_vendor/patches/0001-zstd-compiler-warning.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/compress/zstd_compress_superblock.c b/lib/compress/zstd_compress_superblock.c
+index e23e619e..4a244f5c 100644
+--- a/lib/compress/zstd_compress_superblock.c
++++ b/lib/compress/zstd_compress_superblock.c
+@@ -410,6 +410,7 @@ static size_t ZSTD_seqDecompressedSize(seqStore_t const* seqStore, const seqDef*
+     const seqDef* sp = sstart;
+     size_t matchLengthSum = 0;
+     size_t litLengthSum = 0;
++    (void) litLengthSum;
+     while (send-sp > 0) {
+         ZSTD_sequenceLength const seqLen = ZSTD_getSequenceLength(seqStore, sp);
+         litLengthSum += seqLen.litLength;

--- a/zstd_vendor/patches/0001.patch
+++ b/zstd_vendor/patches/0001.patch
@@ -1,15 +1,23 @@
 diff --git a/lib/legacy/zstd_v04.c b/lib/legacy/zstd_v04.c
-index 57be832b..94efc253 100644
+index 57be832b..cc4d3c2b 100644
 --- a/lib/legacy/zstd_v04.c
 +++ b/lib/legacy/zstd_v04.c
-@@ -3545,8 +3545,8 @@ static size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDs
+@@ -3545,10 +3545,15 @@ static size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDs
  unsigned ZBUFFv04_isError(size_t errorCode) { return ERR_isError(errorCode); }
  const char* ZBUFFv04_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
-
+ 
 -size_t ZBUFFv04_recommendedDInSize()  { return BLOCKSIZE + 3; }
 -size_t ZBUFFv04_recommendedDOutSize() { return BLOCKSIZE; }
-+size_t ZBUFFv04_recommendedDInSize(void)  { return BLOCKSIZE + 3; }
-+size_t ZBUFFv04_recommendedDOutSize(void) { return BLOCKSIZE; }
-
-
-
+-
++size_t ZBUFFv04_recommendedDInSize(void)
++{ 
++    return BLOCKSIZE + 3; 
++}
+ 
++size_t ZBUFFv04_recommendedDOutSize(void)
++{
++    return BLOCKSIZE;
++}
+ 
+ /*- ========================================================================= -*/
+ 

--- a/zstd_vendor/patches/0001.patch
+++ b/zstd_vendor/patches/0001.patch
@@ -5,19 +5,19 @@ index 57be832b..cc4d3c2b 100644
 @@ -3545,10 +3545,15 @@ static size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDs
  unsigned ZBUFFv04_isError(size_t errorCode) { return ERR_isError(errorCode); }
  const char* ZBUFFv04_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
- 
+
 -size_t ZBUFFv04_recommendedDInSize()  { return BLOCKSIZE + 3; }
 -size_t ZBUFFv04_recommendedDOutSize() { return BLOCKSIZE; }
 -
 +size_t ZBUFFv04_recommendedDInSize(void)
-+{ 
-+    return BLOCKSIZE + 3; 
++{
++    return BLOCKSIZE + 3;
 +}
- 
+
 +size_t ZBUFFv04_recommendedDOutSize(void)
 +{
 +    return BLOCKSIZE;
 +}
- 
+
  /*- ========================================================================= -*/
- 
+


### PR DESCRIPTION
Removed this warning
```bash
/root/ros2_ws/build/zstd_vendor/zstd_vendor-prefix/src/zstd_vendor/lib/compress/zstd_compress_superblock.c:412:12: warning: variable 'litLengthSum' set but not used [-Wunused-but-set-variable]
  412 |     size_t litLengthSum = 0;
```