### PR TITLE
Fix a maybe-uninitialized warning in player_action_client.cpp

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player_action_client.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player_action_client.cpp
@@ -220,11 +220,8 @@ PlayerActionClient::get_service_event_type(
     case ServiceInterfaceInAction::GET_RESULT_SERVICE:
       service_event_type_members = result_service_event_type_members_;
       break;
-  }
-
-  // We should never get here, but to prevent maybe-uninitialized warnings.
-  if (service_event_type_members->member_count_ == 0) {
-    throw std::out_of_range("Invalid service introspection");
+    default:
+      throw std::invalid_argument("Unknown service type in action");
   }
 
   // members_[0]: service_info, members_[1]: request[<=1], members_[2]: response[<=1]

--- a/rosbag2_transport/src/rosbag2_transport/player_action_client.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player_action_client.cpp
@@ -221,6 +221,12 @@ PlayerActionClient::get_service_event_type(
       service_event_type_members = result_service_event_type_members_;
       break;
   }
+
+  // We should never get here, but to prevent maybe-uninitialized warnings.
+  if (service_event_type_members->member_count_ == 0) {
+    throw std::out_of_range("Invalid service introspection");
+  }
+
   // members_[0]: service_info, members_[1]: request[<=1], members_[2]: response[<=1]
   const auto & service_info_member = service_event_type_members->members_[0];
   auto service_event_info_ptr =


### PR DESCRIPTION
- This PR addresses a warning about maybe an uninitialized variable found on the https://ci.ros2.org/view/nightly/job/nightly_linux_release/3438/clang/