### PR TITLE
Sweep cleanup in rosbag2 recorder CLI args verification code

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -224,46 +224,18 @@ class RecordVerb(VerbExtension):
             args.topics = args.topics_positional
 
         if not self._check_necessary_argument(args):
-            return print_error('Need to specify one option out of --all, --all-topics, '
-                               '--all-services, --services, --topics, --topic-types and --regex')
-
-        # Only one option out of --all, --all-services --services or --regex can be used
-        if (args.all and args.all_services) or \
-           ((args.all or args.all_services) and args.regex) or \
-           ((args.all or args.all_services or args.regex) and args.services):
-            return print_error('Must specify only one option out of --all, --all-services, '
-                               '--services or --regex')
-
-        # Only one option out of --all, --all-topics, --topics, --topic-types or --regex can
-        # be used
-        if (args.all and args.all_topics) or \
-           ((args.all or args.all_topics) and args.regex) or \
-           ((args.all or args.all_topics or args.regex) and args.topics) or \
-           ((args.all or args.all_topics or args.regex or args.topics) and args.topic_types):
-            return print_error('Must specify only one option out of --all, --all-topics, '
-                               '--topics, --topic-types or --regex')
-
-        if (args.exclude_regex and
-           not (args.regex or args.all or args.all_topics or args.all_services)):
-            return print_error('--exclude-regex argument requires either --all, '
-                               '--all-topics, --all-services or --regex')
-
-        if args.exclude_topics and not (args.regex or args.all or args.all_topics):
-            return print_error('--exclude-topics argument requires either --all, --all-topics '
-                               'or --regex')
-
-        if args.exclude_topic_types and not (args.regex or args.all or args.all_topics):
-            return print_error('--exclude-topic-types argument requires either --all, '
-                               '--all-topics or --regex')
-
-        if args.exclude_services and not (args.regex or args.all or args.all_services):
-            return print_error('--exclude-services argument requires either --all, --all-services '
-                               'or --regex')
+            return print_error('Need to specify at least one option out of --all, --all-topics, '
+                               '--all-services, --services, --topics, --topic-types or --regex')
 
         uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
 
         if os.path.isdir(uri):
             return print_error("Output folder '{}' already exists.".format(uri))
