### PR TITLE
Address flakiness in tests where need to spin a node

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/service_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/service_manager.hpp
@@ -85,6 +85,17 @@ public:
       [this]() {
         exec_.spin();
       });
+
+    // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
+    using clock = std::chrono::steady_clock;
+    auto start = clock::now();
+    while (!exec_.is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (!exec_.is_spinning()) {
+      std::cerr << "Failed to start spinning node: " << service_node_->get_name() << std::endl;
+      throw std::runtime_error("Failed to start spinning node");
+    }
   }
 
   bool all_services_ready()

--- a/rosbag2_test_common/include/rosbag2_test_common/service_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/service_manager.hpp
@@ -23,6 +23,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include "rosbag2_test_common/wait_for.hpp"
+
 namespace rosbag2_test_common
 {
 class ServiceManager
@@ -87,13 +89,8 @@ public:
       });
 
     // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
-    using clock = std::chrono::steady_clock;
-    auto start = clock::now();
-    while (!exec_.is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-    if (!exec_.is_spinning()) {
-      std::cerr << "Failed to start spinning node: " << service_node_->get_name() << std::endl;
+    if (!wait_until_condition([this]() {return exec_.is_spinning();}, std::chrono::seconds(5))) {
+      std::cerr << "Failed to start spinning node:" << service_node_->get_name() << std::endl;
       throw std::runtime_error("Failed to start spinning node");
     }
   }

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <future>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -55,6 +56,17 @@ public:
       [this]() {
         exec_->spin();
       });
+
+    // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
+    using clock = std::chrono::steady_clock;
+    auto start = clock::now();
+    while (!exec_->is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (!exec_->is_spinning()) {
+      std::cerr << "Failed to start spinning node" << std::endl;
+      throw std::runtime_error("Failed to start spinning node");
+    }
   }
 
   ~PlayEndToEndTestFixture() override

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -26,6 +26,7 @@
 #include "rosbag2_test_common/process_execution_helpers.hpp"
 #include "rosbag2_test_common/subscription_manager.hpp"
 #include "rosbag2_test_common/tested_storage_ids.hpp"
+#include "rosbag2_test_common/wait_for.hpp"
 
 #include "test_msgs/msg/arrays.hpp"
 #include "test_msgs/msg/basic_types.hpp"
@@ -58,13 +59,8 @@ public:
       });
 
     // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
-    using clock = std::chrono::steady_clock;
-    auto start = clock::now();
-    while (!exec_->is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-    if (!exec_->is_spinning()) {
-      std::cerr << "Failed to start spinning node" << std::endl;
+    if (!wait_until_condition([this]() {return exec_->is_spinning();}, std::chrono::seconds(5))) {
+      std::cerr << "Failed to start spinning node" << client_node_->get_name() << std::endl;
       throw std::runtime_error("Failed to start spinning node");
     }
   }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -95,6 +95,18 @@ public:
         exec_.spin();
       });
 
+    // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
+    using clock = std::chrono::steady_clock;
+    auto start = clock::now();
+    while (!exec_.is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (!exec_.is_spinning()) {
+      std::cerr << "Failed to start spinning nodes: '" <<
+        player_->get_name() << ", " << client_node_->get_name() << "'" << std::endl;
+      throw std::runtime_error("Failed to start spinning nodes");
+    }
+
     // Make sure all expected services are present before starting any test
     ASSERT_TRUE(cli_resume_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_pause_->wait_for_service(service_wait_timeout_));

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -32,6 +32,7 @@
 #include "rosbag2_interfaces/srv/resume.hpp"
 #include "rosbag2_interfaces/srv/stop.hpp"
 #include "rosbag2_interfaces/srv/toggle_paused.hpp"
+#include "rosbag2_test_common/wait_for.hpp"
 #include "rosbag2_transport/player.hpp"
 #include "test_msgs/msg/basic_types.hpp"
 #include "test_msgs/message_fixtures.hpp"
@@ -96,12 +97,7 @@ public:
       });
 
     // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
