### PR TITLE
On ros humble, the ros2 bag reindex was generating metadata.yaml without topics which has 0 message count.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ venv/
 **/.pytest_cache/
 __pycache__/
 *.db3-*
-
+log/
+install/

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -51,6 +51,10 @@ public:
 
   virtual const rosbag2_storage::BagMetadata & get_metadata() const = 0;
 
+  virtual void setMetadataAllow0MessageCount(__attribute__((unused)) bool enable)
+  {
+  }
+
   virtual std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() const = 0;
 
   virtual void set_filter(const rosbag2_storage::StorageFilter & storage_filter) = 0;

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -72,6 +72,8 @@ public:
 
   const rosbag2_storage::BagMetadata & get_metadata() const override;
 
+  void setMetadataAllow0MessageCount(bool enable) override;
+
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() const override;
 
   void set_filter(const rosbag2_storage::StorageFilter & storage_filter) override;
@@ -187,6 +189,7 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 
   bag_events::EventCallbackManager callback_manager_;
+  bool allow_metadata0MessageCount = false;
 };
 
 }  // namespace readers

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -79,6 +79,11 @@ void SequentialReader::close()
   }
 }
 
+void SequentialReader::setMetadataAllow0MessageCount(bool enable)
+{
+  allow_metadata0MessageCount = enable;
+}
+
 void SequentialReader::open(
   const rosbag2_storage::StorageOptions & storage_options,
   const ConverterOptions & converter_options)
