### PR TITLE
Bugfix: `ros2 bag convert` dropping messages with compression mode message

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -427,6 +427,12 @@ void SequentialCompressionWriter::write(
     while (compressor_message_queue_.size() > compression_options_.compression_queue_size &&
       compression_options_.compression_queue_size > 0u)
     {
+      // Drop the message if the queue is full and the compression queue size is set.
+      message = compressor_message_queue_.front();
+      ROSBAG2_COMPRESSION_LOG_WARN_STREAM(
+        "Dropping message on topic:" << message->topic_name <<
+          "from compression queue because it is full. Queue size: " <<
+          compressor_message_queue_.size());
       compressor_message_queue_.pop();
     }
 

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -501,7 +501,7 @@ void bag_rewrite(
     rosbag2_storage::StorageOptions storage_options{};
     YAML::convert<rosbag2_storage::StorageOptions>::decode(bag_node, storage_options);
     rosbag2_transport::RecordOptions record_options = bag_rewrite_default_record_options();
-    record_options = bag_node.as<rosbag2_transport::RecordOptions>();
+    YAML::convert<rosbag2_storage::RecordOptions>::decode(bag_node, record_options);
     output_options.push_back(std::make_pair(storage_options, record_options));
   }
   rosbag2_transport::bag_rewrite(input_options, output_options);

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -501,7 +501,7 @@ void bag_rewrite(
     rosbag2_storage::StorageOptions storage_options{};
     YAML::convert<rosbag2_storage::StorageOptions>::decode(bag_node, storage_options);
     rosbag2_transport::RecordOptions record_options = bag_rewrite_default_record_options();
-    YAML::convert<rosbag2_storage::RecordOptions>::decode(bag_node, record_options);
+    YAML::convert<rosbag2_transport::RecordOptions>::decode(bag_node, record_options);
     output_options.push_back(std::make_pair(storage_options, record_options));
   }
   rosbag2_transport::bag_rewrite(input_options, output_options);

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -49,7 +49,7 @@ public:
   std::string node_prefix = "";
   std::string compression_mode = "";
   std::string compression_format = "";
-  uint64_t compression_queue_size = 1;
+  uint64_t compression_queue_size = 0;
   /// \brief // The number of compression threads
   uint64_t compression_threads = 0;
   /// \brief Compression threads scheduling priority.


### PR DESCRIPTION
- This PR addresses issue described in the #1973

Revert the change that ignores `record_options` when parsing settings from yaml file.
Set `RecordOptions.compression_queue_size` to **0** by default to avoid messages drops.
Add logging when messages are dropped during compression
