### PR TITLE
Bugfix for wrong timestamps in ros2 bag info

### DIFF
--- a/rosbag2_py/src/rosbag2_py/format_bag_metadata.cpp
+++ b/rosbag2_py/src/rosbag2_py/format_bag_metadata.cpp
@@ -42,9 +42,10 @@ std::unordered_map<std::string, std::string> format_duration(
   std::chrono::high_resolution_clock::duration duration)
 {
   std::unordered_map<std::string, std::string> formatted_duration;
-  auto m_seconds = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
-  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(m_seconds);
-  std::string fractional_seconds = std::to_string(m_seconds.count() % 1000);
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+  auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+  auto nanoseconds_from_seconds = std::chrono::duration_cast<std::chrono::nanoseconds>(seconds);
+  std::string fractional_seconds = std::to_string((nanoseconds - nanoseconds_from_seconds).count());
   std::time_t std_time_point = seconds.count();
   tm time;
 #ifdef _WIN32

--- a/rosbag2_py/src/rosbag2_py/format_bag_metadata.cpp
+++ b/rosbag2_py/src/rosbag2_py/format_bag_metadata.cpp
@@ -45,7 +45,9 @@ std::unordered_map<std::string, std::string> format_duration(
   auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
   auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
   auto nanoseconds_from_seconds = std::chrono::duration_cast<std::chrono::nanoseconds>(seconds);
-  std::string fractional_seconds = std::to_string((nanoseconds - nanoseconds_from_seconds).count());
+  std::stringstream fractional_seconds_ss;
+  fractional_seconds_ss << std::setw(9) << std::setfill('0') <<
+    (nanoseconds - nanoseconds_from_seconds).count();
   std::time_t std_time_point = seconds.count();
   tm time;
 #ifdef _WIN32
@@ -53,14 +55,14 @@ std::unordered_map<std::string, std::string> format_duration(
 #else
   localtime_r(&std_time_point, &time);
 #endif
-
   std::stringstream formatted_date;
   std::stringstream formatted_time;
   formatted_date << std::put_time(&time, "%b %e %Y");
-  formatted_time << std::put_time(&time, "%H:%M:%S") << "." << fractional_seconds;
+  formatted_time << std::put_time(&time, "%H:%M:%S") << "." << fractional_seconds_ss.str();
   formatted_duration["date"] = formatted_date.str();
   formatted_duration["time"] = formatted_time.str();
-  formatted_duration["time_in_sec"] = std::to_string(seconds.count()) + "." + fractional_seconds;
+  formatted_duration["time_in_sec"] = std::to_string(seconds.count()) + "." +
+    fractional_seconds_ss.str();
 
   return formatted_duration;
 }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -54,9 +54,9 @@ TEST_P(InfoEndToEndTestFixture, info_end_to_end_test) {
       "\nBag size:          .*B"
       "\nStorage id:        " + expected_storage +
       "\nROS Distro:        " + expected_ros_distro +
-      "\nDuration:          0\\.151s"
-      "\nStart:             Apr  .+ 2020 .*:.*:36.763 \\(1586406456\\.763\\)"
-      "\nEnd:               Apr  .+ 2020 .*:.*:36.914 \\(1586406456\\.914\\)"
+      "\nDuration:          0.151137181s"
+      "\nStart:             Apr  .+ 2020 .*:.*:36.763032325 \\(1586406456.763032325\\)"
+      "\nEnd:               Apr  .+ 2020 .*:.*:36.914169506 \\(1586406456.914169506\\)"
       "\nMessages:          7"
       "\nTopic information: "));
   EXPECT_THAT(
@@ -94,7 +94,7 @@ TEST_P(InfoEndToEndTestFixture, info_with_verbose_option_and_topic_name_option) 
       "\nBag size:          .*B"
       "\nStorage id:        " + expected_storage +
       "\nROS Distro:        " + expected_ros_distro +
-      "\nDuration:          0\\.70s"
+      "\nDuration:          0\\.706.*s"
       "\nStart:             Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nEnd:               Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nMessages:          2"
@@ -122,7 +122,7 @@ TEST_P(InfoEndToEndTestFixture, info_with_verbose_option_end_to_end_test) {
       "\nBag size:          .*B"
       "\nStorage id:        " + expected_storage +
       "\nROS Distro:        " + expected_ros_distro +
-      "\nDuration:          0\\.70s"
+      "\nDuration:          0\\.706.*s"
       "\nStart:             Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nEnd:               Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nMessages:          2"

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp
@@ -94,7 +94,7 @@ TEST_P(InfoEndToEndTestFixture, info_with_verbose_option_and_topic_name_option) 
       "\nBag size:          .*B"
       "\nStorage id:        " + expected_storage +
       "\nROS Distro:        " + expected_ros_distro +
-      "\nDuration:          0\\.706.*s"
+      "\nDuration:          0\\.0706.*s"
       "\nStart:             Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nEnd:               Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nMessages:          2"
@@ -122,7 +122,7 @@ TEST_P(InfoEndToEndTestFixture, info_with_verbose_option_end_to_end_test) {
       "\nBag size:          .*B"
       "\nStorage id:        " + expected_storage +
       "\nROS Distro:        " + expected_ros_distro +
-      "\nDuration:          0\\.706.*s"
+      "\nDuration:          0\\.0706.*s"
       "\nStart:             Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nEnd:               Nov  7 2023 .*:30:36\\..* \\(1699345836\\..*\\)"
       "\nMessages:          2"


### PR DESCRIPTION
- This PR addresses the incorrect display of the fractional part of the seconds in the `ros2 bag info` found in the #1744.

Correctly calculate the fractional part for seconds by subtracting `nanoseconds_from_seconds` from `nanoseconds`.

The changes covered by 
https://github.com/ros2/rosbag2/blob/a85672fdf2baf19e6f739879adbbdcfa331948b7/rosbag2_tests/test/rosbag2_tests/test_rosbag2_info_end_to_end.cpp#L41-L61

- Relates #1744