### PR TITLE
[WIP] Bugfix for "--topics/--services cannot work without extra option before bag file path"

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -75,9 +75,10 @@ def add_player_arguments(parser: ArgumentParser) -> None:
         help='enables loop playback when playing a bagfile: it starts back at the beginning '
              'on reaching the end and plays indefinitely.')
     parser.add_argument(
-        '--remap', '-m', default='', nargs='+',
-        help='list of topics to be remapped: in the form '
-             '"old_topic1:=new_topic1 old_topic2:=new_topic2 etc." ')
+        '--remap', '-m', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"old_topic1:=new_topic1 old_topic2:=new_topic2"',
+        help='Space-delimited and surrounded by double quote marks list of topics to be remapped: '
+             'in the form "old_topic1:=new_topic1 old_topic2:=new_topic2" etc.')
     parser.add_argument(
         '--storage-config-file', type=FileType('r'),
         help='Path to a yaml file defining storage specific configurations. '

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -60,10 +60,12 @@ def add_player_arguments(parser: ArgumentParser) -> None:
         '-x', '--exclude-regex', default='',
         help='regular expressions to exclude topics and services from replay.')
     parser.add_argument(
-        '--exclude-topics', type=lambda s: list(s.split(' ')), default=[], metavar='topic',
+        '--exclude-topics', type=lambda s: list(s.split(' ')),
+        default=[], metavar='exclude_topics',
         help='Space-delimited list of topics not to play.')
     parser.add_argument(
-        '--exclude-services', type=lambda s: list(s.split(' ')), default=[], metavar='service',
+        '--exclude-services', type=lambda s: list(s.split(' ')),
+        default=[], metavar='exclude_services',
         help='Space-delimited list of services not to play.')
     parser.add_argument(
         '--qos-profile-overrides-path', type=FileType('r'),
@@ -86,7 +88,7 @@ def add_player_arguments(parser: ArgumentParser) -> None:
         help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
              'Value must be positive. Defaults to not publishing.')
     clock_args_group.add_argument(
-        '--clock-topics', type=lambda s: list(s.split(' ')), default=[],
+        '--clock-topics', type=lambda s: list(s.split(' ')), default=[], metavar='clock_topics',
         help='List of topics separated by spaces that will trigger a /clock update '
              'when a message is published on them'
     )

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -48,11 +48,11 @@ def add_player_arguments(parser: ArgumentParser) -> None:
         '-r', '--rate', type=check_positive_float, default=1.0,
         help='rate at which to play back messages. Valid range > 0.0.')
     parser.add_argument(
-        '--topics', type=lambda s: list(s.split(' ')), default=[], metavar='topic',
-        help='Space-delimited list of topics to play.')
+        '--topics', type=lambda s: list(s.split(' ')), default=[], metavar='"topic1 topic2"',
+        help='Space-delimited and surrounded by double quote marks list of topics to play.')
     parser.add_argument(
-        '--services', type=lambda s: list(s.split(' ')), default=[], metavar='service',
-        help='Space-delimited list of services to play.')
+        '--services', type=lambda s: list(s.split(' ')), default=[], metavar='"service1 service2"',
+        help='Space-delimited and surrounded by double quote marks list of services to play.')
     parser.add_argument(
         '-e', '--regex', default='',
         help='Play only topics and services matches with regular expression.')
@@ -61,12 +61,12 @@ def add_player_arguments(parser: ArgumentParser) -> None:
         help='regular expressions to exclude topics and services from replay.')
     parser.add_argument(
         '--exclude-topics', type=lambda s: list(s.split(' ')),
-        default=[], metavar='exclude_topics',
-        help='Space-delimited list of topics not to play.')
+        default=[], metavar='"topic1 topic2"',
+        help='Space-delimited and surrounded by double quote marks list of topics not to play.')
     parser.add_argument(
         '--exclude-services', type=lambda s: list(s.split(' ')),
-        default=[], metavar='exclude_services',
-        help='Space-delimited list of services not to play.')
+        default=[], metavar='"service1 service2"',
+        help='Space-delimited and surrounded by double quote marks list of services not to play.')
     parser.add_argument(
         '--qos-profile-overrides-path', type=FileType('r'),
         help='Path to a yaml file defining overrides of the QoS profile for specific topics.')
