### PR TITLE
Fix for failing test_record_qos_profiles on Windows

### DIFF
--- a/ros2bag/test/test_record.py
+++ b/ros2bag/test/test_record.py
@@ -57,7 +57,7 @@ class TestRecord(unittest.TestCase):
             process=record_all_process
         )
         proc_output.assertWaitFor(
-            "Subscribed to topic '/rosout'",
+            'Recording...',
             process=record_all_process
         )
 

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -72,7 +72,7 @@ class TestRos2BagRecord(unittest.TestCase):
     def tearDownClass(cls):
         try:
             cls.tmpdir.cleanup()
-        except OSError:
+        except (OSError, PermissionError):
             if sys.platform != 'win32':
                 raise
             # HACK to allow Windows to close pending file handles

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -72,7 +72,7 @@ class TestRos2BagRecord(unittest.TestCase):
     def tearDownClass(cls):
         try:
             cls.tmpdir.cleanup()
-        except (OSError, PermissionError):
+        except OSError:
             if sys.platform != 'win32':
                 raise
             # HACK to allow Windows to close pending file handles

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -86,7 +86,7 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmp_dir_name) / 'ros2bag_test_basic'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_output = 'Listening for topics...'
+        expected_output = 'Recording...'
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_output in output,
@@ -101,7 +101,7 @@ class TestRos2BagRecord(unittest.TestCase):
         output_path = Path(self.tmp_dir_name) / 'ros2bag_test_incomplete'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
-        expected_output = 'Listening for topics...'
+        expected_output = 'Recording...'
         with self.launch_bag_command(arguments=arguments) as bag_command:
             bag_command.wait_for_output(
                 condition=lambda output: expected_output in output,

--- a/ros2bag/test/test_record_qos_profiles.py
+++ b/ros2bag/test/test_record_qos_profiles.py
@@ -15,6 +15,7 @@
 import contextlib
 from pathlib import Path
 import re
+import shutil
 import sys
 import tempfile
 import time
@@ -66,22 +67,23 @@ class TestRos2BagRecord(unittest.TestCase):
             ) as pkg_command:
                 yield pkg_command
         cls.launch_bag_command = launch_bag_command
-        cls.tmpdir = tempfile.TemporaryDirectory()
+        cls.tmp_dir_name = tempfile.mkdtemp()
 
     @classmethod
     def tearDownClass(cls):
         try:
-            cls.tmpdir.cleanup()
+            # Cleanup
+            shutil.rmtree(cls.tmp_dir_name, ignore_errors=False)
         except OSError:
             if sys.platform != 'win32':
                 raise
             # HACK to allow Windows to close pending file handles
             time.sleep(3)
-            cls.tmpdir.cleanup()
+            shutil.rmtree(cls.tmp_dir_name, ignore_errors=True)
 
     def test_qos_simple(self):
         profile_path = PROFILE_PATH / 'qos_profile.yaml'
-        output_path = Path(self.tmpdir.name) / 'ros2bag_test_basic'
+        output_path = Path(self.tmp_dir_name) / 'ros2bag_test_basic'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         expected_output = 'Listening for topics...'
@@ -96,7 +98,7 @@ class TestRos2BagRecord(unittest.TestCase):
 
     def test_incomplete_qos_profile(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_profile.yaml'
-        output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete'
+        output_path = Path(self.tmp_dir_name) / 'ros2bag_test_incomplete'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         expected_output = 'Listening for topics...'
@@ -111,7 +113,7 @@ class TestRos2BagRecord(unittest.TestCase):
 
     def test_incomplete_qos_duration(self):
         profile_path = PROFILE_PATH / 'incomplete_qos_duration.yaml'
-        output_path = Path(self.tmpdir.name) / 'ros2bag_test_incomplete_duration'
+        output_path = Path(self.tmp_dir_name) / 'ros2bag_test_incomplete_duration'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         expected_string_regex = re.compile(
@@ -128,7 +130,7 @@ class TestRos2BagRecord(unittest.TestCase):
 
     def test_nonexistent_qos_profile(self):
         profile_path = PROFILE_PATH / 'foobar.yaml'
-        output_path = Path(self.tmpdir.name) / 'ros2bag_test_nonexistent'
+        output_path = Path(self.tmp_dir_name) / 'ros2bag_test_nonexistent'
         arguments = ['record', '-a', '--qos-profile-overrides-path', profile_path.as_posix(),
                      '--output', output_path.as_posix()]
         expected_string_regex = re.compile(


### PR DESCRIPTION
Use shell util with `ignore_errors` flag to clean up temp folder in tests.
Ignore errors on a second attempt to clean up the temp folder on Windows.
- Closes https://github.com/ros2/rosbag2/issues/1947