### PR TITLE
Fix incorrect zero size for sqlite storage

### DIFF
--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -217,16 +217,15 @@ void SqliteStorage::open(
     throw std::runtime_error("Failed to setup storage. Error: " + std::string(e.what()));
   }
 
-  db_page_size_ = get_page_size();
-  db_file_size_ = 0;
   page_count_statement_ = database_->prepare_statement("PRAGMA page_count;");
+  db_page_size_ = get_page_size();
+  db_file_size_ = db_page_size_ * read_total_page_count_locked();
 
   // initialize only for READ_WRITE since the DB is already initialized if in APPEND.
   if (is_read_write(io_flag)) {
     db_schema_version_ = kDBSchemaVersion_;
     std::lock_guard<std::mutex> db_lock(db_read_write_mutex_);
     initialize();
-    db_file_size_ = db_page_size_ * read_total_page_count_locked();
   } else {
     db_schema_version_ = read_db_schema_version();
     read_metadata();

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -76,20 +76,21 @@ TEST_F(StorageTestFixture, string_messages_are_written_and_read_to_and_from_sqli
   }
 }
 
-TEST_F(StorageTestFixture, get_bagfile_size_does_not_return_zero_size) {
+TEST_F(StorageTestFixture, check_get_bagfile_size_in_read_only_mode) {
   std::vector<std::tuple<std::string, int64_t, std::string, std::string, std::string>>
   string_messages =
-  {std::make_tuple("first message", 1, "", "", ""),
-    std::make_tuple("second message", 2, "", "", "")};
+  {std::make_tuple("first message", 1, "topic1", "type1", ""),
+    std::make_tuple("second message", 2, "topic2", "type2", "")};
 
   write_messages_to_sqlite(string_messages);
   std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
     std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
 
-  auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").generic_string();
+  const auto bag_path = std::filesystem::path(temporary_dir_path_) / "rosbag.db3";
+  auto db_filename = bag_path.generic_string();
   readable_storage->open({db_filename, kPluginID});
 
-  EXPECT_GT(readable_storage->get_bagfile_size(), 0);
+  EXPECT_EQ(readable_storage->get_bagfile_size(), std::filesystem::file_size(bag_path));
 }
 
 TEST_F(StorageTestFixture, has_next_return_false_if_there_are_no_more_messages) {

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -76,6 +76,22 @@ TEST_F(StorageTestFixture, string_messages_are_written_and_read_to_and_from_sqli
   }
 }
 
+TEST_F(StorageTestFixture, get_bagfile_size_does_not_return_zero_size) {
+  std::vector<std::tuple<std::string, int64_t, std::string, std::string, std::string>>
+  string_messages =
+  {std::make_tuple("first message", 1, "", "", ""),
+    std::make_tuple("second message", 2, "", "", "")};
+
+  write_messages_to_sqlite(string_messages);
+  std::unique_ptr<rosbag2_storage::storage_interfaces::ReadOnlyInterface> readable_storage =
+    std::make_unique<rosbag2_storage_plugins::SqliteStorage>();
+
+  auto db_filename = (std::filesystem::path(temporary_dir_path_) / "rosbag.db3").generic_string();
+  readable_storage->open({db_filename, kPluginID});
+
+  EXPECT_GT(readable_storage->get_bagfile_size(), 0);
+}
+
 TEST_F(StorageTestFixture, has_next_return_false_if_there_are_no_more_messages) {
   std::vector<std::tuple<std::string, int64_t, std::string, std::string, std::string>>
   string_messages =


### PR DESCRIPTION
- Closes https://github.com/ros2/rosbag2/issues/1756

`db_file_size_` was not updated to actual size, when storage was opened in a read only mode.