### PR TITLE
Exclude recorded /clock topic when --clock option is specified

### DIFF
--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -87,7 +87,8 @@ class PlayVerb(VerbExtension):
         clock_args_group.add_argument(
             '--clock', type=positive_float, nargs='?', const=40, default=0,
             help='Publish to /clock at a specific frequency in Hz, to act as a ROS Time Source. '
-                 'Value must be positive. Defaults to not publishing.')
+                 'Value must be positive. Defaults to not publishing.'
+                 'If specified, /clock topic in the bag file is excluded to publish.')
         clock_args_group.add_argument(
             '--clock-topics', type=str, default=[], nargs='+',
             help='List of topics separated by spaces that will trigger a /clock update '

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -208,8 +208,6 @@ class PlayVerb(VerbExtension):
 
         play_options.exclude_regex_to_filter = args.exclude_regex
 
-        play_options.exclude_topics_to_filter = args.exclude_topics if args.exclude_topics else []
-
         play_options.exclude_service_events_to_filter = \
             convert_service_to_service_event_topic(args.exclude_services)
 
@@ -217,6 +215,10 @@ class PlayVerb(VerbExtension):
         play_options.loop = args.loop
         play_options.topic_remapping_options = topic_remapping
         play_options.clock_publish_frequency = args.clock
+        exclude_topics = args.exclude_topics if args.exclude_topics else []
+        if play_options.clock_publish_frequency > 0:
+            exclude_topics.append('/clock')
+        play_options.exclude_topics_to_filter = exclude_topics
         if args.clock_topics_all or len(args.clock_topics) > 0:
             play_options.clock_publish_on_topic_publish = True
         play_options.clock_topics = args.clock_topics


### PR DESCRIPTION
As mentioned in https://github.com/ros2/rosbag2/issues/1645, if you play a rosbag containing `/clock` with `--clock`, it will be double-published.
This PR excludes `/clock` when --clock is specified.


```
ros2 bag play sample_bag --clock 100
```

before
```
---
clock:
  sec: 1715138101
  nanosec: 880998015
---
clock:
  sec: 1666578700
  nanosec: 606046430
---
clock:
  sec: 1666578700
  nanosec: 608539499
---
clock:
  sec: 1715138101
  nanosec: 891000787
---
clock:
  sec: 1666578700
  nanosec: 611041316
```

after
```
clock:
  sec: 1715138117
  nanosec: 244567726
---
clock:
  sec: 1715138117
  nanosec: 254594666
---
clock:
  sec: 1715138117
  nanosec: 264606514
---
clock:
  sec: 1715138117
  nanosec: 274554989
---
clock:
  sec: 1715138117
  nanosec: 284571707
```