### PR TITLE
Bump sqlite3 to 3.45.1

### DIFF
--- a/sqlite3_vendor/CMakeLists.txt
+++ b/sqlite3_vendor/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 ament_vendor(sqlite3_vendor
   SATISFIED ${SQLite3_FOUND}
   VCS_TYPE zip
-  VCS_URL https://www.sqlite.org/2022/sqlite-amalgamation-3370200.zip
-  VCS_VERSION sqlite-amalgamation-3370200
+  VCS_URL https://www.sqlite.org/2024/sqlite-amalgamation-3450100.zip
+  VCS_VERSION sqlite-amalgamation-3450100
   CMAKE_ARGS ${CMAKE_ARGS}
   PATCHES patches
 )


### PR DESCRIPTION
The sqlite3 version on Ubuntu 24.04 Noble is 3.45.1, so we should use that version: https://packages.ubuntu.com/noble/sqlite3.

The `sqlite3.h` header in the ZIP file indeed shows version 3.45.1.

Supersedes #1611