### PR TITLE
Change the python examples to use the rclpy context manager.

### DIFF
--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/data_generator_node.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/data_generator_node.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from example_interfaces.msg import Int32
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.serialization import serialize_message
 import rosbag2_py
@@ -50,10 +51,12 @@ class DataGeneratorNode(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-    dgn = DataGeneratorNode()
-    rclpy.spin(dgn)
-    rclpy.shutdown()
+    try:
+        with rclpy.init(args=args):
+            dgn = DataGeneratorNode()
+            rclpy.spin(dgn)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
 
 
 if __name__ == '__main__':

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_reader.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_reader.py
@@ -44,14 +44,12 @@ class SimpleBagReader(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
     try:
-        sbr = SimpleBagReader(sys.argv[1])
-        rclpy.spin(sbr)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            sbr = SimpleBagReader(sys.argv[1])
+            rclpy.spin(sbr)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    except ExternalShutdownException:
-        rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_recorder.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_recorder.py
@@ -53,14 +53,12 @@ class SimpleBagRecorder(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
     try:
-        sbr = SimpleBagRecorder()
-        rclpy.spin(sbr)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            sbr = SimpleBagRecorder()
+            rclpy.spin(sbr)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    except ExternalShutdownException:
-        rclpy.shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This ensures that we always cleanup and destroy all entities when we leave the context.  We also make sure to always capture the exceptions that are "expected", so we get a clean exit.