### PR TITLE
simple_bag_reader.py should publish the data for each timer callback.

### DIFF
--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_reader.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_reader.py
@@ -41,6 +41,7 @@ class SimpleBagReader(Node):
                 continue
             self.publisher.publish(msg[1])
             self.get_logger().info('Publish serialized data to ' + msg[0])
+            break
 
 
 def main(args=None):


### PR DESCRIPTION
minor fix for example. see https://github.com/ros2/ros2_documentation/pull/4588#discussion_r1697431240

no backport required