### PR TITLE
Improve the reliability of rosbag2 tests

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/wait_for.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/wait_for.hpp
@@ -37,21 +37,6 @@ bool spin_and_wait_for(Timeout timeout, const Node & node, Condition condition)
   return true;
 }
 
-template<typename Timeout, typename Condition>
-bool wait_until_shutdown(Timeout timeout, Condition condition)
-{
-  using clock = std::chrono::system_clock;
-  auto start = clock::now();
-  while (!condition()) {
-    if ((clock::now() - start) > timeout) {
-      return false;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  rclcpp::shutdown();
-  return true;
-}
-
 template<typename Condition>
 bool wait_until_condition(
   Condition condition,

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -67,6 +67,7 @@ public:
 
   void TearDown() override
   {
+    stop_spinning();
     fs::remove_all(root_bag_path_);
   }
 
@@ -200,8 +201,6 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_services_only
   recorder->record();
 
   start_async_spin(recorder);
-  auto cleanup_process_handle = rcpputils::make_scope_exit(
-    [&]() {stop_spinning();});
 
   ASSERT_TRUE(service_client_manager->wait_for_service_to_be_ready());
   ASSERT_TRUE(wait_for_subscriptions(*recorder, {"/test_service/_service_event"}));
@@ -227,8 +226,6 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_services_only
   EXPECT_TRUE(ret) << "Failed to capture " << expected_messages << " expected messages in time";
 
   recorder->stop();
-  stop_spinning();
-  cleanup_process_handle.cancel();
 
   rosbag2_cpp::Info info;
   std::vector<std::shared_ptr<rosbag2_cpp::rosbag2_service_info_t>> ret_service_infos;
@@ -278,8 +275,6 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_topics_and_se
   recorder->record();
 
   start_async_spin(recorder);
-  auto cleanup_process_handle = rcpputils::make_scope_exit(
-    [&]() {stop_spinning();});
 
   ASSERT_TRUE(
     wait_for_subscriptions(
@@ -314,8 +309,6 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_topics_and_se
   EXPECT_TRUE(ret) << "Failed to capture " << expected_messages << " expected messages in time";
 
   recorder->stop();
-  stop_spinning();
-  cleanup_process_handle.cancel();
 
   rosbag2_cpp::Info info;
   std::vector<std::shared_ptr<rosbag2_cpp::rosbag2_service_info_t>> ret_service_infos;

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -86,9 +86,10 @@ public:
       [node, this]() -> void {
         rclcpp::executors::SingleThreadedExecutor exec;
         exec.add_node(node);
-        while (!exit_from_node_spinner_) {
-          exec.spin_some();
+        while (rclcpp::ok() && !exit_from_node_spinner_) {
+          exec.spin_some(std::chrono::milliseconds(100));
         }
+        exec.remove_node(node);
       });
   }
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -91,6 +91,16 @@ public:
         [this]() {
           exec_->spin();
         });
+      // Wait for the executor to start spinning in the newly spawned thread to avoid race condition
+      // with exec_->cancel()
+      using clock = std::chrono::steady_clock;
+      auto start = clock::now();
+      while (!exec_->is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      }
+      if (!exec_->is_spinning()) {
+        throw std::runtime_error("Failed to start spinning node");
+      }
     } else {
       throw std::runtime_error("Already spinning a node, can't start a new node spin");
     }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -103,6 +103,7 @@ public:
       if (spin_thread_.joinable()) {
         spin_thread_.join();
       }
+      exec_ = nullptr;
     }
   }
 
@@ -201,6 +202,7 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_services_only
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(service_client_manager->wait_for_service_to_be_ready());
   ASSERT_TRUE(wait_for_subscriptions(*recorder, {"/test_service/_service_event"}));
@@ -275,6 +277,7 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_topics_and_se
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(
     wait_for_subscriptions(

--- a/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
@@ -73,6 +73,7 @@ public:
       if (spin_thread_.joinable()) {
         spin_thread_.join();
       }
+      exec_ = nullptr;
     }
   }
 

