### PR TITLE
Propagate "custom_data" and "ros_distro" in to the metadata.yaml file during re-indexing

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -162,8 +162,8 @@ void Reindexer::aggregate_metadata(
   const rosbag2_storage::StorageOptions & storage_options)
 {
   std::map<std::string, rosbag2_storage::TopicInformation> temp_topic_info;
-  std::chrono::system_clock::time_point latest_log_start =
-    std::chrono::system_clock::time_point::min();
+  std::chrono::time_point<std::chrono::high_resolution_clock> latest_log_start =
+    std::chrono::time_point<std::chrono::high_resolution_clock>::min();
 
   // In order to most accurately reconstruct the metadata, we need to
   // visit each of the contained relative files files in the bag,

--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -191,10 +191,14 @@ void Reindexer::aggregate_metadata(
     metadata_.storage_identifier = temp_metadata.storage_identifier;
 
     // try to find the last log for the most complete custom data section
-    if (latest_log_start < temp_metadata.starting_time) {
+    if (latest_log_start < temp_metadata.starting_time ) {
       latest_log_start = temp_metadata.starting_time;
-      metadata_.custom_data = temp_metadata.custom_data;
-      metadata_.ros_distro = temp_metadata.ros_distro;
+      if (temp_metadata.custom_data.size() > 0) {
+        metadata_.custom_data = temp_metadata.custom_data;
+      }
+      if (temp_metadata.ros_distro.size() > 0) {
+        metadata_.ros_distro = temp_metadata.ros_distro;
+      }
     }
 
     if (temp_metadata.starting_time < metadata_.starting_time) {

--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -191,12 +191,12 @@ void Reindexer::aggregate_metadata(
     metadata_.storage_identifier = temp_metadata.storage_identifier;
 
     // try to find the last log for the most complete custom data section
-    if (latest_log_start < temp_metadata.starting_time ) {
+    if (latest_log_start < temp_metadata.starting_time) {
       latest_log_start = temp_metadata.starting_time;
-      if (temp_metadata.custom_data.size() > 0) {
+      if (!temp_metadata.custom_data.empty()) {
         metadata_.custom_data = temp_metadata.custom_data;
       }
-      if (temp_metadata.ros_distro.size() > 0) {
+      if (!temp_metadata.ros_distro.empty()) {
         metadata_.ros_distro = temp_metadata.ros_distro;
       }
     }

--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -162,6 +162,8 @@ void Reindexer::aggregate_metadata(
   const rosbag2_storage::StorageOptions & storage_options)
 {
   std::map<std::string, rosbag2_storage::TopicInformation> temp_topic_info;
+  std::chrono::system_clock::time_point latest_log_start =
+    std::chrono::system_clock::time_point::min();
 
   // In order to most accurately reconstruct the metadata, we need to
   // visit each of the contained relative files files in the bag,
@@ -187,6 +189,13 @@ void Reindexer::aggregate_metadata(
     bag_reader->open(temp_so, blank_converter_options);
     auto temp_metadata = bag_reader->get_metadata();
     metadata_.storage_identifier = temp_metadata.storage_identifier;
+
+    // try to find the last log for the most complete custom data section
+    if(latest_log_start < temp_metadata.starting_time){
+      latest_log_start = temp_metadata.starting_time;
+      metadata_.custom_data = temp_metadata.custom_data;
+      metadata_.ros_distro = temp_metadata.ros_distro;
+    }
 
     if (temp_metadata.starting_time < metadata_.starting_time) {
       metadata_.starting_time = temp_metadata.starting_time;

--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -191,7 +191,7 @@ void Reindexer::aggregate_metadata(
     metadata_.storage_identifier = temp_metadata.storage_identifier;
 
     // try to find the last log for the most complete custom data section
-    if(latest_log_start < temp_metadata.starting_time){
+    if (latest_log_start < temp_metadata.starting_time) {
       latest_log_start = temp_metadata.starting_time;
       metadata_.custom_data = temp_metadata.custom_data;
       metadata_.ros_distro = temp_metadata.ros_distro;

--- a/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_reindexer.cpp
@@ -81,6 +81,7 @@ public:
       rosbag2_storage::StorageOptions storage_options;
       storage_options.storage_id = GetParam();
       storage_options.uri = root_bag_path_.string();
+      storage_options.custom_data["name"] = "value";
       writer.open(storage_options);
       rosbag2_storage::TopicMetadata topic;
       topic.name = "/test_topic";
@@ -132,6 +133,8 @@ TEST_P(ReindexTestFixture, test_multiple_files) {
 
   EXPECT_EQ(generated_metadata.storage_identifier, GetParam());
   EXPECT_EQ(generated_metadata.version, target_metadata.version);
+  EXPECT_EQ(generated_metadata.ros_distro, target_metadata.ros_distro);
+  EXPECT_EQ(generated_metadata.custom_data, target_metadata.custom_data);
 
   for (const auto & gen_rel_path : generated_metadata.relative_file_paths) {
     EXPECT_TRUE(


### PR DESCRIPTION
Propagates the `custom_data` and `ros_distro` fields from the underlying storage into the `metadata.yaml` file during re-indexing. 
- Previously this data was not extracted from the storage and the subsequent fields in `metadata.yaml` were left as default. 
- The implementation in this PR uses the `custom_data` and `ros_distro` metadata from the newest storage file contained within the log as custom data can be modified in the storage API between successive split files. 

This fixes #1699 