### PR TITLE
Backporting missing cstdint Include in MCAP sources

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -39,6 +39,16 @@ macro(build_mcap_vendor)
   )
   fetchcontent_makeavailable(mcap)
 
+  message(WARN "DJA: ${CMAKE_CURRENT_SOURCE_DIR}")
+  file(GLOB PATCHES
+    "${CMAKE_CURRENT_SOURCE_DIR}/patches/*.patch"
+  )
+  message(WARN "DJA: ${PATCHES}")
+
+  foreach(PATCH ${PATCHES})
+    execute_process(COMMAND git apply --whitespace=nowarn -p1 ${PATCH})
+  endforeach()
+
   add_library(mcap SHARED
     src/main.cpp
   )

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -39,11 +39,9 @@ macro(build_mcap_vendor)
   )
   fetchcontent_makeavailable(mcap)
 
-  message(WARN "DJA: ${CMAKE_CURRENT_SOURCE_DIR}")
   file(GLOB PATCHES
     "${CMAKE_CURRENT_SOURCE_DIR}/patches/*.patch"
   )
-  message(WARN "DJA: ${PATCHES}")
 
   foreach(PATCH ${PATCHES})
     execute_process(COMMAND git apply --whitespace=nowarn -p1 ${PATCH})

--- a/mcap_vendor/patches/0001-fix-gcc15.patch
+++ b/mcap_vendor/patches/0001-fix-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/mcap/include/mcap/types.hpp b/cpp/mcap/include/mcap/types.hpp
+index ffd8f4e..5352702 100644
+--- a/_deps/mcap-src/cpp/mcap/include/mcap/types.hpp
++++ b/_deps/mcap-src/cpp/mcap/include/mcap/types.hpp
+@@ -3,6 +3,7 @@
+ #include "errors.hpp"
+ #include "visibility.hpp"
+ #include <cstddef>
++#include <cstdint>
+ #include <functional>
+ #include <limits>
+ #include <memory>

--- a/mcap_vendor/patches/gcc15.patch
+++ b/mcap_vendor/patches/gcc15.patch
@@ -1,0 +1,10 @@
+--- /tmp/types.hpp	2025-05-10 17:36:18.117912264 -0500
++++ build/mcap_vendor/_deps/mcap-src/cpp/mcap/include/mcap/types.hpp	2025-05-10 17:35:39.688314498 -0500
+@@ -3,6 +3,7 @@
+ #include "errors.hpp"
+ #include "visibility.hpp"
+ #include <cstddef>
++#include <cstdint>
+ #include <functional>
+ #include <limits>
+ #include <memory>

--- a/mcap_vendor/patches/gcc15.patch
+++ b/mcap_vendor/patches/gcc15.patch
@@ -1,8 +1,0 @@
-@@ -3,6 +3,7 @@
- #include "errors.hpp"
- #include "visibility.hpp"
- #include <cstddef>
-+#include <cstdint>
- #include <functional>
- #include <limits>
- #include <memory>

--- a/mcap_vendor/patches/gcc15.patch
+++ b/mcap_vendor/patches/gcc15.patch
@@ -1,5 +1,3 @@
---- /tmp/types.hpp	2025-05-10 17:36:18.117912264 -0500
-+++ build/mcap_vendor/_deps/mcap-src/cpp/mcap/include/mcap/types.hpp	2025-05-10 17:35:39.688314498 -0500
 @@ -3,6 +3,7 @@
  #include "errors.hpp"
  #include "visibility.hpp"

--- a/rosbag2_transport/src/rosbag2_transport/player_action_client.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player_action_client.cpp
@@ -141,7 +141,6 @@ PlayerActionClient::~PlayerActionClient()
     recorded_goal_to_goal_id_id_map_.clear();
     goal_id_to_goal_handle_map_.clear();
   }
-  client_->async_cancel_all_goals();
 
   {
     std::lock_guard<std::mutex> lock(goal_ids_to_postpone_send_cancel_mutex_);


### PR DESCRIPTION
Backport of: https://github.com/foxglove/mcap/pull/1371 to fix build failures with new versions of GCC. Addresses https://github.com/ros2/rosbag2/issues/2009.