### PR TITLE
Use DDS queue depth for subscriptions as a maximum value across publishers

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/qos.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/qos.hpp
@@ -53,6 +53,10 @@ public:
     return *this;
   }
 
+  /// \brief Convert this QoS profile to a string representation.
+  /// \return string representation of this QoS profile.
+  [[nodiscard]] std::string to_string() const;
+
   // Create an adaptive QoS profile to use for subscribing to a set of offers from publishers.
   /**
     * - Uses history keep last with the maximum depth from all publishers. If depth is 0, it

--- a/rosbag2_storage/include/rosbag2_storage/qos.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/qos.hpp
@@ -55,7 +55,8 @@ public:
 
   // Create an adaptive QoS profile to use for subscribing to a set of offers from publishers.
   /**
-    * - Uses rosbag2_storage defaults for History since they do not affect compatibility.
+    * - Uses history keep last with the maximum depth from all publishers. If depth is 0, it
+    * falls back to the history keep_all.
     * - Adapts Durability and Reliability, falling back to the least strict publisher when there
     * is a mixed offer. This behavior errs on the side of forming connections with all publishers.
     * - Does not specify Lifespan, Deadline, or Liveliness to be maximally compatible, because

--- a/rosbag2_storage/src/rosbag2_storage/qos.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/qos.cpp
@@ -341,9 +341,15 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   Rosbag2QoS request_qos{};
   // Policy: history, depth
   // History does not affect compatibility. However, it could affect messages drop on the DDS side.
-  if (max_history_depth > 0) {
+  if (max_history_depth > 1) {
     request_qos.keep_last(max_history_depth);
   } else {
+    if (max_history_depth == 1) {
+      ROSBAG2_STORAGE_LOG_DEBUG_STREAM(
+        "Publishers on topic \"" << topic_name << "\" are offering "
+          "RMW_QOS_POLICY_HISTORY_KEEP_LAST with depth = 1. There is a high probability that "
+          "messages will be dropped. Falling back to the RMW_QOS_POLICY_HISTORY_KEEP_ALL.");
+    }
     request_qos.keep_all();
   }
 

--- a/rosbag2_storage/src/rosbag2_storage/qos.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/qos.cpp
@@ -306,6 +306,14 @@ bool convert<std::unordered_map<std::string, rclcpp::QoS>>::decode(
 
 namespace rosbag2_storage
 {
+
+std::string Rosbag2QoS::to_string() const
+{
+  YAML::Node yaml_qos_node = YAML::convert<rosbag2_storage::Rosbag2QoS>::encode(*this);
+  std::string serialized_qos = YAML::Dump(yaml_qos_node);
+  return serialized_qos;
+}
+
 Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   const std::string & topic_name, const std::vector<rclcpp::TopicEndpointInfo> & endpoints)
 {

--- a/rosbag2_storage/src/rosbag2_storage/qos.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/qos.cpp
@@ -315,6 +315,7 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
   size_t num_endpoints = endpoints.size();
   size_t reliability_reliable_endpoints_count = 0;
   size_t durability_transient_local_endpoints_count = 0;
+  size_t max_history_depth = 0;
   for (const auto & endpoint : endpoints) {
     const auto & profile = endpoint.qos_profile().get_rmw_qos_profile();
     if (profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
@@ -323,12 +324,20 @@ Rosbag2QoS Rosbag2QoS::adapt_request_to_offers(
     if (profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
       durability_transient_local_endpoints_count++;
     }
+    if (profile.depth > max_history_depth) {
+      max_history_depth = profile.depth;
+    }
   }
 
   // We set policies in order as defined in rmw_qos_profile_t
   Rosbag2QoS request_qos{};
   // Policy: history, depth
-  // History does not affect compatibility
+  // History does not affect compatibility. However, it could affect messages drop on the DDS side.
+  if (max_history_depth > 0) {
+    request_qos.keep_last(max_history_depth);
+  } else {
+    request_qos.keep_all();
+  }
 
   // Policy: reliability
   if (reliability_reliable_endpoints_count == num_endpoints) {

--- a/rosbag2_test_common/include/rosbag2_test_common/action_client_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/action_client_manager.hpp
@@ -65,7 +65,7 @@ public:
       introspection_state = RCL_SERVICE_INTROSPECTION_OFF;
     }
     action_server_->configure_introspection(
-      get_clock(), rclcpp::SystemDefaultsQoS(), introspection_state);
+      get_clock(), rclcpp::ServicesQoS(), introspection_state);
 
     if (enable_action_client_introspection_) {
       introspection_state = RCL_SERVICE_INTROSPECTION_CONTENTS;
@@ -75,7 +75,7 @@ public:
 
     for (auto & action_client : action_clients_) {
       action_client->configure_introspection(
-        get_clock(), rclcpp::SystemDefaultsQoS(), introspection_state);
+        get_clock(), rclcpp::ServicesQoS(), introspection_state);
     }
   }
 

--- a/rosbag2_test_common/include/rosbag2_test_common/action_server_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/action_server_manager.hpp
@@ -95,10 +95,15 @@ public:
 
     auto server = rclcpp_action::create_server<ActionT>(
       action_server_node_, action_name, handle_goal, handle_cancel, handle_accepted);
+    server->configure_introspection(
+      action_server_node_->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
     action_servers_.emplace(action_name, server);
 
     auto client = rclcpp_action::create_client<ActionT>(
       check_action_server_ready_node_, action_name);
+    client->configure_introspection(
+      action_server_node_->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+
     action_clients_.emplace_back(client);
   }
 

--- a/rosbag2_test_common/include/rosbag2_test_common/client_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/client_manager.hpp
@@ -66,7 +66,7 @@ public:
       introspection_state = RCL_SERVICE_INTROSPECTION_OFF;
     }
     service_->configure_introspection(
-      get_clock(), rclcpp::SystemDefaultsQoS(), introspection_state);
+      get_clock(), rclcpp::ServicesQoS(), introspection_state);
 
     if (enable_client_event_contents_) {
       introspection_state = RCL_SERVICE_INTROSPECTION_CONTENTS;
@@ -77,7 +77,7 @@ public:
     for (size_t i = 0; i < number_of_clients_; i++) {
       auto client = create_client<ServiceT>(service_name_);
       client->configure_introspection(
-        get_clock(), rclcpp::SystemDefaultsQoS(), introspection_state);
+        get_clock(), rclcpp::ServicesQoS(), introspection_state);
       clients_.emplace_back(client);
     }
   }

--- a/rosbag2_test_common/include/rosbag2_test_common/service_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/service_manager.hpp
@@ -68,9 +68,13 @@ public:
 
     auto service = service_node_->create_service<ServiceT>(
       service_name, std::forward<decltype(callback)>(callback));
+    service->configure_introspection(
+      service_node_->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
     services_.emplace(service_name, service);
 
     auto client = check_service_ready_node_->create_client<ServiceT>(service_name);
+    client->configure_introspection(
+      service_node_->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
     clients_.emplace_back(client);
   }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -566,9 +566,13 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   auto subscription = create_subscription(topic.name, topic.type, subscription_qos);
   if (subscription) {
     subscriptions_.insert({topic.name, subscription});
-    RCLCPP_INFO_STREAM(node->get_logger(), "Subscribed to topic '" << topic.name << "'");
-    RCLCPP_DEBUG_STREAM(node->get_logger(),
-      "Subscribed to topic '" << topic.name << "' with QoS:\n" << subscription_qos.to_string());
+    if (node->get_logger().get_effective_level() == rclcpp::Logger::Level::Debug) {
+      RCLCPP_DEBUG_STREAM(node->get_logger(),
+        "Subscribed to topic '" << topic.name << "' with QoS:\n" << subscription_qos.to_string());
+    } else {
+      RCLCPP_INFO_STREAM(node->get_logger(), "Subscribed to topic '" << topic.name << "'");
+    }
+
   } else {
     writer_->remove_topic(topic);
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -567,6 +567,8 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   if (subscription) {
     subscriptions_.insert({topic.name, subscription});
     RCLCPP_INFO_STREAM(node->get_logger(), "Subscribed to topic '" << topic.name << "'");
+    RCLCPP_DEBUG_STREAM(node->get_logger(),
+      "Subscribed to topic '" << topic.name << "' with QoS:\n" << subscription_qos.to_string());
   } else {
     writer_->remove_topic(topic);
   }

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -167,6 +167,11 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_actions_ar
   ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(
     "/test_action_2/_action/get_result/_service_event"));
 
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(
+    "/test_action_1/_action/send_goal/_service_event"));
+  ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(
+    "/test_action_2/_action/send_goal/_service_event"));
+
   ASSERT_TRUE(action_client_manager_1->send_goal());
   ASSERT_TRUE(action_client_manager_2->send_goal());
 
@@ -183,6 +188,12 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_actions_ar
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
   auto recorded_messages = mock_writer.get_messages();
   EXPECT_EQ(recorded_messages.size(), expected_messages);
+  if (!ret) {
+    std::cout << "Recorded messages: " << std::endl;
+    for (const auto & message : recorded_messages) {
+      std::cout << message->topic_name << std::endl;
+    }
+  }
 }
 
 TEST_F(RecordIntegrationTestFixture, published_messages_from_topic_service_action_are_recorded)


### PR DESCRIPTION
This PR will mitigate possible messages lost on the DDS layer during recording in cases when the default `rmw_qos_profile_default.depth` is not enough.

While DDS queue kind and depth don't affect QoS compatibility. However, when the queue depth is too low, it could potentially cause messages to be lost on the DDS layer. 
In Apex.AI we have `rmw_qos_profile_default.depth = 1` and observing some rosbag2_transport test failures.