+
+        if args.use_sim_time and args.no_discovery:
+            return print_error(
+                '--use-sim-time and --no-discovery both set, but are incompatible settings. '
+                'The /clock topic needs to be discovered to record with sim time.')
 
         if args.compression_format and args.compression_mode == 'none':
             return print_error('Invalid choice: Cannot specify compression format '
@@ -278,15 +250,9 @@ class RecordVerb(VerbExtension):
         if args.qos_profile_overrides_path:
             qos_profile_dict = yaml.safe_load(args.qos_profile_overrides_path)
             try:
-                qos_profile_overrides = convert_yaml_to_qos_profile(
-                    qos_profile_dict)
+                qos_profile_overrides = convert_yaml_to_qos_profile(qos_profile_dict)
             except (InvalidQoSProfileException, ValueError) as e:
                 return print_error(str(e))
-
-        if args.use_sim_time and args.no_discovery:
-            return print_error(
-                '--use-sim-time and --no-discovery both set, but are incompatible settings. '
-                'The /clock topic needs to be discovered to record with sim time.')
 
         # Prepare custom_data dictionary
         custom_data = {}

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -84,8 +84,7 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
     parser.add_argument(
         '-e', '--regex', default='',
         help='Record only topics and services containing provided regular expression. '
-             'Overrides --all, --all-topics and --all-services, applies on top of '
-             'topics list and service list.')
+             'Note:  --all, --all-topics or --all-services will override --regex.')
     parser.add_argument(
         '--exclude-regex', default='',
         help='Exclude topics and services containing provided regular expression. '
@@ -98,11 +97,11 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
     parser.add_argument(
         '--exclude-topics', type=str, metavar='Topic', nargs='+',
         help='Space-delimited list of topics not being recorded. '
-             'Works on top of --all, --all-topics, or --regex.')
+             'Works on top of --all, --all-topics, --topics or --regex.')
     parser.add_argument(
         '--exclude-services', type=str, metavar='ServiceName', nargs='+',
         help='Space-delimited list of services not being recorded. '
-             'Works on top of --all, --all-services, or --regex.')
+             'Works on top of --all, --all-services, --services or --regex.')
 
     # Discovery behavior
     parser.add_argument(

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -211,7 +211,8 @@ class RecordVerb(VerbExtension):
         # At least one options out of --all, --all-topics, --all-services, --services, --topics,
         # --topic-types or --regex must be used
         if not (args.all or args.all_topics or args.all_services or
-                args.services or (args.topics and len(args.topics) > 0) or
+                (args.services and len(args.services) > 0) or
+                (args.topics and len(args.topics) > 0) or
                 (args.topic_types and len(args.topic_types) > 0) or args.regex):
             return False
         return True

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -216,18 +216,15 @@ class RecordVerb(VerbExtension):
             return False
         return True
 
-    def main(self, *, args):  # noqa: D102
-
+    def validate_parsed_arguments(self, args, uri) -> str:
         if args.topics_positional:
-            print('Warning! Positional "topics" argument deprecated. '
-                  'Please use optional "--topics" argument instead.')
+            print(print_error('Warning! Positional "topics" argument deprecated. '
+                              'Please use optional "--topics" argument instead.'))
             args.topics = args.topics_positional
 
         if not self._check_necessary_argument(args):
             return print_error('Need to specify at least one option out of --all, --all-topics, '
                                '--all-services, --services, --topics, --topic-types or --regex')
-
-        uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
 
         if os.path.isdir(uri):
             return print_error("Output folder '{}' already exists.".format(uri))
@@ -243,6 +240,14 @@ class RecordVerb(VerbExtension):
 
         if args.compression_queue_size < 0:
             return print_error('Compression queue size must be at least 0.')
+
+    def main(self, *, args):  # noqa: D102
+
+        uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+
+        error_str = self.validate_parsed_arguments(args, uri)
+        if error_str and len(error_str) > 0:
+            return error_str
 
         args.compression_mode = args.compression_mode.upper()
 

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 
 import argparse
+import datetime
 from pathlib import Path
 
 import pytest
 
 from ros2bag.verb.record import add_recorder_arguments
+from ros2bag.verb.record import validate_parsed_arguments
 
 RESOURCES_PATH = Path(__file__).parent / 'resources'
+ERROR_STRING_MSG = 'ros2bag record CLI did not produce the expected output' \
+                   '\n Expected output pattern: {}\n Actual output: {}'
 
 
 @pytest.fixture(scope='function')
@@ -128,3 +132,98 @@ def test_recorder_custom_data_list_argument(test_arguments_parser):
     )
     assert ['Key1=Value1', 'key2=value2'] == args.custom_data
     assert output_path.as_posix() == args.output
