### PR TITLE
Bugfix: Event publisher not starting for second run Recorder::Record() after Stop()

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -328,7 +328,11 @@ void RecorderImpl::record()
     node->create_publisher<rosbag2_interfaces::msg::WriteSplitEvent>("events/write_split", 1);
 
   // Start the thread that will publish events
-  event_publisher_thread_ = std::thread(&RecorderImpl::event_publisher_thread_main, this);
+  {
+    std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+    event_publisher_thread_should_exit_ = false;
+    event_publisher_thread_ = std::thread(&RecorderImpl::event_publisher_thread_main, this);
+  }
 
   rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
   callbacks.write_split_callback =


### PR DESCRIPTION
This PR fixes a bug when the event publisher thread, which is responsible for publishing `on_bag_split_event` events, doesn't start when calling `Recorder::Record()` after a previous call to `Recorder::Stop()`.

RCA: The event publisher thread was starting and exiting immediately because `event_publisher_thread_should_exit_` was not initialized to false after calling the `Recorder::Stop()` API.