-    using clock = std::chrono::steady_clock;
-    auto start = clock::now();
-    while (!exec_.is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-    if (!exec_.is_spinning()) {
+    if (!wait_until_condition([this]() {return exec_.is_spinning();}, std::chrono::seconds(5))) {
       std::cerr << "Failed to start spinning nodes: '" <<
         player_->get_name() << ", " << client_node_->get_name() << "'" << std::endl;
       throw std::runtime_error("Failed to start spinning nodes");

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -463,10 +463,9 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
   mock_writer.set_max_messages_per_file(5);
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {string_topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, false, false, false, {string_topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
-  recorder->record();
 
   start_async_spin(recorder);
   auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
@@ -478,6 +477,8 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
 
   rosbag2_test_common::PublicationManager pub_manager;
   pub_manager.setup_publisher(string_topic, string_message, expected_messages);
+
+  recorder->record();
 
   ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
   pub_manager.run_publishers();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -58,6 +58,17 @@ public:
       [this]() {
         exec_.spin();
       });
+
+    // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
+    using clock = std::chrono::steady_clock;
+    auto start = clock::now();
+    while (!exec_.is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (!exec_.is_spinning()) {
+      std::cerr << "Failed to start spinning node: " << node_->get_name() << std::endl;
+      throw std::runtime_error("Failed to start spinning node");
+    }
   }
 
   ~ClockPublisher()

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -60,12 +60,7 @@ public:
       });
 
     // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
-    using clock = std::chrono::steady_clock;
-    auto start = clock::now();
-    while (!exec_.is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-    if (!exec_.is_spinning()) {
+    if (!wait_until_condition([this]() {return exec_.is_spinning();}, std::chrono::seconds(5))) {
       std::cerr << "Failed to start spinning node: " << node_->get_name() << std::endl;
       throw std::runtime_error("Failed to start spinning node");
     }

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -29,6 +29,7 @@
 #include "rosbag2_transport/recorder.hpp"
 
 #include "rosbag2_test_common/publication_manager.hpp"
+#include "rosbag2_test_common/wait_for.hpp"
 
 #include "test_msgs/message_fixtures.hpp"
 
@@ -95,14 +96,10 @@ public:
       });
 
     // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
-    using clock = std::chrono::steady_clock;
-    auto start = clock::now();
-    while (!exec_->is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-    if (!exec_->is_spinning()) {
-      std::cerr << "Failed to start spinning node" << std::endl;
-      throw std::runtime_error("Failed to start spinning node");
+    if (!wait_until_condition([this]() {return exec_->is_spinning();}, std::chrono::seconds(5))) {
+      std::cerr << "Failed to start spinning nodes: '" <<
+        recorder_->get_name() << ", " << client_node_->get_name() << "'" << std::endl;
+      throw std::runtime_error("Failed to start spinning nodes");
     }
 
     ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -94,6 +94,17 @@ public:
         exec_->spin();
       });
 
+    // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
+    using clock = std::chrono::steady_clock;
+    auto start = clock::now();
+    while (!exec_->is_spinning() && (clock::now() - start) < std::chrono::seconds(5)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (!exec_->is_spinning()) {
+      std::cerr << "Failed to start spinning node" << std::endl;
+      throw std::runtime_error("Failed to start spinning node");
+    }
+
     ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
     pub_manager.run_publishers();
 


### PR DESCRIPTION
This PR addresses some flaky tests in Rosbag2
 1. Address flakiness in tests where need to spin a node
    - Wait for the executor to start spinning in the newly spawned thread to avoid race conditions. The same approach as from the (ros2/rosbag2#1796)
 2. Address flakiness in `write_split_callback_is_called` test
    - Reduce subscriptions polling interval in recorder to 10ms
    - Start recording after creating publishers to let recorder opportunity to subscribe to the test topic before starting topics discovery.