### PR TITLE
Address clang warning in the `TimeControllerClock::wakeup()`

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -200,6 +200,7 @@ bool TimeControllerClock::is_sleeping()
 
 void TimeControllerClock::wakeup()
 {
+  std::lock_guard<std::mutex> lock(impl_->state_mutex);
   impl_->cv.notify_all();
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -201,14 +201,14 @@ bool TimeControllerClock::is_sleeping()
 void TimeControllerClock::wakeup()
 {
 #if defined(__clang__)
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wthread-safety-analysis"
 #endif
-    // Note. We shall not lock mutex before notify_all since the notified thread would immediately
-    // block again, waiting for the notifying thread to release the lock
-    impl_->cv.notify_all();
+  // Note. We shall not lock mutex before notify_all since the notified thread would immediately
+  // block again, waiting for the notifying thread to release the lock
+  impl_->cv.notify_all();
 #if defined(__clang__)
-    #pragma clang diagnostic pop
+  #pragma clang diagnostic pop
 #endif
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -200,10 +200,16 @@ bool TimeControllerClock::is_sleeping()
 
 void TimeControllerClock::wakeup()
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wthread-safety-analysis"
-  impl_->cv.notify_all();
-#pragma clang diagnostic pop
+#if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
+    // Note. We shall not lock mutex before notify_all since the notified thread would immediately
+    // block again, waiting for the notifying thread to release the lock
+    impl_->cv.notify_all();
+#if defined(__clang__)
+    #pragma clang diagnostic pop
+#endif
 }
 
 bool TimeControllerClock::set_rate(double rate)

--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -200,8 +200,10 @@ bool TimeControllerClock::is_sleeping()
 
 void TimeControllerClock::wakeup()
 {
-  std::lock_guard<std::mutex> lock(impl_->state_mutex);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
   impl_->cv.notify_all();
+#pragma clang diagnostic pop
 }
 
 bool TimeControllerClock::set_rate(double rate)


### PR DESCRIPTION
- This PR will suppress the clang warning in the `TimeControllerClock::wakeup()`.

I saw this warning on this clang nightly CI job https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/2219/clang/folder.535941802/source.4a5d9a19-e847-4d34-b16a-7d33e0a22acb/#203