### PR TITLE
Do not crash on failed writes but skip the file

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -333,10 +333,8 @@ void SequentialWriter::switch_to_next_storage()
     metadata_.relative_file_paths.size());
   storage_ = storage_factory_->open_read_write(storage_options_);
   if (!storage_) {
-    std::stringstream errmsg;
-    errmsg << "Failed to rollover bagfile to new file: \"" << storage_options_.uri << "\"!";
-
-    throw std::runtime_error(errmsg.str());
+    ROSBAG2_CPP_LOG_ERROR_STREAM("Failed to rollover bagfile to new file: \"" <<
+          storage_options_.uri << "\"! Nothing will be written until the next split.");
   }
 
   rosbag2_storage::FileInformation file_info{};


### PR DESCRIPTION
In the current implementation when a write cannot be performed, the recorder node crashes.

But since we have it running in a composable container with other  nodes, this takes down much more than it should.

So I propose to handle this a bit more graceful.