--- a/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/record_integration_fixture.hpp
@@ -47,6 +47,7 @@ public:
 
   void TearDown() override
   {
+    stop_spinning();
     rclcpp::shutdown();
   }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
@@ -203,7 +203,8 @@ TEST_F(RecordIntegrationTestFixture, test_keyboard_controls)
 
   recorder->record();
 
-  this->start_async_spin(recorder);
+  start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   EXPECT_THAT(recorder->is_paused(), true);
   keyboard_handler->simulate_key_press(rosbag2_transport::Recorder::kPauseResumeToggleKey);

--- a/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
@@ -210,6 +210,4 @@ TEST_F(RecordIntegrationTestFixture, test_keyboard_controls)
   EXPECT_THAT(recorder->is_paused(), false);
   keyboard_handler->simulate_key_press(rosbag2_transport::Recorder::kPauseResumeToggleKey);
   EXPECT_THAT(recorder->is_paused(), true);
-
-  this->stop_spinning();
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -54,6 +54,17 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   start_async_spin(recorder);
 
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /string_topic
+  // /array_topic
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 2;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
@@ -126,10 +137,21 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
     std::move(writer_), storage_options_, record_options);
   recorder->record();
 
+  start_async_spin(recorder);
+
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /string_topic
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 1;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   auto & writer = recorder->get_writer_handle();
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  start_async_spin(recorder);
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
   pub_manager.run_publishers();
@@ -187,6 +209,16 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   recorder->record();
 
   start_async_spin(recorder);
+
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /qos_chatter
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 1;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
@@ -252,6 +284,16 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
 
   start_async_spin(recorder);
 
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /sensor_chatter
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 1;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
   pub_manager.run_publishers();
@@ -294,6 +336,16 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   recorder->record();
 
   start_async_spin(recorder);
+
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /latched_chatter
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 1;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
@@ -436,6 +488,17 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
 
   rosbag2_test_common::PublicationManager pub_manager;
   pub_manager.setup_publisher(string_topic, string_message, expected_messages);
+
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /string_topic
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 1;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
   pub_manager.run_publishers();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -73,7 +73,6 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   EXPECT_TRUE(ret) << "failed to capture expected messages in time" <<
     "recorded messages = " << recorded_messages.size();
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));
-  stop_spinning();
 
   auto recorded_topics = mock_writer.get_topics();
   ASSERT_THAT(recorded_topics, SizeIs(2));

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -53,6 +53,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
@@ -126,6 +127,7 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   auto & writer = recorder->get_writer_handle();
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
@@ -187,6 +189,7 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
@@ -251,6 +254,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
@@ -294,6 +298,7 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
@@ -428,6 +433,7 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   auto & writer = recorder->get_writer_handle();
   mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -64,11 +64,11 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 4;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_TRUE(ret) << "failed to capture expected messages in time" <<
     "recorded messages = " << recorded_messages.size();
@@ -146,11 +146,11 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
 
   // 4 because we're running recorder->record() and publishers twice
   constexpr size_t expected_messages = 4;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));
@@ -197,11 +197,11 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 2;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));
@@ -261,11 +261,11 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 2;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -302,11 +302,11 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   size_t expected_messages = num_latched_messages;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [&mock_writer, &expected_messages]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -439,11 +439,11 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
   pub_manager.run_publishers();
 
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [&mock_writer, &expected_messages]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -54,17 +54,6 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   start_async_spin(recorder);
 
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /string_topic
-  // /array_topic
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 2;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
-
   ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
@@ -139,16 +128,6 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
 
   start_async_spin(recorder);
 
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /string_topic
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 1;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
-
   auto & writer = recorder->get_writer_handle();
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
@@ -209,16 +188,6 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   recorder->record();
 
   start_async_spin(recorder);
-
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /qos_chatter
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 1;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
@@ -284,16 +253,6 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
 
   start_async_spin(recorder);
 
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /sensor_chatter
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 1;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
-
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
   pub_manager.run_publishers();
