### PR TITLE
Upgrade to version of MCAP used in rolling

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -32,8 +32,8 @@ endif()
 macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
-    URL https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.8.0.tar.gz
-    URL_HASH SHA1=b44637791da2c9c1cec61a3ba6994f1ef63a228c # v0.8.0
+    URL https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.3.0.tar.gz
+    URL_HASH SHA1=558833d0cde8193a04b77251421aabee3447acb2 # v1.3.0
   )
   fetchcontent_makeavailable(mcap)
 


### PR DESCRIPTION
This upgrades the MCAP vendor library to be the same one used in Rolling (0.8.0 -> 1.3.0).

There is at least one bug fix in the CPP library that makes the newer version helpful to those directly using the MCAP library through this package. For us, the 0.8.0 version does not accept channels with no schema even though it is explicitly allowed in the spec. The logic is fixed in the new version.