### PR TITLE
Snapshot writes to a different file every time it is triggered

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -140,6 +140,10 @@ class RecordVerb(VerbExtension):
                  'the "/rosbag2_recorder/snapshot" service is called.'
         )
         parser.add_argument(
+            '--split-snapshots', action='store_true',
+            help='Splitting the bag file if a snapshot is taken'
+        )
+        parser.add_argument(
             '--ignore-leaf-topics', action='store_true',
             help='Ignore topics without a publisher.'
         )
@@ -236,7 +240,8 @@ class RecordVerb(VerbExtension):
             max_cache_size=args.max_cache_size,
             storage_preset_profile=args.storage_preset_profile,
             storage_config_uri=storage_config_file,
-            snapshot_mode=args.snapshot_mode
+            snapshot_mode=args.snapshot_mode,
+            split_snapshots=args.split_snapshots
         )
         record_options = RecordOptions()
         record_options.all = args.all

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -390,7 +390,7 @@ bool SequentialWriter::take_snapshot()
   }
   message_cache_->notify_data_ready();
   if (storage_options_.split_snapshots) {
-      split_bagfile();
+    split_bagfile();
   }
   return true;
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -389,6 +389,9 @@ bool SequentialWriter::take_snapshot()
     return false;
   }
   message_cache_->notify_data_ready();
+  if (storage_options_.split_snapshots) {
+      split_bagfile();
+  }
   return true;
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -511,6 +511,97 @@ TEST_F(SequentialWriterTest, snapshot_mode_zero_cache_size_throws_exception)
   EXPECT_THROW(writer_->open(storage_options_, {rmw_format, rmw_format}), std::runtime_error);
 }
 
