### PR TITLE
Address windows warnings in the progress bar class

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/player_progress_bar.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player_progress_bar.hpp
@@ -21,6 +21,20 @@
 #include "rcutils/time.h"
 #include "rosbag2_transport/visibility_control.hpp"
 
+#ifdef _WIN32
+#  pragma warning(push)
+// Suppress warning "rosbag2_transport::PlayerProgressBar::pimpl_': class 'std::unique_ptr>' needs
+// to have dll-interface to be used by clients of class 'rosbag2_transport::PlayerProgressBar'"
+// Justification:
+// 1. We never inline code in the header that actually calls methods on PlayerProgressBarImpl.
+// 2. While the `PlayerProgressBarImpl` is defined in the `player_progress_bar_impl.hpp` file, we
+// include it only in the `player_progress_bar.cpp` file, and it does not leak into the external
+// API.
+// 3. The pimpl design pattern imply that implementation details are hidden and shouldn't be
+// exposed with the dll-interface.
+#  pragma warning(disable:4251)
+#endif
+
 namespace rosbag2_transport
 {
 class PlayerProgressBarImpl;
@@ -92,5 +106,9 @@ private:
 };
 
 }  // namespace rosbag2_transport
+
+#ifdef _WIN32
+#  pragma warning(pop)
+#endif
 
 #endif  // ROSBAG2_TRANSPORT__PLAYER_PROGRESS_BAR_HPP_

--- a/rosbag2_transport/test/rosbag2_transport/test_player_progress_bar.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_player_progress_bar.cpp
@@ -226,10 +226,10 @@ TEST_F(TestPlayerProgressBar, update_with_limited_rate_respect_update_rate) {
 
   // Test if update rate of the progress bar is respected
   std::ostringstream oss;
-  const size_t update_rate = 4;
+  const int32_t update_rate = 4;
   const rcutils_duration_value_t update_period_ns = RCUTILS_S_TO_NS(1) / update_rate;
   auto progress_bar =
-    std::make_unique<PlayerProgressBar>(oss, starting_time, ending_time, update_rate, 0);
+    std::make_unique<PlayerProgressBar>(oss, starting_time, ending_time, update_rate, 0U);
 
   std::vector<rcutils_time_point_value_t> timestamps;
   timestamps.push_back(starting_time);  // 1st update of the progress bar


### PR DESCRIPTION
This PR addresses MSVS compiler warnings found on nightly CI jobs.
- Closes https://github.com/ros2/rosbag2/issues/1926