### PR TITLE
Add support for action types in LocalMessageDefinitionSource class

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -61,10 +61,10 @@ class ROSBAG2_CPP_PUBLIC LocalMessageDefinitionSource final
 public:
   /**
    * Concatenate the message definition with its dependencies into a self-contained schema.
-   * The format is different for MSG/SRV/ACT and IDL definitions, and is described fully in
+   * The format is different for MSG/SRV/ACTION and IDL definitions, and is described fully in
    * docs/message_definition_encoding.md
    * For SRV type, root_type must include a string '/srv/'.
-   * For ACT type, root_type must include a string '/action/'.
+   * For ACTION type, root_type must include a string '/action/'.
    * Throws DefinitionNotFoundError if one or more definition files are missing for the given
    * package resource name.
    */
@@ -76,7 +76,7 @@ public:
     MSG = 1,
     IDL = 2,
     SRV = 3,
-    ACT = 4,
+    ACTION = 4,
   };
 
   explicit LocalMessageDefinitionSource() = default;

--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -61,9 +61,10 @@ class ROSBAG2_CPP_PUBLIC LocalMessageDefinitionSource final
 public:
   /**
    * Concatenate the message definition with its dependencies into a self-contained schema.
-   * The format is different for MSG/SRV and IDL definitions, and is described fully in
+   * The format is different for MSG/SRV/ACT and IDL definitions, and is described fully in
    * docs/message_definition_encoding.md
    * For SRV type, root_type must include a string '/srv/'.
+   * For ACT type, root_type must include a string '/action/'.
    * Throws DefinitionNotFoundError if one or more definition files are missing for the given
    * package resource name.
    */
@@ -75,6 +76,7 @@ public:
     MSG = 1,
     IDL = 2,
     SRV = 3,
+    ACT = 4,
   };
 
   explicit LocalMessageDefinitionSource() = default;

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -49,9 +49,11 @@ public:
 };
 
 // Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar)
-static const std::regex PACKAGE_TYPENAME_REGEX{R"(^([a-zA-Z0-9_]+)/(?:msg/|srv/)?([a-zA-Z0-9_]+)$)"};
+static const std::regex PACKAGE_TYPENAME_REGEX{
+  R"(^([a-zA-Z0-9_]+)/(?:msg/|srv/|action/)?([a-zA-Z0-9_]+)$)"};
 
-// Match field types from .msg and .srv definitions ("foo_msgs/Bar" in "foo_msgs/Bar[] bar")
+// Match field types from .msg, .srv and .action definitions
+// ("foo_msgs/Bar" in "foo_msgs/Bar[] bar")
 static const std::regex MSG_FIELD_TYPE_REGEX{R"((?:^|\n)\s*([a-zA-Z0-9_/]+)(?:\[[^\]]*\])?\s+)"};
 
 // match field types from `.idl` definitions ("foo_msgs/msg/bar" in #include <foo_msgs/msg/Bar.idl>)
