### PR TITLE
Sort Topic information by name when executing ros2 bag info

### DIFF
--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -38,7 +38,7 @@ class InfoVerb(VerbExtension):
         m = Info().read_metadata(args.bag_path, args.storage)
 
         sorted_topics = sorted(m.topics_with_message_count, key=lambda topic_info: topic_info.topic_metadata.name)
-        m.topics = sorted_topics = sorted_topics
+        m.topics = sorted_topics
 
         if args.verbose:
             Info().print_output_verbose(args.bag_path, m)

--- a/ros2bag/ros2bag/verb/info.py
+++ b/ros2bag/ros2bag/verb/info.py
@@ -36,6 +36,10 @@ class InfoVerb(VerbExtension):
             print("Warning! You have set both the '-t' and '-v' parameters. The '-t' parameter "
                   'will be ignored.')
         m = Info().read_metadata(args.bag_path, args.storage)
+
+        sorted_topics = sorted(m.topics_with_message_count, key=lambda topic_info: topic_info.topic_metadata.name)
+        m.topics = sorted_topics = sorted_topics
+
         if args.verbose:
             Info().print_output_verbose(args.bag_path, m)
         else:


### PR DESCRIPTION
Closes #1797.

Sort the topics_with_message_count list by the TopicMetadata name attribute.
In the future, could add flag that changes what the topics_with_message_count list is sorted by, e.g. topic type or message count.