### PR TITLE
Add missing throws documentation to  rosbag_cpp writer open() #1788

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -74,12 +74,7 @@ public:
    * more storage and converter options.
    *
    * \param storage_uri URI of the storage to open.
-   * \throws runtime_error if 
-   * database directory already exists,
-   * failed to create database directory,
-   * no storage could be initialized,
-   * invalid bag splitting size given,
-   * max cache size less or equal 0 when snapshot mode is enabled.
+   * \throws runtime_error if internal error happens.
    **/
   void open(const std::string & uri);
 

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -74,6 +74,12 @@ public:
    * more storage and converter options.
    *
    * \param storage_uri URI of the storage to open.
+   * \throws runtime_error if 
+   * database directory already exists,
+   * failed to create database directory,
+   * no storage could be initialized,
+   * invalid bag splitting size given,
+   * max cache size less or equal 0 when snapshot mode is enabled.
    **/
   void open(const std::string & uri);
 
@@ -83,6 +89,12 @@ public:
    *
    * \param storage_options Options to configure the storage
    * \param converter_options options to define in which format incoming messages are stored
+   * \throws runtime_error if 
+   * database directory already exists,
+   * failed to create database directory,
+   * no storage could be initialized,
+   * invalid bag splitting size given,
+   * max cache size less or equal 0 when snapshot mode is enabled.
    **/
   void open(
     const rosbag2_storage::StorageOptions & storage_options,

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -77,12 +77,10 @@ public:
    *
    * \param storage_options Options to configure the storage
    * \param converter_options options to define in which format incoming messages are stored
-   * \throws runtime_error if 
-   * database directory already exists,
-   * failed to create database directory,
-   * no storage could be initialized,
-   * invalid bag splitting size given,
-   * max cache size less or equal 0 when snapshot mode is enabled.
+   * \throws runtime_error if database directory already exists,
+   *   failed to create database directory, no storage could be initialized,
+   *   invalid bag splitting size given,
+   *   max cache size less or equal 0 when snapshot mode is enabled.
    **/
   void open(
     const rosbag2_storage::StorageOptions & storage_options,

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -77,6 +77,12 @@ public:
    *
    * \param storage_options Options to configure the storage
    * \param converter_options options to define in which format incoming messages are stored
+   * \throws runtime_error if 
+   * database directory already exists,
+   * failed to create database directory,
+   * no storage could be initialized,
+   * invalid bag splitting size given,
+   * max cache size less or equal 0 when snapshot mode is enabled.
    **/
   void open(
     const rosbag2_storage::StorageOptions & storage_options,


### PR DESCRIPTION
Closes #1788 

Document that open() may throw.