### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# Reviewers (and by extension approvers) will be the default owners for everything in the repo.
-# Unless a later match takes precedence, @reviewers will be requested for review when someone opens a pull request.
-* @ros2/tooling-reviewers


### PR DESCRIPTION
It points to a team that contains many people who are not active (i.e., not doing reviews) anymore, so it's not really useful. Just remove it.