### PR TITLE
Update CI scripts to use Ubuntu Noble distros for linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-rolling-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Use `ubuntu-noble-ros-rolling-ros-base-latest` instead of the outdated `ubuntu-focal-ros-rolling-ros-base-latest` docker image when running Uncrustify and CPPLint to be up to date with the latest versions of linters.

Rationale:
 Uncrustify on CI throws formatting errors different from the latest version compiled from sources.