### PR TITLE
Use tmpfs in rosbag2 temporary_directory_fixture

### DIFF
--- a/rosbag2_test_common/CMakeLists.txt
+++ b/rosbag2_test_common/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(test_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -34,7 +34,7 @@ public:
   TemporaryDirectoryFixture()
   {
     std::filesystem::path parent_path = std::filesystem::path("/tmpfs");
-    if (!std::filesystem::exists(std::filesystem::path("/tmpfs"))) {
+    if (!std::filesystem::exists(parent_path)) {
       std::cerr << "The '/tmpfs' doesn't exist, falling back to the default temp directory \n";
       parent_path = std::filesystem::temp_directory_path();
     }

--- a/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/temporary_directory_fixture.hpp
@@ -17,6 +17,8 @@
 
 #include <gmock/gmock.h>
 
+#include <filesystem>
+#include <iostream>
 #include <string>
 
 #include "rcpputils/filesystem_helper.hpp"
@@ -31,7 +33,14 @@ class TemporaryDirectoryFixture : public Test
 public:
   TemporaryDirectoryFixture()
   {
-    temporary_dir_path_ = rcpputils::fs::create_temporary_directory("tmp_test_dir_").string();
+    std::filesystem::path parent_path = std::filesystem::path("/tmpfs");
+    if (!std::filesystem::exists(std::filesystem::path("/tmpfs"))) {
+      std::cerr << "The '/tmpfs' doesn't exist, falling back to the default temp directory \n";
+      parent_path = std::filesystem::temp_directory_path();
+    }
+
+    temporary_dir_path_ =
+      rcpputils::fs::create_temporary_directory("tmp_test_dir_", parent_path).string();
   }
 
   ~TemporaryDirectoryFixture() override

--- a/rosbag2_test_common/package.xml
+++ b/rosbag2_test_common/package.xml
@@ -15,10 +15,12 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
+  <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>test_msgs</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>test_msgs</exec_depend>
 

--- a/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_rewrite.cpp
@@ -19,11 +19,13 @@
 #include <vector>
 #include <utility>
 
+#include "rosbag2_test_common/temporary_directory_fixture.hpp"
 #include "rosbag2_test_common/tested_storage_ids.hpp"
 #include "rosbag2_transport/bag_rewrite.hpp"
 #include "rosbag2_transport/reader_writer_factory.hpp"
 
 using namespace ::testing;  // NOLINT
+using namespace rosbag2_test_common;  // NOLINT
 
 namespace fs = std::filesystem;
 
@@ -48,13 +50,12 @@ rewriter_b:
     - 50 messages
     - 1 offered QoS Profile
 */
-class TestRewrite : public Test, public WithParamInterface<std::string>
+class TestRewrite : public ParametrizedTemporaryDirectoryFixture
 {
 public:
   TestRewrite()
   {
-    auto tmp_dir = rcpputils::fs::create_temporary_directory("test_bag_rewrite");
-    output_dir_ = fs::path(tmp_dir.string());
+    output_dir_ = fs::path(temporary_dir_path_);
     storage_id_ = GetParam();
     bags_path_ = fs::path(_SRC_RESOURCES_DIR_PATH) / storage_id_;
   }
@@ -75,10 +76,7 @@ public:
     input_bags_.push_back(storage);
   }
 
-  ~TestRewrite()
-  {
-    fs::remove_all(output_dir_);
-  }
+  ~TestRewrite() override = default;
 
   fs::path output_dir_;
   fs::path bags_path_{_SRC_RESOURCES_DIR_PATH};


### PR DESCRIPTION
Trying to address flakiness in the `rosbag2_end_to_end` tests due to the slow filesystem on CI machines.

- Use `tmpfs` in `rosbag2 temporary_directory_fixture if it is available.
- Added missing `rcpputils` dependency in rosbag2_test_common package.
- Use ParametrizedTemporaryDirectoryFixture in the "rosbag2_transport/test_rewrite.cpp".