### PR TITLE
Handle transient local messages in snapshot mode when the buffer is full

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/cache/circular_message_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/circular_message_cache.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 
 #include "rcpputils/thread_safety_annotations.hpp"
 
@@ -28,6 +29,7 @@
 #include "rosbag2_cpp/cache/cache_buffer_interface.hpp"
 #include "rosbag2_cpp/visibility_control.hpp"
 
+#include "rosbag2_storage/rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
 // This is necessary because of using stl types here. It is completely safe, because
@@ -52,7 +54,9 @@ class ROSBAG2_CPP_PUBLIC CircularMessageCache
   : public MessageCacheInterface
 {
 public:
-  explicit CircularMessageCache(size_t max_buffer_size);
+  explicit CircularMessageCache(
+    size_t max_buffer_size, const std::unordered_map<std::string,
+    rosbag2_storage::TopicInformation> & topics_names_to_info);
 
   ~CircularMessageCache() override;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_circular_buffer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_circular_buffer.hpp
@@ -18,9 +18,12 @@
 #include <deque>
 #include <memory>
 #include <vector>
+#include <unordered_map>
+#include <string>
 
 #include "rosbag2_cpp/visibility_control.hpp"
 #include "rosbag2_cpp/cache/cache_buffer_interface.hpp"
+#include "rosbag2_storage/rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
 // This is necessary because of using stl types here. It is completely safe, because
@@ -51,7 +54,9 @@ class ROSBAG2_CPP_PUBLIC MessageCacheCircularBuffer
 public:
   // Delete default constructor since max_cache_size is required
   MessageCacheCircularBuffer() = delete;
-  explicit MessageCacheCircularBuffer(size_t max_cache_size);
+  explicit MessageCacheCircularBuffer(
+    size_t max_cache_size, const std::unordered_map<std::string,
+    rosbag2_storage::TopicInformation> & topics_names_to_info);
 
   /**
   * If buffer size has some space left, we push the message regardless of its size,
@@ -73,6 +78,7 @@ private:
   std::vector<CacheBufferInterface::buffer_element_t> msg_vector_;
   size_t buffer_bytes_size_ {0u};
   const size_t max_bytes_size_;
+  const std::unordered_map<std::string, rosbag2_storage::TopicInformation> & topics_names_to_info_;
 };
 
 }  // namespace cache

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
@@ -27,10 +27,16 @@ namespace rosbag2_cpp
 namespace cache
 {
 
-CircularMessageCache::CircularMessageCache(size_t max_buffer_size)
+CircularMessageCache::CircularMessageCache(
+  size_t max_buffer_size,
+  const std::unordered_map<std::string, rosbag2_storage::TopicInformation> & topics_names_to_info)
 {
-  producer_buffer_ = std::make_shared<MessageCacheCircularBuffer>(max_buffer_size);
-  consumer_buffer_ = std::make_shared<MessageCacheCircularBuffer>(max_buffer_size);
+  producer_buffer_ = std::make_shared<MessageCacheCircularBuffer>(
+    max_buffer_size,
+    topics_names_to_info);
+  consumer_buffer_ = std::make_shared<MessageCacheCircularBuffer>(
+    max_buffer_size,
+    topics_names_to_info);
 }
 
 CircularMessageCache::~CircularMessageCache()

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -160,7 +160,7 @@ void SequentialWriter::open(
   if (use_cache_) {
     if (storage_options.snapshot_mode) {
       message_cache_ = std::make_shared<rosbag2_cpp::cache::CircularMessageCache>(
-        storage_options.max_cache_size);
+        storage_options.max_cache_size, topics_names_to_info_);
     } else {
       message_cache_ = std::make_shared<rosbag2_cpp::cache::MessageCache>(
         storage_options.max_cache_size);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
@@ -72,8 +72,9 @@ public:
 TEST_F(CircularMessageCacheTest, circular_message_cache_overwrites_old) {
   const unsigned message_count = 100;
 
+  std::unordered_map<std::string, rosbag2_storage::TopicInformation> topics_names_to_info;
   auto circular_message_cache = std::make_shared<rosbag2_cpp::cache::CircularMessageCache>(
-    cache_size_);
+    cache_size_, topics_names_to_info);
 
   for (unsigned i = 0; i < message_count; ++i) {
     auto msg = make_test_msg();
@@ -109,8 +110,9 @@ TEST_F(CircularMessageCacheTest, circular_message_cache_overwrites_old) {
 TEST_F(CircularMessageCacheTest, circular_message_cache_ensure_empty) {
   const unsigned message_count = 100;
 
+  std::unordered_map<std::string, rosbag2_storage::TopicInformation> topics_names_to_info;
   auto circular_message_cache = std::make_shared<rosbag2_cpp::cache::CircularMessageCache>(
-    cache_size_);
+    cache_size_, topics_names_to_info);
 
   for (unsigned i = 0; i < message_count; ++i) {
     auto msg = make_test_msg();


### PR DESCRIPTION
Draft to discuss ways of solving https://github.com/ros2/rosbag2/issues/1886

Naive solution which throws away the first message that is not transient local when the buffer is full, as long as the number of messages at the beginning of the buffer accounts for less than 10% of the total number of messages in the buffer.

That will not solve completely the `/tf_static` use case if other transient local messages are recorded and periodically published: at some point there will be more than 10% of transient local messages in the buffer, and the first ones (i.e `/tf_static`) will be removed.

Interested in debating and suggestions on how to solve this properly :
- Different buffers for each transient local topic ? But then how to control their max size ?
- A buffer dedicated to `/tf_static`? But then loss of generality.
- Something else ?