### PR TITLE
Allow to specify start offset from CLI arguments equal to 0.0 for the rosbag2 player

### DIFF
--- a/ros2bag/ros2bag/api/__init__.py
+++ b/ros2bag/ros2bag/api/__init__.py
@@ -125,6 +125,17 @@ def check_positive_float(value: Any) -> float:
         raise ArgumentTypeError('{} is not the valid type (float)'.format(value))
 
 
+def check_not_negative_float(value: Any) -> float:
+    """Argparse validator to verify that a value is a float and that not negative."""
+    try:
+        fvalue = float(value)
+        if fvalue < 0.0:
+            raise ArgumentTypeError(f'Value {value} is less than zero.')
+        return fvalue
+    except ValueError:
+        raise ArgumentTypeError('{} is not the valid type (float)'.format(value))
+
+
 def check_path_exists(value: Any) -> str:
     """Argparse validator to verify a path exists."""
     try:

--- a/ros2bag/ros2bag/verb/burst.py
+++ b/ros2bag/ros2bag/verb/burst.py
@@ -16,8 +16,8 @@ from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
 from ros2bag.api import add_standard_reader_args
+from ros2bag.api import check_not_negative_float
 from ros2bag.api import check_not_negative_int
-from ros2bag.api import check_positive_float
 from ros2bag.api import convert_service_to_service_event_topic
 from ros2bag.api import convert_yaml_to_qos_profile
 from ros2bag.api import print_error
@@ -60,7 +60,7 @@ class BurstVerb(VerbExtension):
             help='Path to a yaml file defining storage specific configurations. '
                  'See storage plugin documentation for the format of this file.')
         parser.add_argument(
-            '--start-offset', type=check_positive_float, default=0.0,
+            '--start-offset', type=check_not_negative_float, default=0.0,
             help='Start the playback player this many seconds into the bag file.')
         parser.add_argument(
             '-n', '--num-messages', type=check_not_negative_int, default=0,

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -16,6 +16,7 @@ from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
 from ros2bag.api import add_standard_reader_args
+from ros2bag.api import check_not_negative_float
 from ros2bag.api import check_not_negative_int
 from ros2bag.api import check_positive_float
 from ros2bag.api import convert_service_to_service_event_topic
@@ -134,7 +135,7 @@ class PlayVerb(VerbExtension):
             '-p', '--start-paused', action='store_true', default=False,
             help='Start the playback player in a paused state.')
         parser.add_argument(
-            '--start-offset', type=check_positive_float, default=0.0,
+            '--start-offset', type=check_not_negative_float, default=0.0,
             help='Start the playback player this many seconds into the bag file.')
         parser.add_argument(
             '--wait-for-all-acked', type=check_not_negative_int, default=-1,


### PR DESCRIPTION
- This PR will allow to specify start offset from CLI arguments equal to `0.0` for the rosbag2 player.

- The default is specified as `0.0` but this is not allowed by the user.