### PR TITLE
update documentation for rosbag2 composable player

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ recorder:
   ros__parameters:
     use_sim_time: false
     record:
-      all: true
+      all_topics: true
       is_discovery_disabled: false
       topic_polling_interval:
         sec: 0


### PR DESCRIPTION
all: true should read all_topics: true

This was brought to my attention on the robotics stack exchange [here](https://robotics.stackexchange.com/questions/112800/ros2-bag-dropping-some-images-after-recording-for-around-20-seconds/112823?noredirect=1#comment48807_112823)
