### PR TITLE
Upstream quality changes from Apex.AI part-2

### DIFF
--- a/docs/message_definition_encoding.md
+++ b/docs/message_definition_encoding.md
@@ -16,10 +16,14 @@ This set of definitions with all field types recursively included can be called 
 
 ## `ros2msg` encoding
 
-This encoding consists of definitions in [.msg](https://docs.ros.org/en/rolling/Concepts/Basic/About-Interfaces.html#messages) and [.srv](https://docs.ros.org/en/rolling/Concepts/Basic/About-Interfaces.html#services) format, concatenated together in human-readable form with
+This encoding consists of definitions in
+[.msg](https://docs.ros.org/en/rolling/Concepts/Basic/About-Interfaces.html#messages) and
+[.srv](https://docs.ros.org/en/rolling/Concepts/Basic/About-Interfaces.html#services) format,
+concatenated together in human-readable form with
 a delimiter.
 
-The top-level message definition is present first, with no delimiter. All dependent .msg definitions are preceded by a two-line delimiter:
+The top-level message definition is present first, with no delimiter. All dependent .msg definitions
+are preceded by a two-line delimiter:
 
 * One line containing exactly 80 `=` characters
 * One line containing `MSG: <package resource name>` for that type. The space between MSG: and the
@@ -29,7 +33,7 @@ The top-level message definition is present first, with no delimiter. All depend
 
 For example, the complete message definition for `my_msgs/msg/ExampleMsg` in `ros2msg` form is:
 
-```
+```ini
 # defines a message that includes a field of a custom message type
 my_msgs/BasicMsg my_basic_field
 ================================================================================
@@ -40,7 +44,7 @@ float32 my_float
 
 Another example is a service message definition for `my_msgs/srv/ExampleSrv` in `ros2msg` form
 
-```
+```ini
 # defines a service message that includes a field of a custom message type
 my_msgs/BasicMsg request
 ---
@@ -53,16 +57,20 @@ float32 my_float
 
 ## `ros2idl` encoding
 
-The IDL definition of the type specified by name along with all dependent types are stored together. The IDL definitions can be stored in any order. Every definition is preceded by a two-line delimiter:
+The IDL definition of the type specified by name along with all dependent types are stored together.
+The IDL definitions can be stored in any order. Every definition is preceded by a two-line
+delimiter:
 
 * a line containing exactly 80 `=` characters, then
-* A line containing only `IDL: <package resource name>` for that definition. The space between IDL: and the package resource name is mandatory. The package resource name does not include a file extension.
+* A line containing only `IDL: <package resource name>` for that definition. The space between IDL:
+  and the package resource name is mandatory. The package resource name does not include a file
+  extension.
 
 ### `ros2idl` example
 
 For example, the complete message definition for `my_msgs/msg/ComplexMsg` in `ros2idl` form is:
 
-```
+```idl
 ================================================================================
 IDL: my_msgs/msg/ComplexMsg
 // generated from rosidl_adapter/resource/msg.idl.em

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -242,7 +242,7 @@ def check_necessary_argument(args):
 def validate_parsed_arguments(args, uri) -> str:
     if args.topics_positional:
         print(print_warn('Positional "topics" argument deprecated. '
-                         'Please use optional "--topics" argument instead.'))
+                         'Please use optional "--topics" argument instead.'), flush=True)
         args.topics = args.topics_positional
 
     if not check_necessary_argument(args):
@@ -274,17 +274,17 @@ def validate_parsed_arguments(args, uri) -> str:
                            'or --regex')
 
     if (args.all or args.all_services) and args.services:
-        print(print_warn('--all or --all-services will override --services'))
+        print(print_warn('--all or --all-services will override --services'), flush=True)
 
     if (args.all or args.all_topics) and args.topics:
-        print(print_warn('--all or --all-topics will override --topics'))
+        print(print_warn('--all or --all-topics will override --topics'), flush=True)
 
     if (args.all or args.all_actions) and args.actions:
         print(print_warn('--all or --all-actions will override --actions'))
 
     if (args.all or args.all_topics or args.all_services or args.all_actions) and args.regex:
         print(print_warn('--all, --all-topics --all-services or --all-actions will override '
-                         '--regex'))
+                         '--regex'),  flush=True)
 
     if os.path.isdir(uri):
         return print_error("Output folder '{}' already exists.".format(uri))

--- a/rosbag2_cpp/src/rosbag2_cpp/info.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/info.cpp
@@ -17,8 +17,11 @@
 #include <filesystem>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
+#include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "rmw/rmw.h"
 #include "rosidl_typesupport_cpp/message_type_support.hpp"