@@ -336,16 +295,6 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   recorder->record();
 
   start_async_spin(recorder);
-
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /latched_chatter
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 1;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
 
@@ -488,16 +437,6 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
 
   rosbag2_test_common::PublicationManager pub_manager;
   pub_manager.setup_publisher(string_topic, string_message, expected_messages);
-
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /string_topic
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 1;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
   pub_manager.run_publishers();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -57,6 +57,18 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   start_async_spin(recorder);
 
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /string_topic
+  // /events/write_split
+  // /array_topic
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 3;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
@@ -104,6 +116,17 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_services_a
 
   start_async_spin(recorder);
 
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /test_service_1/_service_event
+  // /test_service_2/_service_event
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 2;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(client_manager_1->wait_for_service_to_be_ready());
   ASSERT_TRUE(client_manager_2->wait_for_service_to_be_ready());
 
@@ -145,6 +168,18 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_topic_and_service_a
   recorder->record();
 
   start_async_spin(recorder);
+
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /test_service/_service_event
+  // /string_topic
+  // /events/write_split
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 3;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -57,6 +57,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
@@ -104,6 +105,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_services_a
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(client_manager_1->wait_for_service_to_be_ready());
   ASSERT_TRUE(client_manager_2->wait_for_service_to_be_ready());
@@ -153,6 +155,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_topic_and_service_a
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -52,7 +52,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   rosbag2_transport::RecordOptions record_options =
   {true, false, false, {}, {}, {}, {"/rosout"}, {}, {}, "rmw_format", 100ms};
