### PR TITLE
Removed deprecated write method

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -163,28 +163,6 @@ public:
    * Write a serialized message to a bagfile.
    * The topic will be created if it has not been created already.
    *
-   * \param message rclcpp::SerializedMessage The serialized message to be written to the bagfile
-   * \param topic_name the string of the topic this messages belongs to
-   * \param type_name the string of the type associated with this message
-   * \param time The time stamp of the message
-   * \throws runtime_error if the Writer is not open or duplicating message is failed.
-   */
-  [[deprecated(
-    "Use write(std::shared_ptr<rclcpp::SerializedMessage> message," \
-    " const std::string & topic_name," \
-    " const std::string & type_name," \
-    " const rclcpp::Time & time) instead."
-  )]]
-  void write(
-    const rclcpp::SerializedMessage & message,
-    const std::string & topic_name,
-    const std::string & type_name,
-    const rclcpp::Time & time);
-
-  /**
-   * Write a serialized message to a bagfile.
-   * The topic will be created if it has not been created already.
-   *
    * \warning after calling this function, the serialized data will no longer be managed by message.
    *
    * \param message rclcpp::SerializedMessage The serialized message to be written to the bagfile

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -130,57 +130,6 @@ void Writer::write(
 }
 
 void Writer::write(
-  const rclcpp::SerializedMessage & message,
-  const std::string & topic_name,
-  const std::string & type_name,
-  const rclcpp::Time & time)
-{
-  auto serialized_bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-  serialized_bag_message->topic_name = topic_name;
-  serialized_bag_message->recv_timestamp = time.nanoseconds();
-  serialized_bag_message->send_timestamp = time.nanoseconds();
-
-  serialized_bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
-    new rcutils_uint8_array_t,
-    [](rcutils_uint8_array_t * msg) {
-      auto fini_return = rcutils_uint8_array_fini(msg);
-      delete msg;
-      if (fini_return != RCUTILS_RET_OK) {
-        RCLCPP_ERROR_STREAM(
-          rclcpp::get_logger("rosbag2_cpp"),
-          "Failed to destroy serialized message: " << rcutils_get_error_string().str);
-      }
-    });
-
-  // While using compression mode and cache size isn't 0, another thread deals with this serialized
-  // message asynchronously.
-  // In order to keep serialized message valid, have to duplicate message.
-
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
-
-  rcutils_ret_t ret = rcutils_uint8_array_init(
-    serialized_bag_message->serialized_data.get(),
-    message.get_rcl_serialized_message().buffer_capacity,
-    &allocator);
-  if (ret != RCUTILS_RET_OK) {
-    auto err = std::string("Failed to call rcutils_uint8_array_init(): return ");
-    err += ret;
-    throw std::runtime_error(err);
-  }
-
-  std::memcpy(
-    serialized_bag_message->serialized_data->buffer,
-    message.get_rcl_serialized_message().buffer,
-    message.get_rcl_serialized_message().buffer_length);
-
-  serialized_bag_message->serialized_data->buffer_length =
-    message.get_rcl_serialized_message().buffer_length;
-
-  return write(
-    serialized_bag_message, topic_name, type_name, rmw_get_serialization_format());
-}
-
-void Writer::write(
   std::shared_ptr<const rclcpp::SerializedMessage> message,
   const std::string & topic_name,
   const std::string & type_name,


### PR DESCRIPTION
This method is deprecated since `humble` https://github.com/ros2/rosbag2/blob/humble/rosbag2_cpp/include/rosbag2_cpp/writer.hpp#L150-L160 It should be safe to remove it here 