### PR TITLE
Add unit tests to cover message's send and received timestamps during recording

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -586,10 +586,10 @@ RecorderImpl::create_subscription(
   }
 #endif
 
-  static bool rwm_has_received_timestamp_support =
+  static bool rmw_has_received_timestamp_support =
     std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == std::string::npos;
 
-  if (record_options_.use_sim_time || !rwm_has_received_timestamp_support) {
+  if (record_options_.use_sim_time || !rmw_has_received_timestamp_support) {
     return node->create_generic_subscription(
       topic_name,
       topic_type,

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -586,10 +586,7 @@ RecorderImpl::create_subscription(
   }
 #endif
 
-  static bool rmw_has_received_timestamp_support =
-    std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == std::string::npos;
-
-  if (record_options_.use_sim_time || !rmw_has_received_timestamp_support) {
+  if (record_options_.use_sim_time) {
     return node->create_generic_subscription(
       topic_name,
       topic_type,

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -586,7 +586,10 @@ RecorderImpl::create_subscription(
   }
 #endif
 
-  if (record_options_.use_sim_time) {
+  static bool rwm_has_received_timestamp_support =
+    std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == std::string::npos;
+
+  if (record_options_.use_sim_time || !rwm_has_received_timestamp_support) {
     return node->create_generic_subscription(
       topic_name,
       topic_type,

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -91,19 +91,20 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   EXPECT_THAT(array_messages[0]->float32_values, Eq(array_message->float32_values));
 
   // Check for send and received timestamps
-  bool rwm_has_send_timestamp_support = true;
+  bool rmw_has_send_timestamp_support = true;
 #ifdef _WIN32
   if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") !=
     std::string::npos)
   {
-    rwm_has_send_timestamp_support = false;
+    rmw_has_send_timestamp_support = false;
   }
 #endif
   for (const auto & message : recorded_messages) {
     EXPECT_NE(message->recv_timestamp, 0) << "topic : " << message->topic_name;
-    if (rwm_has_send_timestamp_support) {
+    if (rmw_has_send_timestamp_support) {
       // Check that the send_timestamp is not the same as the clock message
       EXPECT_NE(message->send_timestamp, 0);
+      EXPECT_THAT(message->recv_timestamp, Ge(message->send_timestamp));
     } else {
       // if rwm has not sent timestamp support, send_timestamp must be zero
       EXPECT_EQ(message->send_timestamp, 0);

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -70,8 +70,10 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
       return mock_writer.get_messages().size() >= expected_messages;
     });
   auto recorded_messages = mock_writer.get_messages();
-  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
+  EXPECT_TRUE(ret) << "failed to capture expected messages in time" <<
+    "recorded messages = " << recorded_messages.size();
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));
+  stop_spinning();
 
   auto recorded_topics = mock_writer.get_topics();
   ASSERT_THAT(recorded_topics, SizeIs(2));
@@ -87,6 +89,26 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   EXPECT_THAT(string_messages[0]->string_value, Eq(string_message->string_value));
   EXPECT_THAT(array_messages[0]->bool_values, Eq(array_message->bool_values));
   EXPECT_THAT(array_messages[0]->float32_values, Eq(array_message->float32_values));
+
+  // Check for send and received timestamps
+  bool rwm_has_send_timestamp_support = true;
+#ifdef _WIN32
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") !=
+    std::string::npos)
+  {
+    rwm_has_send_timestamp_support = false;
+  }
+#endif
+  for (const auto & message : recorded_messages) {
+    EXPECT_NE(message->recv_timestamp, 0) << "topic : " << message->topic_name;
+    if (rwm_has_send_timestamp_support) {
+      // Check that the send_timestamp is not the same as the clock message
+      EXPECT_NE(message->send_timestamp, 0);
+    } else {
+      // if rwm has not sent timestamp support, send_timestamp must be zero
+      EXPECT_EQ(message->send_timestamp, 0);
+    }
+  }
 }
 
 TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -137,17 +137,17 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
   // check that the timestamp is same as the clock message
   EXPECT_THAT(string_messages[0]->recv_timestamp, time_value);
 
-  bool rwm_has_timestamp_support = true;
+  bool rmw_has_timestamp_support = true;
 
 #ifdef _WIN32
   if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") !=
     std::string::npos)
   {
-    rwm_has_timestamp_support = false;
+    rmw_has_timestamp_support = false;
   }
 #endif
 
-  if (rwm_has_timestamp_support) {
+  if (rmw_has_timestamp_support) {
     // Check that the send_timestamp is not the same as the clock message
     EXPECT_NE(string_messages[0]->send_timestamp, time_value);
     EXPECT_NE(string_messages[0]->send_timestamp, 0);


### PR DESCRIPTION
- Closes https://github.com/ros2/rosbag2/issues/1638
- CycloneDDS doesn't support `received_timestamps` and settling up zeros in `message_info` for that field.
- Fallback to the timestamp from the node clock in case of the CycloneDDS.
- Full RCA can be found in the https://github.com/ros2/rosbag2/issues/1638#issuecomment-2097426872