-  auto recorder = std::make_shared<MockRecorder>(
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
 
@@ -60,11 +60,6 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   ASSERT_TRUE(pub_manager.wait_for_matched(array_topic.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
-
-  // At this point, we expect that the topics /string_topic, /array_topic, and /events/write_split
-  // are available to be recorded.  However, wait_for_matched() only checks for /string_topic
-  // and /array_topic, so ask the recorder to make sure it has successfully subscribed to all.
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/events/write_split"));
 
   pub_manager.run_publishers();
 
@@ -169,7 +164,6 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_topic_and_service_a
   // check on the service and the topic, not the event or the split topic, so ask the recorder to
   // make sure it has successfully subscribed to all.
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/test_service/_service_event"));
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/events/write_split"));
 
   pub_manager.run_publishers();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -66,11 +66,11 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 4;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_EQ(recorded_messages.size(), expected_messages);
@@ -108,7 +108,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_services_a
   ASSERT_TRUE(client_manager_2->wait_for_service_to_be_ready());
 
   // By default, only client introspection is enabled.
-  // For one request, service event topic get 2 messages.
+  // For one request, service event topic gets 2 messages.
   ASSERT_TRUE(client_manager_1->send_request());
   ASSERT_TRUE(client_manager_2->send_request());
 
@@ -116,11 +116,11 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_services_a
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 4;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_EQ(recorded_messages.size(), expected_messages);
@@ -160,11 +160,11 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_topic_and_service_a
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 3;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_EQ(recorded_messages.size(), expected_messages);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_ignore_leaf_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_ignore_leaf_topics.cpp
@@ -69,11 +69,11 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_two_topics_ignore_l
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 2;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   // We may receive additional messages from rosout, it doesn't matter,
   // as long as we have received at least as many total messages as we expect

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
@@ -42,18 +42,6 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignore
   recorder->record();
   start_async_spin(recorder);
 
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /rosout
-  // /parameter_events
-  // /events/write_split
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 3;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
-
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
   ASSERT_FALSE(recorder->topic_available_for_recording(string_topic));
 }
@@ -71,19 +59,6 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_true_include
   auto recorder = std::make_shared<MockRecorder>(writer_, storage_options_, record_options);
   recorder->record();
   start_async_spin(recorder);
-
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /string_topic
-  // /rosout
-  // /parameter_events
-  // /events/write_split
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 4;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
   ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
@@ -105,18 +80,6 @@ TEST_F(
   recorder->record();
   start_async_spin(recorder);
 
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /rosout
-  // /parameter_events
-  // /events/write_split
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 3;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
-
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
   ASSERT_FALSE(recorder->topic_available_for_recording(string_topic));
 
@@ -128,18 +91,6 @@ TEST_F(
   // Publish 10 messages at a 30ms interval for a steady 300 milliseconds worth of data
   pub_manager.setup_publisher(
     string_topic, string_message, 10, rclcpp::QoS{rclcpp::KeepAll()}, 30ms);
-  // Wait again until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /string_topic
-  // /rosout
-  // /parameter_events
-  // /events/write_split
-  discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 4;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
   pub_manager.run_publishers();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
@@ -41,6 +41,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignore
   auto recorder = std::make_shared<MockRecorder>(writer_, storage_options_, record_options);
   recorder->record();
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
   ASSERT_FALSE(recorder->topic_available_for_recording(string_topic));
@@ -59,6 +60,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_true_include
   auto recorder = std::make_shared<MockRecorder>(writer_, storage_options_, record_options);
   recorder->record();
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
   ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
@@ -79,6 +81,7 @@ TEST_F(
   auto recorder = std::make_shared<MockRecorder>(writer_, storage_options_, record_options);
   recorder->record();
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
   ASSERT_FALSE(recorder->topic_available_for_recording(string_topic));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
@@ -54,11 +54,11 @@ TEST_F(RecordIntegrationTestFixture, record_all_without_discovery_ignores_later_
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 0;
-  rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(2),
+  rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() > expected_messages;
-    });
+    },
+    std::chrono::seconds(2));
   // We can't EXPECT anything here, since there may be some messages from rosout
 
   auto recorded_topics = mock_writer.get_topics();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
@@ -44,6 +44,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_without_discovery_ignores_later_
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   rosbag2_test_common::PublicationManager pub_manager;
   pub_manager.setup_publisher(topic, string_message, 5);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -106,9 +106,6 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
 
-  // We have to ensure that the /clock topic is available as well
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/clock"));
-
   pub_manager.run_publishers();
 
   auto & writer = recorder->get_writer_handle();
@@ -122,11 +119,12 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
-  EXPECT_TRUE(ret) << "failed to capture expected messages in time. " <<
+  ASSERT_TRUE(ret) << "failed to capture expected messages in time. " <<
     "recorded messages = " << recorded_messages.size();
   stop_spinning();
 
   auto messages_per_topic = mock_writer.messages_per_topic();
+  ASSERT_EQ(messages_per_topic.count(string_topic), 1u);
   EXPECT_EQ(messages_per_topic[string_topic], 5u);
 
   EXPECT_THAT(recorded_messages, SizeIs(Ge(expected_messages)));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -99,6 +99,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -113,11 +113,11 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 10;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_TRUE(ret) << "failed to capture expected messages in time. " <<
     "recorded messages = " << recorded_messages.size();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -121,7 +121,6 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
   auto recorded_messages = mock_writer.get_messages();
   ASSERT_TRUE(ret) << "failed to capture expected messages in time. " <<
     "recorded messages = " << recorded_messages.size();
-  stop_spinning();
 
   auto messages_per_topic = mock_writer.messages_per_topic();
   ASSERT_EQ(messages_per_topic.count(string_topic), 1u);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -100,22 +100,14 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   start_async_spin(recorder);
 
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /clock
-  // /string_topic
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 2;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
-
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
 
   ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
+
+  // We have to ensure that the /clock topic is available as well
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/clock"));
 
   pub_manager.run_publishers();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -100,6 +100,17 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   start_async_spin(recorder);
 
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /clock
+  // /string_topic
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 2;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -98,32 +98,37 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
     std::move(writer_), storage_options_, record_options);
   recorder->record();
 
-  start_async_spin(recorder);
-  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
-
-  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
-
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
-
-  ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
-
-  pub_manager.run_publishers();
-
-  auto & writer = recorder->get_writer_handle();
-  MockSequentialWriter & mock_writer =
-    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
-
   constexpr size_t expected_messages = 10;
-  auto ret = rosbag2_test_common::wait_until_condition(
-    [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
-    },
-    std::chrono::seconds(5));
-  auto recorded_messages = mock_writer.get_messages();
-  ASSERT_TRUE(ret) << "failed to capture expected messages in time. " <<
-    "recorded messages = " << recorded_messages.size();
+  std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> recorded_messages;
+  std::unordered_map<std::string, size_t> messages_per_topic;
 
-  auto messages_per_topic = mock_writer.messages_per_topic();
+  start_async_spin(recorder);
+  {
+    auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
+
+    ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
+
+    ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
+
+    ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
+
+    pub_manager.run_publishers();
+
+    auto & writer = recorder->get_writer_handle();
+    MockSequentialWriter & mock_writer =
+      static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+    auto ret = rosbag2_test_common::wait_until_condition(
+      [ =, &mock_writer]() {
+        return mock_writer.get_messages().size() >= expected_messages;
+      },
+      std::chrono::seconds(5));
+    ASSERT_TRUE(ret) << "failed to capture expected messages in time. " <<
+      "recorded messages = " << recorded_messages.size();
+    recorded_messages = mock_writer.get_messages();
+    messages_per_topic = mock_writer.messages_per_topic();
+  }
+
   ASSERT_EQ(messages_per_topic.count(string_topic), 1u);
   EXPECT_EQ(messages_per_topic[string_topic], 5u);
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -78,6 +78,16 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
 
   start_async_spin(recorder);
 
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /aa
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 1;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
 
   pub_manager.run_publishers();
@@ -137,7 +147,6 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
   record_options.regex = regex;
   record_options.exclude_regex = topics_regex_to_exclude;
 
-
   // TODO(karsten1987) Refactor this into publication manager
   rosbag2_test_common::PublicationManager pub_manager;
   pub_manager.setup_publisher(v1, test_string_messages[0], 3);
@@ -151,6 +160,17 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
   recorder->record();
 
   start_async_spin(recorder);
+
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /still_nice_topic
+  // /awesome_nice_topic
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 2;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str()));
@@ -227,6 +247,17 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_topic_topic_recording)
 
   start_async_spin(recorder);
 
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /still_nice_topic
+  // /awesome_nice_topic
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 2;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
+
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str()));
 
