### PR TITLE
Add debug information for flaky can_record_again_after_stop test

### DIFF
--- a/rosbag2_test_common/CMakeLists.txt
+++ b/rosbag2_test_common/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(test_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
@@ -32,6 +33,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 target_link_libraries(${PROJECT_NAME} INTERFACE
   rclcpp::rclcpp
   rcutils::rcutils
+  ${test_msgs_TARGETS}
 )
 
 install(
@@ -48,7 +50,7 @@ endif()
 
 ament_python_install_package(${PROJECT_NAME})
 
-ament_export_dependencies(rclcpp rcutils)
+ament_export_dependencies(rclcpp rcutils test_msgs)
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")

--- a/rosbag2_test_common/package.xml
+++ b/rosbag2_test_common/package.xml
@@ -16,9 +16,11 @@
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rcutils</build_depend>
+  <build_depend>test_msgs</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rcutils</exec_depend>
+  <exec_depend>test_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -23,12 +23,12 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "rosbag2_test_common/publication_manager.hpp"
-#include "rosbag2_test_common/client_manager.hpp"
 #include "rosbag2_test_common/wait_for.hpp"
 
 #include "rosbag2_transport/recorder.hpp"
 
 #include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/basic_types.hpp"
 #include "test_msgs/message_fixtures.hpp"
 
 #include "rosbag2_storage/qos.hpp"
@@ -123,14 +123,18 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
 TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
 {
-  auto string_message = get_messages_strings()[1];
-  std::string string_topic = "/string_topic";
+  auto basic_type_message = get_messages_basic_types()[0];
+  basic_type_message->uint64_value = 5;
+  basic_type_message->int64_value = -1;
+  std::string test_topic = "/can_record_again_after_stop_topic";
+  const size_t num_messages_to_publish = 2;
 
   rosbag2_test_common::PublicationManager pub_manager;
-  pub_manager.setup_publisher(string_topic, string_message, 2);
+  pub_manager.setup_publisher(
+    test_topic, basic_type_message, num_messages_to_publish, rclcpp::QoS{rclcpp::KeepAll()}, 50ms);
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, {string_topic}, {}, {}, {}, {}, {}, "rmw_format", 50ms};
+  {false, false, false, {test_topic}, {}, {}, {}, {}, {}, "rmw_format", 50ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -141,7 +145,7 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
   auto & writer = recorder->get_writer_handle();
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic.c_str()));
 
   pub_manager.run_publishers();
 
@@ -152,7 +156,7 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
   // Record one more time after stop()
   recorder->record();
 
-  ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic.c_str()));
   pub_manager.run_publishers();
 
   // 4 because we're running recorder->record() and publishers twice
@@ -166,6 +170,16 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));
 
+  // Output debug info if test fails
+  if (recorded_messages.size() != expected_messages) {
+    for (size_t i = 0; i < recorded_messages.size(); i++) {
+      std::cerr << "=> recorded_messages[" << i << "].send_timestamp = " <<
+        recorded_messages[i]->send_timestamp << std::endl;
+      std::cerr << "recorded_messages[" << i << "].recv_timestamp = " <<
+        recorded_messages[i]->recv_timestamp << std::endl;
+    }
+  }
+
   auto recorded_topics = mock_writer.get_topics();
   EXPECT_THAT(recorded_topics, SizeIs(1)) << "size=" << recorded_topics.size();
   if (recorded_topics.size() != 1) {
@@ -173,13 +187,25 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
       std::cerr << "recorded topic name : " << topic.first << std::endl;
     }
   }
-  EXPECT_THAT(recorded_topics.at(string_topic).first.serialization_format, Eq("rmw_format"));
+  EXPECT_THAT(recorded_topics.at(test_topic).first.serialization_format, Eq("rmw_format"));
 
-  auto string_messages =
-    filter_messages<test_msgs::msg::Strings>(recorded_messages, string_topic);
-  EXPECT_THAT(string_messages, SizeIs(4));
-  for (const auto & str_msg : string_messages) {
-    EXPECT_THAT(str_msg->string_value, Eq(string_message->string_value));
+  auto basic_type_messages =
+    filter_messages<test_msgs::msg::BasicTypes>(recorded_messages, test_topic);
+  EXPECT_THAT(basic_type_messages, SizeIs(expected_messages));
+
+  // Output debug info if test fails
+  if (basic_type_messages.size() != expected_messages) {
+    for (size_t i = 0; i < basic_type_messages.size(); i++) {
+      std::cerr << "=> basic_type_messages[" << i << "].uint64_value = " <<
+        basic_type_messages[i]->uint64_value << std::endl;
+      std::cerr << "basic_type_messages[" << i << "].int64_value = " <<
+        basic_type_messages[i]->int64_value << std::endl;
+    }
+  }
+
+  for (size_t i = 0; i < basic_type_messages.size(); i++) {
+    const uint64_t expected_u64_value = i % num_messages_to_publish;
+    EXPECT_THAT(basic_type_messages[i]->uint64_value, Eq(expected_u64_value));
   }
 }
 


