### PR TITLE
Performance improvements in Rosbag2 recorder discovery

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -129,17 +129,6 @@ bool TopicFilter::take_topic(
   const std::string & topic_type = topic_types[0];
   bool is_service_event_topic = rosbag2_cpp::is_service_event_topic(topic_name, topic_type);
 
-  if (!record_options_.include_unpublished_topics && node_graph_ &&
-    topic_is_unpublished(topic_name, *node_graph_))
-  {
-    return false;
-  }
-
-  if (record_options_.ignore_leaf_topics && node_graph_ &&
-    is_leaf_topic(topic_name, *node_graph_))
-  {
-    return false;
-  }
 
   if (!is_service_event_topic) {
     if (!record_options_.all_topics &&
@@ -232,6 +221,18 @@ bool TopicFilter::take_topic(
   }
 
   if (!allow_unknown_types_ && !type_is_known(topic_name, topic_type)) {
+    return false;
+  }
+
+  if (!record_options_.include_unpublished_topics && node_graph_ &&
+    topic_is_unpublished(topic_name, *node_graph_))
+  {
+    return false;
+  }
+
+  if (record_options_.ignore_leaf_topics && node_graph_ &&
+    is_leaf_topic(topic_name, *node_graph_))
+  {
     return false;
   }
 


### PR DESCRIPTION
- This PR improves the performance of the Rosbag2 recorder discovery by moving graph checks such as `topic_is_unpublished(topic_name, *node_graph_))` and `is_leaf_topic(topic_name, *node_graph_))`, which are expensive to the end of the checklist.

- This PR is similar to the fix from 51a83f4421ff335c2237e6214e9bb7e6ae206a92 which was discussed in https://github.com/ros2/rosbag2/issues/1485. This gives a massive CPU improvement.

- In the screenshot below you can see the performance difference:

![Screenshot from 2024-09-27 15-22-25](https://github.com/user-attachments/assets/7084ada7-f28f-41e6-a2f1-96bdf40c9c2b)
