### PR TITLE
Bugfix for issue where unable to create composable nodes with compression

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -40,6 +40,7 @@
 #include "rosbag2_storage/qos.hpp"
 #include "rosbag2_transport/config_options_from_node_params.hpp"
 #include "rosbag2_transport/player_service_client.hpp"
+#include "rosbag2_transport/reader_writer_factory.hpp"
 
 #include "logging.hpp"
 
@@ -1543,7 +1544,7 @@ Player::Player(const std::string & node_name, const rclcpp::NodeOptions & node_o
     keyboard_handler = std::make_shared<KeyboardHandler>();
   }
 
-  auto reader = std::make_unique<rosbag2_cpp::Reader>();
+  auto reader = ReaderWriterFactory::make_reader(storage_options);
 
   pimpl_ = std::make_unique<PlayerImpl>(
     this, std::move(reader), keyboard_handler, storage_options, play_options);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -42,6 +42,7 @@
 
 #include "logging.hpp"
 #include "rosbag2_transport/config_options_from_node_params.hpp"
+#include "rosbag2_transport/reader_writer_factory.hpp"
 #include "rosbag2_transport/topic_filter.hpp"
 
 namespace rosbag2_transport
@@ -756,7 +757,7 @@ Recorder::Recorder(
     keyboard_handler = std::make_shared<KeyboardHandler>();
   }
 
-  auto writer = std::make_unique<rosbag2_cpp::Writer>();
+  auto writer = ReaderWriterFactory::make_writer(record_options);
 
   pimpl_ = std::make_unique<RecorderImpl>(
     this, std::move(writer), keyboard_handler,

--- a/rosbag2_transport/test/resources/recorder_node_params.yaml
+++ b/rosbag2_transport/test/resources/recorder_node_params.yaml
@@ -20,8 +20,8 @@ recorder_params_node:
       exclude_topics: ["exclude_topic", "other_exclude_topic"]
       exclude_services: ["exclude_service", "other_exclude_service"]
       node_prefix: "prefix"
-      compression_mode: "stream"
-      compression_format: "h264"
+      compression_mode: "file"
+      compression_format: "zstd"
       compression_queue_size: 10
       compression_threads: 2
       compression_threads_priority: -1

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
@@ -230,8 +230,8 @@ TEST_P(ComposableRecorderTests, recorder_can_parse_parameters_from_file) {
     "/exclude_service/_service_event", "/other_exclude_service/_service_event"};
   EXPECT_EQ(record_options.exclude_service_events, exclude_services);
   EXPECT_EQ(record_options.node_prefix, "prefix");
-  EXPECT_EQ(record_options.compression_mode, "stream");
-  EXPECT_EQ(record_options.compression_format, "h264");
+  EXPECT_EQ(record_options.compression_mode, "file");
+  EXPECT_EQ(record_options.compression_format, "zstd");
   EXPECT_EQ(record_options.compression_queue_size, 10);
   EXPECT_EQ(record_options.compression_threads, 2);
   EXPECT_EQ(record_options.compression_threads_priority, -1);


### PR DESCRIPTION
- This PR addresses a bug in which, instead of `SequentialCompressionReader` and `SequentialCompressionWriter`, regular `Reader` and `Writer` classes are created when creating `Player` or `Recorder` classes via composition.

- Use factory methods to create a reader and writer in constructors for composable Player and Recorder nodes.