### PR TITLE
Bugfix for no output in `cout` if progress bar is disabled

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player_progress_bar_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player_progress_bar_impl.hpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 #include <iostream>
+#include <sstream>
 
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
@@ -81,16 +82,16 @@ public:
 
   void print_help_str() const
   {
-    std::stringstream ss;
     if (enable_progress_bar_) {
+      std::stringstream ss;
       if (progress_bar_update_period_ms_ > 0) {
         ss << "Progress bar enabled at " << (1000 / progress_bar_update_period_ms_) << " Hz.\n";
       } else {
         ss << "Progress bar enabled for every message.\n";
       }
       ss << "Progress bar [?]: [R]unning, [P]aused, [B]urst, [D]elayed, [S]topped\n";
+      o_stream_ << ss.rdbuf() << std::flush;
     }
-    o_stream_ << ss.rdbuf() << std::flush;
   }
 
   void update_with_limited_rate(
@@ -158,7 +159,7 @@ private:
   double duration_secs_ = 0.0;
   std::string progress_bar_helper_move_cursor_down_;
   std::string progress_bar_helper_move_cursor_up_;
-  bool enable_progress_bar_;
+  bool enable_progress_bar_{false};
   uint16_t progress_bar_update_period_ms_;
   std::chrono::steady_clock::time_point progress_bar_last_time_updated_{};
   uint32_t progress_bar_separation_lines_ = 3;


### PR DESCRIPTION
## Description

Bugfix for no output in `cout` if the Rosbag2 player progress bar is disabled.

Currently, we have a regression that if the Player's progress bar is disabled via CLI command or node parameters as soon as the progress bar is constructed and initialized. There are no more logs or any other outputs from the `std::cout` visible in the console.

Fixes # (issue)
N/A

### Is this user-facing behavior change?
The user will continue to see log messages when the Rosbag2 player's progress bar is disabled.

### Did you use Generative AI?
No.

### Additional Information
N/A
