### PR TITLE
[humble] Handle unsupported serialization formats in rosbag2's. 

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -187,6 +187,8 @@ private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
 
   bag_events::EventCallbackManager callback_manager_;
+
+  std::string storage_serialization_format;
 };
 
 }  // namespace readers

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -185,9 +185,7 @@ void SequentialReader::set_filter(const rosbag2_storage::StorageFilter & storage
   {
     // Empty filter. Add all topics with a supported serialization format.
     for (const auto & topic : topics_metadata_) {
-      if (topic.serialization_format != storage_serialization_format) {
-        topics_filter_.topics.push_back(topic.name);
-      }
+      topics_filter_.topics.push_back(topic.name);
     }
   } else {
     // Non-empty filter. Add all requested topics with a supported serialization format.
@@ -201,12 +199,12 @@ void SequentialReader::set_filter(const rosbag2_storage::StorageFilter & storage
         ROSBAG2_CPP_LOG_WARN(
           "Requested topic %s not found or has unsupported serialization format.", topic.c_str());
       }
+    }
 
-      // Edge case: we cannot find any supported topic.
-      // To avoid reading all messages, throw an error.
-      if (topics_filter_.topics.empty()) {
-        throw std::runtime_error("No topics found that match the filter.");
-      }
+    // Edge case: we cannot find any supported topic.
+    // To avoid reading all messages, throw an error.
+    if (topics_filter_.topics.empty()) {
+      throw std::runtime_error("No topics found that match the filter.");
     }
   }
 
@@ -252,7 +250,6 @@ void SequentialReader::load_current_file()
   }
   // set filters
   storage_->seek(seek_time_);
-  set_filter(topics_filter_);
 }
 
 void SequentialReader::load_next_file()

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -203,6 +203,11 @@ void SequentialReader::set_filter(
       } else {
         ROSBAG2_CPP_LOG_WARN("Requested topic %s not found or has unsupported serialization format.", topic.c_str());
       }
