### PR TITLE
Add more logging info to storage and reader/writer open operations

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -87,6 +87,10 @@ void SequentialReader::open(
   const rosbag2_storage::StorageOptions & storage_options,
   const ConverterOptions & converter_options)
 {
+  if (storage_options.uri.empty()) {
+    throw std::runtime_error("Can't open rosbag2_cpp::SequentialReader. The input URI is empty");
+  }
+
   storage_options_ = storage_options;
   base_folder_ = storage_options.uri;
 
@@ -108,7 +112,8 @@ void SequentialReader::open(
   } else {
     storage_ = storage_factory_->open_read_only(storage_options_);
     if (!storage_) {
-      throw std::runtime_error{"No storage could be initialized from the inputs."};
+      throw std::runtime_error("No storage could be initialized for the input uri: " +
+            storage_options.uri);
     }
     if (!set_read_order(read_order_)) {
       ROSBAG2_CPP_LOG_WARN(

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -112,7 +112,7 @@ void SequentialReader::open(
   } else {
     storage_ = storage_factory_->open_read_only(storage_options_);
     if (!storage_) {
-      throw std::runtime_error("No storage could be initialized for the input uri: " +
+      throw std::runtime_error("No storage could be initialized for the input URI: " +
             storage_options.uri);
     }
     if (!set_read_order(read_order_)) {

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -103,6 +103,10 @@ void SequentialWriter::open(
   if (is_open_) {
     return;  // The writer already opened
   }
+  if (storage_options.uri.empty()) {
+    throw std::runtime_error("Can't open rosbag2_cpp::SequentialWriter. The input URI is empty");
+  }
+
   base_folder_ = storage_options.uri;
   storage_options_ = storage_options;
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_storage_without_metadata_file.cpp
@@ -74,6 +74,7 @@ TEST_F(StorageWithoutMetadataFileTest, open_uses_storage_id_from_storage_options
   EXPECT_CALL(*metadata_io, metadata_file_exists).Times(1).WillOnce(Return(false));
 
   rosbag2_storage::StorageOptions storage_options;
+  storage_options.uri = "foo.bar";
   storage_options.storage_id = kStorageId;
 
   auto sequential_reader = std::make_unique<rosbag2_cpp::readers::SequentialReader>(

--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -17,10 +17,10 @@
 #define ROSBAG2_STORAGE__IMPL__STORAGE_FACTORY_IMPL_HPP_
 
 #include <algorithm>
-#include <vector>
 #include <memory>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "pluginlib/class_loader.hpp"
 

--- a/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
+++ b/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp
@@ -17,8 +17,10 @@
 #define ROSBAG2_STORAGE__IMPL__STORAGE_FACTORY_IMPL_HPP_
 
 #include <algorithm>
+#include <vector>
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 #include "pluginlib/class_loader.hpp"
 
@@ -160,19 +162,38 @@ public:
 
   virtual ~StorageFactoryImpl() = default;
 
+  std::unordered_set<std::string> get_registered_plugin_names()
+  {
+    std::vector<std::string> read_only_plugins = read_only_class_loader_->getDeclaredClasses();
+    std::vector<std::string> read_write_plugins = read_write_class_loader_->getDeclaredClasses();
+
+    // Merge read-only and read-write plugins
+    std::unordered_set<std::string> combined_plugins(
+      read_only_plugins.begin(), read_only_plugins.end());
+    combined_plugins.insert(read_write_plugins.begin(), read_write_plugins.end());
+    return combined_plugins;
+  }
+
   std::shared_ptr<ReadWriteInterface> open_read_write(const StorageOptions & storage_options)
   {
-    auto instance =
-      get_interface_instance(read_write_class_loader_, storage_options);
+    auto instance = get_interface_instance(read_write_class_loader_, storage_options);
 
     if (instance == nullptr) {
       if (storage_options.storage_id.empty()) {
         ROSBAG2_STORAGE_LOG_ERROR_STREAM(
-          "No storage id specified, and no plugin found that could open URI");
+          "No storage id specified, and no plugin found that could open URI: '" <<
+            storage_options.uri << "'");
       } else {
         ROSBAG2_STORAGE_LOG_ERROR_STREAM(
           "Could not load/open plugin with storage id '" << storage_options.storage_id << "'");
       }
+      auto available_plugins = read_write_class_loader_->getDeclaredClasses();
+      std::stringstream ss;
+      ss << "Available read-write storage plugins: ";
+      for (const auto & storage_plugin : available_plugins) {
+        ss << "'" << storage_plugin << "', ";
+      }
+      ROSBAG2_STORAGE_LOG_INFO("%s", ss.str().c_str());
     }
 
     return instance;
@@ -193,11 +214,19 @@ public:
     if (instance == nullptr) {
       if (storage_options.storage_id.empty()) {
         ROSBAG2_STORAGE_LOG_ERROR_STREAM(
-          "No storage id specified, and no plugin found that could open URI");
+          "No storage id specified, and no plugin found that could open URI: '" <<
+            storage_options.uri << "'");
       } else {
         ROSBAG2_STORAGE_LOG_ERROR_STREAM(
-          "Could not load/open plugin with storage id '" << storage_options.storage_id << "'");
+          "Could not load/open plugin with storage id: '" << storage_options.storage_id << "'");
       }
+      auto available_plugins = get_registered_plugin_names();
+      std::stringstream ss;
+      ss << "Available storage plugins: ";
+      for (const auto & storage_plugin : available_plugins) {
+        ss << "'" << storage_plugin << "', ";
+      }
+      ROSBAG2_STORAGE_LOG_INFO("%s", ss.str().c_str());
     }
 
     return instance;


### PR DESCRIPTION
This PR adds more logging information in cases when the reader or writer fails to open bag files.
- Added check if `storage.uri` is an empty string
- Print out a list of available storage plugins in case of failure to open a bag file
- Print out the value of the provided `storage.uri` if fail to open a bag file.