### PR TITLE
[humble] Expose more Writer methods in python interface (backport #1220 and #1339)

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -53,7 +53,7 @@ class BaseWriterInterface;
  * The Writer allows writing messages to a new bag. For every topic, information about its type
  * needs to be added before writing the first message.
  */
-class ROSBAG2_CPP_PUBLIC Writer final
+class ROSBAG2_CPP_PUBLIC Writer
 {
 public:
   explicit Writer(

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -36,7 +36,7 @@ namespace rosbag2_py
 {
 
 template<typename T>
-class Writer
+class Writer : public rosbag2_cpp::Writer
 {
 public:
   Writer()
@@ -113,6 +113,7 @@ PYBIND11_MODULE(_writer, m) {
   .def(pybind11::init())
   .def("open", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::open)
   .def("write", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::write)
+  .def("close", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::close)
   .def("remove_topic", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::remove_topic)
   .def("create_topic", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::create_topic);
 

--- a/rosbag2_py/src/rosbag2_py/_writer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_writer.cpp
@@ -39,27 +39,10 @@ template<typename T>
 class Writer : public rosbag2_cpp::Writer
 {
 public:
-  Writer()
-  : writer_(std::make_unique<rosbag2_cpp::Writer>(std::make_unique<T>()))
-  {
-  }
-
-  void open(
-    rosbag2_storage::StorageOptions & storage_options,
-    rosbag2_cpp::ConverterOptions & converter_options)
-  {
-    writer_->open(storage_options, converter_options);
-  }
-
-  void create_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
-  {
-    writer_->create_topic(topic_with_type);
-  }
-
-  void remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
-  {
-    writer_->remove_topic(topic_with_type);
-  }
+  template<typename ... Args>
+  explicit Writer(Args && ... args)
+  : rosbag2_cpp::Writer(std::make_unique<T>(std::forward<Args>(args)...))
+  {}
 
   /// Write a serialized message to a bag file
   void write(
@@ -74,11 +57,8 @@ public:
       rosbag2_storage::make_serialized_message(message.c_str(), message.length());
     bag_message->time_stamp = time_stamp;
 
-    writer_->write(bag_message);
+    rosbag2_cpp::Writer::write(bag_message);
   }
-
-protected:
-  std::unique_ptr<rosbag2_cpp::Writer> writer_;
 };
 
 std::unordered_set<std::string> get_registered_writers()
@@ -105,29 +85,38 @@ std::unordered_set<std::string> get_registered_serializers()
 
 }  // namespace rosbag2_py
 
+using PyWriter = rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>;
+using PyCompressionWriter = rosbag2_py::Writer<rosbag2_compression::SequentialCompressionWriter>;
+
 PYBIND11_MODULE(_writer, m) {
   m.doc() = "Python wrapper of the rosbag2_cpp writer API";
 
-  pybind11::class_<rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>>(
-    m, "SequentialWriter")
+  pybind11::class_<PyWriter>(m, "SequentialWriter")
   .def(pybind11::init())
-  .def("open", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::open)
-  .def("write", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::write)
-  .def("close", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::close)
-  .def("remove_topic", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::remove_topic)
-  .def("create_topic", &rosbag2_py::Writer<rosbag2_cpp::writers::SequentialWriter>::create_topic);
+  .def(
+    "open",
+    pybind11::overload_cast<
+      const rosbag2_storage::StorageOptions &, const rosbag2_cpp::ConverterOptions &
+    >(&PyWriter::open))
+  .def("write", &PyWriter::write)
+  .def("close", &PyWriter::close)
+  .def("remove_topic", &PyWriter::remove_topic)
+  .def("create_topic", &PyWriter::create_topic)
+  .def("take_snapshot", &PyWriter::take_snapshot)
+  ;
 
-  pybind11::class_<rosbag2_py::Writer<rosbag2_compression::SequentialCompressionWriter>>(
-    m, "SequentialCompressionWriter")
+  pybind11::class_<PyCompressionWriter>(m, "SequentialCompressionWriter")
   .def(pybind11::init())
-  .def("open", &rosbag2_py::Writer<rosbag2_compression::SequentialCompressionWriter>::open)
-  .def("write", &rosbag2_py::Writer<rosbag2_compression::SequentialCompressionWriter>::write)
   .def(
-    "remove_topic",
-    &rosbag2_py::Writer<rosbag2_compression::SequentialCompressionWriter>::remove_topic)
-  .def(
-    "create_topic",
-    &rosbag2_py::Writer<rosbag2_compression::SequentialCompressionWriter>::create_topic);
+    "open",
+    pybind11::overload_cast<
+      const rosbag2_storage::StorageOptions &, const rosbag2_cpp::ConverterOptions &
+    >(&PyCompressionWriter::open))
+  .def("write", &PyCompressionWriter::write)
+  .def("remove_topic", &PyCompressionWriter::remove_topic)
+  .def("create_topic", &PyCompressionWriter::create_topic)
+  .def("take_snapshot", &PyCompressionWriter::take_snapshot)
+  ;
 
   m.def(
     "get_registered_writers",


### PR DESCRIPTION
Backport #1220 and #1339 to humble, exposing the `close()` and `take_snapshot()` Writer methods in the python interface