### PR TITLE
fixed compilation issues for the backport to humble of issue 1842

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -500,7 +500,6 @@ TEST_F(SequentialCompressionWriterTest, snapshot_writes_to_new_file_with_file_co
     rosbag2_compression::CompressionMode::FILE,
     1,
     1,
-    kDefaultCompressionQueueThreadsPriority
   };
   initializeWriter(compression_options);
 
@@ -524,7 +523,7 @@ TEST_F(SequentialCompressionWriterTest, snapshot_writes_to_new_file_with_file_co
     rosbag2_storage::make_serialized_message(msg_content.c_str(), msg_length);
 
   writer_->open(tmp_dir_storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({0u, "test_topic", "test_msgs/BasicTypes", "", {}, ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
 
   for (size_t i = 0; i < 100; i++) {
     writer_->write(message);
@@ -551,10 +550,10 @@ TEST_F(SequentialCompressionWriterTest, snapshot_writes_to_new_file_with_file_co
       (bag_base_dir_ + "_" + std::to_string(i) + "." + DefaultTestCompressor);
     auto expected_opened = (i == 1) ?
       // The last opened file shall be empty string when we do "writer->close();"
-      "" : fs::path(tmp_dir_storage_options_.uri) /
-      (bag_base_dir_ + "_" + std::to_string(i + 1));
-    ASSERT_STREQ(closed_files[i].c_str(), expected_closed.generic_string().c_str());
-    ASSERT_STREQ(opened_files[i].c_str(), expected_opened.generic_string().c_str());
+                           fs::path("") : fs::path(tmp_dir_storage_options_.uri) /
+                                          (bag_base_dir_ + "_" + std::to_string(i + 1));
+    ASSERT_STREQ(closed_files[i].c_str(), expected_closed.string().c_str());
+    ASSERT_STREQ(opened_files[i].c_str(), expected_opened.string().c_str());
   }
 }
 

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -549,9 +549,8 @@ TEST_F(SequentialCompressionWriterTest, snapshot_writes_to_new_file_with_file_co
     auto expected_closed = fs::path(tmp_dir_storage_options_.uri) /
       (bag_base_dir_ + "_" + std::to_string(i) + "." + DefaultTestCompressor);
     auto expected_opened = (i == 1) ?
-      // The last opened file shall be empty string when we do "writer->close();"
-                           fs::path("") : fs::path(tmp_dir_storage_options_.uri) /
-                                          (bag_base_dir_ + "_" + std::to_string(i + 1));
+      fs::path("") : fs::path(tmp_dir_storage_options_.uri) /
+      (bag_base_dir_ + "_" + std::to_string(i + 1));
     ASSERT_STREQ(closed_files[i].c_str(), expected_closed.string().c_str());
     ASSERT_STREQ(opened_files[i].c_str(), expected_opened.string().c_str());
   }

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -462,9 +462,9 @@ void SequentialWriter::write_messages(
   if (storage_options_.snapshot_mode) {
     // Update FileInformation about the last file in metadata in case of snapshot mode
     const auto first_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
-      std::chrono::nanoseconds(messages.front()->recv_timestamp));
+      std::chrono::nanoseconds(messages.front()->time_stamp));
     const auto last_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
-      std::chrono::nanoseconds(messages.back()->recv_timestamp));
+      std::chrono::nanoseconds(messages.back()->time_stamp));
     metadata_.files.back().starting_time = first_msg_timestamp;
     metadata_.files.back().duration = last_msg_timestamp - first_msg_timestamp;
     metadata_.files.back().message_count = messages.size();

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -534,7 +534,7 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
   // Expect a single write call when the snapshot is triggered
   EXPECT_CALL(
     *storage_, write(
-    An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
+      An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
   ).Times(1);
 
   ON_CALL(
@@ -576,7 +576,7 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
   std::string rmw_format = "rmw_format";
 
   writer_->open(storage_options_, {rmw_format, rmw_format});
-  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "",  ""});
+  writer_->create_topic({"test_topic", "test_msgs/BasicTypes", "", ""});
 
   for (const auto & message : messages) {
     writer_->write(message);
@@ -615,7 +615,7 @@ TEST_F(SequentialWriterTest, snapshot_can_be_called_twice)
   // Expect to call write method twice. Once per each snapshot.
   EXPECT_CALL(
     *storage_, write(
-    An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
+      An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
   ).Times(2);
 
   ON_CALL(*storage_, get_relative_file_path).WillByDefault(


### PR DESCRIPTION
Fixed the compilation problems with using time_stamp instead of recv_timestamp because recv_timestamp is not available in humble and time_stamp is set to the time of reception.
Removed any metadata checks in the tests as there is no callback for the updated metadata.
Fixed issues with using fs::path (Humble does not use std::fs)
Fixed issues within the tests to create topics (topic metadata is different from rolling)

Hopefully this will support the backport.