### PR TITLE
Update sqlite

### DIFF
--- a/sqlite3_vendor/CMakeLists.txt
+++ b/sqlite3_vendor/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 ament_vendor(sqlite3_vendor
   SATISFIED ${SQLite3_FOUND}
   VCS_TYPE zip
-  VCS_URL https://www.sqlite.org/2024/sqlite-amalgamation-3450100.zip
-  VCS_VERSION sqlite-amalgamation-3450100
+  VCS_URL https://www.sqlite.org/2024/sqlite-amalgamation-3460000.zip
+  VCS_VERSION sqlite-amalgamation-3460000
   CMAKE_ARGS ${CMAKE_ARGS}
   PATCHES patches
 )


### PR DESCRIPTION
Allocate additional memory from the heap for the SQL parser stack if that stack overflows, rather than reporting a "parser stack overflow" error.

Complete change list::
https://www.sqlite.org/releaselog/3_46_0.html