### PR TITLE
Fix for failing throws_on_invalid_pragma_in_config_file test on Windows

### DIFF
--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_statement_wrapper.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_statement_wrapper.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_rese
     std::stringstream errmsg;
     errmsg << "Error when processing SQL statement. SQLite error (" <<
       return_code << "): " << sqlite3_errstr(return_code);
-
+    reset();
     throw SqliteException{errmsg.str(), return_code};
   }
 
@@ -72,7 +72,7 @@ std::shared_ptr<SqliteStatementWrapper> SqliteStatementWrapper::execute_and_rese
       std::stringstream errmsg;
       errmsg << "Statement returned empty value while result was expected: \'" <<
         sqlite3_sql(statement_) << "\'";
-
+      reset();
       throw SqliteException{errmsg.str(), return_code};
     }
   }

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_wrapper.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_wrapper.cpp
@@ -85,10 +85,19 @@ SqliteWrapper::SqliteWrapper(
       throw SqliteException{errmsg.str()};
     }
   }
-
-  apply_pragma_settings(pragmas, io_flag);
-  sqlite3_extended_result_codes(db_ptr, 1);
-  initialize_application_functions();
+  try {
+    apply_pragma_settings(pragmas, io_flag);
+    sqlite3_extended_result_codes(db_ptr, 1);
+    initialize_application_functions();
+  } catch (...) {
+    const int rc = sqlite3_close(db_ptr);
+    if (rc != SQLITE_OK) {
+      ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_ERROR_STREAM(
+        "Could not close open database. Error code: " << rc <<
+          " Error message: " << sqlite3_errstr(rc));
+    }
+    throw;
+  }
 }
 
 SqliteWrapper::SqliteWrapper()


### PR DESCRIPTION
- This PR fixes [StorageTestFixture.throws_on_invalid_pragma_in_config_file](https://github.com/ros2/rosbag2/blob/e860f65b62a0e93972d5fd17bdc488dd4b43c204/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp#L522) test failure on Windows reported in the https://github.com/ros2/rosbag2/pull/1576#issuecomment-2006060701 and https://github.com/ros2/rosbag2/pull/1740#issuecomment-2221655757 after replacing 
https://github.com/ros2/rosbag2/blob/e860f65b62a0e93972d5fd17bdc488dd4b43c204/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp#L37-L40
with **std::filesystem::remove_all(std::filesystem::path(temporary_dir_path_));**

#### RCA (Root Cause Analysis)
The failure was because the database file was not properly closed after throwing an exception from the SqliteWrapper constructor, and std::filesystem::remove_all(..) failed to delete a temporary folder in the test fixture destructor.

#### Fixes
- I added a reset for the prepared SQL statement before throwing the exception.
- Try to close the database in the constructor if we get an exception after opening the database since the destructor will not be called in this case.