@@ -107,6 +109,7 @@ std::set<std::string> parse_definition_dependencies(
     case LocalMessageDefinitionSource::Format::IDL:
       return parse_idl_dependencies(text);
     case LocalMessageDefinitionSource::Format::SRV:
+    case LocalMessageDefinitionSource::Format::ACT:
       {
         auto dep = parse_msg_dependencies(text, package_context);
         if (!dep.empty()) {
@@ -129,6 +132,8 @@ static const char * extension_for_format(LocalMessageDefinitionSource::Format fo
       return ".idl";
     case LocalMessageDefinitionSource::Format::SRV:
       return ".srv";
+    case LocalMessageDefinitionSource::Format::ACT:
+      return ".action";
     default:
       throw std::runtime_error("switch is not exhaustive");
   }
@@ -148,6 +153,9 @@ std::string LocalMessageDefinitionSource::delimiter(
       break;
     case Format::SRV:
       result += "SRV: ";
+      break;
+    case Format::ACT:
+      result += "ACT: ";
       break;
     default:
       throw std::runtime_error("switch is not exhaustive");
@@ -187,8 +195,18 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
     ROSBAG2_CPP_LOG_WARN("'%s'", e.what());
     throw DefinitionNotFoundError(definition_identifier.topic_type());
   }
-  std::string dir = definition_identifier.format() == Format::MSG ||
-    definition_identifier.format() == Format::IDL ? "/msg/" : "/srv/";
+  std::string dir;
+  if (definition_identifier.format() == Format::MSG ||
+    definition_identifier.format() == Format::IDL)
+  {
+    dir = "/msg/";
+  } else if (definition_identifier.format() == Format::SRV) {
+    dir = "/srv/";
+  } else if (definition_identifier.format() == Format::ACT) {
+    dir = "/action/";
+  } else {
+    throw std::runtime_error("Unknown format type");
+  }
   std::ifstream file{share_dir + dir + match[2].str() +
     extension_for_format(definition_identifier.format())};
   if (!file.good()) {
@@ -234,7 +252,9 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
   Format format = Format::UNKNOWN;
   int32_t max_recursion_depth = ROSBAG2_CPP_LOCAL_MESSAGE_DEFINITION_SOURCE_MAX_RECURSION_DEPTH;
 
-  if (root_type.find("/srv/") == std::string::npos) {  // Not a service
+  if (root_type.find("/srv/") == std::string::npos &&
+    root_type.find("/action/") == std::string::npos)
+  {  // Neither srv nor action
     try {
       format = Format::MSG;
       result = append_recursive(DefinitionIdentifier(root_type, format), max_recursion_depth);
@@ -251,11 +271,16 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
       format = Format::UNKNOWN;
     }
   } else {
-    // The service dependencies could be either in the msg or idl files. Therefore, will try to
-    // search service dependencies in MSG files first then in IDL files via two separate recursive
-    // searches for each dependency.
+    // The service and action dependencies could be either in the msg or idl files.
+    // Therefore, will try to search dependencies in MSG files first then in IDL files
+    // via two separate recursive searches for each dependency.
     format = Format::UNKNOWN;
-    DefinitionIdentifier def_identifier{root_type, Format::SRV};
+    if (root_type.find("/srv/") != std::string::npos) {
+      format = Format::SRV;
+    } else if (root_type.find("/action/") != std::string::npos) {
+      format = Format::ACT;
+    }
+    DefinitionIdentifier def_identifier{root_type, format};
     (void)seen_deps.insert(def_identifier).second;
     result = delimiter(def_identifier);
     const MessageSpec & spec = load_message_spec(def_identifier);
@@ -304,6 +329,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
       throw std::runtime_error("switch is not exhaustive");
   }
 
+  ROSBAG2_CPP_LOG_INFO("Message result '%s'", result.c_str());
   out.encoded_message_definition = result;
   out.topic_type = root_type;
   return out;

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -329,7 +329,6 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
       throw std::runtime_error("switch is not exhaustive");
   }
 
-  ROSBAG2_CPP_LOG_INFO("Message result '%s'", result.c_str());
   out.encoded_message_definition = result;
   out.topic_type = root_type;
   return out;

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -109,7 +109,7 @@ std::set<std::string> parse_definition_dependencies(
     case LocalMessageDefinitionSource::Format::IDL:
       return parse_idl_dependencies(text);
     case LocalMessageDefinitionSource::Format::SRV:
-    case LocalMessageDefinitionSource::Format::ACT:
+    case LocalMessageDefinitionSource::Format::ACTION:
       {
         auto dep = parse_msg_dependencies(text, package_context);
         if (!dep.empty()) {
@@ -132,7 +132,7 @@ static const char * extension_for_format(LocalMessageDefinitionSource::Format fo
       return ".idl";
     case LocalMessageDefinitionSource::Format::SRV:
       return ".srv";
-    case LocalMessageDefinitionSource::Format::ACT:
+    case LocalMessageDefinitionSource::Format::ACTION:
       return ".action";
     default:
       throw std::runtime_error("switch is not exhaustive");
@@ -154,8 +154,8 @@ std::string LocalMessageDefinitionSource::delimiter(
     case Format::SRV:
       result += "SRV: ";
       break;
-    case Format::ACT:
-      result += "ACT: ";
+    case Format::ACTION:
+      result += "ACTION: ";
       break;
     default:
       throw std::runtime_error("switch is not exhaustive");
@@ -202,7 +202,7 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
     dir = "/msg/";
   } else if (definition_identifier.format() == Format::SRV) {
     dir = "/srv/";
-  } else if (definition_identifier.format() == Format::ACT) {
+  } else if (definition_identifier.format() == Format::ACTION) {
     dir = "/action/";
   } else {
     throw std::runtime_error("Unknown format type");
@@ -254,7 +254,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
 
   if (root_type.find("/srv/") == std::string::npos &&
     root_type.find("/action/") == std::string::npos)
-  {  // Neither srv nor action
+  {  // Only msg and idl files
     try {
       format = Format::MSG;
       result = append_recursive(DefinitionIdentifier(root_type, format), max_recursion_depth);
@@ -278,7 +278,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
     if (root_type.find("/srv/") != std::string::npos) {
       format = Format::SRV;
     } else if (root_type.find("/action/") != std::string::npos) {
-      format = Format::ACT;
+      format = Format::ACTION;
     }
     DefinitionIdentifier def_identifier{root_type, format};
     (void)seen_deps.insert(def_identifier).second;

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -107,6 +107,55 @@ TEST(test_local_message_definition_source, can_find_srv_deps_in_idl)
     "};\n") << result.encoded_message_definition << std::endl;
 }
 
+TEST(test_local_message_definition_source, can_find_action_deps_in_msg)
+{
+  LocalMessageDefinitionSource source;
+  auto result = source.get_full_text("rosbag2_test_msgdefs/action/ComplexActionMsg");
+  ASSERT_EQ(result.encoding, "ros2msg");
+  ASSERT_EQ(
+    result.encoded_message_definition,
+    "================================================================================\n"
+    "ACT: rosbag2_test_msgdefs/action/ComplexActionMsg\n"
+    "rosbag2_test_msgdefs/BasicMsg goal\n"
+    "---\n"
+    "rosbag2_test_msgdefs/BasicMsg result\n"
+    "---\n"
+    "rosbag2_test_msgdefs/BasicMsg feedback\n"
+    "\n"
+    "================================================================================\n"
+    "MSG: rosbag2_test_msgdefs/BasicMsg\n"
+    "float32 c\n") << result.encoded_message_definition << std::endl;
+}
+
+TEST(test_local_message_definition_source, can_find_action_deps_in_idl)
+{
+  LocalMessageDefinitionSource source;
+  auto result = source.get_full_text("rosbag2_test_msgdefs/action/ComplexActionIdl");
+  ASSERT_EQ(result.encoding, "ros2idl");
+  ASSERT_EQ(
+    result.encoded_message_definition,
+    "================================================================================\n"
+    "ACT: rosbag2_test_msgdefs/action/ComplexActionIdl\n"
+    "rosbag2_test_msgdefs/BasicIdl goal\n"
+    "---\n"
+    "rosbag2_test_msgdefs/BasicIdl result\n"
+    "---\n"
+    "rosbag2_test_msgdefs/BasicIdl feedback\n"
+    "\n"
+    "================================================================================\n"
+    "MSG: rosbag2_test_msgdefs/BasicIdl\n"
+    "\n"
+    "================================================================================\n"
+    "IDL: rosbag2_test_msgdefs/BasicIdl\n"
+    "module rosbag2_test_msgdefs {\n"
+    "  module msg {\n"
+    "    struct BasicIdl {\n"
+    "        float x;\n"
+    "    };\n"
+    "  };\n"
+    "};\n") << result.encoded_message_definition << std::endl;
+}
+
 TEST(test_local_message_definition_source, can_find_idl_deps)
 {
   LocalMessageDefinitionSource source;

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -115,7 +115,7 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_msg)
   ASSERT_EQ(
     result.encoded_message_definition,
     "================================================================================\n"
-    "ACT: rosbag2_test_msgdefs/action/ComplexActionMsg\n"
+    "ACTION: rosbag2_test_msgdefs/action/ComplexActionMsg\n"
     "rosbag2_test_msgdefs/BasicMsg goal\n"
     "---\n"
     "rosbag2_test_msgdefs/BasicMsg result\n"
@@ -135,7 +135,7 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_idl)
   ASSERT_EQ(
     result.encoded_message_definition,
     "================================================================================\n"
-    "ACT: rosbag2_test_msgdefs/action/ComplexActionIdl\n"
+    "ACTION: rosbag2_test_msgdefs/action/ComplexActionIdl\n"
     "rosbag2_test_msgdefs/BasicIdl goal\n"
     "---\n"
     "rosbag2_test_msgdefs/BasicIdl result\n"

--- a/rosbag2_test_msgdefs/CMakeLists.txt
+++ b/rosbag2_test_msgdefs/CMakeLists.txt
@@ -17,6 +17,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/BasicSrv.srv"
   "srv/ComplexSrvMsg.srv"
   "srv/ComplexSrvIdl.srv"
+  "action/BasicAction.action"
+  "action/ComplexActionMsg.action"
+  "action/ComplexActionIdl.action"
   ADD_LINTER_TESTS
 )
 

--- a/rosbag2_test_msgdefs/action/BasicAction.action
+++ b/rosbag2_test_msgdefs/action/BasicAction.action
@@ -1,0 +1,5 @@
+string goal
+---
+string result
+---
+string feedback

--- a/rosbag2_test_msgdefs/action/ComplexActionIdl.action
+++ b/rosbag2_test_msgdefs/action/ComplexActionIdl.action
@@ -1,0 +1,5 @@
+rosbag2_test_msgdefs/BasicIdl goal
+---
+rosbag2_test_msgdefs/BasicIdl result
+---
+rosbag2_test_msgdefs/BasicIdl feedback

--- a/rosbag2_test_msgdefs/action/ComplexActionMsg.action
+++ b/rosbag2_test_msgdefs/action/ComplexActionMsg.action
@@ -1,0 +1,5 @@
+rosbag2_test_msgdefs/BasicMsg goal
+---
+rosbag2_test_msgdefs/BasicMsg result
+---
+rosbag2_test_msgdefs/BasicMsg feedback


### PR DESCRIPTION
- This PR adds support for finding action types message definitions in `LocalMessageDefinitionSource` class to be able store actions message definitions during recording.
- Closes https://github.com/ros2/rosbag2/issues/1964