### PR TITLE
Humble: Suppress mcap warnings.

### DIFF
--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -38,6 +38,11 @@
   #endif
 #endif
 
+#ifdef _WIN32
+  #pragma warning(push)
+  #pragma warning(disable : 4251)
+#endif
+
 #include <mcap/mcap.hpp>
 
 #include <algorithm>
@@ -823,3 +828,7 @@ void MCAPStorage::ensure_rosdistro_metadata_added()
 #include "pluginlib/class_list_macros.hpp"  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rosbag2_storage_plugins::MCAPStorage,
                        rosbag2_storage::storage_interfaces::ReadWriteInterface)
+
+#ifdef _WIN32
+  #pragma warning(pop)
+#endif

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -23,6 +23,10 @@
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 #include "std_msgs/msg/string.hpp"
 
+#ifdef _WIN32
+  #pragma warning(push)
+  #pragma warning(disable : 4251)
+#endif
 #include <mcap/mcap.hpp>
 
 #include <gmock/gmock.h>
@@ -204,3 +208,7 @@ TEST_F(TemporaryDirectoryFixture, mcap_contains_ros_distro)
   }
   EXPECT_EQ(read_metadata_ros_distro, current_ros_distro);
 }
+
+#ifdef _WIN32
+  #pragma warning(pop)
+#endif


### PR DESCRIPTION
When building humble with Conda, we get lots of warnings about dll-import problems.  However, we know that these are safe to ignore for mcap, as this library is strictly used internally and we suppress this on Rolling.  Do the same suppression here.

(to be perfectly frank, I don't understand why this is a problem with conda and not with the current setup, but this is an easy enough solution)