### PR TITLE
Allow unknown types in bag rewrite

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <ament_index_cpp/get_package_prefix.hpp>
 
 #include "rosbag2_cpp/logging.hpp"
 
@@ -179,7 +180,13 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
     throw TypenameNotUnderstoodError(topic_type);
   }
   std::string package = match[1];
-  std::string share_dir = ament_index_cpp::get_package_share_directory(package);
+  std::string share_dir;
+  try {
+    share_dir = ament_index_cpp::get_package_share_directory(package);
+  } catch (const ament_index_cpp::PackageNotFoundError & e) {
+    ROSBAG2_CPP_LOG_WARN("'%s'", e.what());
+    throw DefinitionNotFoundError(definition_identifier.topic_type());
+  }
   std::string dir = definition_identifier.format() == Format::MSG ||
     definition_identifier.format() == Format::IDL ? "/msg/" : "/srv/";
   std::ifstream file{share_dir + dir + match[2].str() +

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -185,10 +185,14 @@ TEST(test_local_message_definition_source, no_crash_on_bad_name)
 TEST(test_local_message_definition_source, throw_definition_not_found_for_unknown_msg)
 {
   LocalMessageDefinitionSource source;
-  ASSERT_THROW(source.get_full_text("rosbag2_test_msgdefs/msg/UnknownMessage"),
-    rosbag2_cpp::DefinitionNotFoundError);
+  ASSERT_THROW(
+  {
+    source.get_full_text("rosbag2_test_msgdefs/msg/UnknownMessage");
+  }, rosbag2_cpp::DefinitionNotFoundError);
 
   // Throw DefinitionNotFoundError for not found message definition package name
-  ASSERT_THROW(source.get_full_text("not_found_msgdefs_pkg/msg/UnknownMessage"),
-    rosbag2_cpp::DefinitionNotFoundError);
+  ASSERT_THROW(
+  {
+    source.get_full_text("not_found_msgdefs_pkg/msg/UnknownMessage");
+  }, rosbag2_cpp::DefinitionNotFoundError);
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -181,3 +181,14 @@ TEST(test_local_message_definition_source, no_crash_on_bad_name)
   });
   ASSERT_EQ(result.encoding, "unknown");
 }
+
+TEST(test_local_message_definition_source, throw_definition_not_found_for_unknown_msg)
+{
+  LocalMessageDefinitionSource source;
+  ASSERT_THROW(source.get_full_text("rosbag2_test_msgdefs/msg/UnknownMessage"),
+    rosbag2_cpp::DefinitionNotFoundError);
+
+  // Throw DefinitionNotFoundError for not found message definition package name
+  ASSERT_THROW(source.get_full_text("not_found_msgdefs_pkg/msg/UnknownMessage"),
+    rosbag2_cpp::DefinitionNotFoundError);
+}

--- a/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
@@ -111,7 +111,7 @@ setup_topic_filtering(
   }
 
   for (const auto & [writer, record_options] : output_bags) {
-    rosbag2_transport::TopicFilter topic_filter{record_options};
+    rosbag2_transport::TopicFilter topic_filter{record_options, nullptr, true};
     auto filtered_topics_and_types = topic_filter.filter_topics(input_topics);
 
     // Done filtering - set up writer


### PR DESCRIPTION
This PR will allow `ros2 bag convert` to process bag files with "unknown" message types.
Unknown are the types which typesupport is not available during the bag conversion operation.

 Also added proper handling for the `ament_index_cpp::PackageNotFoundError` exception throwing from the `ament_index_cpp::get_package_share_directory(package);`. It was causing abnormal converter or recorder termination if the package for message definition was not found in ament_index.

- Closes https://github.com/ros2/rosbag2/issues/1811