+
+      // Edge case: we cannot find any supported topic. To avoid reading all messages, throw an error.
+      if (topics_filter_.topics.empty()) {
+        throw std::runtime_error("No topics found that match the filter.");
+      }
     }
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -181,8 +181,7 @@ void SequentialReader::set_filter(const rosbag2_storage::StorageFilter & storage
   topics_filter_ = {};
 
   // Create a new filter that is the intersection of the storage filter and the topics metadata.
-  if (storage_filter.topics.empty())
-  {
+  if (storage_filter.topics.empty()) {
     // Empty filter. Add all topics with a supported serialization format.
     for (const auto & topic : topics_metadata_) {
       topics_filter_.topics.push_back(topic.name);

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -119,13 +119,22 @@ void SequentialReader::open(
     ROSBAG2_CPP_LOG_WARN("No topics were listed in metadata.");
     return;
   }
-  fill_topics_metadata();
+
+  // Set the current storage serialization format to the output serialization format
+  storage_serialization_format = converter_options.output_serialization_format;
 
   // Currently a bag file can only be played if all topics have the same serialization format.
   check_topics_serialization_formats(topics);
   check_converter_serialization_format(
     converter_options.output_serialization_format,
-    topics[0].topic_metadata.serialization_format);
+    storage_serialization_format);
+
+  // Fill topics metadata. The storage serialization format is known by this point, so only supported
+  // topics will be added
+  fill_topics_metadata();
+
+  // Set initial filter to read all supported topics.
+  set_filter({});
 }
 
 bool SequentialReader::has_next()
@@ -175,7 +184,28 @@ std::vector<rosbag2_storage::TopicMetadata> SequentialReader::get_all_topics_and
 void SequentialReader::set_filter(
   const rosbag2_storage::StorageFilter & storage_filter)
 {
-  topics_filter_ = storage_filter;
+  // Clear the current topics_filter
+  topics_filter_ = {};
+
+  // Create a new filter that is the intersection of the storage filter and the topics metadata.
+  if(storage_filter.topics.empty()) { // Empty filter. Add all topics with a supported serialization format.
+    for(const auto & topic : topics_metadata_) {
+      if (topic.serialization_format != storage_serialization_format) {
+        topics_filter_.topics.push_back(topic.name);
+      }
+    }
+  } else {  // Non-empty filter. Add all requested topics with a supported serialization format.
+    for (const auto& topic : storage_filter.topics) {
+      auto it = std::find_if(topics_metadata_.begin(), topics_metadata_.end(),
+                             [&topic](const auto& topic_metadata) { return topic_metadata.name == topic; });
+      if (it != topics_metadata_.end()) {
+        topics_filter_.topics.push_back(topic);
+      } else {
+        ROSBAG2_CPP_LOG_WARN("Requested topic %s not found or has unsupported serialization format.", topic.c_str());
+      }
+    }
+  }
+
   if (storage_) {
     storage_->set_filter(topics_filter_);
     return;
@@ -249,17 +279,39 @@ std::string SequentialReader::get_current_uri() const
   return current_uri.string();
 }
 
+
 void SequentialReader::check_topics_serialization_formats(
   const std::vector<rosbag2_storage::TopicInformation> & topics)
 {
-  auto storage_serialization_format = topics[0].topic_metadata.serialization_format;
-  for (const auto & topic : topics) {
-    if (topic.topic_metadata.serialization_format != storage_serialization_format) {
-      throw std::runtime_error(
-              "Topics with different rwm serialization format have been found. "
-              "All topics must have the same serialization format.");
+
+  // Check if we have any messages stored in the output serialization format. If that's the case, we don't need to check all converter plugins.
+  bool need_topic_conversion = true;
+  for (const auto & topic: topics) {
+    if(topic.topic_metadata.serialization_format == storage_serialization_format) {
+      need_topic_conversion = false;
+      break;
     }
   }
+
+  // If we haven't found any messages in the output serialization format, lets see if we have any serialization format we can convert from.
+  if(need_topic_conversion) {
+    bool found_topic_to_convert = false;
+    storage_serialization_format = "";  // Clarify that we haven't found any serialization format to convert from.
+    for (const auto& topic : topics) {
+      if (converter_factory_->load_deserializer(topic.topic_metadata.serialization_format) != nullptr) {
+        storage_serialization_format = topic.topic_metadata.serialization_format;
+        found_topic_to_convert = true;
+        break;
+      }
+    }
+
+    // If we cannot convert, fail.
+    if (!found_topic_to_convert) {
+      throw std::runtime_error("No topics with a known serialization format have been found. ");
+    }
+  }
+
+  // User is warned of non-supported topics in set_filter
 }
 
 void SequentialReader::check_converter_serialization_format(
@@ -280,13 +332,21 @@ void SequentialReader::check_converter_serialization_format(
   }
 }
 
-void SequentialReader::fill_topics_metadata()
-{
+void SequentialReader::fill_topics_metadata() {
   rcpputils::check_true(storage_ != nullptr, "Bag is not open. Call open() before reading.");
+
+  // Add only topics with the same serialization format as the storage serialization format
   topics_metadata_.clear();
   topics_metadata_.reserve(metadata_.topics_with_message_count.size());
-  for (const auto & topic_information : metadata_.topics_with_message_count) {
-    topics_metadata_.push_back(topic_information.topic_metadata);
+  for (const auto& topic_information : metadata_.topics_with_message_count) {
+    if (topic_information.topic_metadata.serialization_format == storage_serialization_format) {
+      topics_metadata_.push_back(topic_information.topic_metadata);
+    } else {
+      ROSBAG2_CPP_LOG_WARN("Topic %s with serialization format %s doesn't match the storage format %s.",
+                           topic_information.topic_metadata.name.c_str(),
+                           topic_information.topic_metadata.serialization_format.c_str(),
+                           storage_serialization_format.c_str());
+    }
   }
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -128,13 +128,14 @@ public:
 TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_format) {
   std::string output_format = "rmw2_format";
 
-  auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
   auto format2_converter = std::make_unique<StrictMock<MockConverter>>();
-  EXPECT_CALL(*format1_converter, deserialize(_, _, _)).Times(1);
   EXPECT_CALL(*format2_converter, serialize(_, _, _)).Times(1);
 
   EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_))
-  .WillOnce(Return(ByMove(std::move(format1_converter))));
+  .WillRepeatedly(
+    [](const std::string &) {
+      return std::make_unique<StrictMock<MockConverter>>();
+    });
   EXPECT_CALL(*converter_factory_, load_serializer(output_format))
   .WillOnce(Return(ByMove(std::move(format2_converter))));
 
@@ -145,9 +146,11 @@ TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_
 TEST_F(SequentialReaderTest, open_throws_error_if_converter_plugin_does_not_exist) {
   std::string output_format = "rmw2_format";
 
-  auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
   EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_))
-  .WillOnce(Return(ByMove(std::move(format1_converter))));
+  .WillRepeatedly(
+    [](const std::string &) {
+      return std::make_unique<StrictMock<MockConverter>>();
+    });
   EXPECT_CALL(*converter_factory_, load_serializer(output_format))
   .WillOnce(Return(ByMove(nullptr)));
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -58,7 +58,12 @@ public:
     topic_with_type.name = "topic";
     topic_with_type.type = "test_msgs/BasicTypes";
     topic_with_type.serialization_format = storage_serialization_format_;
-    auto topics_and_types = std::vector<rosbag2_storage::TopicMetadata>{topic_with_type};
+    rosbag2_storage::TopicMetadata topic2_with_type;
+    topic2_with_type.name = "topic2";
+    topic2_with_type.type = "test_msgs/BasicTypes";
+    topic2_with_type.serialization_format = storage_serialization_format_;
+    auto topics_and_types =
+      std::vector<rosbag2_storage::TopicMetadata>{topic_with_type, topic2_with_type};
 
     auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     message->topic_name = topic_with_type.name;
@@ -72,6 +77,7 @@ public:
     metadata_.relative_file_paths = {bag_file_1_path_.string(), bag_file_2_path_.string()};
     metadata_.version = 4;
     metadata_.topics_with_message_count.push_back({{topic_with_type}, 6});
+    metadata_.topics_with_message_count.push_back({{topic2_with_type}, 1});
     metadata_.storage_identifier = "mock_storage";
 
     EXPECT_CALL(*metadata_io, read_metadata(_)).WillRepeatedly(Return(metadata_));

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -134,7 +134,9 @@ TEST_F(SequentialReaderTest, read_next_uses_converters_to_convert_serialization_
   EXPECT_CALL(*converter_factory_, load_deserializer(storage_serialization_format_))
   .WillRepeatedly(
     [](const std::string &) {
-      return std::make_unique<StrictMock<MockConverter>>();
+      auto deserializer = std::make_unique<StrictMock<MockConverter>>();
+      EXPECT_CALL(*deserializer, deserialize(_, _, _)).Times(AtMost(1));
+      return deserializer;
     });
   EXPECT_CALL(*converter_factory_, load_serializer(output_format))
   .WillOnce(Return(ByMove(std::move(format2_converter))));


### PR DESCRIPTION
[Relevant issue](https://github.com/ros2/rosbag2/issues/1847)

This PR allows ros2 bag play to playback rosbags that have unsupported topics inside. 

The implementation finds the first topic with a supported format, and ignores all other topics. 

Currently based on humble, as that unblocks us immediately. Once the general approach is approved, we can rebase onto rolling. 