+TEST_F(SequentialWriterTest, snapshot_mode_write_on_trigger_with_splitting)
+{
+    storage_options_.max_bagfile_size = 0;
+    storage_options_.max_cache_size = 200;
+    storage_options_.snapshot_mode = true;
+    storage_options_.split_snapshots = true;
+
+    // Expect a single write call when the snapshot is triggered
+    EXPECT_CALL(
+        *storage_, write(
+        An
+            <const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
+    ).Times(1);
+
+    ON_CALL(
+        *storage_,
+        write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
+        [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+            fake_storage_size_ += 1;
+        });
+
+    ON_CALL(*storage_, get_bagfile_size).WillByDefault(
+        [this]() {
+            return fake_storage_size_.load();
+        });
+
+    ON_CALL(*metadata_io_, write_metadata).WillByDefault(
+        [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
+            fake_metadata_ = metadata;
+        });
+
+    ON_CALL(*storage_, get_relative_file_path).WillByDefault(
+        [this]() {
+            return fake_storage_uri_;
+        });
+
+    auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+        std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+    std::vector<std::string> closed_files;
+    std::vector<std::string> opened_files;
+    rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+    callbacks.write_split_callback =
+        [&closed_files, &opened_files](rosbag2_cpp::bag_events::BagSplitInfo & info) {
+            closed_files.emplace_back(info.closed_file);
+            opened_files.emplace_back(info.opened_file);
+        };
+    writer_->add_event_callbacks(callbacks);
+
+    std::string rmw_format = "rmw_format";
+
+    std::string msg_content = "Hello";
+    auto msg_length = msg_content.length();
+    auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+    message->topic_name = "test_topic";
+    message->serialized_data = rosbag2_storage::make_serialized_message(
+        msg_content.c_str(), msg_length);
+
+    writer_->open(storage_options_, {rmw_format, rmw_format});
+    writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+
+    for (auto i = 0u; i < 100; ++i) {
+        writer_->write(message);
+    }
+    writer_->take_snapshot();
+
+    EXPECT_THAT(closed_files.size(), 1);
+    EXPECT_THAT(opened_files.size(), 1);
+
+    if (!((closed_files.size() == opened_files.size()) && (opened_files.size() == 1))) {
+        // Output debug info
+        for (size_t i = 0; i < opened_files.size(); i++) {
+            std::cout << "opened_file[" << i << "] = '" << opened_files[i] <<
+                      "'; closed_file[" << i << "] = '" << closed_files[i] << "';" << std::endl;
+        }
+    }
+
+    ASSERT_GE(opened_files.size(), 1);
+    ASSERT_GE(closed_files.size(), 1);
+    for (size_t i = 0; i < 1; i++) {
+        auto expected_closed =
+            fs::path(storage_options_.uri) / (bag_base_dir_ + "_" + std::to_string(i));
+        auto expected_opened = (i == 1) ?
+            // The last opened file shall be empty string when we do "writer->close();"
+            fs::path("") : fs::path(storage_options_.uri) / (bag_base_dir_ + "_" + std::to_string(i + 1));
+        EXPECT_EQ(closed_files[i], expected_closed.string());
+        EXPECT_EQ(opened_files[i], expected_opened.string());
+    }
+}
+
 TEST_F(SequentialWriterTest, split_event_calls_callback)
 {
   const uint64_t max_bagfile_size = 3;

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -513,93 +513,93 @@ TEST_F(SequentialWriterTest, snapshot_mode_zero_cache_size_throws_exception)
 
 TEST_F(SequentialWriterTest, snapshot_mode_write_on_trigger_with_splitting)
 {
-    storage_options_.max_bagfile_size = 0;
-    storage_options_.max_cache_size = 200;
-    storage_options_.snapshot_mode = true;
-    storage_options_.split_snapshots = true;
+  storage_options_.max_bagfile_size = 0;
+  storage_options_.max_cache_size = 200;
+  storage_options_.snapshot_mode = true;
+  storage_options_.split_snapshots = true;
 
-    // Expect a single write call when the snapshot is triggered
-    EXPECT_CALL(
-        *storage_, write(
-        An
-            <const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
-    ).Times(1);
+  // Expect a single write call when the snapshot is triggered
+  EXPECT_CALL(
+    *storage_, write(
+      An
+      <const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
+  ).Times(1);
 
-    ON_CALL(
-        *storage_,
-        write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
-        [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
-            fake_storage_size_ += 1;
-        });
+  ON_CALL(
+    *storage_,
+    write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
+    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+      fake_storage_size_ += 1;
+    });
 
-    ON_CALL(*storage_, get_bagfile_size).WillByDefault(
-        [this]() {
-            return fake_storage_size_.load();
-        });
+  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
+    [this]() {
+      return fake_storage_size_.load();
+    });
 
-    ON_CALL(*metadata_io_, write_metadata).WillByDefault(
-        [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
-            fake_metadata_ = metadata;
-        });
+  ON_CALL(*metadata_io_, write_metadata).WillByDefault(
+    [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
+      fake_metadata_ = metadata;
+    });
 
-    ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-        [this]() {
-            return fake_storage_uri_;
-        });
+  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
+    [this]() {
+      return fake_storage_uri_;
+    });
 
-    auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
-        std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
-    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
 
-    std::vector<std::string> closed_files;
-    std::vector<std::string> opened_files;
-    rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
-    callbacks.write_split_callback =
-        [&closed_files, &opened_files](rosbag2_cpp::bag_events::BagSplitInfo & info) {
-            closed_files.emplace_back(info.closed_file);
-            opened_files.emplace_back(info.opened_file);
-        };
-    writer_->add_event_callbacks(callbacks);
+  std::vector<std::string> closed_files;
+  std::vector<std::string> opened_files;
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  callbacks.write_split_callback =
+    [&closed_files, &opened_files](rosbag2_cpp::bag_events::BagSplitInfo & info) {
+      closed_files.emplace_back(info.closed_file);
+      opened_files.emplace_back(info.opened_file);
+    };
+  writer_->add_event_callbacks(callbacks);
 
-    std::string rmw_format = "rmw_format";
+  std::string rmw_format = "rmw_format";
 
-    std::string msg_content = "Hello";
-    auto msg_length = msg_content.length();
-    auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
-    message->topic_name = "test_topic";
-    message->serialized_data = rosbag2_storage::make_serialized_message(
-        msg_content.c_str(), msg_length);
+  std::string msg_content = "Hello";
+  auto msg_length = msg_content.length();
+  auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+  message->serialized_data = rosbag2_storage::make_serialized_message(
+    msg_content.c_str(), msg_length);
 
-    writer_->open(storage_options_, {rmw_format, rmw_format});
-    writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
 
-    for (auto i = 0u; i < 100; ++i) {
-        writer_->write(message);
+  for (auto i = 0u; i < 100; ++i) {
+    writer_->write(message);
+  }
+  writer_->take_snapshot();
+
+  EXPECT_THAT(closed_files.size(), 1);
+  EXPECT_THAT(opened_files.size(), 1);
+
+  if (!((closed_files.size() == opened_files.size()) && (opened_files.size() == 1))) {
+    // Output debug info
+    for (size_t i = 0; i < opened_files.size(); i++) {
+      std::cout << "opened_file[" << i << "] = '" << opened_files[i] <<
+        "'; closed_file[" << i << "] = '" << closed_files[i] << "';" << std::endl;
     }
-    writer_->take_snapshot();
+  }
 
-    EXPECT_THAT(closed_files.size(), 1);
-    EXPECT_THAT(opened_files.size(), 1);
-
-    if (!((closed_files.size() == opened_files.size()) && (opened_files.size() == 1))) {
-        // Output debug info
-        for (size_t i = 0; i < opened_files.size(); i++) {
-            std::cout << "opened_file[" << i << "] = '" << opened_files[i] <<
-                      "'; closed_file[" << i << "] = '" << closed_files[i] << "';" << std::endl;
-        }
-    }
-
-    ASSERT_GE(opened_files.size(), 1);
-    ASSERT_GE(closed_files.size(), 1);
-    for (size_t i = 0; i < 1; i++) {
-        auto expected_closed =
-            fs::path(storage_options_.uri) / (bag_base_dir_ + "_" + std::to_string(i));
-        auto expected_opened = (i == 1) ?
-            // The last opened file shall be empty string when we do "writer->close();"
-            fs::path("") : fs::path(storage_options_.uri) / (bag_base_dir_ + "_" + std::to_string(i + 1));
-        EXPECT_EQ(closed_files[i], expected_closed.string());
-        EXPECT_EQ(opened_files[i], expected_opened.string());
-    }
+  ASSERT_GE(opened_files.size(), 1);
+  ASSERT_GE(closed_files.size(), 1);
+  for (size_t i = 0; i < 1; i++) {
+    auto expected_closed =
+      fs::path(storage_options_.uri) / (bag_base_dir_ + "_" + std::to_string(i));
+    auto expected_opened = (i == 1) ?
+      // The last opened file shall be empty string when we do "writer->close();"
+      fs::path("") : fs::path(storage_options_.uri) / (bag_base_dir_ + "_" + std::to_string(i + 1));
+    EXPECT_EQ(closed_files[i], expected_closed.string());
+    EXPECT_EQ(opened_files[i], expected_opened.string());
+  }
 }
 
 TEST_F(SequentialWriterTest, split_event_calls_callback)

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -79,7 +79,8 @@ PYBIND11_MODULE(_storage, m) {
   pybind11::class_<rosbag2_storage::StorageOptions>(m, "StorageOptions")
   .def(
     pybind11::init<
-      std::string, std::string, uint64_t, uint64_t, uint64_t, std::string, std::string, bool, bool>(),
+      std::string, std::string, uint64_t, uint64_t, uint64_t, std::string, std::string, bool,
+      bool>(),
     pybind11::arg("uri"),
     pybind11::arg("storage_id") = "",
     pybind11::arg("max_bagfile_size") = 0,
@@ -110,8 +111,8 @@ PYBIND11_MODULE(_storage, m) {
     "snapshot_mode",
     &rosbag2_storage::StorageOptions::snapshot_mode)
   .def_readwrite(
-      "split_snapshots",
-      &rosbag2_storage::StorageOptions::split_snapshots);
+    "split_snapshots",
+    &rosbag2_storage::StorageOptions::split_snapshots);
 
   pybind11::class_<rosbag2_storage::StorageFilter>(m, "StorageFilter")
   .def(

--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -79,7 +79,7 @@ PYBIND11_MODULE(_storage, m) {
   pybind11::class_<rosbag2_storage::StorageOptions>(m, "StorageOptions")
   .def(
     pybind11::init<
-      std::string, std::string, uint64_t, uint64_t, uint64_t, std::string, std::string, bool>(),
+      std::string, std::string, uint64_t, uint64_t, uint64_t, std::string, std::string, bool, bool>(),
     pybind11::arg("uri"),
     pybind11::arg("storage_id") = "",
     pybind11::arg("max_bagfile_size") = 0,
@@ -87,7 +87,8 @@ PYBIND11_MODULE(_storage, m) {
     pybind11::arg("max_cache_size") = 0,
     pybind11::arg("storage_preset_profile") = "",
     pybind11::arg("storage_config_uri") = "",
-    pybind11::arg("snapshot_mode") = false)
+    pybind11::arg("snapshot_mode") = false,
+    pybind11::arg("split_snapshots") = false)
   .def_readwrite("uri", &rosbag2_storage::StorageOptions::uri)
   .def_readwrite("storage_id", &rosbag2_storage::StorageOptions::storage_id)
   .def_readwrite(
@@ -107,7 +108,10 @@ PYBIND11_MODULE(_storage, m) {
     &rosbag2_storage::StorageOptions::storage_config_uri)
   .def_readwrite(
     "snapshot_mode",
-    &rosbag2_storage::StorageOptions::snapshot_mode);
+    &rosbag2_storage::StorageOptions::snapshot_mode)
+  .def_readwrite(
+      "split_snapshots",
+      &rosbag2_storage::StorageOptions::split_snapshots);
 
   pybind11::class_<rosbag2_storage::StorageFilter>(m, "StorageFilter")
   .def(

--- a/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
@@ -54,6 +54,10 @@ public:
   // Enable snapshot mode.
   // Defaults to disabled.
   bool snapshot_mode = false;
+
+  // Split the bag files if a snapshot is created. Only used in snapshot mode.
+  // Defaults to disabled.
+  bool split_snapshots = false;
 };
 
 }  // namespace rosbag2_storage

--- a/rosbag2_storage/src/rosbag2_storage/storage_options.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/storage_options.cpp
@@ -31,6 +31,7 @@ Node convert<rosbag2_storage::StorageOptions>::encode(
   node["storage_preset_profile"] = storage_options.storage_preset_profile;
   node["storage_config_uri"] = storage_options.storage_config_uri;
   node["snapshot_mode"] = storage_options.snapshot_mode;
+  node["split_snapshots"] = storage_options.split_snapshots;
   return node;
 }
 
@@ -46,6 +47,7 @@ bool convert<rosbag2_storage::StorageOptions>::decode(
     node, "storage_preset_profile", storage_options.storage_preset_profile);
   optional_assign<std::string>(node, "storage_config_uri", storage_options.storage_config_uri);
   optional_assign<bool>(node, "snapshot_mode", storage_options.snapshot_mode);
+  optional_assign<bool>(node, "split_snapshots", storage_options.split_snapshots);
   return true;
 }
 

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_options.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_options.cpp
@@ -29,6 +29,7 @@ TEST(storage_options, test_yaml_serialization)
   original.storage_preset_profile = "profile";
   original.storage_config_uri = "config_uri";
   original.snapshot_mode = true;
+  original.split_snapshots = true;
 
   auto node = YAML::convert<rosbag2_storage::StorageOptions>().encode(original);
 
@@ -46,4 +47,5 @@ TEST(storage_options, test_yaml_serialization)
   ASSERT_EQ(original.storage_preset_profile, reconstructed.storage_preset_profile);
   ASSERT_EQ(original.storage_config_uri, reconstructed.storage_config_uri);
   ASSERT_EQ(original.snapshot_mode, reconstructed.snapshot_mode);
+  ASSERT_EQ(original.split_snapshots, reconstructed.split_snapshots);
 }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -105,8 +105,6 @@ Recorder::Recorder(
     get_logger(),
     "Press " << key_str << " for pausing/resuming");
 
-    RCLCPP_INFO_STREAM(get_logger(), "split_snapshots: " << (storage_options_.split_snapshots ? "true":"false"));
-
   for (auto & topic : record_options_.topics) {
     topic = rclcpp::expand_topic_or_service_name(topic, get_name(), get_namespace(), false);
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -105,6 +105,8 @@ Recorder::Recorder(
     get_logger(),
     "Press " << key_str << " for pausing/resuming");
 
+    RCLCPP_INFO_STREAM(get_logger(), "split_snapshots: " << (storage_options_.split_snapshots ? "true":"false"));
+
   for (auto & topic : record_options_.topics) {
     topic = rclcpp::expand_topic_or_service_name(topic, get_name(), get_namespace(), false);
   }


### PR DESCRIPTION
Addresses the issue described in #1099.

This is a simple change adding an argument on the command line to use a split function each time a snapshot is taken. It uses split bagfile function already implemented. Any improvement on this function regarding file names or returns can be simple translated to the snapshot function afterwards. 

It is developed on the Humble branch as we need this feature in humble. But it should be easily ported to rolling. 

There might be one concern the StorageOptions struct has a change (a member was added). This might cause issues with the ABI (depend on if this structure is part of it or not). 