+
+
+def test_recorder_validate_exclude_regex_needs_inclusive_args(test_arguments_parser):
+    """Test that --exclude-regex needs inclusive arguments."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-regex', '%s-%s', '--services', 'service1', '--topics', 'topic1',
+         '--output', output_path.as_posix()]
+    )
+    assert '%s-%s' == args.exclude_regex
+    assert args.all is False
+    assert args.all_topics is False
+    assert [] == args.topic_types
+    assert args.all_services is False
+    assert '' == args.regex
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is not None
+    expected_output = '--exclude-regex argument requires either --all, ' \
+                      '--all-topics, --topic-types, --all-services or --regex'
+    matches = expected_output in error_str
+    assert matches, ERROR_STRING_MSG.format(expected_output, error_str)
+
+
+def test_recorder_validate_exclude_topics_needs_inclusive_args(test_arguments_parser):
+    """Test that --exclude-topics inclusive arguments."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-topics', 'topic1', '--all-services', '--topics', 'topic1',
+         '--output', output_path.as_posix()]
+    )
+    assert ['topic1'] == args.exclude_topics
+    assert args.all is False
+    assert args.all_topics is False
+    assert [] == args.topic_types
+    assert args.all_services is True
+    assert '' == args.regex
+    assert '' == args.exclude_regex
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is not None
+    expected_output = '--exclude-topics argument requires either --all, --all-topics, ' \
+                      '--topic-types or --regex'
+    matches = expected_output in error_str
+    assert matches, ERROR_STRING_MSG.format(expected_output, error_str)
+
+
+def test_recorder_validate_exclude_topics_types_needs_inclusive_args(test_arguments_parser):
+    """Test that --exclude-topic-types needs inclusive argument."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-topic-types', '/topic_type1', '--all-services', '--topics', 'topic1',
+         '--output', output_path.as_posix()]
+    )
+    assert ['/topic_type1'] == args.exclude_topic_types
+    assert args.all is False
+    assert args.all_topics is False
+    assert [] == args.topic_types
+    assert args.all_services is True
+    assert '' == args.regex
+    assert '' == args.exclude_regex
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is not None
+    expected_output = '--exclude-topic-types argument requires either --all, ' \
+                      '--all-topics or --regex'
+    matches = expected_output in error_str
+    assert matches, ERROR_STRING_MSG.format(expected_output, error_str)
+
+
+def test_recorder_validate_exclude_services_needs_inclusive_args(test_arguments_parser):
+    """Test that --exclude-services needs at least --all, --all-services or --regex arguments."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--exclude-services', 'service1', '--services', 'service1', '--all-topics',
+         '--output', output_path.as_posix()]
+    )
+    assert ['service1'] == args.exclude_services
+    assert args.all is False
+    assert args.all_topics is True
+    assert [] == args.topic_types
+    assert args.all_services is False
+    assert '' == args.regex
+    assert '' == args.exclude_regex
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is not None
+    expected_output = '--exclude-services argument requires either --all, --all-services '
+    'or --regex'
+    matches = expected_output in error_str
+    assert matches, ERROR_STRING_MSG.format(expected_output, error_str)


### PR DESCRIPTION
- Relates (fixes on Rolling and Jazzy) issue https://github.com/ros2/rosbag2/issues/1620
- Depends from https://github.com/ros2/rosbag2/pull/1632
#### Motivation:
We have reworked `rosbag2_transport ::topic_filter` in the scope of the Services recording/Replay feature and removed many constraints and limitations which was applied to the topic filter. However, the recorder CLI arguments verification code and help section hasn't been updated so far.

#### List of changes:
- Remove outdated checks that impose limitations that only one option out of others can be used. Such as:
   - "Only one option out of --all, --all-services --services or --regex can be used"
   - "Only one option out of --all, --all-topics, --topics, --topic-types or --regex can be used"
   - "--exclude-regex argument requires either --all, --all-topics, --all-services or --regex"
   - and so on..
- Move arguments checks to a separate method 'validate_parsed_arguments(self, args, uri)'
- Fix the wrong limitation on arguments in the recorder CLI help section.
  - The `--regex` now can be used together with `--topics` and `--services` lists. Also now --all, --all-topics or --all-services will override `--regex`. Before, it was the opposite.
  - `--exclude-topics` can be used together with `--topics`. Sort of nonsense but why not..
  - `--exclude--services` can be used together with `--services`.

Note: We already have test coverage for most (almost all) of the newly defined behavior in the https://github.com/ros2/rosbag2/blob/rolling/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp

Note: There are no API/ABI breaking changes in this PR. However, it is not backportable to the Iron or Humble since we have different logic in the `rosbag2_transport ::topic_filter`.