@@ -106,6 +111,7 @@ void SequentialReader::open(
     if (!storage_) {
       throw std::runtime_error{"No storage could be initialized from the inputs."};
     }
+    storage_->setMetadataAllow0MessageCount(allow_metadata0MessageCount);
     metadata_ = storage_->get_metadata();
     if (metadata_.relative_file_paths.empty()) {
       ROSBAG2_CPP_LOG_WARN("No file paths were found in metadata.");

--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -187,6 +187,8 @@ void Reindexer::aggregate_metadata(
 
     // We aren't actually interested in reading messages, so use a blank converter option
     rosbag2_cpp::ConverterOptions blank_converter_options {};
+    // Shall be before open as metadata is read during file openning
+    bag_reader->setMetadataAllow0MessageCount(true);
     bag_reader->open(temp_so, blank_converter_options);
     auto temp_metadata = bag_reader->get_metadata();
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_info_interface.hpp
@@ -33,6 +33,10 @@ public:
 
   virtual BagMetadata get_metadata() = 0;
 
+  virtual void setMetadataAllow0MessageCount(__attribute__((unused)) bool enable)
+  {
+  }
+
   /**
    * Retrieves the relative path to the backing of the storage plugin.
    *

--- a/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
+++ b/rosbag2_storage_default_plugins/include/rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp
@@ -72,6 +72,8 @@ public:
 
   rosbag2_storage::BagMetadata get_metadata() override;
 
+  void setMetadataAllow0MessageCount(bool enable) override;
+
   std::string get_relative_file_path() const override;
 
   uint64_t get_bagfile_size() const override;
@@ -115,6 +117,7 @@ private:
   void write_locked(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
   RCPPUTILS_TSA_REQUIRES(database_write_mutex_);
   int read_db_schema_version();
+  bool allow_metadata0MessageCount = false;
 
   using ReadQueryResult = SqliteStatementWrapper::QueryResult<
     std::shared_ptr<rcutils_uint8_array_t>, rcutils_time_point_value_t, std::string, int>;

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -522,22 +522,25 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
       max_time = std::get<5>(result) > max_time ? std::get<5>(result) : max_time;
     }
 
-    //\==https://github.com/ros2/rosbag2/issues/1719 patch: Add a dedicated case for topics that are declared but have no message inside messges table
+    // \==https://github.com/ros2/rosbag2/issues/1719 patch: Add a dedicated case for topics that
+    // are declared but have no message inside messges table
     std::string query2 =
       "SELECT name, type, serialization_format, offered_qos_profiles "
-      "FROM topics " 
+      "FROM topics "
       "WHERE NOT EXISTS (SELECT * FROM messages WHERE topics.id = messages.topic_id) "
       "GROUP BY topics.name;";
     auto statement2 = database_->prepare_statement(query2);
-    auto query_results2 = statement2->execute_query<std::string, std::string, std::string, std::string>();    
+    auto query_results2 = statement2->execute_query<
+      std::string, std::string, std::string, std::string>();
 
     for (auto result2 : query_results2) {
       metadata.topics_with_message_count.push_back(
         {
-          {std::get<0>(result2), std::get<1>(result2), std::get<2>(result2), std::get<3>(result2)}, 0
+          {std::get<0>(result2), std::get<1>(result2), std::get<2>(result2), std::get<3>(result2)},
+          0
         });
-    }   
-    //==/ 
+    }
+    // ==/
 
 
   } else {
@@ -563,23 +566,23 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
       max_time = std::get<5>(result) > max_time ? std::get<5>(result) : max_time;
     }
 
-    //\==https://github.com/ros2/rosbag2/issues/1719 patch: Add a dedicated case for topics that are declared but have no message inside messges table
+    // \==https://github.com/ros2/rosbag2/issues/1719 patch: Add a dedicated case for topics that
+    // are declared but have no message inside messges table
     std::string query2 =
-      "SELECT name, type, serialization_format"
-      "FROM topics " 
+      "SELECT name, type, serialization_format "
+      "FROM topics "
       "WHERE NOT EXISTS (SELECT * FROM messages WHERE topics.id = messages.topic_id) "
       "GROUP BY topics.name;";
     auto statement2 = database_->prepare_statement(query2);
-    auto query_results2 = statement2->execute_query<std::string, std::string, std::string>();    
+    auto query_results2 = statement2->execute_query<std::string, std::string, std::string>();
 
     for (auto result : query_results2) {
       metadata.topics_with_message_count.push_back(
         {
-          {std::get<0>(result), std::get<1>(result), std::get<2>(result), ""},0
+          {std::get<0>(result), std::get<1>(result), std::get<2>(result), ""}, 0
         });
-    } 
-    //==/
-
+    }
+    // ==/
   }
 
   if (metadata.message_count == 0) {

--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -15,7 +15,6 @@
 #include "rosbag2_storage_default_plugins/sqlite/sqlite_storage.hpp"
 
 #include <sys/stat.h>
-
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -518,11 +517,29 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
           {std::get<0>(result), std::get<1>(result), std::get<2>(result), std::get<6>(result)},
           static_cast<size_t>(std::get<3>(result))
         });
-
       metadata.message_count += std::get<3>(result);
       min_time = std::get<4>(result) < min_time ? std::get<4>(result) : min_time;
       max_time = std::get<5>(result) > max_time ? std::get<5>(result) : max_time;
     }
+
+    //\==https://github.com/ros2/rosbag2/issues/1719 patch: Add a dedicated case for topics that are declared but have no message inside messges table
+    std::string query2 =
+      "SELECT name, type, serialization_format, offered_qos_profiles "
+      "FROM topics " 
+      "WHERE NOT EXISTS (SELECT * FROM messages WHERE topics.id = messages.topic_id) "
+      "GROUP BY topics.name;";
+    auto statement2 = database_->prepare_statement(query2);
+    auto query_results2 = statement2->execute_query<std::string, std::string, std::string, std::string>();    
+
+    for (auto result2 : query_results2) {
+      metadata.topics_with_message_count.push_back(
+        {
+          {std::get<0>(result2), std::get<1>(result2), std::get<2>(result2), std::get<3>(result2)}, 0
+        });
+    }   
+    //==/ 
+
+
   } else {
     std::string query =
       "SELECT name, type, serialization_format, COUNT(messages.id), MIN(messages.timestamp), "
@@ -545,6 +562,24 @@ rosbag2_storage::BagMetadata SqliteStorage::get_metadata()
       min_time = std::get<4>(result) < min_time ? std::get<4>(result) : min_time;
       max_time = std::get<5>(result) > max_time ? std::get<5>(result) : max_time;
     }
+
+    //\==https://github.com/ros2/rosbag2/issues/1719 patch: Add a dedicated case for topics that are declared but have no message inside messges table
+    std::string query2 =
+      "SELECT name, type, serialization_format"
+      "FROM topics " 
+      "WHERE NOT EXISTS (SELECT * FROM messages WHERE topics.id = messages.topic_id) "
+      "GROUP BY topics.name;";
+    auto statement2 = database_->prepare_statement(query2);
+    auto query_results2 = statement2->execute_query<std::string, std::string, std::string>();    
+
+    for (auto result : query_results2) {
+      metadata.topics_with_message_count.push_back(
+        {
+          {std::get<0>(result), std::get<1>(result), std::get<2>(result), ""},0
+        });
+    } 
+    //==/
+
   }
 
   if (metadata.message_count == 0) {


### PR DESCRIPTION
Add all topics present inside db3 to metadata.yaml  (even the 0 message count):

This patch solve the hereunder issue:
https://github.com/ros2/rosbag2/issues/1719