### PR TITLE
Link `rcpputils::filesystem` to solve error on RHEL

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -45,6 +45,12 @@ ament_target_dependencies(${PROJECT_NAME}
   rosbag2_storage)
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROSBAG2_COMPRESSION_BUILDING_DLL)
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+  target_link_libraries(${PROJECT_NAME}
+    rcpputils::filesystem
+  )
+endif()
+
 install(
   DIRECTORY include/
   DESTINATION include/${PROJECT_NAME})

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -45,12 +45,6 @@ ament_target_dependencies(${PROJECT_NAME}
   rosbag2_storage)
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROSBAG2_COMPRESSION_BUILDING_DLL)
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-  target_link_libraries(${PROJECT_NAME}
-    rcpputils::filesystem
-  )
-endif()
-
 install(
   DIRECTORY include/
   DESTINATION include/${PROJECT_NAME})

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -14,7 +14,6 @@
 
 #include <gmock/gmock.h>
 
-#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -22,6 +21,7 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/compression_options.hpp"
 #include "rosbag2_compression/sequential_compression_writer.hpp"
@@ -39,8 +39,6 @@
 
 using namespace testing;  // NOLINT
 
-namespace fs = std::filesystem;
-
 static constexpr const char * DefaultTestCompressor = "fake_comp";
 
 class SequentialCompressionWriterTest : public Test
@@ -51,12 +49,12 @@ public:
     storage_{std::make_shared<NiceMock<MockStorage>>()},
     converter_factory_{std::make_shared<StrictMock<MockConverterFactory>>()},
     metadata_io_{std::make_unique<NiceMock<MockMetadataIo>>()},
-    tmp_dir_{fs::temp_directory_path() / "SequentialCompressionWriterTest"},
+    tmp_dir_{rcpputils::fs::temp_directory_path() / "SequentialCompressionWriterTest"},
     tmp_dir_storage_options_{},
     serialization_format_{"rmw_format"}
   {
     tmp_dir_storage_options_.uri = tmp_dir_.string();
-    fs::remove_all(tmp_dir_);
+    rcpputils::fs::remove_all(tmp_dir_);
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(Return(storage_));
     EXPECT_CALL(*storage_factory_, open_read_write(_)).Times(AtLeast(0));
     // intercept the metadata write so we can analyze it.
@@ -68,7 +66,7 @@ public:
 
   ~SequentialCompressionWriterTest()
   {
-    fs::remove_all(tmp_dir_);
+    rcpputils::fs::remove_all(tmp_dir_);
   }
 
   void initializeFakeFileStorage()
@@ -127,7 +125,7 @@ public:
   std::shared_ptr<NiceMock<MockStorage>> storage_;
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<MockMetadataIo> metadata_io_;
-  fs::path tmp_dir_;
+  rcpputils::fs::path tmp_dir_;
   rosbag2_storage::StorageOptions tmp_dir_storage_options_;
   rosbag2_storage::BagMetadata intercepted_metadata_;
   std::unique_ptr<rosbag2_cpp::Writer> writer_;


### PR DESCRIPTION
It seems #1653 created a [regression](https://build.ros2.org/view/Hbin_rhel_el864/job/Hbin_rhel_el864__rosbag2_compression__rhel_8_x86_64__binary/65/) on Humble on RHEL.

Here is an attempt to fix it. I'll run RHEL CI before merging.