@@ -295,6 +326,17 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_service_recording)
   recorder->record();
 
   start_async_spin(recorder);
+
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /still_nice_servce/_service_event
+  // /awesome_nice_service/_service_event
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 2;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(service_manager_v1->wait_for_service_to_be_ready());
   ASSERT_TRUE(service_manager_v2->wait_for_service_to_be_ready());
@@ -366,6 +408,16 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_service_service_recording
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
+  // Wait until recorder discovery is complete, otherwise messages might be missed.
+  // The currently expected topics:
+  // /still_nice_servce/_service_event
+  // /awesome_nice_service/_service_event
+  auto discovery_ret = rosbag2_test_common::wait_until_condition(
+    [&recorder]() {
+      return recorder->subscriptions().size() == 2;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(discovery_ret);
 
   start_async_spin(recorder);
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -87,11 +87,11 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 3;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   // We may receive additional messages from rosout, it doesn't matter,
   // as long as we have received at least as many total messages as we expect
@@ -162,11 +162,11 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 3;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   // We may receive additional messages from rosout, it doesn't matter,
   // as long as we have received at least as many total messages as we expect
@@ -237,11 +237,11 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_topic_topic_recording)
     static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   constexpr size_t expected_messages = 3;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
   // We may receive additional messages from rosout, it doesn't matter,
   // as long as we have received at least as many total messages as we expect
@@ -312,11 +312,11 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_service_recording)
   ASSERT_TRUE(service_manager_b2->send_request());
 
   constexpr size_t expected_messages = 4;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));
