### PR TITLE
Add PlayerClock::wakeup() to interrupt sleeping

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/player_clock.hpp
@@ -78,6 +78,19 @@ public:
   virtual bool sleep_until(rclcpp::Time time) = 0;
 
   /**
+   * \return whether the clock is currently sleeping.
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual bool is_sleeping() = 0;
+
+  /**
+   * \brief Wake up the clock if it is sleeping.
+   * \note This will wake any waiting `sleep_until`.
+   */
+  ROSBAG2_CPP_PUBLIC
+  virtual void wakeup() = 0;
+
+  /**
    * Change the rate of the flow of time for the clock.
    * \param rate new rate of clock playback
    * \bool false if rate is invalid for the clock implementation

--- a/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/clocks/time_controller_clock.hpp
@@ -81,6 +81,12 @@ public:
   ROSBAG2_CPP_PUBLIC
   bool sleep_until(rclcpp::Time until) override;
 
+  ROSBAG2_CPP_PUBLIC
+  bool is_sleeping() override;
+
+  ROSBAG2_CPP_PUBLIC
+  void wakeup() override;
+
   /**
    * Change the rate of the flow of time for the clock.
    *

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -739,10 +739,8 @@ bool PlayerImpl::play_next()
 
   // Wait for play next to be done, and then return the result
   std::unique_lock<std::mutex> lk(finished_play_next_mutex_);
-  // Temporarily resume clock to force wakeup in clock_->sleep_until(time),
-  // then return in pause mode to preserve original state of the player
-  clock_->resume();
-  clock_->pause();
+  // Wake up the clock in case it's in a sleep_until(time) call
+  clock_->wakeup();
   finished_play_next_ = false;
   finished_play_next_cv_.wait(lk, [this] {return finished_play_next_.load();});
   play_next_ = false;
@@ -1044,9 +1042,8 @@ void PlayerImpl::play_messages_from_queue()
     while (!stop_playback_ && is_paused() && !play_next_.load() && rclcpp::ok()) {
       clock_->sleep_until(clock_->now());
     }
-    // If we ran out of messages and are not in pause state, it means we're done playing,
-    // unless play_next() is resuming and pausing the clock in order to wake us up
-    if (!is_paused() && !play_next_.load()) {
+    // If we ran out of messages and are not in pause state, it means we're done playing
+    if (!is_paused()) {
       break;
     }
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -641,8 +641,8 @@ void PlayerImpl::stop()
     }
 
     if (clock_->is_paused()) {
-      clock_->resume();  // Temporary resume clock to force wakeup in clock_->sleep_until(time)
-      clock_->pause();   // Return in pause mode to preserve original state of the player
+      // Wake up the clock in case it's in a sleep_until(time) call
+      clock_->wakeup();
     }
     // Note: Don't clean up message queue here. It will be cleaned up automatically in
     // playback thread after finishing play_messages_from_queue();


### PR DESCRIPTION
This adds a new `wakeup()` method to `PlayerClock`. It wakes up the clock, which is (only) useful if it is currently sleeping, i.e., in a `sleep_until()` call. Just calling `std::condition_variable::notify_all()` on the clock's condition variable wakes it up from its sleep (i.e., [`std::condition_variable::wait_for()`](https://en.cppreference.com/w/cpp/thread/condition_variable/wait_for) and [`std::condition_variable::wait_until()`](https://en.cppreference.com/w/cpp/thread/condition_variable/wait_until)):

> The thread will be unblocked when [notify_all()](https://en.cppreference.com/w/cpp/thread/condition_variable/notify_all) or [notify_one()](https://en.cppreference.com/w/cpp/thread/condition_variable/notify_one) is executed, or abs_time is reached. It may also be unblocked spuriously.

This can then replace the current workaround in `Player::stop()` to force-wakeup the clock, which is to resume the clock and then immediately pause it. Since we don't actually want to pause the clock, doing this may have unintended consequences, e.g., if the player is woken up and then thinks it's not in pause mode anymore.

I want to use this in #1848, but I thought a separate PR would be easier to review.