### PR TITLE
Add examples for compressing bag files

### DIFF
--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -49,6 +49,17 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+add_executable(compressed_bag_rewriter src/compressed_bag_rewriter.cpp)
+target_link_libraries(compressed_bag_rewriter
+  rosbag2_transport::rosbag2_transport
+  ${example_interfaces_TARGETS}
+)
+
+install(TARGETS
+  compressed_bag_rewriter
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 add_executable(simple_bag_reader src/simple_bag_reader.cpp)
 target_link_libraries(simple_bag_reader
   rclcpp::rclcpp

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rosbag2_compression REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_transport REQUIRED)
 find_package(example_interfaces REQUIRED)
@@ -32,6 +33,19 @@ target_link_libraries(simple_bag_recorder
 
 install(TARGETS
   simple_bag_recorder
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(compressed_bag_recorder src/compressed_bag_recorder.cpp)
+target_link_libraries(compressed_bag_recorder
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_compression::rosbag2_compression
+  ${example_interfaces_TARGETS}
+)
+
+install(TARGETS
+  compressed_bag_recorder
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rosbag2_examples/rosbag2_examples_cpp/package.xml
+++ b/rosbag2_examples/rosbag2_examples_cpp/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>rosbag2_compression</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_transport</depend>
   <depend>example_interfaces</depend>

--- a/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_recorder.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_recorder.cpp
@@ -1,0 +1,65 @@
+// Copyright 2025 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "example_interfaces/msg/string.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rosbag2_compression/compression_options.hpp"
+#include "rosbag2_compression/sequential_compression_writer.hpp"
+
+#include "rosbag2_cpp/writer.hpp"
+
+using std::placeholders::_1;
+
+class CompressedBagRecorder : public rclcpp::Node {
+public:
+  CompressedBagRecorder()
+  : Node("compressed_bag_recorder")
+  {
+    rosbag2_compression::CompressionOptions compression_options;
+
+    compression_options.compression_format = "zstd";
+    compression_options.compression_mode = rosbag2_compression::CompressionMode::FILE;
+
+    auto compressed_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
+      compression_options);
+
+    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(compressed_writer));
+    writer_->open("my_bag");
+
+    subscription_ = this->create_subscription<example_interfaces::msg::String>(
+      "chatter", 10, std::bind(&CompressedBagRecorder::topic_callback, this, _1));
+  }
+
+private:
+  void topic_callback(std::shared_ptr<rclcpp::SerializedMessage> msg) const
+  {
+    rclcpp::Time time_stamp = this->now();
+
+    writer_->write(msg, "chatter", "example_interfaces/msg/String", time_stamp);
+  }
+
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr subscription_;
+  std::unique_ptr<rosbag2_cpp::Writer> writer_;
+};
+
+int main(int argc, char *argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<CompressedBagRecorder>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_rewriter.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_rewriter.cpp
@@ -1,0 +1,42 @@
+// Copyright 2025 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "rosbag2_transport/bag_rewrite.hpp"
+
+int main(int, char **)
+{
+  rosbag2_storage::StorageOptions input_storage;
+  input_storage.uri = "input_bag";
+
+  rosbag2_storage::StorageOptions output_storage;
+  output_storage.uri = "output_bag";
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.all_topics = true;
+  record_options.compression_format = "zstd";
+  record_options.compression_mode = "message";
+
+  std::vector<rosbag2_storage::StorageOptions> input_bags;
+  input_bags.push_back(input_storage);
+
+  std::vector<std::pair<rosbag2_storage::StorageOptions,
+    rosbag2_transport::RecordOptions>> output_bags;
+  output_bags.push_back({output_storage, record_options});
+
+  rosbag2_transport::bag_rewrite(input_bags, output_bags);
+
+  return 0;
+}

--- a/rosbag2_examples/rosbag2_examples_py/package.xml
+++ b/rosbag2_examples/rosbag2_examples_py/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <depend>rclpy</depend>
+  <depend>rosbag2_compression</depend>
   <depend>rosbag2_py</depend>
   <depend>example_interfaces</depend>
   <depend>std_msgs</depend>

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/compressed_bag_recorder.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/compressed_bag_recorder.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from rclpy.serialization import serialize_message
+import rosbag2_py
+from std_msgs.msg import String
+
+
+class CompressedBagRecorder(Node):
+
+    def __init__(self):
+        super().__init__('compressed_bag_recorder')
+
+        compression_options = rosbag2_py.CompressionOptions(
+            compression_format='zstd',
+            compression_mode=rosbag2_py.CompressionMode.MESSAGE)
+
+        storage_options = rosbag2_py.StorageOptions(
+            uri='my_bag',
+            storage_id='sqlite3')
+        converter_options = rosbag2_py.ConverterOptions('', '')
+
+        self.compressed_writer = rosbag2_py.SequentialCompressionWriter(compression_options)
+        self.compressed_writer.open(storage_options, converter_options)
+
+        topic_info = rosbag2_py.TopicMetadata(
+            id=0,
+            name='chatter',
+            type='std_msgs/msg/String',
+            serialization_format='cdr')
+        self.compressed_writer.create_topic(topic_info)
+
+        self.subscription = self.create_subscription(
+            String,
+            'chatter',
+            self.topic_callback,
+            10)
+        self.subscription
+
+    def topic_callback(self, msg):
+        self.compressed_writer.write(
+            'chatter',
+            serialize_message(msg),
+            self.get_clock().now().nanoseconds)
+
+
+def main(args=None):
+    try:
+        with rclpy.init(args=args):
+            cbr = CompressedBagRecorder()
+            rclpy.spin(cbr)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/rosbag2_examples/rosbag2_examples_py/setup.py
+++ b/rosbag2_examples/rosbag2_examples_py/setup.py
@@ -24,6 +24,7 @@ setup(
             'simple_bag_reader = rosbag2_examples_py.simple_bag_reader:main',
             'data_generator_node = rosbag2_examples_py.data_generator_node:main',
             'data_generator_executable = rosbag2_examples_py.data_generator_executable:main',
+            'compressed_bag_recorder = rosbag2_examples_py.compressed_bag_recorder:main',
         ],
     },
 )


### PR DESCRIPTION
This PR adds two new examples for cpp:
- Record a compressed bag file using `CompressionMode::FILE` (Python and C++)
- Rewrite an existing bag file to a new one using `CompressionMode::MESSAGE` compression, using the `rosbag2_transport` API. Currently, this example is only for C++, because the python version for `bag_rewrite` does not seem to support additional record options here.

Addresses #1945. 