### PR TITLE
Prevent using message compression mode with mcap storage

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -200,6 +200,11 @@ class RecordVerb(VerbExtension):
             return print_error('Invalid choice: Cannot specify compression format '
                                'without a compression mode.')
 
+        if args.compression_mode == 'message' and args.storage == 'mcap':
+            return print_error("Invalid choice: compression_mode 'message' is not supported "
+                               'by the MCAP storage plugin. You can enable chunk compression by '
+                               "setting `compression: 'Zstd'` in storage config")
+
         if args.compression_queue_size < 0:
             return print_error('Compression queue size must be at least 0.')
 

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -217,6 +217,15 @@ void SequentialCompressionWriter::open(
   if (storage_) {
     return;  // The writer already opened.
   }
+  // Note: a better solution was implemented in rosbag2-storage version 0.18+
+  // See MCAPStorage::update_metadata() for details.
+  if (compression_options_.compression_mode == CompressionMode::MESSAGE &&
+    storage_options.storage_id == "mcap")
+  {
+    throw std::runtime_error(
+            "MCAP storage plugin does not support message compression, "
+            "consider using chunk compression by setting `compression: 'Zstd'` in storage config");
+  }
   SequentialWriter::open(storage_options, converter_options);
   setup_compression();
 }


### PR DESCRIPTION
MCAP does not support per-message compression. To prevent users from falling into the trap of recording such files, this change throws an error if per-message compression is used with the mcap storage plugin.

This is a backport of the same behavior present in iron onwards: (https://github.com/ros2/rosbag2/blob/iron/rosbag2_storage_mcap/src/mcap_storage.cpp#L821).

Continuation of https://github.com/ros2/rosbag2/pull/1705 which has gone dead.