### PR TITLE
Add support for "all" and "exclude" in RecordOptions YAML decoder

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -60,6 +60,13 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
 {
   optional_assign<bool>(node, "all_topics", record_options.all_topics);
   optional_assign<bool>(node, "all_services", record_options.all_services);
+  bool record_options_all{false};  // Parse `all` for backward compatability and convenient usage
+  optional_assign<bool>(node, "all", record_options_all);
+  if (record_options_all) {
+    record_options.all_topics = true;
+    record_options.all_services = true;
+  }
+
   optional_assign<bool>(node, "is_discovery_disabled", record_options.is_discovery_disabled);
   optional_assign<std::vector<std::string>>(node, "topics", record_options.topics);
   optional_assign<std::vector<std::string>>(node, "topic_types", record_options.topic_types);
@@ -71,6 +78,8 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
     node, "topic_polling_interval", record_options.topic_polling_interval);
 
   optional_assign<std::string>(node, "regex", record_options.regex);
+  // Map exclude to the "exclude_regex" for backward compatability.
+  optional_assign<std::string>(node, "exclude", record_options.exclude_regex);
   optional_assign<std::string>(node, "exclude_regex", record_options.exclude_regex);
   optional_assign<std::vector<std::string>>(node, "exclude_topics", record_options.exclude_topics);
   optional_assign<std::vector<std::string>>(

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -59,3 +59,21 @@ TEST(record_options, test_yaml_serialization)
   CHECK(rmw_serialization_format);
   #undef CHECK
 }
+
+TEST(record_options, test_yaml_decode_for_all_and_exclude)
+{
+  std::string serialized_record_options =
+    "  all: true\n"
+    "  all_topics: false\n"
+    "  topics: []\n"
+    "  rmw_serialization_format: \"\"  # defaults to using the format of the input topic\n"
+    "  regex: \"[xyz]/topic\"\n"
+    "  exclude: \"[x]/topic\"\n";
+
+  YAML::Node loaded_node = YAML::Load(serialized_record_options);
+  auto record_options = loaded_node.as<rosbag2_transport::RecordOptions>();
+  ASSERT_EQ(record_options.all_topics, true);
+  ASSERT_EQ(record_options.all_services, true);
+  ASSERT_EQ(record_options.regex, "[xyz]/topic");
+  ASSERT_EQ(record_options.exclude_regex, "[x]/topic");
+}


### PR DESCRIPTION
- Fixes https://github.com/ros2/rosbag2/issues/1660
-  This PR adds support for old-style options "all" and "exclude" in the `RecordOptions` YAML parser for backward compatibility with old versions of the config files for the "ros2 bag convert" CLI.