@@ -385,11 +385,11 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_service_service_recording
   ASSERT_TRUE(service_manager_b2->send_request());
 
   constexpr size_t expected_messages = 4;
-  auto ret = rosbag2_test_common::wait_until_shutdown(
-    std::chrono::seconds(5),
+  auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
       return mock_writer.get_messages().size() >= expected_messages;
-    });
+    },
+    std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -78,16 +78,6 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
 
   start_async_spin(recorder);
 
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /aa
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 1;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
-
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
 
   pub_manager.run_publishers();
@@ -160,17 +150,6 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
   recorder->record();
 
   start_async_spin(recorder);
-
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /still_nice_topic
-  // /awesome_nice_topic
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 2;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str()));
@@ -246,17 +225,6 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_topic_topic_recording)
   recorder->record();
 
   start_async_spin(recorder);
-
-  // Wait until recorder discovery is complete, otherwise messages might be missed.
-  // The currently expected topics:
-  // /still_nice_topic
-  // /awesome_nice_topic
-  auto discovery_ret = rosbag2_test_common::wait_until_condition(
-    [&recorder]() {
-      return recorder->subscriptions().size() == 2;
-    },
-    std::chrono::seconds(5));
-  ASSERT_TRUE(discovery_ret);
 
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str()));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -307,8 +307,8 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_service_recording)
   // and /awesome_nice_service/_service_event are available to be recorded.  However,
   // wait_for_service_to_be_ready() only checks the services, not the event topics, so ask the
   // recorder to make sure it has successfully subscribed to all.
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/still_nice_service/_service_event"));
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/awesome_nice_service/_service_event"));
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(v1 + "/_service_event"));
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(v2 + "/_service_event"));
 
   auto & writer = recorder->get_writer_handle();
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
@@ -388,8 +388,8 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_service_service_recording
   // and /awesome_nice_service/_service_event are available to be recorded.  However,
   // wait_for_service_to_be_ready() only checks the services, not the event topics, so ask the
   // recorder to make sure it has successfully subscribed to all.
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/still_nice_service/_service_event"));
-  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered("/awesome_nice_service/_service_event"));
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(v1 + "/_service_event"));
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(v2 + "/_service_event"));
 
   auto & writer = recorder->get_writer_handle();
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -78,6 +78,7 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
 
@@ -151,6 +152,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str()));
@@ -226,6 +228,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_topic_topic_recording)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(pub_manager.wait_for_matched(v1.c_str()));
   ASSERT_TRUE(pub_manager.wait_for_matched(v2.c_str()));
@@ -295,6 +298,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_service_recording)
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(service_manager_v1->wait_for_service_to_be_ready());
   ASSERT_TRUE(service_manager_v2->wait_for_service_to_be_ready());
@@ -376,6 +380,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_service_service_recording
   recorder->record();
 
   start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   ASSERT_TRUE(service_manager_v1->wait_for_service_to_be_ready());
   ASSERT_TRUE(service_manager_v2->wait_for_service_to_be_ready());


### PR DESCRIPTION
I initially started this series trying to track down a rare failing flakey test with `test_record__rmw_cyclonedds_cpp`.  That particular flake seems to be able to happen because sometimes discovery takes longer than we expect, and it is possible that the tests "miss" the first publication.  If that's the case, then the rest of the test may fail because it is expecting a certai number of messages.  Along the way, we cleanup the tests a bit:

1.  Remove the unnecessary `wait_until_shutdown` method, which was almost exactly the same as `wait_for_condition`.
2.  Slightly revamp how the async spinner works, so it doesn't need to call `rclcpp::shutdown`.
3.  Do a similar revamp for the custom async spinner in rosbag2_tests.
4.  Wait for topics to be discovered right after calling `recorder->record()`.  This ensures we can't get into the above situation.

With this series in place, the particular flake of `test_record` on `rmw_cyclonedds_cpp` is fixed (or, at least, I can no longer reproduce it).  There are still other flakes that can happen under load, but I think fixes for those will have to come separately.