@@ -88,9 +88,10 @@ def add_player_arguments(parser: ArgumentParser) -> None:
         help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
              'Value must be positive. Defaults to not publishing.')
     clock_args_group.add_argument(
-        '--clock-topics', type=lambda s: list(s.split(' ')), default=[], metavar='clock_topics',
-        help='List of topics separated by spaces that will trigger a /clock update '
-             'when a message is published on them'
+        '--clock-topics', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"topic1 topic2"',
+        help='Space-delimited and surrounded by double quote marks list of topics that will'
+             ' trigger a /clock update when a message is published on them.'
     )
     clock_args_group.add_argument(
         '--clock-topics-all', default=False, action='store_true',

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -51,10 +51,10 @@ class PlayVerb(VerbExtension):
             '-r', '--rate', type=check_positive_float, default=1.0,
             help='rate at which to play back messages. Valid range > 0.0.')
         parser.add_argument(
-            '--topics', type=str, default=[], metavar='topic', nargs='+',
+            '--topics', type=lambda s: list(s.split(' ')), default=[], metavar='topic',
             help='Space-delimited list of topics to play.')
         parser.add_argument(
-            '--services', type=str, default=[], metavar='service', nargs='+',
+            '--services', type=lambda s: list(s.split(' ')), default=[], metavar='service',
             help='Space-delimited list of services to play.')
         parser.add_argument(
             '-e', '--regex', default='',
@@ -63,10 +63,10 @@ class PlayVerb(VerbExtension):
             '-x', '--exclude-regex', default='',
             help='regular expressions to exclude topics and services from replay.')
         parser.add_argument(
-            '--exclude-topics', type=str, default=[], metavar='topic', nargs='+',
+            '--exclude-topics', type=lambda s: list(s.split(' ')), default=[], metavar='topic',
             help='Space-delimited list of topics not to play.')
         parser.add_argument(
-            '--exclude-services', type=str, default=[], metavar='service', nargs='+',
+            '--exclude-services', type=lambda s: list(s.split(' ')), default=[], metavar='service',
             help='Space-delimited list of services not to play.')
         parser.add_argument(
             '--qos-profile-overrides-path', type=FileType('r'),
@@ -89,7 +89,7 @@ class PlayVerb(VerbExtension):
             help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
                  'Value must be positive. Defaults to not publishing.')
         clock_args_group.add_argument(
-            '--clock-topics', type=str, default=[], nargs='+',
+            '--clock-topics', type=lambda s: list(s.split(' ')), default=[],
             help='List of topics separated by spaces that will trigger a /clock update '
                  'when a message is published on them'
         )

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -63,9 +63,18 @@ class RecordVerb(VerbExtension):
 
         # Topic filter arguments
         parser.add_argument(
-            'topics', nargs='*', default=None, help='List of topics to record.')
+            '--topics', type=lambda s: list(s.split(' ')), default=[], metavar='"topic1 topic2"',
+            help='Space-delimited and surrounded by double quote marks list of topics to record.')
         parser.add_argument(
-            '--topic-types', nargs='+', default=[], help='List of topic types to record.')
+            '--services', type=lambda s: list(s.split(' ')),
+            default=[], metavar='"service1 service2"',
+            help='Space-delimited and surrounded by double quote marks list of services to '
+                 'record.')
+        parser.add_argument(
+            '--topic-types', type=lambda s: list(s.split(' ')),
+            default=[], metavar='"topic_type1 topic_type2"',
+            help='Space-delimited and surrounded by double quote marks list of topic types '
+                 'to record.')
         parser.add_argument(
             '-a', '--all', action='store_true',
             help='Record all topics and services (Exclude hidden topic).')
