### PR TITLE
Add in python3-dev build dependency.

### DIFF
--- a/rosbag2_py/package.xml
+++ b/rosbag2_py/package.xml
@@ -17,6 +17,8 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <build_depend>python3-dev</build_depend>
+
   <depend>pybind11_vendor</depend>
   <depend>rosbag2_compression</depend>
   <depend>rosbag2_cpp</depend>


### PR DESCRIPTION
We need this because we call find_package(Python3 Development) in our CMakeLists.txt here.

Also see https://github.com/ros2/ros2_tracing/pull/146#issuecomment-2492724725 for a long explanation of why we need this.