### PR TITLE
Bugfix: Undefined behavior in the `rosbag2_storage` and `rosbag2_storage_sqlite3` packages

### DIFF
--- a/rosbag2_storage/src/rosbag2_storage/ros_helper.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/ros_helper.cpp
@@ -29,8 +29,11 @@ std::shared_ptr<rcutils_uint8_array_t>
 make_serialized_message(const void * data, size_t size)
 {
   auto serialized_message = make_empty_serialized_message(size);
-  memcpy(serialized_message->buffer, data, size);
-  serialized_message->buffer_length = size;
+  // Note: // It will be undefined behavior to call memcpy with nullptr even if size is 0
+  if (data != nullptr) {
+    memcpy(serialized_message->buffer, data, size);
+    serialized_message->buffer_length = size;
+  }
 
   return serialized_message;
 }

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_statement_wrapper.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_statement_wrapper.cpp
@@ -168,7 +168,8 @@ void SqliteStatementWrapper::obtain_column_value(size_t index, double & value) c
 
 void SqliteStatementWrapper::obtain_column_value(size_t index, std::string & value) const
 {
-  value = reinterpret_cast<const char *>(sqlite3_column_text(statement_, static_cast<int>(index)));
+  auto col_text_ptr = sqlite3_column_text(statement_, static_cast<int>(index));
+  value = col_text_ptr ? reinterpret_cast<const char *>(col_text_ptr) : "";
 }
 
 void SqliteStatementWrapper::obtain_column_value(


### PR DESCRIPTION
This PR addresses a possible undefined behavior in the `rosbag2_storage` and `rosbag2_storage_sqlite3` packages.

1. RCA (Root cause analysis) for undefined behavior in the `rosbag2_storage_sqlite3` can be found in https://github.com/ros2/rosbag2/issues/1996#issuecomment-2843792582

2.  There is possible the similar situation with returning `nullptr` from the `sqlite3_column_bytes(statement_, static_cast<int>(index)));` in the
https://github.com/ros2/rosbag2/blob/8ddae20e5b019676c7c2ce78adfe240eca08f0b0/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_statement_wrapper.cpp#L174-L180

A similar undefined behavior could be in the downstream `rosbag2_storage::make_serialized_message(const void * data, size_t size)` if call `memcpy` with `nullptr` even if the size is 0.
This PR also addresses this undefined behavior.

- Relates https://github.com/ros2/rosbag2/issues/1996