### PR TITLE
Add a simple example showing how to convert bags to the csv file

### DIFF
--- a/rosbag2_examples/rosbag2_examples_py/package.xml
+++ b/rosbag2_examples/rosbag2_examples_py/package.xml
@@ -12,6 +12,8 @@
   <depend>example_interfaces</depend>
   <depend>std_msgs</depend>
 
+  <exec_depend>rosidl_runtime_py</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/rosbag2csv.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/rosbag2csv.py
@@ -47,7 +47,7 @@ def read_messages(input_bag: str):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '-i', '--input', help="input bag path (folder or filepath) to read from"
+        '-i', '--input', help='input bag path (folder or filepath) to read from'
     )
 
     args = parser.parse_args()
@@ -56,10 +56,10 @@ def main():
         # Workaround for Bazel to support the relative path's for input and output files
         os.chdir(os.environ['BUILD_WORKING_DIRECTORY'])
 
-    with open(f"{args.input}.csv", "w", newline="") as f_out:
+    with open(f'{args.input}.csv', 'w', newline='') as f_out:
         csv_writer = csv.writer(f_out)
         # Write header
-        csv_writer.writerow(["topic_name", "topic_type", "timestamp_ns", "data"])
+        csv_writer.writerow(['topic_name', 'topic_type', 'timestamp_ns', 'data'])
 
         for topic_name, msg, timestamp_ns in read_messages(args.input):
             # Convert to YAML
@@ -69,5 +69,5 @@ def main():
             # print(f"{topic_name} ({type(msg).__name__}) [{timestamp_ns}]: '{yaml_str}'")
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/rosbag2csv.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/rosbag2csv.py
@@ -1,0 +1,73 @@
+# Copyright 2025 Apex.AI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script that reads ROS 2 messages from a bag file and saves them to a csv file."""
+
+import argparse
+import csv
+import os
+
+from rclpy.serialization import deserialize_message
+import rosbag2_py
+from rosidl_runtime_py.convert import message_to_yaml
+from rosidl_runtime_py.utilities import get_message
+
+
+def read_messages(input_bag: str):
+    reader = rosbag2_py.SequentialReader()
+    reader.open(
+        rosbag2_py.StorageOptions(uri=input_bag),
+        rosbag2_py.ConverterOptions('', ''),
+    )
+
+    topic_types = reader.get_all_topics_and_types()
+
+    # Create a map for quicker lookup
+    type_map = {topic_types[i].name: topic_types[i].type for i in range(len(topic_types))}
+
+    while reader.has_next():
+        topic, data, timestamp = reader.read_next()
+        msg_type = get_message(type_map[topic])
+        msg = deserialize_message(data, msg_type)
+        yield topic, msg, timestamp
+    del reader
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '-i', '--input', help="input bag path (folder or filepath) to read from"
+    )
+
+    args = parser.parse_args()
+
+    if 'BUILD_WORKING_DIRECTORY' in os.environ:
+        # Workaround for Bazel to support the relative path's for input and output files
+        os.chdir(os.environ['BUILD_WORKING_DIRECTORY'])
+
+    with open(f"{args.input}.csv", "w", newline="") as f_out:
+        csv_writer = csv.writer(f_out)
+        # Write header
+        csv_writer.writerow(["topic_name", "topic_type", "timestamp_ns", "data"])
+
+        for topic_name, msg, timestamp_ns in read_messages(args.input):
+            # Convert to YAML
+            yaml_str = message_to_yaml(msg)
+            # Write the YAML string in the 'data' field
+            csv_writer.writerow([topic_name, type(msg).__name__, timestamp_ns, yaml_str])
+            # print(f"{topic_name} ({type(msg).__name__}) [{timestamp_ns}]: '{yaml_str}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/rosbag2_examples/rosbag2_examples_py/setup.py
+++ b/rosbag2_examples/rosbag2_examples_py/setup.py
@@ -20,6 +20,7 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
+            'rosbag2csv = rosbag2_examples_py.rosbag2csv:main',
             'simple_bag_recorder = rosbag2_examples_py.simple_bag_recorder:main',
             'simple_bag_reader = rosbag2_examples_py.simple_bag_reader:main',
             'data_generator_node = rosbag2_examples_py.data_generator_node:main',


### PR DESCRIPTION
- This PR adds a simple example to the `rosbag2_examples_py` package showing how to convert bags to the csv file.