--- a/rosbag2_cpp/src/rosbag2_cpp/info.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/info.cpp
@@ -12,26 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rosbag2_cpp/info.hpp"
-
 #include <filesystem>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "rmw/rmw.h"
-#include "rosidl_typesupport_cpp/message_type_support.hpp"
-#include "service_msgs/msg/service_event_info.hpp"
-
 #include "rosbag2_cpp/action_utils.hpp"
+#include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/service_utils.hpp"
-
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "service_msgs/msg/service_event_info.hpp"
 
 namespace fs = std::filesystem;
 

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -192,7 +192,8 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   try {
     share_dir = ament_index_cpp::get_package_share_directory(package);
   } catch (const ament_index_cpp::PackageNotFoundError & e) {
-    ROSBAG2_CPP_LOG_WARN("'%s'", e.what());
+    ROSBAG2_CPP_LOG_WARN(
+      "get_package_share_directory(%s) failed with error: '%s'", package.c_str(), e.what());
     throw DefinitionNotFoundError(definition_identifier.topic_type());
   }
   std::string dir;
@@ -265,7 +266,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
       result = (delimiter(root_definition_identifier) +
         append_recursive(root_definition_identifier, max_recursion_depth));
     } catch (const TypenameNotUnderstoodError & err) {
-      ROSBAG2_CPP_LOG_ERROR(
+      ROSBAG2_CPP_LOG_WARN(
         "Message type name '%s' not understood by type definition search, "
         "definition will be left empty in bag.", err.what());
       format = Format::UNKNOWN;
@@ -305,7 +306,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
             format = Format::IDL;
           }
         } catch (const TypenameNotUnderstoodError & err) {
-          ROSBAG2_CPP_LOG_ERROR(
+          ROSBAG2_CPP_LOG_WARN(
             "Message type name '%s' not understood by type definition search, "
             "definition will be left empty in bag.", err.what());
           format = Format::UNKNOWN;

--- a/rosbag2_cpp/src/rosbag2_cpp/service_utils.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/service_utils.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstring>
+#include <string>
 
 #include "rcl/service_introspection.h"
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_service_utils.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_service_utils.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <utility>
 
 #include "rosbag2_cpp/service_utils.hpp"
 #include "rosbag2_test_common/memory_management.hpp"

--- a/rosbag2_cpp/test/rosbag2_cpp/test_service_utils.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_service_utils.cpp
@@ -15,8 +15,8 @@
 
 #include <string>
 #include <tuple>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "rosbag2_cpp/service_utils.hpp"
 #include "rosbag2_test_common/memory_management.hpp"

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/data_generator_executable.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/data_generator_executable.py
@@ -43,6 +43,8 @@ def main(args=None):
             serialize_message(data),
             time_stamp.nanoseconds)
         time_stamp += Duration(seconds=1)
+    writer.close()
+    print("Generated data saved into the '%s'" % storage_options.uri)
 
 
 if __name__ == '__main__':

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/data_generator_node.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/data_generator_node.py
@@ -29,7 +29,7 @@ class DataGeneratorNode(Node):
 
         storage_options = rosbag2_py.StorageOptions(
             uri='timed_synthetic_bag',
-            storage_id='sqlite3')
+            storage_id='mcap')
         converter_options = rosbag2_py.ConverterOptions('', '')
         self.writer.open(storage_options, converter_options)
 

--- a/rosbag2_performance/rosbag2_performance_benchmarking/include/msg_utils/message_producer.hpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/include/msg_utils/message_producer.hpp
@@ -33,7 +33,7 @@ public:
 };
 
 template<typename T>
