### PR TITLE
[humble] Rollback to rcpputils::fs and workaround failure in "open_succeds_twice" on second run.

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -14,7 +14,6 @@
 
 #include <gmock/gmock.h>
 
-#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -22,6 +21,7 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 
 #include "rosbag2_compression/compression_options.hpp"
 #include "rosbag2_compression/sequential_compression_writer.hpp"
@@ -39,8 +39,6 @@
 
 using namespace testing;  // NOLINT
 
-namespace fs = std::filesystem;
-
 static constexpr const char * DefaultTestCompressor = "fake_comp";
 
 class SequentialCompressionWriterTest : public Test
@@ -51,12 +49,12 @@ public:
     storage_{std::make_shared<NiceMock<MockStorage>>()},
     converter_factory_{std::make_shared<StrictMock<MockConverterFactory>>()},
     metadata_io_{std::make_unique<NiceMock<MockMetadataIo>>()},
-    tmp_dir_{fs::temp_directory_path() / "SequentialCompressionWriterTest"},
+    tmp_dir_{rcpputils::fs::temp_directory_path() / "SequentialCompressionWriterTest"},
     tmp_dir_storage_options_{},
     serialization_format_{"rmw_format"}
   {
     tmp_dir_storage_options_.uri = tmp_dir_.string();
-    fs::remove_all(tmp_dir_);
+    rcpputils::fs::remove_all(tmp_dir_);
     ON_CALL(*storage_factory_, open_read_write(_)).WillByDefault(Return(storage_));
     EXPECT_CALL(*storage_factory_, open_read_write(_)).Times(AtLeast(0));
     // intercept the metadata write so we can analyze it.
@@ -68,7 +66,7 @@ public:
 
   ~SequentialCompressionWriterTest()
   {
-    fs::remove_all(tmp_dir_);
+    rcpputils::fs::remove_all(tmp_dir_);
   }
 
   void initializeFakeFileStorage()
@@ -127,7 +125,7 @@ public:
   std::shared_ptr<NiceMock<MockStorage>> storage_;
   std::shared_ptr<StrictMock<MockConverterFactory>> converter_factory_;
   std::unique_ptr<MockMetadataIo> metadata_io_;
-  fs::path tmp_dir_;
+  rcpputils::fs::path tmp_dir_;
   rosbag2_storage::StorageOptions tmp_dir_storage_options_;
   rosbag2_storage::BagMetadata intercepted_metadata_;
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
@@ -193,7 +191,7 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_on_supported_compression_f
     kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
   initializeWriter(compression_options);
 
-  auto tmp_dir = tmp_dir_ / "path_not_empty";
+  auto tmp_dir = rcpputils::fs::temp_directory_path() / "path_not_empty";
   auto storage_options = rosbag2_storage::StorageOptions();
   storage_options.uri = tmp_dir.string();
 
@@ -208,8 +206,8 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_twice)
     kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
   initializeWriter(compression_options);
 
-  auto tmp_dir = tmp_dir_ / "path_not_empty";
-  auto tmp_dir_next = tmp_dir_ / "path_not_empty_next";
+  auto tmp_dir = rcpputils::fs::temp_directory_path() / "path_not_empty";
+  auto tmp_dir_next = rcpputils::fs::temp_directory_path() / "path_not_empty_next";
 
   auto storage_options = rosbag2_storage::StorageOptions();
   auto storage_options_next = rosbag2_storage::StorageOptions();

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -191,12 +191,15 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_on_supported_compression_f
     kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
   initializeWriter(compression_options);
 
-  auto tmp_dir = rcpputils::fs::temp_directory_path() / "path_not_empty";
+  auto tmp_dir = tmp_dir_ / "path_not_empty";
+  // Cleanup leftovers from previous run if any
+  rcpputils::fs::remove_all(tmp_dir);
   auto storage_options = rosbag2_storage::StorageOptions();
   storage_options.uri = tmp_dir.string();
 
   EXPECT_NO_THROW(
     writer_->open(tmp_dir_storage_options_, {serialization_format_, serialization_format_}));
+  rcpputils::fs::remove_all(tmp_dir);
 }
 
 TEST_F(SequentialCompressionWriterTest, open_succeeds_twice)
@@ -206,8 +209,8 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_twice)
     kDefaultCompressionQueueSize, kDefaultCompressionQueueThreads};
   initializeWriter(compression_options);
 
-  auto tmp_dir = rcpputils::fs::temp_directory_path() / "path_not_empty";
-  auto tmp_dir_next = rcpputils::fs::temp_directory_path() / "path_not_empty_next";
+  auto tmp_dir = tmp_dir_ / "path_not_empty";
+  auto tmp_dir_next = tmp_dir_ / "path_not_empty_next";
 
   // Cleanup leftovers from previous run if any
   rcpputils::fs::remove_all(tmp_dir);

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -209,6 +209,10 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_twice)
   auto tmp_dir = rcpputils::fs::temp_directory_path() / "path_not_empty";
   auto tmp_dir_next = rcpputils::fs::temp_directory_path() / "path_not_empty_next";
 
+  // Cleanup leftovers from previous run if any
+  rcpputils::fs::remove_all(tmp_dir);
+  rcpputils::fs::remove_all(tmp_dir_next);
+
   auto storage_options = rosbag2_storage::StorageOptions();
   auto storage_options_next = rosbag2_storage::StorageOptions();
 
@@ -221,6 +225,9 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_twice)
   writer_->close();
   EXPECT_NO_THROW(
     writer_->open(storage_options_next, {serialization_format_, serialization_format_}));
+
+  rcpputils::fs::remove_all(tmp_dir);
+  rcpputils::fs::remove_all(tmp_dir_next);
 }
 
 TEST_F(SequentialCompressionWriterTest, writer_calls_create_compressor)


### PR DESCRIPTION
- Fix for [regression]((https://build.ros2.org/view/Hbin_rhel_el864/job/Hbin_rhel_el864__rosbag2_compression__rhel_8_x86_64__binary/65/)) on on Humble with RHEL created by https://github.com/ros2/rosbag2/pull/1653
- Replaces #1665 

Note. The original failure in the "open_succeeds_twice" on the second run was because `rcpputils::fs::delete_all(tmp_dir_)` failed to delete the temp folder in destructor because it was there two subfolders.