### PR DESCRIPTION
This PR adds debug output for flaky `rosbag2_transport::can_record_again_after_stop` test.

Some times `can_record_again_after_stop` test fail with error messages like
```
/tmp/ws/src/rosbag2/rosbag2_transport/test/rosbag2_transport/test_record.cpp:167
Value of: recorded_messages
Expected: has a size that is equal to 4
  Actual: { (ptr = 0x7f429c0023e0, value = 64-byte object <60-23 00-9C 42-7F 00-00 F0-22 00-9C 42-7F 00-00 98-12 B6-45 47-6C 0A-18 D1-BA B5-45 47-6C 0A-18 10-24 00-9C 42-7F 00-00 0D-00 00-00 00-00 00-00 2F-73 74-72 69-6E 67-5F 74-6F 70-69 63-00 00-00>), (ptr = 0x7f429c003670, value = 64-byte object <F0-1E 00-9C 42-7F 00-00 70-18 00-9C 42-7F 00-00 BE-31 B3-48 47-6C 0A-18 5A-B9 B2-48 47-6C 0A-18 A0-36 00-9C 42-7F 00-00 0D-00 00-00 00-00 00-00 2F-73 74-72 69-6E 67-5F 74-6F 70-69 63-00 00-00>), (ptr = 0x7f429c003870, value = 64-byte object <10-37 00-9C 42-7F 00-00 70-33 00-9C 42-7F 00-00 D9-94 DA-4B 47-6C 0A-18 0D-7A DA-4B 47-6C 0A-18 A0-38 00-9C 42-7F 00-00 0D-00 00-00 00-00 00-00 2F-73 74-72 69-6E 67-5F 74-6F 70-69 63-00 00-00>), (ptr = 0x55695db64300, value = 64-byte object <50-D8 B5-5D 69-55 00-00 30-7C 9D-5D 69-55 00-00 3D-A9 DA-4B 47-6C 0A-18 0D-7A DA-4B 47-6C 0A-18 30-43 B6-5D 69-55 00-00 0D-00 00-00 00-00 00-00 2F-73 74-72 69-6E 67-5F 74-6F 70-69 63-00 00-00>), (ptr = 0x55695d9b0390, value = 64-byte object <00-05 9B-5D 69-55 00-00 10-F3 8F-5D 69-55 00-00 B2-0B D8-4E 47-6C 0A-18 33-7B D7-4E 47-6C 0A-18 C0-03 9B-5D 69-55 00-00 0D-00 00-00 00-00 00-00 2F-73 74-72 69-6E 67-5F 74-6F 70-69 63-00 00-00>) }, whose size 5 doesn't match


/tmp/ws/src/rosbag2/rosbag2_transport/test/rosbag2_transport/test_record.cpp:180
Value of: string_messages
Expected: has a size that is equal to 4
  Actual: { (ptr = 0x55695d7b3b70, value = 384-byte object <80-3B 7B-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-7F 00-00 A0-3B 7B-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-00 00-00 ... C0-3C 7B-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-27 77-6F 72-6C 64-21 00-00 00-00 E0-3C 7B-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-22 77-6F 72-6C 64-21 00-00 00-00>), (ptr = 0x55695d720600, value = 384-byte object <10-06 72-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-33 34-00 30-06 72-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-00 00-00 ... 50-07 72-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-27 77-6F 72-6C 64-21 00-00 00-00 70-07 72-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-22 77-6F 72-6C 64-21 00-00 00-00>), (ptr = 0x55695dba00b0, value = 384-byte object <C0-00 BA-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-21 00-00 E0-00 BA-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-00 00-00 ... 00-02 BA-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-27 77-6F 72-6C 64-21 00-00 00-00 20-02 BA-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-22 77-6F 72-6C 64-21 00-00 00-00>), (ptr = 0x55695db9e0b0, value = 384-byte object <C0-E0 B9-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-00 00-00 E0-E0 B9-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-00 00-00 ... 00-E2 B9-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-27 77-6F 72-6C 64-21 00-00 00-00 20-E2 B9-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-22 77-6F 72-6C 64-21 00-00 00-00>), (ptr = 0x55695d6669b0, value = 384-byte object <C0-69 66-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-21 00-00 E0-69 66-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-20 77-6F 72-6C 64-21 00-00 00-00 ... 00-6B 66-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-27 77-6F 72-6C 64-21 00-00 00-00 20-6B 66-5D 69-55 00-00 0C-00 00-00 00-00 00-00 48-65 6C-6C 6F-22 77-6F 72-6C 64-21 00-00 00-00>) }, whose size 5 doesn't match
```
Link to the failing rpr job https://build.ros2.org/job/Jpr__rosbag2__ubuntu_noble_amd64/66/testReport/junit/rosbag2_transport/RecordIntegrationTestFixture/can_record_again_after_stop/