@@ -85,22 +94,20 @@ class RecordVerb(VerbExtension):
             help='Exclude topics and services containing provided regular expression. '
                  'Works on top of --all, --all-topics, or --regex.')
         parser.add_argument(
-            '--exclude-topic-types', type=str, default=[], metavar='ExcludeTypes', nargs='+',
-            help='List of topic types not being recorded. '
-                 'Works on top of --all, --all-topics, or --regex.')
+            '--exclude-topic-types', type=lambda s: list(s.split(' ')),
+            default=[], metavar='"topic_type1 topic_type2"',
+            help='Space-delimited and surrounded by double quote marks list of topic types '
+                 'not being recorded. Works on top of --all, --all-topics, or --regex.')
         parser.add_argument(
-            '--exclude-topics', type=str, metavar='Topic', nargs='+',
-            help='List of topics not being recorded. '
-                 'Works on top of --all, --all-topics, or --regex.')
+            '--exclude-topics', type=lambda s: list(s.split(' ')),
+            default=[], metavar='"topic1 topic2"',
+            help='Space-delimited and surrounded by double quote marks list of topics '
+                 'not being recorded. Works on top of --all, --all-topics, or --regex.')
         parser.add_argument(
-            '--exclude-services', type=str, metavar='ServiceName', nargs='+',
-            help='List of services not being recorded. '
-                 'Works on top of --all, --all-services, or --regex.')
-
-        # Enable to record service
-        parser.add_argument(
-            '--services', type=str, metavar='ServiceName', nargs='+',
-            help='List of services to record.')
+            '--exclude-services', type=lambda s: list(s.split(' ')),
+            default=[], metavar='"service1 service2"',
+            help='Space-delimited and surrounded by double quote marks list of services '
+                 'not being recorded. Works on top of --all, --all-topics, or --regex.')
 
         # Discovery behavior
         parser.add_argument(
@@ -165,9 +172,11 @@ class RecordVerb(VerbExtension):
             '--node-name', type=str, default='rosbag2_recorder',
             help='Specify the recorder node name. Default is %(default)s.')
         parser.add_argument(
-            '--custom-data', type=str, metavar='KEY=VALUE', nargs='*',
-            help='Store the custom data in metadata.yaml '
-                 'under "rosbag2_bagfile_information/custom_data". The key=value pair can '
+            '--custom-data', type=lambda s: list(s.split(' ')),
+            default=[], metavar='"KEY1=VALUE1 KEY2=VALUE2"',
+            help='Space-delimited and surrounded by double quote marks list of key=value pairs. '
+                 'Store the custom data in metadata under the '
+                 '"rosbag2_bagfile_information/custom_data". The key=value pair can '
                  'appear more than once. The last value will override the former ones.')
         parser.add_argument(
             '--snapshot-mode', action='store_true',

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import FileType
+from argparse import ArgumentParser, FileType
 import datetime
 import os
 
@@ -34,177 +34,182 @@ from rosbag2_py import StorageOptions
 import yaml
 
 
+def add_recorder_arguments(parser: ArgumentParser) -> None:
+    parser.formatter_class = SplitLineFormatter
+    writer_choices = get_registered_writers()
+    default_storage_id = get_default_storage_id()
+    default_writer = default_storage_id if default_storage_id in writer_choices else \
+        next(iter(writer_choices))
+
+    serialization_choices = get_registered_serializers()
+    converter_suffix = '_converter'
+    serialization_choices = {
+        f[:-len(converter_suffix)]
+        for f in serialization_choices
+        if f.endswith(converter_suffix)
+    }
+
+    # Base output
+    parser.add_argument(
+        '-o', '--output',
+        help='Destination of the bagfile to create, '
+             'defaults to a timestamped folder in the current directory.')
+    parser.add_argument(
+        '-s', '--storage', default=default_writer, choices=writer_choices,
+        help="Storage identifier to be used, defaults to '%(default)s'.")
+
+    # Topic filter arguments
+    parser.add_argument(
+        'topics', nargs='?', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"topic1 topic2"',
+        help='Space-delimited and surrounded by double quote marks list of topics to record.')
+    parser.add_argument(
+        '--services', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"service1 service2"',
+        help='Space-delimited and surrounded by double quote marks list of services to '
+             'record.')
+    parser.add_argument(
+        '--topic-types', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"topic_type1 topic_type2"',
+        help='Space-delimited and surrounded by double quote marks list of topic types '
+             'to record.')
+    parser.add_argument(
+        '-a', '--all', action='store_true',
+        help='Record all topics and services (Exclude hidden topic).')
+    parser.add_argument(
+        '--all-topics', action='store_true',
+        help='Record all topics (Exclude hidden topic).')
+    parser.add_argument(
+        '--all-services', action='store_true',
+        help='Record all services via service event topics.')
+    parser.add_argument(
+        '-e', '--regex', default='',
+        help='Record only topics and services containing provided regular expression. '
+             'Overrides --all, --all-topics and --all-services, applies on top of '
+             'topics list and service list.')
+    parser.add_argument(
+        '--exclude-regex', default='',
+        help='Exclude topics and services containing provided regular expression. '
+             'Works on top of --all, --all-topics, or --regex.')
+    parser.add_argument(
+        '--exclude-topic-types', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"topic_type1 topic_type2"',
+        help='Space-delimited and surrounded by double quote marks list of topic types '
+             'not being recorded. Works on top of --all, --all-topics, or --regex.')
+    parser.add_argument(
+        '--exclude-topics', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"topic1 topic2"',
+        help='Space-delimited and surrounded by double quote marks list of topics '
+             'not being recorded. Works on top of --all, --all-topics, or --regex.')
+    parser.add_argument(
+        '--exclude-services', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"service1 service2"',
+        help='Space-delimited and surrounded by double quote marks list of services '
+             'not being recorded. Works on top of --all, --all-topics, or --regex.')
+
+    # Discovery behavior
+    parser.add_argument(
+        '--include-unpublished-topics', action='store_true',
+        help='Discover and record topics which have no publisher. '
+             'Subscriptions on such topics will be made with default QoS unless otherwise '
+             'specified in a QoS overrides file.')
+    parser.add_argument(
+        '--include-hidden-topics', action='store_true',
+        help='Discover and record hidden topics as well. '
+             'These are topics used internally by ROS 2 implementation.')
+    parser.add_argument(
+        '--no-discovery', action='store_true',
+        help='Disables topic auto discovery during recording: only topics present at '
+             'startup will be recorded.')
+    parser.add_argument(
+        '-p', '--polling-interval', type=int, default=100,
+        help='Time in ms to wait between querying available topics for recording. '
+             'It has no effect if --no-discovery is enabled.')
+    parser.add_argument(
+        '--ignore-leaf-topics', action='store_true',
+        help='Ignore topics without a subscription.')
+    parser.add_argument(
+        '--qos-profile-overrides-path', type=FileType('r'),
+        help='Path to a yaml file defining overrides of the QoS profile for specific topics.')
+
+    # Core config
+    parser.add_argument(
+        '-f', '--serialization-format', default='', choices=serialization_choices,
+        help='The rmw serialization format in which the messages are saved, defaults to the '
+             'rmw currently in use.')
+    parser.add_argument(
+        '-b', '--max-bag-size', type=int, default=0,
+        help='Maximum size in bytes before the bagfile will be split. '
+             'Default: %(default)d, recording written in single bagfile and splitting '
+             'is disabled.')
+    parser.add_argument(
+        '-d', '--max-bag-duration', type=int, default=0,
+        help='Maximum duration in seconds before the bagfile will be split. '
+             'Default: %(default)d, recording written in single bagfile and splitting '
+             'is disabled. If both splitting by size and duration are enabled, '
+             'the bag will split at whichever threshold is reached first.')
+    parser.add_argument(
+        '--max-cache-size', type=int, default=100*1024*1024,
+        help='Maximum size (in bytes) of messages to hold in each buffer of cache. '
+             'Default: %(default)d. The cache is handled through double buffering, '
+             'which means that in pessimistic case up to twice the parameter value of memory '
+             'is needed. A rule of thumb is to cache an order of magnitude corresponding to '
+             'about one second of total recorded data volume. '
+             'If the value specified is 0, then every message is directly written to disk.')
+    parser.add_argument(
+        '--disable-keyboard-controls', action='store_true', default=False,
+        help='disables keyboard controls for recorder')
+    parser.add_argument(
+        '--start-paused', action='store_true', default=False,
+        help='Start the recorder in a paused state.')
+    parser.add_argument(
+        '--use-sim-time', action='store_true', default=False,
+        help='Use simulation time for message timestamps by subscribing to the /clock topic. '
+             'Until first /clock message is received, no messages will be written to bag.')
+    parser.add_argument(
+        '--node-name', type=str, default='rosbag2_recorder',
+        help='Specify the recorder node name. Default is %(default)s.')
+    parser.add_argument(
+        '--custom-data', type=lambda s: list(s.split(' ')),
+        default=[], metavar='"KEY1=VALUE1 KEY2=VALUE2"',
+        help='Space-delimited and surrounded by double quote marks list of key=value pairs. '
+             'Store the custom data in metadata under the '
+             '"rosbag2_bagfile_information/custom_data". The key=value pair can '
+             'appear more than once. The last value will override the former ones.')
+    parser.add_argument(
+        '--snapshot-mode', action='store_true',
+        help='Enable snapshot mode. Messages will not be written to the bagfile until '
+             'the "/rosbag2_recorder/snapshot" service is called.')
+
+    # Storage configuration
+    add_writer_storage_plugin_extensions(parser)
+
+    # Core compression configuration
+    # TODO(emersonknapp) this configuration will be moved down to implementing plugins
+    parser.add_argument(
+        '--compression-queue-size', type=int, default=1,
+        help='Number of files or messages that may be queued for compression '
+             'before being dropped.  Default is %(default)d.')
+    parser.add_argument(
+        '--compression-threads', type=int, default=0,
+        help='Number of files or messages that may be compressed in parallel. '
+             'Default is %(default)d, which will be interpreted as the number of CPU cores.')
+    parser.add_argument(
+        '--compression-mode', type=str, default='none',
+        choices=['none', 'file', 'message'],
+        help='Choose mode of compression for the storage. Default: %(default)s.')
+    parser.add_argument(
+        '--compression-format', type=str, default='',
+        choices=get_registered_compressors(),
+        help='Choose the compression format/algorithm. '
+             'Has no effect if no compression mode is chosen. Default: %(default)s.')
+
+
 class RecordVerb(VerbExtension):
     """Record ROS data to a bag."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
-        parser.formatter_class = SplitLineFormatter
-        writer_choices = get_registered_writers()
-        default_storage_id = get_default_storage_id()
-        default_writer = default_storage_id if default_storage_id in writer_choices else \
-            next(iter(writer_choices))
-
-        serialization_choices = get_registered_serializers()
-        converter_suffix = '_converter'
-        serialization_choices = {
-            f[:-len(converter_suffix)]
-            for f in serialization_choices
-            if f.endswith(converter_suffix)
-        }
-
-        # Base output
-        parser.add_argument(
-            '-o', '--output',
-            help='Destination of the bagfile to create, '
-                 'defaults to a timestamped folder in the current directory.')
-        parser.add_argument(
-            '-s', '--storage', default=default_writer, choices=writer_choices,
-            help="Storage identifier to be used, defaults to '%(default)s'.")
-
-        # Topic filter arguments
-        parser.add_argument(
-            '--topics', type=lambda s: list(s.split(' ')), default=[], metavar='"topic1 topic2"',
-            help='Space-delimited and surrounded by double quote marks list of topics to record.')
-        parser.add_argument(
-            '--services', type=lambda s: list(s.split(' ')),
-            default=[], metavar='"service1 service2"',
-            help='Space-delimited and surrounded by double quote marks list of services to '
-                 'record.')
-        parser.add_argument(
-            '--topic-types', type=lambda s: list(s.split(' ')),
-            default=[], metavar='"topic_type1 topic_type2"',
-            help='Space-delimited and surrounded by double quote marks list of topic types '
-                 'to record.')
-        parser.add_argument(
-            '-a', '--all', action='store_true',
-            help='Record all topics and services (Exclude hidden topic).')
-        parser.add_argument(
-            '--all-topics', action='store_true',
-            help='Record all topics (Exclude hidden topic).')
-        parser.add_argument(
-            '--all-services', action='store_true',
-            help='Record all services via service event topics.')
-        parser.add_argument(
-            '-e', '--regex', default='',
-            help='Record only topics and services containing provided regular expression. '
-                 'Overrides --all, --all-topics and --all-services, applies on top of '
-                 'topics list and service list.')
-        parser.add_argument(
-            '--exclude-regex', default='',
-            help='Exclude topics and services containing provided regular expression. '
-                 'Works on top of --all, --all-topics, or --regex.')
-        parser.add_argument(
-            '--exclude-topic-types', type=lambda s: list(s.split(' ')),
-            default=[], metavar='"topic_type1 topic_type2"',
-            help='Space-delimited and surrounded by double quote marks list of topic types '
-                 'not being recorded. Works on top of --all, --all-topics, or --regex.')
-        parser.add_argument(
-            '--exclude-topics', type=lambda s: list(s.split(' ')),
-            default=[], metavar='"topic1 topic2"',
-            help='Space-delimited and surrounded by double quote marks list of topics '
-                 'not being recorded. Works on top of --all, --all-topics, or --regex.')
-        parser.add_argument(
-            '--exclude-services', type=lambda s: list(s.split(' ')),
-            default=[], metavar='"service1 service2"',
-            help='Space-delimited and surrounded by double quote marks list of services '
-                 'not being recorded. Works on top of --all, --all-topics, or --regex.')
-
-        # Discovery behavior
-        parser.add_argument(
-            '--include-unpublished-topics', action='store_true',
-            help='Discover and record topics which have no publisher. '
-                 'Subscriptions on such topics will be made with default QoS unless otherwise '
-                 'specified in a QoS overrides file.')
-        parser.add_argument(
-            '--include-hidden-topics', action='store_true',
-            help='Discover and record hidden topics as well. '
-                 'These are topics used internally by ROS 2 implementation.')
-        parser.add_argument(
-            '--no-discovery', action='store_true',
-            help='Disables topic auto discovery during recording: only topics present at '
-                 'startup will be recorded.')
-        parser.add_argument(
-            '-p', '--polling-interval', type=int, default=100,
-            help='Time in ms to wait between querying available topics for recording. '
-                 'It has no effect if --no-discovery is enabled.')
-        parser.add_argument(
-            '--ignore-leaf-topics', action='store_true',
-            help='Ignore topics without a subscription.')
-        parser.add_argument(
-            '--qos-profile-overrides-path', type=FileType('r'),
-            help='Path to a yaml file defining overrides of the QoS profile for specific topics.')
-
-        # Core config
-        parser.add_argument(
-            '-f', '--serialization-format', default='', choices=serialization_choices,
-            help='The rmw serialization format in which the messages are saved, defaults to the '
-                 'rmw currently in use.')
-        parser.add_argument(
-            '-b', '--max-bag-size', type=int, default=0,
-            help='Maximum size in bytes before the bagfile will be split. '
-                 'Default: %(default)d, recording written in single bagfile and splitting '
-                 'is disabled.')
-        parser.add_argument(
-            '-d', '--max-bag-duration', type=int, default=0,
-            help='Maximum duration in seconds before the bagfile will be split. '
-                 'Default: %(default)d, recording written in single bagfile and splitting '
-                 'is disabled. If both splitting by size and duration are enabled, '
-                 'the bag will split at whichever threshold is reached first.')
-        parser.add_argument(
-            '--max-cache-size', type=int, default=100*1024*1024,
-            help='Maximum size (in bytes) of messages to hold in each buffer of cache. '
-                 'Default: %(default)d. The cache is handled through double buffering, '
-                 'which means that in pessimistic case up to twice the parameter value of memory '
-                 'is needed. A rule of thumb is to cache an order of magnitude corresponding to '
-                 'about one second of total recorded data volume. '
-                 'If the value specified is 0, then every message is directly written to disk.')
-        parser.add_argument(
-            '--disable-keyboard-controls', action='store_true', default=False,
-            help='disables keyboard controls for recorder')
-        parser.add_argument(
-            '--start-paused', action='store_true', default=False,
-            help='Start the recorder in a paused state.')
-        parser.add_argument(
-            '--use-sim-time', action='store_true', default=False,
-            help='Use simulation time for message timestamps by subscribing to the /clock topic. '
-                 'Until first /clock message is received, no messages will be written to bag.')
-        parser.add_argument(
-            '--node-name', type=str, default='rosbag2_recorder',
-            help='Specify the recorder node name. Default is %(default)s.')
-        parser.add_argument(
-            '--custom-data', type=lambda s: list(s.split(' ')),
-            default=[], metavar='"KEY1=VALUE1 KEY2=VALUE2"',
-            help='Space-delimited and surrounded by double quote marks list of key=value pairs. '
-                 'Store the custom data in metadata under the '
-                 '"rosbag2_bagfile_information/custom_data". The key=value pair can '
-                 'appear more than once. The last value will override the former ones.')
-        parser.add_argument(
-            '--snapshot-mode', action='store_true',
-            help='Enable snapshot mode. Messages will not be written to the bagfile until '
-                 'the "/rosbag2_recorder/snapshot" service is called.')
-
-        # Storage configuration
-        add_writer_storage_plugin_extensions(parser)
-
-        # Core compression configuration
-        # TODO(emersonknapp) this configuration will be moved down to implementing plugins
-        parser.add_argument(
-            '--compression-queue-size', type=int, default=1,
-            help='Number of files or messages that may be queued for compression '
-                 'before being dropped.  Default is %(default)d.')
-        parser.add_argument(
-            '--compression-threads', type=int, default=0,
-            help='Number of files or messages that may be compressed in parallel. '
-                 'Default is %(default)d, which will be interpreted as the number of CPU cores.')
-        parser.add_argument(
-            '--compression-mode', type=str, default='none',
-            choices=['none', 'file', 'message'],
-            help='Choose mode of compression for the storage. Default: %(default)s.')
-        parser.add_argument(
-            '--compression-format', type=str, default='',
-            choices=get_registered_compressors(),
-            help='Choose the compression format/algorithm. '
-                 'Has no effect if no compression mode is chosen. Default: %(default)s.')
+        add_recorder_arguments(parser)
 
     def _check_necessary_argument(self, args):
         # At least one options out of --all, --all-topics, --all-services, --services, --topics,

--- a/ros2bag/test/test_burst_args_parser.py
+++ b/ros2bag/test/test_burst_args_parser.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from ros2bag.verb.burst import add_burst_arguments
+
+RESOURCES_PATH = Path(__file__).parent / 'resources'
+
+
+@pytest.fixture(scope='function')
+def test_arguments_parser():
+    parser = argparse.ArgumentParser()
+    add_burst_arguments(parser)
+    return parser
+
+
+def test_burst_topics_list_argument(test_arguments_parser):
+    """Test burst --topics list argument parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(['--topics', 'topic1 topic2', bag_path.as_posix()])
+    assert ['topic1', 'topic2'] == args.topics
+    assert args.bag_path is not None
+
+
+def test_burst_services_list_argument(test_arguments_parser):
+    """Test burst --services list argument parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(
+        ['--services', 'service1 service2', bag_path.as_posix()]
+    )
+    assert ['service1', 'service2'] == args.services
+    assert args.bag_path is not None
+
+
+def test_burst_remap_list_argument(test_arguments_parser):
+    """Test burst --remap list arguments parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(
+        ['--remap', 'old_topic1:=new_topic1 old_topic2:=new_topic2', bag_path.as_posix()]
+    )
+    assert ['old_topic1:=new_topic1', 'old_topic2:=new_topic2'] == args.remap
+    assert args.bag_path is not None

--- a/ros2bag/test/test_player_args_parser.py
+++ b/ros2bag/test/test_player_args_parser.py
@@ -30,16 +30,48 @@ def test_arguments_parser():
 
 
 def test_topics_list_arguments(test_arguments_parser):
-    """Test player topic list arguments parser."""
+    """Test player --topics list arguments parser."""
     bag_path = RESOURCES_PATH / 'empty_bag'
     args = test_arguments_parser.parse_args(['--topics', 'topic1 topic2', bag_path.as_posix()])
     assert ['topic1', 'topic2'] == args.topics
+    assert args.bag_path is not None
 
 
 def test_services_list_arguments(test_arguments_parser):
-    """Test player services list arguments parser."""
+    """Test player --services list arguments parser."""
     bag_path = RESOURCES_PATH / 'empty_bag'
     args = test_arguments_parser.parse_args(
         ['--services', 'service1 service2', bag_path.as_posix()]
     )
     assert ['service1', 'service2'] == args.services
+    assert args.bag_path is not None
+
+
+def test_exclude_topics_list_arguments(test_arguments_parser):
+    """Test player --exclude-topics list arguments parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-topics', 'topic1 topic2', bag_path.as_posix()]
+    )
+    assert ['topic1', 'topic2'] == args.exclude_topics
+    assert args.bag_path is not None
+
+
+def test_exclude_services_list_arguments(test_arguments_parser):
+    """Test player --exclude-services list arguments parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-services', 'service1 service2', bag_path.as_posix()]
+    )
+    assert ['service1', 'service2'] == args.exclude_services
+    assert args.bag_path is not None
+
+
+def test_clock_topics_list_arguments(test_arguments_parser):
+    """Test player --clock-topics list arguments parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(
+        ['--clock-topics', 'topic1 topic2', bag_path.as_posix()]
+    )
+    assert ['topic1', 'topic2'] == args.clock_topics
+    assert args.bag_path is not None

--- a/ros2bag/test/test_player_args_parser.py
+++ b/ros2bag/test/test_player_args_parser.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from ros2bag.verb.play import add_player_arguments
+
+RESOURCES_PATH = Path(__file__).parent / 'resources'
+
+
+@pytest.fixture(scope='function')
+def test_arguments_parser():
+    parser = argparse.ArgumentParser()
+    add_player_arguments(parser)
+    return parser
+
+
+def test_topics_list_arguments(test_arguments_parser):
+    """Test player topic list arguments parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(['--topics', 'topic1 topic2', bag_path.as_posix()])
+    assert ['topic1', 'topic2'] == args.topics
+
+
+def test_services_list_arguments(test_arguments_parser):
+    """Test player services list arguments parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(
+        ['--services', 'service1 service2', bag_path.as_posix()]
+    )
+    assert ['service1', 'service2'] == args.services

--- a/ros2bag/test/test_player_args_parser.py
+++ b/ros2bag/test/test_player_args_parser.py
@@ -29,16 +29,16 @@ def test_arguments_parser():
     return parser
 
 
-def test_topics_list_arguments(test_arguments_parser):
-    """Test player --topics list arguments parser."""
+def test_player_topics_list_argument(test_arguments_parser):
+    """Test player --topics list argument parser."""
     bag_path = RESOURCES_PATH / 'empty_bag'
     args = test_arguments_parser.parse_args(['--topics', 'topic1 topic2', bag_path.as_posix()])
     assert ['topic1', 'topic2'] == args.topics
     assert args.bag_path is not None
 
 
-def test_services_list_arguments(test_arguments_parser):
-    """Test player --services list arguments parser."""
+def test_player_services_list_argument(test_arguments_parser):
+    """Test player --services list argument parser."""
     bag_path = RESOURCES_PATH / 'empty_bag'
     args = test_arguments_parser.parse_args(
         ['--services', 'service1 service2', bag_path.as_posix()]
@@ -47,8 +47,8 @@ def test_services_list_arguments(test_arguments_parser):
     assert args.bag_path is not None
 
 
-def test_exclude_topics_list_arguments(test_arguments_parser):
-    """Test player --exclude-topics list arguments parser."""
+def test_player_exclude_topics_list_argument(test_arguments_parser):
+    """Test player --exclude-topics list argument parser."""
     bag_path = RESOURCES_PATH / 'empty_bag'
     args = test_arguments_parser.parse_args(
         ['--exclude-topics', 'topic1 topic2', bag_path.as_posix()]
@@ -57,8 +57,8 @@ def test_exclude_topics_list_arguments(test_arguments_parser):
     assert args.bag_path is not None
 
 
-def test_exclude_services_list_arguments(test_arguments_parser):
-    """Test player --exclude-services list arguments parser."""
+def test_player_exclude_services_list_argument(test_arguments_parser):
+    """Test player --exclude-services list argument parser."""
     bag_path = RESOURCES_PATH / 'empty_bag'
     args = test_arguments_parser.parse_args(
         ['--exclude-services', 'service1 service2', bag_path.as_posix()]
@@ -67,11 +67,21 @@ def test_exclude_services_list_arguments(test_arguments_parser):
     assert args.bag_path is not None
 
 
-def test_clock_topics_list_arguments(test_arguments_parser):
-    """Test player --clock-topics list arguments parser."""
+def test_player_clock_topics_list_argument(test_arguments_parser):
+    """Test player --clock-topics list argument parser."""
     bag_path = RESOURCES_PATH / 'empty_bag'
     args = test_arguments_parser.parse_args(
         ['--clock-topics', 'topic1 topic2', bag_path.as_posix()]
     )
     assert ['topic1', 'topic2'] == args.clock_topics
+    assert args.bag_path is not None
+
+
+def test_player_remap_list_argument(test_arguments_parser):
+    """Test player --remap list argument parser."""
+    bag_path = RESOURCES_PATH / 'empty_bag'
+    args = test_arguments_parser.parse_args(
+        ['--remap', 'old_topic1:=new_topic1 old_topic2:=new_topic2', bag_path.as_posix()]
+    )
+    assert ['old_topic1:=new_topic1', 'old_topic2:=new_topic2'] == args.remap
     assert args.bag_path is not None

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -1,0 +1,106 @@
+# Copyright 2024 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from ros2bag.verb.record import add_recorder_arguments
+
+RESOURCES_PATH = Path(__file__).parent / 'resources'
+
+
+@pytest.fixture(scope='function')
+def test_arguments_parser():
+    parser = argparse.ArgumentParser()
+    add_recorder_arguments(parser)
+    return parser
+
+
+def test_recorder_topics_list_argument(test_arguments_parser):
+    """Test recorder positional topics list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['topic1 topic2', '--output', output_path.as_posix()])
+    assert ['topic1', 'topic2'] == args.topics
+    assert output_path.as_posix() == args.output
+
+
+def test_recorder_services_list_argument(test_arguments_parser):
+    """Test recorder --services list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--services', 'service1 service2', '--output', output_path.as_posix()]
+    )
+    assert ['service1', 'service2'] == args.services
+    assert output_path.as_posix() == args.output
+
+
+def test_recorder_services_and_positional_topics_list_arguments(test_arguments_parser):
+    """Test recorder --services list and positional topics list arguments parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--services', 'service1 service2', 'topic1 topic2', '--output', output_path.as_posix()])
+    assert ['service1', 'service2'] == args.services
+    assert ['topic1', 'topic2'] == args.topics
+    assert output_path.as_posix() == args.output
+
+
+def test_recorder_topic_types_list_argument(test_arguments_parser):
+    """Test recorder --topic-types list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--topic-types', 'topic_type1 topic_type2', '--output', output_path.as_posix()])
+    assert ['topic_type1', 'topic_type2'] == args.topic_types
+    assert output_path.as_posix() == args.output
+
+
+def test_recorder_exclude_topic_types_list_argument(test_arguments_parser):
+    """Test recorder --exclude-topic-types list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-topic-types', 'topic_type1 topic_type2', '--output', output_path.as_posix()])
+    assert ['topic_type1', 'topic_type2'] == args.exclude_topic_types
+    assert output_path.as_posix() == args.output
+
+
+def test_recorder_exclude_topics_list_argument(test_arguments_parser):
+    """Test recorder --exclude-topics list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-topics', 'topic1 topic2', '--output', output_path.as_posix()]
+    )
+    assert ['topic1', 'topic2'] == args.exclude_topics
+    assert output_path.as_posix() == args.output
+
+
+def test_recorder_exclude_services_list_argument(test_arguments_parser):
+    """Test recorder --exclude-services list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-services', 'service1 service2', '--output', output_path.as_posix()]
+    )
+    assert ['service1', 'service2'] == args.exclude_services
+    assert output_path.as_posix() == args.output
+
+
+def test_recorder_custom_data_list_argument(test_arguments_parser):
+    """Test recorder --custom-data list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--custom-data', 'Key1=Value1 key2=value2', '--output', output_path.as_posix()]
+    )
+    assert ['Key1=Value1', 'key2=value2'] == args.custom_data
+    assert output_path.as_posix() == args.output

--- a/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
@@ -41,7 +41,23 @@ std::vector<char *> command_string_to_arguments(const std::string & command)
   while (std::getline(ss, token, ' ')) {
     // dup strings to get non-const, should be free'd after execvp
     if (!token.empty()) {  // Skipping extra spaces between arguments
-      arguments.push_back(strdup(token.c_str()));
+      if (token.front() == '"') {  // Start of the list surrounded with double quote marks
+        std::string list_argument;
+        // We need to exclude quote marks when adding a space separated list to the arguments
+        list_argument.append(token.begin() + 1, token.end());
+
+        while (!token.empty() && token.back() != '"' && std::getline(ss, token, ' ')) {
+          if (token.back() != '"') {
+            list_argument.append(" " + token);
+          } else {
+            list_argument.append(" ");
+            list_argument.append(token.begin(), token.end() - 1);
+          }
+        }
+        arguments.push_back(strdup(list_argument.c_str()));
+      } else {
+        arguments.push_back(strdup(token.c_str()));
+      }
     }
   }
   arguments.push_back(nullptr);  // explicit nullptr to tell execvp where to stop

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -183,7 +183,7 @@ TEST_P(PlayEndToEndTestFixture, play_filters_by_topic) {
 
     // Start ros2 bag play in pause mode
     auto process_id =
-      start_execution("ros2 bag play -p " + bags_path_ + "/cdr_test --topics /test_topic");
+      start_execution("ros2 bag play -p --topics /test_topic " + bags_path_ + "/cdr_test");
     auto cleanup_process_handle = rcpputils::make_scope_exit(
       [process_id]() {
         stop_execution(process_id);
@@ -214,8 +214,9 @@ TEST_P(PlayEndToEndTestFixture, play_filters_by_topic) {
     sub_->add_subscription<test_msgs::msg::Arrays>("/array_topic", num_array_msgs, sub_qos_);
 
     // Start ros2 bag play in pause mode
-    auto process_id = start_execution(
-      "ros2 bag play -p " + bags_path_ + "/cdr_test --topics /test_topic /array_topic");
+    const std::string command =
+      "ros2 bag play -p --topics \"/test_topic /array_topic\" " + bags_path_ + "/cdr_test";
+    auto process_id = start_execution(command);
     auto cleanup_process_handle = rcpputils::make_scope_exit(
       [process_id]() {
         stop_execution(process_id);
@@ -247,7 +248,7 @@ TEST_P(PlayEndToEndTestFixture, play_filters_by_topic) {
 
     // Start ros2 bag play in pause mode
     auto process_id = start_execution(
-      "ros2 bag play -p " + bags_path_ + "/cdr_test --topics /nonexistent_topic");
+      "ros2 bag play -p --topics /nonexistent_topic " + bags_path_ + "/cdr_test");
     auto cleanup_process_handle = rcpputils::make_scope_exit(
       [process_id]() {
         stop_execution(process_id);


### PR DESCRIPTION
- Closes https://github.com/ros2/rosbag2/issues/1628
- Add a quote guarded space-separated list type to player CLI
- For example, after the fix, the list of topics could be passed as:
1. `ros2 bag play --topics "topic1 topic2" bagpath`
2. `ros2 bag play --topics 'topic1 topic2' bagpath`
3. `ros2 bag play --topics topic1 bagpath`