-class MessageProducer : public ProducerBase
+class MessageProducer final : public ProducerBase
 {
 public:
   MessageProducer(rclcpp::Node & node, std::string topic, const PublisherGroupConfig & config);

--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/writer_benchmark.cpp
@@ -58,7 +58,6 @@ void WriterBenchmark::start_benchmark()
   RCLCPP_INFO(get_logger(), "Starting the WriterBenchmark");
   start_producers();
   while (rclcpp::ok()) {
-    int count = 0;
     unsigned int complete_count = 0;
 
     // TODO(adamdbrw) Performance can be improved. Use conditional variables
@@ -121,7 +120,6 @@ void WriterBenchmark::start_benchmark()
         } catch (const std::runtime_error & e) {
           RCLCPP_ERROR_STREAM(get_logger(), "Failed to record: " << e.what());
         }
-        ++count;
       }
     }
     if (complete_count == queues_.size()) {

--- a/rosbag2_py/src/rosbag2_py/_info.cpp
+++ b/rosbag2_py/src/rosbag2_py/_info.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 #include <algorithm>
 
 #include "info_sorting_method.hpp"

--- a/rosbag2_py/src/rosbag2_py/_info.cpp
+++ b/rosbag2_py/src/rosbag2_py/_info.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "info_sorting_method.hpp"
 #include "format_bag_metadata.hpp"

--- a/rosbag2_py/src/rosbag2_py/format_service_info.cpp
+++ b/rosbag2_py/src/rosbag2_py/format_service_info.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <vector>
+#include <memory>
 #include <sstream>
+#include <string>
 
 #include "format_service_info.hpp"
 #include "format_utils.hpp"

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -29,7 +29,7 @@ from rosbag2_test_common import TESTED_STORAGE_IDS
 from std_msgs.msg import String
 
 
-RESOURCES_PATH = Path(__file__).parent / 'resources'
+RESOURCES_PATH = Path(os.environ['ROSBAG2_PY_TEST_RESOURCES_DIR'])
 PLAYBACK_UNTIL_TIMESTAMP_REGEX_STRING = r'\[rosbag2_player]: Playback until timestamp: -1'
 
 

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import datetime
 from pathlib import Path
 import re
@@ -117,6 +118,8 @@ def test_record_cancel(tmp_path, storage_id):
 @pytest.mark.parametrize('storage_id', TESTED_STORAGE_IDS)
 def test_play_cancel(storage_id, capfd):
     bag_path = str(RESOURCES_PATH / storage_id / 'talker')
+    assert os.path.exists(bag_path), 'Could not find test bag file: ' + bag_path
+
     storage_options, converter_options = get_rosbag_options(bag_path, storage_id)
 
     player = rosbag2_py.Player()
@@ -131,18 +134,24 @@ def test_play_cancel(storage_id, capfd):
         daemon=True)
     player_thread.start()
 
-    def check_playback_start_output(cumulative_out, cumulative_err):
+    def check_playback_start_output(cap_streams):
         out, err = capfd.readouterr()
-        cumulative_err += err
-        cumulative_out += out
+        cap_streams["err"] += err
+        cap_streams["out"] += out
         expected_string_regex = re.compile(PLAYBACK_UNTIL_TIMESTAMP_REGEX_STRING)
-        matches = expected_string_regex.search(cumulative_err)
+        matches = expected_string_regex.search(cap_streams["err"])
         return matches is not None
 
-    captured_out = ''
-    captured_err = ''
-    assert wait_for(lambda: check_playback_start_output(captured_out, captured_err),
-                    timeout=rclpy.duration.Duration(seconds=3))
+    captured_streams = {"out": '', "err": ''}
+
+    if not wait_for(lambda: check_playback_start_output(captured_streams),
+                    timeout=rclpy.duration.Duration(seconds=5)):
+        with capfd.disabled():
+            print("\nCaptured stdout:", captured_streams["out"])
+            print("\nCaptured stderr:", captured_streams["err"])
+        player.cancel()
+        player_thread.join()
+        assert False
 
     player.cancel()
     player_thread.join(3)

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import datetime
+import os
 from pathlib import Path
 import re
 import threading
@@ -136,19 +136,19 @@ def test_play_cancel(storage_id, capfd):
 
     def check_playback_start_output(cap_streams):
         out, err = capfd.readouterr()
-        cap_streams["err"] += err
-        cap_streams["out"] += out
+        cap_streams['err'] += err
+        cap_streams['out'] += out
         expected_string_regex = re.compile(PLAYBACK_UNTIL_TIMESTAMP_REGEX_STRING)
-        matches = expected_string_regex.search(cap_streams["err"])
+        matches = expected_string_regex.search(cap_streams['err'])
         return matches is not None
 
-    captured_streams = {"out": '', "err": ''}
+    captured_streams = {'out': '', 'err': ''}
 
     if not wait_for(lambda: check_playback_start_output(captured_streams),
                     timeout=rclpy.duration.Duration(seconds=5)):
         with capfd.disabled():
-            print("\nCaptured stdout:", captured_streams["out"])
-            print("\nCaptured stderr:", captured_streams["err"])
+            print('\nCaptured stdout:', captured_streams['out'])
+            print('\nCaptured stderr:', captured_streams['err'])
         player.cancel()
         player_thread.join()
         assert False

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -19,9 +19,9 @@
 #include <atomic>
 #include <chrono>
 #include <cstring>
-#include <filesystem>
-#include <fstream>
+#include <filesystem>  // NOLINT cpplint: FP, filesystem is a C++17 system header
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
@@ -20,7 +20,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
-#include <filesystem>
+#include <filesystem>  // NOLINT cpplint: FP, filesystem is a C++17 system header
 #include <fstream>
 #include <memory>
 #include <string>

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -15,7 +15,7 @@
 #include <gmock/gmock.h>
 
 #include <algorithm>
