### PR TITLE
Bugfix: Update metadata with new file_info before saving it the first time in the file

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -392,7 +392,7 @@ TEST_F(SequentialCompressionWriterTest, writer_call_metadata_update_on_bag_split
   EXPECT_EQ(compression_mode, rosbag2_compression::CompressionMode::MESSAGE);
   EXPECT_EQ(v_intercepted_update_metadata_[0].message_count, 0u);  // On opening first bag file
   EXPECT_EQ(v_intercepted_update_metadata_[1].files.size(), 1u);   // On closing first bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[2].files.size(), 1u);   // On opening second bag file
+  EXPECT_EQ(v_intercepted_update_metadata_[2].files.size(), 2u);   // On opening second bag file
   EXPECT_EQ(v_intercepted_update_metadata_[3].files.size(), 2u);   // On writer destruction
   EXPECT_EQ(v_intercepted_update_metadata_[3].message_count, 2 * kNumMessagesToWrite);
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -334,6 +334,14 @@ void SequentialWriter::switch_to_next_storage()
 
     throw std::runtime_error(errmsg.str());
   }
+
+  rosbag2_storage::FileInformation file_info{};
+  file_info.starting_time =
+    std::chrono::time_point<std::chrono::high_resolution_clock>(std::chrono::nanoseconds::max());
+  file_info.path = strip_parent_path(storage_->get_relative_file_path());
+  metadata_.files.push_back(file_info);
+  metadata_.relative_file_paths.push_back(file_info.path);
+
   storage_->update_metadata(metadata_);
   // Re-register all topics since we rolled-over to a new bagfile.
   for (const auto & topic : topics_names_to_info_) {
@@ -352,14 +360,6 @@ std::string SequentialWriter::split_bagfile_local(bool execute_callbacks)
   auto closed_file = storage_->get_relative_file_path();
   switch_to_next_storage();
   auto opened_file = storage_->get_relative_file_path();
-
-  metadata_.relative_file_paths.push_back(strip_parent_path(storage_->get_relative_file_path()));
-
-  rosbag2_storage::FileInformation file_info{};
-  file_info.starting_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
-    std::chrono::nanoseconds::max());
-  file_info.path = strip_parent_path(storage_->get_relative_file_path());
-  metadata_.files.push_back(file_info);
 
   if (execute_callbacks) {
     execute_bag_split_callbacks(closed_file, opened_file);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -226,7 +226,7 @@ TEST_F(SequentialWriterTest, sequantial_writer_call_metadata_update_on_bag_split
   EXPECT_TRUE(v_intercepted_update_metadata_[0].compression_mode.empty());
   EXPECT_EQ(v_intercepted_update_metadata_[0].message_count, 0u);  // On opening first bag file
   EXPECT_EQ(v_intercepted_update_metadata_[1].files.size(), 1u);   // On closing first bag file
-  EXPECT_EQ(v_intercepted_update_metadata_[2].files.size(), 1u);   // On opening second bag file
+  EXPECT_EQ(v_intercepted_update_metadata_[2].files.size(), 2u);   // On opening second bag file
   EXPECT_EQ(v_intercepted_update_metadata_[3].files.size(), 2u);   // On writer destruction
   EXPECT_EQ(v_intercepted_update_metadata_[3].message_count, 2 * kNumMessagesToWrite);
 }


### PR DESCRIPTION
This PR is a bug fix for missing file_info for newly created file in saved metadata.

When we are switching to new storage, the correct behavior shall be as follows:
1. Save metadata to storage
2. Close current storage 
3. Open new storage for read_write
4. **Update metadata with a newly created file**
5. **Save metadata to storage**