### PR TITLE
Fix for regression in `open_succeeds_twice` and `minimal_writer_example` tests

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -214,7 +214,7 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_on_supported_compression_f
     kDefaultCompressionQueueThreadsPriority};
   initializeWriter(compression_options);
 
-  auto tmp_dir = fs::temp_directory_path() / "path_not_empty";
+  auto tmp_dir = tmp_dir_ / "path_not_empty";
   auto storage_options = rosbag2_storage::StorageOptions();
   storage_options.uri = tmp_dir.string();
 
@@ -230,8 +230,8 @@ TEST_F(SequentialCompressionWriterTest, open_succeeds_twice)
     kDefaultCompressionQueueThreadsPriority};
   initializeWriter(compression_options);
 
-  auto tmp_dir = fs::temp_directory_path() / "path_not_empty";
-  auto tmp_dir_next = fs::temp_directory_path() / "path_not_empty_next";
+  auto tmp_dir = tmp_dir_ / "path_not_empty";
+  auto tmp_dir_next = tmp_dir_ / "path_not_empty_next";
 
   auto storage_options = rosbag2_storage::StorageOptions();
   auto storage_options_next = rosbag2_storage::StorageOptions();

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_api.cpp
@@ -108,9 +108,7 @@ TEST_P(TestRosbag2CPPAPI, minimal_writer_example)
     writer.open(rosbag_directory_next.string());
 
     // write same topic to different bag
-    writer.write(
-      serialized_msg2, "/yet/another/topic", "test_msgs/msg/BasicTypes",
-      rclcpp::Clock().now());
+    writer.write(bag_message, "/my/other/topic", "test_msgs/msg/BasicTypes");
 
     // close by scope
   }
@@ -154,7 +152,7 @@ TEST_P(TestRosbag2CPPAPI, minimal_writer_example)
       &extracted_serialized_msg, &extracted_test_msg);
 
     EXPECT_EQ(test_msg, extracted_test_msg);
-    EXPECT_EQ("/yet/another/topic", topic);
+    EXPECT_EQ("/my/other/topic", topic);
   }
 
   // alternative reader


### PR DESCRIPTION
- This PR fixes tests regression introduced in the #1599
- Follow up from the https://github.com/osrf/buildfarm-tools/issues/53#issuecomment-2122724421

The error message from [CI reference build](https://ci.ros2.org/job/nightly_linux-aarch64_repeated/2762):
```
/home/jenkins-agent/workspace/nightly_linux-aarch64_repeated/ws/src/ros2/rosbag2/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp:242
Expected: writer_->open(storage_options, {serialization_format_, serialization_format_}) doesn't throw an exception.
  Actual: it throws std::runtime_error with description "Bag directory already exists (/tmp/path_not_empty), can't overwrite existing bag
```

- This PR addresses the failure in the `rosbag2_compression.SequentialCompressionWriterTest.open_succeeds_twice` on a second run due to the leftovers in the temp folder.
It also addresses the flakiness in `TestRosbag2CPPAPI::minimal_writer_example` due to using shared ptr to the serialized message twice in the `writer.write(msg)` call.
Note. The "serialized_msg2" in the `TestRosbag2CPPAPI::minimal_writer_example` does not own the serialized data after the first call writer.write(serialized_msg2,..). i.e. need to use another message or another API in the test for the second call to the writer.write(msg).