-#include <filesystem>
+#include <filesystem>  // NOLINT cpplint: FP, filesystem is a C++17 system header
 #include <limits>
 #include <memory>
 #include <string>

--- a/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/process_execution_helpers_unix.hpp
@@ -116,9 +116,13 @@ bool wait_until_completion(
     // WNOHANG - wait for processes without causing the caller to be blocked
     wait_ret_code = waitpid(process_id, &status, WNOHANG);
   }
+  EXPECT_NE(wait_ret_code, 0) << "Testing process " << process_id << " hangout.\n";
   EXPECT_NE(wait_ret_code, -1);
   EXPECT_EQ(wait_ret_code, process_id) << "status = " << status;
-  return wait_ret_code != 0;
+  EXPECT_EQ(WIFEXITED(status), true) << "status = " << status;
+  EXPECT_EQ(WIFSIGNALED(status), false) << "Process terminated by signal: " << WTERMSIG(status);
+  EXPECT_EQ(WEXITSTATUS(status), EXIT_SUCCESS) << "status = " << status;
+  return WIFSIGNALED(status) != true && WEXITSTATUS(status) == EXIT_SUCCESS;
 }
 
 /// @brief Force to stop process with signal if it's currently running

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -14,11 +14,13 @@
 
 #include <gmock/gmock.h>
 
-#include <atomic>
-#include <chrono>
 #include <filesystem>
+#include <chrono>
+#include <vector>
+#include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/writer.hpp"

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -14,13 +14,13 @@
 
 #include <gmock/gmock.h>
 
-#include <filesystem>
 #include <chrono>
