### PR TITLE
Removed warnings - unqualified-std-cast-call

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
@@ -71,7 +71,7 @@ public:
 };
 
 TEST_F(Rosbag2PlayCallbacksTestFixture, nullptr_as_callback) {
-  MockPlayer player(move(reader_), storage_options_, play_options_);
+  MockPlayer player(std::move(reader_), storage_options_, play_options_);
   EXPECT_EQ(player.add_on_play_message_pre_callback(nullptr), Player::invalid_callback_handle);
   EXPECT_EQ(player.add_on_play_message_post_callback(nullptr), Player::invalid_callback_handle);
 
@@ -80,7 +80,7 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, nullptr_as_callback) {
 }
 
 TEST_F(Rosbag2PlayCallbacksTestFixture, register_unregister_callbacks) {
-  MockPlayer player(move(reader_), storage_options_, play_options_);
+  MockPlayer player(std::move(reader_), storage_options_, play_options_);
 
   auto lambda_as_callback = [](std::shared_ptr<rosbag2_storage::SerializedBagMessage>) {
       ASSERT_FALSE(true) << "This code should not be called \n";
@@ -124,7 +124,7 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, register_unregister_callbacks) {
 
 TEST_F(Rosbag2PlayCallbacksTestFixture, call_callbacks) {
   using SerializedBagMessage = rosbag2_storage::SerializedBagMessage;
-  MockPlayer player(move(reader_), storage_options_, play_options_);
+  MockPlayer player(std::move(reader_), storage_options_, play_options_);
 
   testing::MockFunction<void(std::shared_ptr<SerializedBagMessage>)> mock_pre_callback;
   EXPECT_CALL(mock_pre_callback, Call(_)).Times(Exactly(static_cast<int>(num_test_messages_)));

--- a/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
@@ -73,7 +73,7 @@ public:
 };
 
 TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_explicit) {
-  rosbag2_transport::Player player(move(reader_), storage_options_, play_options_);
+  rosbag2_transport::Player player(std::move(reader_), storage_options_, play_options_);
   player.pause();
   ASSERT_TRUE(player.is_paused());
 
@@ -86,7 +86,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_explicit) {
 TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_implicit) {
   std::future<void> play_future_result;
   {
-    rosbag2_transport::Player player(move(reader_), storage_options_, play_options_);
+    rosbag2_transport::Player player(std::move(reader_), storage_options_, play_options_);
     player.pause();
     ASSERT_TRUE(player.is_paused());
 
@@ -99,7 +99,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_implicit) {
 }
 
 TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_explicit) {
-  MockPlayer player(move(reader_), storage_options_, play_options_);
+  MockPlayer player(std::move(reader_), storage_options_, play_options_);
   auto calls = 0;
   std::mutex m;
   std::condition_variable cv;
@@ -138,7 +138,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_implict) {
   std::condition_variable cv;
   std::future<void> play_future_result;
   {
-    MockPlayer player(move(reader_), storage_options_, play_options_);
+    MockPlayer player(std::move(reader_), storage_options_, play_options_);
     const auto callback = [&](std::shared_ptr<rosbag2_storage::SerializedBagMessage>) {
         std::unique_lock<std::mutex> lk{m};
         ++calls;
@@ -171,12 +171,12 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_implict) {
 }
 
 TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_before_play_explicit) {
-  rosbag2_transport::Player player(move(reader_), storage_options_, play_options_);
+  rosbag2_transport::Player player(std::move(reader_), storage_options_, play_options_);
   player.stop();    // test for not being stuck in stop
   SUCCEED();  // test for not being stuck in dtor
 }
 
 TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_before_play_implict) {
-  rosbag2_transport::Player player(move(reader_), storage_options_, play_options_);
+  rosbag2_transport::Player player(std::move(reader_), storage_options_, play_options_);
   SUCCEED();  // test for not being stuck in dtor
 }


### PR DESCRIPTION
Removed warnings - unqualified-std-cast-call
```bash
/root/ros2_ws/src/ros2/rosbag2/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp:141:23: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
  141 |     MockPlayer player(move(reader_), storage_options_, play_options_);
      |                       ^
      |                       std::
```