### PR TITLE
Improvements in message publishing timings

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/clocks/time_controller_clock.cpp
@@ -124,6 +124,7 @@ public:
   double rate RCPPUTILS_TSA_GUARDED_BY(state_mutex) = 1.0;
   bool paused RCPPUTILS_TSA_GUARDED_BY(state_mutex) = false;
   bool is_sleeping RCPPUTILS_TSA_GUARDED_BY(state_mutex) = false;
+  bool wake_up_ RCPPUTILS_TSA_GUARDED_BY(state_mutex) = false;
   TimeReference reference RCPPUTILS_TSA_GUARDED_BY(state_mutex);
 };
 
@@ -174,7 +175,8 @@ bool TimeControllerClock::sleep_until(rcutils_time_point_value_t until)
       // wait only if necessary for performance
       if (steady_until > impl_->now_fn()) {
         impl_->is_sleeping = true;
-        impl_->cv.wait_until(lock, steady_until);
+        impl_->wake_up_ = false;
+        impl_->cv.wait_until(lock, steady_until, [&]() {return impl_->wake_up_;});
         impl_->is_sleeping = false;
       }
     }
@@ -204,6 +206,10 @@ void TimeControllerClock::wakeup()
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wthread-safety-analysis"
 #endif
+  {
+    std::lock_guard<std::mutex> lock(impl_->state_mutex);
+    impl_->wake_up_ = true;
+  }
   // Note. We shall not lock mutex before notify_all since the notified thread would immediately
   // block again, waiting for the notifying thread to release the lock
   impl_->cv.notify_all();

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -624,12 +624,7 @@ bool PlayerImpl::play()
             for (const auto & [reader, _] : readers_with_options_) {
               reader->seek(starting_time_);
             }
-            clock_->jump(starting_time_);
           }
-          if (clock_publish_timer_ != nullptr) {
-            clock_publish_timer_->reset();
-          }
-
           progress_bar_->update(clock_->is_paused() ? PlayerStatus::PAUSED : PlayerStatus::RUNNING);
 
           load_storage_content_ = true;
@@ -638,6 +633,12 @@ bool PlayerImpl::play()
               load_storage_content();
             });
           wait_for_filled_queue();
+
+          if (clock_publish_timer_ != nullptr) {
+            clock_publish_timer_->reset();
+          }
+          clock_->jump(starting_time_);
+
           play_messages_from_queue();
 
           load_storage_content_ = false;


### PR DESCRIPTION
## Description

This PR introduces improvements in message publishing timings.
1. Correctly handle sporadic wakeups with predicate in the `TimeControllerClock` class. 
   - These changes can improve playback accuracy in cases when sporadic wakeups on the conditional variable wait method could happen.
3. Bugfix for incorrect message intervals on player start.
   - The internal player clock was initialized too early. Before we start reading messages from readers to the internal cache buffer. That was leading to the situation when the first few messages were past due to publish when playback was ready to start.

Fixes # (issue)
N/A

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
I am using GitHub Copilot, GPT-4.1, in my workflow, but AI generated nothing in this PR.

### Additional Information
N/A