-#include <vector>
+#include <filesystem>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "rosbag2_cpp/info.hpp"
 #include "rosbag2_cpp/writer.hpp"

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_storage_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_storage_api.cpp
@@ -75,8 +75,8 @@ public:
       for (size_t msg_idx = 0; msg_idx < num_msgs_per_topic; msg_idx++) {
         auto std_string_msg = std::make_shared<std_msgs::msg::String>();
         std::stringstream ss;
-        for (int i = 0; i < 100; i++) {
-          ss << topic << "_long_long_string_message_" << msg_idx + 1 << "_repeat_";
+        for (int i = 0; i < 5; i++) {
+          ss << topic << "_long_string_message_" << msg_idx + 1 << "_repeat_";
         }
         std_string_msg->data = ss.str();
 
@@ -133,7 +133,7 @@ TEST_P(Rosbag2StorageAPITests, get_bagfile_size_read_write_interface)
     factory.open_read_write(options);
 
   std::vector<std::string> topics = {"topic1_topic1", "topic2_topic2"};
-  auto serialized_messages = prepare_serialized_messages(topics, 500);
+  auto serialized_messages = prepare_serialized_messages(topics, 500 * 20);
   create_topics(rw_storage, topics);
 
   rw_storage->write(serialized_messages);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -456,7 +456,8 @@ void RecorderImpl::stop_discovery()
   std::lock_guard<std::mutex> state_lock(discovery_mutex_);
   if (discovery_running_.exchange(false)) {
     if (discovery_future_.valid()) {
-      auto status = discovery_future_.wait_for(2 * record_options_.topic_polling_interval);
+      auto status = discovery_future_.wait_for(
+        std::chrono::milliseconds(500) + record_options_.topic_polling_interval);
       if (status != std::future_status::ready) {
         RCLCPP_ERROR_STREAM(
           node->get_logger(),

--- a/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
@@ -200,8 +200,8 @@ TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_play_next) {
   ASSERT_TRUE(player->play_next());
   ASSERT_TRUE(player->play_next());
   ASSERT_TRUE(player->is_paused());
-  player->resume();
   auto start = std::chrono::steady_clock::now();
+  player->resume();
   player->wait_for_playback_to_finish();
   auto replay_time = std::chrono::steady_clock::now() - start;
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -248,8 +248,8 @@ protected:
 public:
   // Basic configuration
   const std::string player_name_ = "rosbag2_player_for_test_srvs";
-  const std::chrono::seconds service_wait_timeout_ {2};
-  const std::chrono::seconds service_call_timeout_ {3};
+  const std::chrono::seconds service_wait_timeout_ {6};
+  const std::chrono::seconds service_call_timeout_ {6};
   const std::string test_topic_ = "/player_srvs_test_topic";
   // publishing at 50hz
   const size_t ms_between_msgs_ = 20;

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -172,7 +172,7 @@ public:
   void expect_messages(bool messages_should_arrive, bool reset_message_counter = true)
   {
     // Not too worried about the exact timing in this test, give a lot of leeway
-    const auto condition_clear_time = std::chrono::milliseconds(ms_between_msgs_ * 10);
+    const auto condition_clear_time = std::chrono::milliseconds(ms_between_msgs_ * 100);
     std::unique_lock<std::mutex> lock(got_msg_mutex_);
     if (reset_message_counter) {
       message_counter_ = 0;
@@ -217,6 +217,7 @@ private:
     player_->pause();  // Start playing in pause mode. Require for play_next test. For all other
     // tests we will resume playback via explicit call to start_playback().
     player_->play();
+    player_->wait_for_playback_to_start();
   }
 
   void topic_callback(std::shared_ptr<const test_msgs::msg::BasicTypes>/* msg */)

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -163,10 +163,10 @@ TEST_F(PlayerTestFixture, playing_rate_negative)
 
 TEST_F(PlayerTestFixture, playing_respects_delay)
 {
-  rclcpp::Duration delay_margin(1, 0);
+  rclcpp::Duration delay_margin(0, static_cast<uint32_t>(RCUTILS_S_TO_NS(0.5)));
 
-  // Sleep 5.0 seconds before play
-  play_options_.delay = rclcpp::Duration(5, 0);
+  // Sleep 1.0 seconds before play
+  play_options_.delay = rclcpp::Duration(1, 0);
   auto lower_expected_duration = message_time_difference + play_options_.delay;
   auto upper_expected_duration = message_time_difference + play_options_.delay + delay_margin;
   auto player = std::make_shared<rosbag2_transport::Player>(

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -29,6 +29,7 @@
 
 #include "rosbag2_transport_test_fixture.hpp"
 
+using namespace std::chrono_literals;  // NOLINT
 using namespace ::testing;  // NOLINT
 using namespace rosbag2_transport;  // NOLINT
 
@@ -163,7 +164,7 @@ TEST_F(PlayerTestFixture, playing_rate_negative)
 
 TEST_F(PlayerTestFixture, playing_respects_delay)
 {
-  rclcpp::Duration delay_margin(0, static_cast<uint32_t>(RCUTILS_S_TO_NS(0.5)));
+  rclcpp::Duration delay_margin(0.5s);
 
   // Sleep 1.0 seconds before play
   play_options_.delay = rclcpp::Duration(1, 0);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
+#include <string>
 
 #include "rosbag2_transport/record_options.hpp"
 


### PR DESCRIPTION
This PR consolidates fixes related to the code quality and stability after backporting Rosbag2 PRs to Apex.AI. PART 2

List of changes:

1. Fix for `record_if_topic_list_service_list_and_all_are_specified`
  Details: Flush output from Python print when printing warnings. Some tests rely on the warning output to be in the std::cout. Without flushing, the warnings may not be captured by tests.
1. Fix for flaky `test_play_services`
  Details: Increase timeouts for service calls in rosbag2_transport `test_play_services` tests
1. Address unused variable warning on the clang16 build
1. Mark `MessageProducer<T>` as final to address clang16 warnings "destructor called on non-final 'msg_utils::MessageProducer<T>' that has virtual functions but non-virtual destructor"
1. Fix linter warnings in the `message_definition_encoding.md`
1. Mitigate flakiness in `record_all_include_unpublished_false`
  Details: Increase timeout when waiting to stop discovery at least to 0.5 sec. The `record_all_include_unpublished_false_includes_later_published` tends to be flaky due to the insufficient timeout for waiting to stop the discovery thread in the recorder.
1. Use `RESOURCES_PATH` from envar in the `test_transport.py`
  Rationale: Fix to avoid failure with remote test execution and to be consistent with other similar tests.
1. Reduce runtime for the `PlayerTestFixture.playing_respects_delay`
1. Fix for flaky `play_respect_messages_timing_after_play_next`.
 Details: Take the start timestamp before calling resume for the player.
1. Add debug info to flaky `test_play_cancel`
1. Print warnings instead of errors for not-found type definitions
1. Adjust `test_rosbag2_storage_api.cpp` for bounded strings.
  Details:  Reduce the size of each `std_string_msg` to fit in a 256-byte boundary.
1. Address CPPLint warnings in the `rosbag2_storage_sqlite3`
1. Fix CPP_LINT warnings about missing include headers
1. Address flakiness in `test_play_services`.
  Details: Increase timeout for `expect_messages(..)`. Also add `player_->wait_for_playback_to_start();` in `setup_player()`
1. Fix for incorrectly handling exit code in `wait_until_completion(..)`