### PR TITLE
Remove rcpputils::fs dependencies in rosbag2 packages

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -26,7 +26,6 @@
 
 #include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/metadata_io.hpp"
-#include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 
 #include "rosbag2_test_common/tested_storage_ids.hpp"
@@ -251,7 +250,7 @@ TEST_P(ParametrizedTemporaryDirectoryFixture, reader_accepts_bare_file) {
 }
 
 TEST_P(ParametrizedTemporaryDirectoryFixture, get_metadata_include_topics_with_zero_messages) {
-  const auto bag_path = rcpputils::fs::path(temporary_dir_path_) / "bag_with_no_msgs";
+  const auto bag_path = fs::path(temporary_dir_path_) / "bag_with_no_msgs";
   const std::string topic_name = "topic_with_0_messages";
   const auto storage_id = GetParam();
   {

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -36,7 +36,7 @@ public:
 
   ~TemporaryDirectoryFixture() override
   {
-    rcpputils::fs::remove_all(rcpputils::fs::path(temporary_dir_path_));
+    std::filesystem::remove_all(std::filesystem::path(temporary_dir_path_));
   }
 
   std::string temporary_dir_path_;

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -17,72 +17,26 @@
 
 #include <gmock/gmock.h>
 
-#include <cstdio>
-#include <exception>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include <random>
-#include <sstream>
 #include <string>
+
+#include "rcpputils/filesystem_helper.hpp"
 
 using namespace ::testing;  // NOLINT
 
 namespace rosbag2_test_common
 {
 
-/// \brief Construct a uniquely named temporary directory, in "parent", with format base_nameXXXXXX
-/// The output, if successful, is guaranteed to be a newly-created directory.
-/// The underlying implementation keeps generating paths until one that does not exist is found or
-/// until the number of iterations exceeded the maximum tries.
-/// This guarantees that there will be no existing files in the returned directory.
-/// \param[in] base_name User-specified portion of the created directory.
-/// \param[in] parent_path The parent path of the directory that will be created.
-/// \param[in] max_tries The maximum number of tries to find a unique directory (default 1000)
-/// \return A path to a newly-created directory with base_name and a 6-character unique suffix.
-/// \throws std::system_error If any OS APIs do not succeed.
-/// \throws std::runtime_error If the number of the iterations exceeds the maximum tries and
-/// a unique directory is not found.
-std::filesystem::path create_temp_directory(
-  const std::string & base_name,
-  std::filesystem::path parent_path = std::filesystem::temp_directory_path(),
-  size_t max_tries = 1000)
-{
-  // mersenne twister random generator engine seeded with the std::random_device
-  std::mt19937 random_generator(std::random_device{}());
-  std::uniform_int_distribution<> distribution(0, 999999);
-  std::filesystem::path path_to_temp_dir;
-  constexpr size_t kSuffixLength = 7;  // 6 chars + 1 null terminator
-  char random_suffix_str[kSuffixLength];
-  size_t current_iteration = 0;
-  while (true) {
-    snprintf(random_suffix_str, kSuffixLength, "%06x", distribution(random_generator));
-    const std::string random_dir_name = base_name + random_suffix_str;
-    path_to_temp_dir = parent_path / random_dir_name;
-    // true if the directory was newly created.
-    if (std::filesystem::create_directory(path_to_temp_dir)) {
-      break;
-    }
-    if (current_iteration == max_tries) {
-      throw std::runtime_error(
-              "Exceeded maximum allowed iterations to find non-existing directory");
-    }
-    current_iteration++;
-  }
-  return path_to_temp_dir;
-}
-
 class TemporaryDirectoryFixture : public Test
 {
 public:
   TemporaryDirectoryFixture()
   {
-    temporary_dir_path_ = create_temp_directory("tmp_test_dir_").string();
+    temporary_dir_path_ = rcpputils::fs::create_temporary_directory("tmp_test_dir_").string();
   }
 
   ~TemporaryDirectoryFixture() override
   {
-    std::filesystem::remove_all(std::filesystem::path(temporary_dir_path_));
+    rcpputils::fs::remove_all(rcpputils::fs::path(temporary_dir_path_));
   }
 
   std::string temporary_dir_path_;

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -17,26 +17,72 @@
 
 #include <gmock/gmock.h>
 
+#include <cstdio>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
 #include <string>
-
-#include "rcpputils/filesystem_helper.hpp"
 
 using namespace ::testing;  // NOLINT
 
 namespace rosbag2_test_common
 {
 
+/// \brief Construct a uniquely named temporary directory, in "parent", with format base_nameXXXXXX
+/// The output, if successful, is guaranteed to be a newly-created directory.
+/// The underlying implementation keeps generating paths until one that does not exist is found or
+/// until the number of iterations exceeded the maximum tries.
+/// This guarantees that there will be no existing files in the returned directory.
+/// \param[in] base_name User-specified portion of the created directory.
+/// \param[in] parent_path The parent path of the directory that will be created.
+/// \param[in] max_tries The maximum number of tries to find a unique directory (default 1000)
+/// \return A path to a newly-created directory with base_name and a 6-character unique suffix.
+/// \throws std::system_error If any OS APIs do not succeed.
+/// \throws std::runtime_error If the number of the iterations exceeds the maximum tries and
+/// a unique directory is not found.
+std::filesystem::path create_temp_directory(
+  const std::string & base_name,
+  std::filesystem::path parent_path = std::filesystem::temp_directory_path(),
+  size_t max_tries = 1000)
+{
+  // mersenne twister random generator engine seeded with the std::random_device
+  std::mt19937 random_generator(std::random_device{}());
+  std::uniform_int_distribution<> distribution(0, 999999);
+  std::filesystem::path path_to_temp_dir;
+  constexpr size_t kSuffixLength = 7;  // 6 chars + 1 null terminator
+  char random_suffix_str[kSuffixLength];
+  size_t current_iteration = 0;
+  while (true) {
+    snprintf(random_suffix_str, kSuffixLength, "%06x", distribution(random_generator));
+    const std::string random_dir_name = base_name + random_suffix_str;
+    path_to_temp_dir = parent_path / random_dir_name;
+    // true if the directory was newly created.
+    if (std::filesystem::create_directory(path_to_temp_dir)) {
+      break;
+    }
+    if (current_iteration == max_tries) {
+      throw std::runtime_error(
+              "Exceeded maximum allowed iterations to find non-existing directory");
+    }
+    current_iteration++;
+  }
+  return path_to_temp_dir;
+}
+
 class TemporaryDirectoryFixture : public Test
 {
 public:
   TemporaryDirectoryFixture()
   {
-    temporary_dir_path_ = rcpputils::fs::create_temp_directory("tmp_test_dir_").string();
+    temporary_dir_path_ = create_temp_directory("tmp_test_dir_").string();
   }
 
   ~TemporaryDirectoryFixture() override
   {
-    rcpputils::fs::remove_all(rcpputils::fs::path(temporary_dir_path_));
+    std::filesystem::remove_all(std::filesystem::path(temporary_dir_path_));
   }
 
   std::string temporary_dir_path_;

--- a/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 #include <utility>
 
-#include "rosbag2_test_common/temporary_directory_fixture.hpp"
 #include "rosbag2_test_common/tested_storage_ids.hpp"
 #include "rosbag2_transport/bag_rewrite.hpp"
 #include "rosbag2_transport/reader_writer_factory.hpp"
@@ -54,7 +53,8 @@ class TestRewrite : public Test, public WithParamInterface<std::string>
 public:
   TestRewrite()
   {
-    output_dir_ = rosbag2_test_common::create_temp_directory("test_bag_rewrite");
+    auto tmp_dir = rcpputils::fs::create_temporary_directory("test_bag_rewrite");
+    output_dir_ = fs::path(tmp_dir.string());
     storage_id_ = GetParam();
     bags_path_ = fs::path(_SRC_RESOURCES_DIR_PATH) / storage_id_;
   }

--- a/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <utility>
 
+#include "rosbag2_test_common/temporary_directory_fixture.hpp"
 #include "rosbag2_test_common/tested_storage_ids.hpp"
 #include "rosbag2_transport/bag_rewrite.hpp"
 #include "rosbag2_transport/reader_writer_factory.hpp"
@@ -53,8 +54,7 @@ class TestRewrite : public Test, public WithParamInterface<std::string>
 public:
   TestRewrite()
   {
-    auto tmp_dir = rcpputils::fs::create_temp_directory("test_bag_rewrite");
-    output_dir_ = fs::path(tmp_dir.string());
+    output_dir_ = rosbag2_test_common::create_temp_directory("test_bag_rewrite");
     storage_id_ = GetParam();
     bags_path_ = fs::path(_SRC_RESOURCES_DIR_PATH) / storage_id_;
   }


### PR DESCRIPTION
- This PR removes residual dependencies from the `rcpputils::fs` in all rosbag2 packages. 
- Rationale: The `rcpputils::fs` will be deprecated soon, and it is advised that `std::filesystem` be used instead.

Added own `rosbag2_test_common::create_temp_directory(..)` function in replacement of the analog from the `rcpputils::fs` since such functionality doesn't exists in the `std::filesystem`.