### PR TITLE
Add new messages write API in BaseWriteInterface, with return status of operation

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
@@ -46,6 +46,7 @@ public:
   MOCK_METHOD1(
     write,
     void(const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &));
+  MOCK_METHOD1(write_message, bool(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
   MOCK_METHOD1(
     write_messages,
     std::vector<size_t>(const rosbag2_storage::SerializedBagMessages &));

--- a/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
+++ b/rosbag2_compression/test/rosbag2_compression/mock_storage.hpp
@@ -46,6 +46,9 @@ public:
   MOCK_METHOD1(
     write,
     void(const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &));
+  MOCK_METHOD1(
+    write_messages,
+    std::vector<size_t>(const rosbag2_storage::SerializedBagMessages &));
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD1(
     get_all_message_definitions,

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -103,12 +103,15 @@ public:
             output.close();
           }),
         Return(storage_)));
-    ON_CALL(
-      *storage_,
-      write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
-      [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+    ON_CALL(*storage_,
+            write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+    .WillByDefault(
+      [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message) {
+        (void)serialized_message;
         fake_storage_size_.fetch_add(1);
-      });
+        return true;
+      }
+    );
     ON_CALL(*storage_, get_bagfile_size).WillByDefault(
       [this]() {
         return fake_storage_size_.load();

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -632,11 +632,9 @@ TEST_F(SequentialCompressionWriterTest, snapshot_writes_to_new_file_with_file_co
   tmp_dir_storage_options_.snapshot_mode = true;
 
   initializeFakeFileStorage();
-  // Expect a single write call when the snapshot is triggered
-  EXPECT_CALL(
-    *storage_, write(
-      An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
-  ).Times(1);
+  // Expect a single write_messages call when the snapshot is triggered
+  EXPECT_CALL(*storage_,
+              write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(1);
 
   rosbag2_compression::CompressionOptions compression_options {
     DefaultTestCompressor,

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -561,8 +561,8 @@ void SequentialWriter::write_messages(
       std::chrono::nanoseconds(messages[last_msg_index]->recv_timestamp));
     metadata_.files.back().starting_time = first_msg_timestamp;
     metadata_.files.back().duration = last_msg_timestamp - first_msg_timestamp;
-    metadata_.files.back().message_count = written_messages_count;
   }
+  metadata_.files.back().message_count += written_messages_count;
   metadata_.message_count += written_messages_count;
   std::lock_guard<std::mutex> lock(topics_info_mutex_);
   // Update message count for each topic in metadata
@@ -574,7 +574,6 @@ void SequentialWriter::write_messages(
         continue;  // Skip lost messages
       }
     }
-    metadata_.files.back().message_count++;
     auto topic_info_it = topics_names_to_info_.find(messages[i]->topic_name);
     if (topic_info_it != topics_names_to_info_.end()) {
       topic_info_it->second.message_count++;

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -528,16 +528,16 @@ void SequentialWriter::write_messages(
   if (messages.empty()) {
     return;
   }
-  auto lost_messages = storage_->write_messages(messages);
-  auto written_messages_count = messages.size() - lost_messages.size();
+  auto lost_messages_idx = storage_->write_messages(messages);
+  auto written_messages_count = messages.size() - lost_messages_idx.size();
   if (storage_options_.snapshot_mode && written_messages_count > 0) {
     // Update FileInformation about the last file in metadata in case of snapshot mode
     size_t first_msg_index = 0;
     // If some messages were lost, we need to find the first message that was written
-    if (!lost_messages.empty()) {
+    if (!lost_messages_idx.empty()) {
       for (size_t i = 0; i < messages.size(); ++i) {
-        auto is_current_lost = std::binary_search(lost_messages.begin(), lost_messages.end(), i);
-        if (!is_current_lost) {
+        auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
+        if (!is_lost) {
           first_msg_index = i;
           break;
         }
@@ -545,10 +545,10 @@ void SequentialWriter::write_messages(
     }
     size_t last_msg_index = messages.size() - 1;
     // If some messages were lost, we need to find the last message that was written
-    if (!lost_messages.empty()) {
+    if (!lost_messages_idx.empty()) {
       for (size_t i = messages.size() - 1; i >= first_msg_index; i--) {
-        auto is_current_lost = std::binary_search(lost_messages.begin(), lost_messages.end(), i);
-        if (!is_current_lost) {
+        auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
+        if (!is_lost) {
           last_msg_index = i;
           break;
         }
@@ -568,8 +568,8 @@ void SequentialWriter::write_messages(
   // Update message count for each topic in metadata
   for (size_t i = 0; i < messages.size(); i++) {
     // If some messages were lost, we need to skip them
-    if (!lost_messages.empty()) {
-      auto is_lost = std::binary_search(lost_messages.begin(), lost_messages.end(), i);
+    if (!lost_messages_idx.empty()) {
+      auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
       if (is_lost) {
         continue;  // Skip lost messages
       }

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -424,11 +424,12 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
 
   auto converted_msg = get_writeable_message(message);
 
-  metadata_.files.back().message_count++;
   if (storage_options_.max_cache_size == 0u) {
     // If cache size is set to zero, we write to storage directly
-    (void)storage_->write_message(converted_msg);
-    ++topic_information->message_count;
+    if (storage_->write_message(converted_msg)) {
+      metadata_.files.back().message_count++;
+      topic_information->message_count++;
+    }
   } else {
     // Otherwise, use cache buffer
     message_cache_->push(converted_msg);
@@ -573,6 +574,7 @@ void SequentialWriter::write_messages(
         continue;  // Skip lost messages
       }
     }
+    metadata_.files.back().message_count++;
     auto topic_info_it = topics_names_to_info_.find(messages[i]->topic_name);
     if (topic_info_it != topics_names_to_info_.end()) {
       topic_info_it->second.message_count++;

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -427,7 +427,7 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
   metadata_.files.back().message_count++;
   if (storage_options_.max_cache_size == 0u) {
     // If cache size is set to zero, we write to storage directly
-    storage_->write(converted_msg);
+    (void)storage_->write_message(converted_msg);
     ++topic_information->message_count;
   } else {
     // Otherwise, use cache buffer

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -527,22 +527,55 @@ void SequentialWriter::write_messages(
   if (messages.empty()) {
     return;
   }
-  storage_->write(messages);
-  if (storage_options_.snapshot_mode) {
+  auto lost_messages = storage_->write_messages(messages);
+  auto written_messages_count = messages.size() - lost_messages.size();
+  if (storage_options_.snapshot_mode && written_messages_count > 0) {
     // Update FileInformation about the last file in metadata in case of snapshot mode
+    size_t first_msg_index = 0;
+    // If some messages were lost, we need to find the first message that was written
+    if (!lost_messages.empty()) {
+      for (size_t i = 0; i < messages.size(); ++i) {
+        auto is_current_lost = std::binary_search(lost_messages.begin(), lost_messages.end(), i);
+        if (!is_current_lost) {
+          first_msg_index = i;
+          break;
+        }
+      }
+    }
+    size_t last_msg_index = messages.size() - 1;
+    // If some messages were lost, we need to find the last message that was written
+    if (!lost_messages.empty()) {
+      for (size_t i = messages.size() - 1; i >= first_msg_index; i--) {
+        auto is_current_lost = std::binary_search(lost_messages.begin(), lost_messages.end(), i);
+        if (!is_current_lost) {
+          last_msg_index = i;
+          break;
+        }
+      }
+    }
+
     const auto first_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
-      std::chrono::nanoseconds(messages.front()->recv_timestamp));
+      std::chrono::nanoseconds(messages[first_msg_index]->recv_timestamp));
     const auto last_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
-      std::chrono::nanoseconds(messages.back()->recv_timestamp));
+      std::chrono::nanoseconds(messages[last_msg_index]->recv_timestamp));
     metadata_.files.back().starting_time = first_msg_timestamp;
     metadata_.files.back().duration = last_msg_timestamp - first_msg_timestamp;
-    metadata_.files.back().message_count = messages.size();
+    metadata_.files.back().message_count = written_messages_count;
   }
-  metadata_.message_count += messages.size();
+  metadata_.message_count += written_messages_count;
   std::lock_guard<std::mutex> lock(topics_info_mutex_);
-  for (const auto & msg : messages) {
-    if (topics_names_to_info_.find(msg->topic_name) != topics_names_to_info_.end()) {
-      topics_names_to_info_[msg->topic_name].message_count++;
+  // Update message count for each topic in metadata
+  for (size_t i = 0; i < messages.size(); i++) {
+    // If some messages were lost, we need to skip them
+    if (!lost_messages.empty()) {
+      auto is_lost = std::binary_search(lost_messages.begin(), lost_messages.end(), i);
+      if (is_lost) {
+        continue;  // Skip lost messages
+      }
+    }
+    auto topic_info_it = topics_names_to_info_.find(messages[i]->topic_name);
+    if (topic_info_it != topics_names_to_info_.end()) {
+      topic_info_it->second.message_count++;
     }
   }
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
@@ -48,6 +48,10 @@ public:
   MOCK_METHOD1(
     write,
     void(const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &));
+  MOCK_METHOD1(
+    write_messages,
+    std::vector<size_t>(const rosbag2_storage::SerializedBagMessages &)
+  );
   MOCK_METHOD0(get_all_topics_and_types, std::vector<rosbag2_storage::TopicMetadata>());
   MOCK_METHOD1(
     get_all_message_definitions,

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_storage.hpp
@@ -48,6 +48,7 @@ public:
   MOCK_METHOD1(
     write,
     void(const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &));
+  MOCK_METHOD1(write_message, bool(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
   MOCK_METHOD1(
     write_messages,
     std::vector<size_t>(const rosbag2_storage::SerializedBagMessages &)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -369,14 +369,14 @@ TEST_F(
   fake_storage_size_ = 0;
   size_t written_messages = 0;
 
-  using VectorSharedBagMessages =
-    std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>;
-
-  ON_CALL(*storage_, write(An<const VectorSharedBagMessages &>())).WillByDefault(
-    [this, &written_messages](const VectorSharedBagMessages & msgs)
+  ON_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
+  .WillByDefault(
+    [this, &written_messages](const rosbag2_storage::SerializedBagMessages & msgs)
     {
       written_messages += msgs.size();
       fake_storage_size_.fetch_add(static_cast<uint32_t>(msgs.size()));
+      std::vector<size_t> lost_messages;
+      return lost_messages;
     });
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
@@ -463,10 +463,9 @@ TEST_F(SequentialWriterTest, do_not_use_cache_if_cache_size_is_zero) {
   const size_t counter = 1000;
   const uint64_t max_cache_size = 0;
 
-  EXPECT_CALL(
-    *storage_,
-    write(An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())).
-  Times(0);
+  EXPECT_CALL(*storage_,
+              write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(0);
+
   EXPECT_CALL(
     *storage_,
     write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).Times(counter);
@@ -503,11 +502,8 @@ TEST_F(SequentialWriterTest, snapshot_mode_write_on_trigger)
   storage_options_.snapshot_mode = true;
 
   // Expect a single write call when the snapshot is triggered
-  EXPECT_CALL(
-    *storage_, write(
-      An
-      <const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
-  ).Times(1);
+  EXPECT_CALL(*storage_,
+              write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(1);
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
@@ -539,11 +535,8 @@ TEST_F(SequentialWriterTest, snapshot_mode_not_triggered_no_storage_write)
 
   // Storage should never be written to when snapshot mode is enabled
   // but a snapshot is never triggered
-  EXPECT_CALL(
-    *storage_, write(
-      An
-      <const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
-  ).Times(0);
+  EXPECT_CALL(*storage_,
+              write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(0);
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
@@ -607,11 +600,8 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
   }
 
   // Expect a single write call when the snapshot is triggered
-  EXPECT_CALL(
-    *storage_, write(
-    An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
-  ).Times(1);
-
+  EXPECT_CALL(*storage_,
+              write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(1);
   ON_CALL(
     *storage_,
     write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
@@ -711,10 +701,8 @@ TEST_F(SequentialWriterTest, snapshot_can_be_called_twice)
   const size_t num_msgs_to_write = 100;
 
   // Expect to call write method twice. Once per each snapshot.
-  EXPECT_CALL(
-    *storage_, write(
-    An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>())
-  ).Times(2);
+  EXPECT_CALL(*storage_,
+              write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(2);
 
   ON_CALL(*storage_, get_relative_file_path).WillByDefault(
     [this]() {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -297,12 +297,16 @@ TEST_F(SequentialWriterTest, writer_splits_when_storage_bagfile_size_gt_max_bagf
   const auto expected_splits = message_count / max_bagfile_size;
   fake_storage_size_ = 0;
 
-  ON_CALL(
-    *storage_,
-    write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+  ON_CALL(*storage_,
+          write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .WillByDefault(
+    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message)
+    {
+      (void)serialized_message;
       fake_storage_size_++;
-    });
+      return true;
+    }
+  );
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
     [this]() {
@@ -466,9 +470,9 @@ TEST_F(SequentialWriterTest, do_not_use_cache_if_cache_size_is_zero) {
   EXPECT_CALL(*storage_,
               write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(0);
 
-  EXPECT_CALL(
-    *storage_,
-    write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).Times(counter);
+  EXPECT_CALL(*storage_,
+              write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .Times(counter);
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
@@ -602,12 +606,14 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
   // Expect a single write call when the snapshot is triggered
   EXPECT_CALL(*storage_,
               write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(1);
-  ON_CALL(
-    *storage_,
-    write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
+  ON_CALL(*storage_,
+    write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .WillByDefault(
     [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
       fake_storage_size_ += 1;
-    });
+      return true;
+    }
+  );
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
     [this]() {
@@ -774,11 +780,13 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
   const size_t num_splits = 2;
   const int message_count = max_bagfile_size * num_splits + max_bagfile_size - 1;  // 8
 
-  ON_CALL(
-    *storage_,
-    write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+  ON_CALL(*storage_,
+          write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .WillByDefault(
+    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message) {
+      (void)serialized_message;
       fake_storage_size_ += 1;
+      return true;
     });
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
@@ -851,12 +859,14 @@ TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
 {
   const int message_count = 7;
 
-  ON_CALL(
-    *storage_,
-    write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
+  ON_CALL(*storage_,
+    write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .WillByDefault(
     [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
       fake_storage_size_ += 1;
-    });
+      return true;
+    }
+  );
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
     [this]() {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -73,6 +73,25 @@ public:
         v_intercepted_update_metadata_.emplace_back(metadata);
       });
     ON_CALL(*storage_, set_read_order).WillByDefault(Return(true));
+
+    ON_CALL(*storage_,
+            write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+    .WillByDefault(
+      [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+        fake_storage_size_ += 1;
+        return true;
+        }
+    );
+
+    ON_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
+    .WillByDefault(
+      [this](const rosbag2_storage::SerializedBagMessages & msgs)
+      {
+        fake_storage_size_.fetch_add(static_cast<uint32_t>(msgs.size()));
+        std::vector<size_t> lost_messages;
+        return lost_messages;
+        }
+    );
   }
 
   ~SequentialWriterTest() override
@@ -296,17 +315,6 @@ TEST_F(SequentialWriterTest, writer_splits_when_storage_bagfile_size_gt_max_bagf
   const int max_bagfile_size = 5;
   const auto expected_splits = message_count / max_bagfile_size;
   fake_storage_size_ = 0;
-
-  ON_CALL(*storage_,
-          write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
-  .WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message)
-    {
-      (void)serialized_message;
-      fake_storage_size_++;
-      return true;
-    }
-  );
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
     [this]() {
@@ -606,14 +614,9 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
   // Expect a single write call when the snapshot is triggered
   EXPECT_CALL(*storage_,
               write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(1);
-  ON_CALL(*storage_,
-    write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
-  .WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
-      fake_storage_size_ += 1;
-      return true;
-    }
-  );
+  EXPECT_CALL(*storage_,
+              write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .Times(0);
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
     [this]() {
@@ -780,15 +783,6 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
   const size_t num_splits = 2;
   const int message_count = max_bagfile_size * num_splits + max_bagfile_size - 1;  // 8
 
-  ON_CALL(*storage_,
-          write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
-  .WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message) {
-      (void)serialized_message;
-      fake_storage_size_ += 1;
-      return true;
-    });
-
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
     [this]() {
       return fake_storage_size_.load();
@@ -858,15 +852,6 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
 TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
 {
   const int message_count = 7;
-
-  ON_CALL(*storage_,
-    write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
-  .WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
-      fake_storage_size_ += 1;
-      return true;
-    }
-  );
 
   ON_CALL(*storage_, get_bagfile_size).WillByDefault(
     [this]() {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -80,17 +80,35 @@ public:
       [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
         fake_storage_size_ += 1;
         return true;
-        }
+      }
     );
 
     ON_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
     .WillByDefault(
-      [this](const rosbag2_storage::SerializedBagMessages & msgs)
-      {
+      [this](const rosbag2_storage::SerializedBagMessages & msgs) {
         fake_storage_size_.fetch_add(static_cast<uint32_t>(msgs.size()));
         std::vector<size_t> lost_messages;
         return lost_messages;
-        }
+      }
+    );
+
+    // intercept the metadata write so we can analyze it.
+    ON_CALL(*metadata_io_, write_metadata).WillByDefault(
+      [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
+        fake_metadata_ = metadata;
+      }
+    );
+
+    ON_CALL(*storage_, get_bagfile_size).WillByDefault(
+      [this]() {
+        return fake_storage_size_.load();
+      }
+    );
+
+    ON_CALL(*storage_, get_relative_file_path).WillByDefault(
+      [this]() {
+        return fake_storage_uri_;
+      }
     );
   }
 
@@ -316,23 +334,7 @@ TEST_F(SequentialWriterTest, writer_splits_when_storage_bagfile_size_gt_max_bagf
   const auto expected_splits = message_count / max_bagfile_size;
   fake_storage_size_ = 0;
 
-  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
-    [this]() {
-      return fake_storage_size_.load();
-    });
-
-  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-    [this]() {
-      return fake_storage_uri_;
-    });
-
   EXPECT_CALL(*metadata_io_, write_metadata).Times(1);
-
-  // intercept the metadata write so we can analyze it.
-  ON_CALL(*metadata_io_, write_metadata).WillByDefault(
-    [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
-      fake_metadata_ = metadata;
-    });
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
@@ -391,25 +393,9 @@ TEST_F(
       return lost_messages;
     });
 
-  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
-    [this]() {
-      return fake_storage_size_.load();
-    });
-
-  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-    [this]() {
-      return fake_storage_uri_;
-    });
-
   EXPECT_CALL(*metadata_io_, write_metadata).Times(1);
 
   EXPECT_CALL(*storage_factory_, open_read_write(_)).Times(3);
-
-  // intercept the metadata write so we can analyze it.
-  ON_CALL(*metadata_io_, write_metadata).WillByDefault(
-    [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
-      fake_metadata_ = metadata;
-    });
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
@@ -618,21 +604,6 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
               write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
   .Times(0);
 
-  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
-    [this]() {
-      return fake_storage_size_.load();
-    });
-
-  ON_CALL(*metadata_io_, write_metadata).WillByDefault(
-    [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
-      fake_metadata_ = metadata;
-    });
-
-  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-    [this]() {
-      return fake_storage_uri_;
-    });
-
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
   writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
@@ -713,11 +684,6 @@ TEST_F(SequentialWriterTest, snapshot_can_be_called_twice)
   EXPECT_CALL(*storage_,
               write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(2);
 
-  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-    [this]() {
-      return fake_storage_uri_;
-    });
-
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
   writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
@@ -783,21 +749,6 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
   const size_t num_splits = 2;
   const int message_count = max_bagfile_size * num_splits + max_bagfile_size - 1;  // 8
 
-  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
-    [this]() {
-      return fake_storage_size_.load();
-    });
-
-  ON_CALL(*metadata_io_, write_metadata).WillByDefault(
-    [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
-      fake_metadata_ = metadata;
-    });
-
-  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-    [this]() {
-      return fake_storage_uri_;
-    });
-
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
   writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
@@ -852,21 +803,6 @@ TEST_F(SequentialWriterTest, split_event_calls_callback)
 TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
 {
   const int message_count = 7;
-
-  ON_CALL(*storage_, get_bagfile_size).WillByDefault(
-    [this]() {
-      return fake_storage_size_.load();
-    });
-
-  ON_CALL(*metadata_io_, write_metadata).WillByDefault(
-    [this](const std::string &, const rosbag2_storage::BagMetadata & metadata) {
-      fake_metadata_ = metadata;
-    });
-
-  ON_CALL(*storage_, get_relative_file_path).WillByDefault(
-    [this]() {
-      return fake_storage_uri_;
-    });
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));

--- a/rosbag2_cpp/test/rosbag2_cpp/test_serialization_converter.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_serialization_converter.cpp
@@ -67,12 +67,15 @@ public:
 
     ON_CALL(*storage_, set_read_order).WillByDefault(Return(true));
 
-    ON_CALL(
-      *storage_,
-      write(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).WillByDefault(
-      [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message) {
+    ON_CALL(*storage_,
+            write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+    .WillByDefault(
+      [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message)
+      {
         mock_storage_data_.push_back(serialized_message);
-      });
+        return true;
+      }
+    );
 
     EXPECT_CALL(*storage_,
                 write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(0);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_serialization_converter.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_serialization_converter.cpp
@@ -74,10 +74,8 @@ public:
         mock_storage_data_.push_back(serialized_message);
       });
 
-    using VectorSharedBagMessages =
-      std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>;
-
-    EXPECT_CALL(*storage_, write(An<const VectorSharedBagMessages &>())).Times(0);
+    EXPECT_CALL(*storage_,
+                write_messages(An<const rosbag2_storage::SerializedBagMessages &>())).Times(0);
 
     EXPECT_CALL(*storage_, get_bagfile_size()).Times(0);
   }

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -33,23 +33,50 @@ using SerializedBagMessages = std::vector<std::shared_ptr<const SerializedBagMes
 namespace storage_interfaces
 {
 
+/// \brief The base interface for writing messages to storage.
 class ROSBAG2_STORAGE_PUBLIC BaseWriteInterface
 {
 public:
+  /// \brief Default destructor.
   virtual ~BaseWriteInterface() = default;
 
+  /// \brief Writes one serialized message to the storage.
+  /// \throws std::runtime_error if the storage is not open, or if create_topic(..) was not called
+  /// previously for the topic associated with the message being written.
   virtual void write(std::shared_ptr<const SerializedBagMessage> msg) = 0;
 
+  // This method is deprecated, use
+  // std::vector<size_t> write_messages(const SerializedBagMessages & messages) instead.
+  [[deprecated("Use write_messages(const SerializedBagMessages & messages) instead.")]]
   virtual void write(const std::vector<std::shared_ptr<const SerializedBagMessage>> & msg) = 0;
 
+  /// \brief Write a batch of messages to the storage.
+  /// \param messages - List of serialized messages to write.
+  /// \return Returns a vector of indexes pointing to the messages from the input list that were
+  /// not written. If all messages were written successfully, the vector will be empty.
+  /// \throws std::runtime_error if the storage is not open or if create_topic(..) has not been
+  /// called for all topics in the messages list.
   virtual std::vector<size_t> write_messages(const SerializedBagMessages & messages) = 0;
 
+  /// \brief Writes provided metadata to the storage i.e. bag file.
+  /// \param bag_metadata - Metadata to be written to the storage.
   virtual void update_metadata(const BagMetadata & bag_metadata) = 0;
 
+  /// \brief Creates a new topic in the storage. Needs to be called for every topic used within a
+  //// message which is passed to write_message(...) or write_messages(...).
+  /// \param topic - Metadata of the topic to create.
+  /// \param message_definition - rosbag2_storage::MessageDefinition containing the full encoded
+  /// message definition for this type and the type hash.
+  /// \throws std::runtime_error if the storage is not open.
   virtual void create_topic(
     const TopicMetadata & topic,
     const rosbag2_storage::MessageDefinition & message_definition) = 0;
 
+  /// \brief Removes a topic from the internal storage references.
+  /// This does not remove the topic from the bag file, but removes it from the internal
+  /// references so that it is not written to the bag file in the future. This is an opposite to
+  /// create_topic, which adds a topic to the internal storage references.
+  /// \param topic - Metadata of the topic to remove.
   virtual void remove_topic(const TopicMetadata & topic) = 0;
 };
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -43,12 +43,15 @@ public:
   /// \brief Writes one serialized message to the storage.
   /// \throws std::runtime_error if the storage is not open, or if create_topic(..) was not called
   /// previously for the topic associated with the message being written.
+  [[deprecated("Use write_message(std::shared_ptr<const SerializedBagMessage> msg) instead.")]]
   virtual void write(std::shared_ptr<const SerializedBagMessage> msg) = 0;
 
   // This method is deprecated, use
   // std::vector<size_t> write_messages(const SerializedBagMessages & messages) instead.
   [[deprecated("Use write_messages(const SerializedBagMessages & messages) instead.")]]
   virtual void write(const std::vector<std::shared_ptr<const SerializedBagMessage>> & msg) = 0;
+
+  virtual bool write_message(std::shared_ptr<const SerializedBagMessage> msg) = 0;
 
   /// \brief Write a batch of messages to the storage.
   /// \param messages - List of serialized messages to write.

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -27,6 +27,9 @@
 
 namespace rosbag2_storage
 {
+
+using SerializedBagMessages = std::vector<std::shared_ptr<const SerializedBagMessage>>;
+
 namespace storage_interfaces
 {
 
@@ -38,6 +41,8 @@ public:
   virtual void write(std::shared_ptr<const SerializedBagMessage> msg) = 0;
 
   virtual void write(const std::vector<std::shared_ptr<const SerializedBagMessage>> & msg) = 0;
+
+  virtual std::vector<size_t> write_messages(const SerializedBagMessages & messages) = 0;
 
   virtual void update_metadata(const BagMetadata & bag_metadata) = 0;
 

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -51,6 +51,11 @@ public:
   [[deprecated("Use write_messages(const SerializedBagMessages & messages) instead.")]]
   virtual void write(const std::vector<std::shared_ptr<const SerializedBagMessage>> & msg) = 0;
 
+  /// \brief Writes one serialized message to the storage.
+  /// \param msg - The serialized message to write.
+  /// \return Returns true if the message was written successfully, false otherwise.
+  /// \throws std::runtime_error if the storage is not open, or if create_topic(..) was not called
+  /// previously for the topic associated with the message being written.
   virtual bool write_message(std::shared_ptr<const SerializedBagMessage> msg) = 0;
 
   /// \brief Write a batch of messages to the storage.

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -95,6 +95,14 @@ void TestPlugin::write(
   std::cout << "\nwriting multiple\n";
 }
 
+bool TestPlugin::write_message(
+  const std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
+{
+  (void) msg;
+  std::cout << "\nwriting message\n";
+  return true;
+}
+
 std::vector<size_t>
 TestPlugin::write_messages(const rosbag2_storage::SerializedBagMessages & messages)
 {

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -95,6 +95,15 @@ void TestPlugin::write(
   std::cout << "\nwriting multiple\n";
 }
 
+std::vector<size_t>
+TestPlugin::write_messages(const rosbag2_storage::SerializedBagMessages & messages)
+{
+  (void)messages;
+  std::cout << "\nwriting multiple messages\n";
+  std::vector<size_t> ret_value;
+  return ret_value;
+}
+
 std::vector<rosbag2_storage::TopicMetadata> TestPlugin::get_all_topics_and_types()
 {
   std::cout << "\nreading topics and types\n";

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -52,6 +52,8 @@ public:
   void write(
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msg) override;
 
+  bool write_message(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
+
   std::vector<size_t>
   write_messages(const rosbag2_storage::SerializedBagMessages & messages) override;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.hpp
@@ -49,8 +49,11 @@ public:
 
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
 
-  void write(const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msg)
-  override;
+  void write(
+    const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msg) override;
+
+  std::vector<size_t>
+  write_messages(const rosbag2_storage::SerializedBagMessages & messages) override;
 
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 

--- a/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_storage_factory.cpp
@@ -56,7 +56,7 @@ TEST_F(StorageFactoryTest, load_test_plugin) {
     read_write_storage->get_bagfile_size());
 
   auto msg = read_write_storage->read_next();
-  read_write_storage->write(msg);
+  EXPECT_TRUE(read_write_storage->write_message(msg));
 
   // Load plugin for read only even though it provides read and write interfaces
   auto read_only_storage = factory.open_read_only(

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -221,6 +221,8 @@ public:
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
   void write(
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msg) override;
+  std::vector<size_t> write_messages(
+    const rosbag2_storage::SerializedBagMessages & messages) override;
   void create_topic(const rosbag2_storage::TopicMetadata & topic,
                     const rosbag2_storage::MessageDefinition & message_definition) override;
   void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
@@ -230,7 +232,7 @@ public:
 
 private:
   void read_metadata();
-  void write_lock_free(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg);
+  bool write_lock_free(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg);
   void open_impl(const std::string & uri, const std::string & preset_profile,
                  rosbag2_storage::storage_interfaces::IOFlag io_flag,
                  const std::string & storage_config_uri);
@@ -865,7 +867,11 @@ uint64_t MCAPStorage::get_minimum_split_file_size() const
 void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
   std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
-  write_lock_free(msg);
+  if (!write_lock_free(msg)) {
+    throw std::runtime_error{std::string{"Message on topic '"} + msg->topic_name + "' of size '" +
+                             std::to_string(msg->serialized_data->buffer_length) +
+                             "' bytes failed to write to MCAP file. It will be lost."};
+  }
 }
 
 void MCAPStorage::write(
@@ -873,11 +879,30 @@ void MCAPStorage::write(
 {
   std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
   for (const auto & msg : msgs) {
-    write_lock_free(msg);
+    if (!write_lock_free(msg)) {
+      throw std::runtime_error{std::string{"Message on topic '"} + msg->topic_name + "' of size '" +
+                               std::to_string(msg->serialized_data->buffer_length) +
+                               "' bytes failed to write to MCAP file. It will be lost."};
+    }
   }
 }
 
-void MCAPStorage::write_lock_free(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
+std::vector<size_t> MCAPStorage::write_messages(
+  const rosbag2_storage::SerializedBagMessages & messages)
+{
+  std::vector<size_t> lost_messages;
+  std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
+  size_t current_message_index = 0;
+  for (const auto & msg : messages) {
+    if (!write_lock_free(msg)) {
+      lost_messages.push_back(current_message_index);
+    }
+    current_message_index++;
+  }
+  return lost_messages;
+}
+
+bool MCAPStorage::write_lock_free(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
   const auto topic_it = topics_.find(msg->topic_name);
   if (topic_it == topics_.end()) {
@@ -903,9 +928,12 @@ void MCAPStorage::write_lock_free(std::shared_ptr<const rosbag2_storage::Seriali
   mcap_msg.data = reinterpret_cast<const std::byte *>(msg->serialized_data->buffer);
   const auto status = mcap_writer_->write(mcap_msg);
   if (!status.ok()) {
-    throw std::runtime_error{std::string{"Failed to write "} +
-                             std::to_string(msg->serialized_data->buffer_length) +
-                             " byte message to MCAP file: " + status.message};
+    RCUTILS_LOG_DEBUG_NAMED(LOG_NAME,
+                            "Message on topic '%s' of size %zu bytes failed to write to MCAP file:"
+                            " %s",
+                            msg->topic_name.c_str(), msg->serialized_data->buffer_length,
+                            status.message.c_str());
+    return false;
   }
 
   /// Update metadata
@@ -916,6 +944,7 @@ void MCAPStorage::write_lock_free(std::shared_ptr<const rosbag2_storage::Seriali
   // Determine recording duration
   const auto message_time = time_point(std::chrono::nanoseconds(msg->recv_timestamp));
   metadata_.duration = std::max(metadata_.duration, message_time - metadata_.starting_time);
+  return true;
 }
 
 void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic,

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -221,6 +221,7 @@ public:
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
   void write(
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msg) override;
+  bool write_message(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
   std::vector<size_t> write_messages(
     const rosbag2_storage::SerializedBagMessages & messages) override;
   void create_topic(const rosbag2_storage::TopicMetadata & topic,
@@ -866,8 +867,7 @@ uint64_t MCAPStorage::get_minimum_split_file_size() const
 /** BaseWriteInterface **/
 void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
-  std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
-  if (!write_lock_free(msg)) {
+  if (!write_message(msg)) {
     throw std::runtime_error{std::string{"Message on topic '"} + msg->topic_name + "' of size '" +
                              std::to_string(msg->serialized_data->buffer_length) +
                              "' bytes failed to write to MCAP file. It will be lost."};
@@ -885,6 +885,12 @@ void MCAPStorage::write(
                                "' bytes failed to write to MCAP file. It will be lost."};
     }
   }
+}
+
+bool MCAPStorage::write_message(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
+{
+  std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
+  return write_lock_free(msg);
 }
 
 std::vector<size_t> MCAPStorage::write_messages(

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -74,7 +74,7 @@ public:
       bag_message->serialized_data = make_serialized_message(std::get<0>(msg));
       bag_message->recv_timestamp = std::get<1>(msg);
       bag_message->topic_name = topic_metadata.name;
-      rw_storage->write(bag_message);
+      EXPECT_TRUE(rw_storage->write_message(bag_message));
     }
     return rw_storage;
   }
@@ -213,7 +213,7 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file)
       [](rcutils_uint8_array_t * /* data */) {});
     serialized_bag_msg->recv_timestamp = time_stamp;
     serialized_bag_msg->topic_name = topic_name;
-    writer->write(serialized_bag_msg);
+    EXPECT_TRUE(writer->write_message(serialized_bag_msg));
   }
   EXPECT_TRUE(std::filesystem::is_regular_file(expected_bag));
   {
@@ -300,8 +300,8 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
       [](rcutils_uint8_array_t * /* data */) {});
     serialized_bag_msg->recv_timestamp = time_stamp;
     serialized_bag_msg->topic_name = topic_name;
-    writer->write(serialized_bag_msg);
-    writer->write(serialized_bag_msg);
+    EXPECT_TRUE(writer->write_message(serialized_bag_msg));
+    EXPECT_TRUE(writer->write_message(serialized_bag_msg));
     EXPECT_TRUE(std::filesystem::is_regular_file(expected_bag));
   }
   {

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_topic_filter.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_topic_filter.cpp
@@ -126,7 +126,7 @@ protected:
       bag_message->recv_timestamp = time_stamp;
       bag_message->send_timestamp = time_stamp;
       bag_message->topic_name = topic_metadata.name;
-      rw_storage->write(bag_message);
+      EXPECT_TRUE(rw_storage->write_message(bag_message));
     }
   }
 

--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -69,6 +69,9 @@ public:
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
   override;
 
+  std::vector<size_t>
+  write_messages(const rosbag2_storage::SerializedBagMessages & messages) override;
+
   bool set_read_order(const rosbag2_storage::ReadOrder &) override;
 
   bool has_next() override;
@@ -125,7 +128,7 @@ private:
   void fill_topics_and_types();
   void activate_transaction();
   void commit_transaction();
-  void write_locked(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
+  bool write_locked(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
   RCPPUTILS_TSA_REQUIRES(db_read_write_mutex_);
   int get_last_rowid();
   int read_db_schema_version();

--- a/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
+++ b/rosbag2_storage_sqlite3/include/rosbag2_storage_sqlite3/sqlite_storage.hpp
@@ -69,6 +69,8 @@ public:
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
   override;
 
+  bool write_message(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message) override;
+
   std::vector<size_t>
   write_messages(const rosbag2_storage::SerializedBagMessages & messages) override;
 

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -282,9 +282,16 @@ void SqliteStorage::commit_transaction()
 
 void SqliteStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
 {
+  (void)write_message(message);
+}
+
+bool
+SqliteStorage::write_message(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
+{
   std::lock_guard<std::mutex> db_lock(db_read_write_mutex_);
-  (void)write_locked(message);
+  bool is_message_written = write_locked(message);
   db_file_size_ = db_page_size_ * read_total_page_count_locked();
+  return is_message_written;
 }
 
 bool SqliteStorage::write_locked(

--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -283,11 +283,11 @@ void SqliteStorage::commit_transaction()
 void SqliteStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
 {
   std::lock_guard<std::mutex> db_lock(db_read_write_mutex_);
-  write_locked(message);
+  (void)write_locked(message);
   db_file_size_ = db_page_size_ * read_total_page_count_locked();
 }
 
-void SqliteStorage::write_locked(
+bool SqliteStorage::write_locked(
   std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
 {
   if (!write_statement_) {
@@ -304,6 +304,7 @@ void SqliteStorage::write_locked(
     write_statement_->bind(
       message->recv_timestamp, topic_entry->second,
       message->serialized_data);
+    write_statement_->execute_and_reset();
   } catch (const SqliteException & exc) {
     if (SQLITE_TOOBIG == exc.get_sqlite_return_code()) {
       // Get the sqlite string/blob limit.
@@ -317,17 +318,24 @@ void SqliteStorage::write_locked(
           "' bytes failed to write because it exceeds the maximum size sqlite can store ('" <<
           sqlite_limit << "' bytes): " <<
           exc.what());
-      return;
     } else {
-      // Rethrow.
-      throw;
+      ROSBAG2_STORAGE_DEFAULT_PLUGINS_LOG_DEBUG_STREAM(
+        "Message on topic '" << message->topic_name << "' of size '" <<
+          message->serialized_data->buffer_length << "' bytes failed to write. It will be lost.");
     }
+    return false;
   }
-  write_statement_->execute_and_reset();
+  return true;
 }
 
 void SqliteStorage::write(
   const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
+{
+  (void)write_messages(messages);
+}
+
+std::vector<size_t>
+SqliteStorage::write_messages(const rosbag2_storage::SerializedBagMessages & messages)
 {
   std::lock_guard<std::mutex> db_lock(db_read_write_mutex_);
   if (!write_statement_) {
@@ -336,16 +344,24 @@ void SqliteStorage::write(
 
   activate_transaction();
 
+  std::vector<size_t> lost_messages;
+  size_t current_message_index = 0;
   for (auto & message : messages) {
-    write_locked(message);
+    if (write_locked(message)) {
     // Update db_file_size_ with the estimated data size written to the DB
     // + 3 * sizeof(int64_t) This is for storing timestamp, topic_id and index for messages table
-    db_file_size_ += message->serialized_data->buffer_length + 3 * sizeof(int64_t);
+      db_file_size_ += message->serialized_data->buffer_length + 3 * sizeof(int64_t);
+    } else {
+      // If the message was not written, we assume it was lost.
+      lost_messages.push_back(current_message_index);
+    }
+    current_message_index++;
   }
 
   commit_transaction();
   // Correct db_file_size_ by reading out the exact numbers from the DB
   db_file_size_ = db_page_size_ * read_total_page_count_locked();
+  return lost_messages;
 }
 
 bool SqliteStorage::set_read_order(const rosbag2_storage::ReadOrder & read_order)

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/storage_test_fixture.hpp
@@ -93,7 +93,8 @@ public:
   std::shared_ptr<rosbag2_storage_plugins::SqliteStorage>
   write_messages_to_sqlite(
     std::vector<std::tuple<std::string, int64_t, std::string, std::string, std::string>> messages,
-    std::shared_ptr<rosbag2_storage_plugins::SqliteStorage> writable_storage = nullptr)
+    std::shared_ptr<rosbag2_storage_plugins::SqliteStorage> writable_storage = nullptr,
+    bool expect_write_to_fail = false)
   {
     if (nullptr == writable_storage) {
       writable_storage = std::make_shared<rosbag2_storage_plugins::SqliteStorage>();
@@ -114,7 +115,11 @@ public:
       bag_message->serialized_data = make_serialized_message(std::get<0>(msg));
       bag_message->recv_timestamp = std::get<1>(msg);
       bag_message->topic_name = topic_name;
-      rw_storage.write(bag_message);
+      if (expect_write_to_fail) {
+        EXPECT_FALSE(rw_storage.write_message(bag_message));
+      } else {
+        EXPECT_TRUE(rw_storage.write_message(bag_message));
+      }
     }
 
     metadata_io_.write_metadata(temporary_dir_path_, rw_storage.get_metadata());

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_storage.cpp
@@ -576,7 +576,7 @@ TEST_F(StorageTestFixture, does_not_throw_on_message_too_big) {
     this->write_messages_to_sqlite(
     {
       {msg, 0, "/too_big_message", "some_type", "some_rmw"}
-    }, writable_storage);
+    }, writable_storage, true /* expect_write_to_fail */);
   });
 }
 

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_topic_filter.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_topic_filter.cpp
@@ -135,7 +135,7 @@ protected:
       bag_message->recv_timestamp = time_stamp;
       bag_message->send_timestamp = time_stamp;
       bag_message->topic_name = topic_metadata.name;
-      rw_storage->write(bag_message);
+      EXPECT_TRUE(rw_storage->write_message(bag_message));
     }
   }
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_storage_api.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_storage_api.cpp
@@ -136,7 +136,9 @@ TEST_P(Rosbag2StorageAPITests, get_bagfile_size_read_write_interface)
   auto serialized_messages = prepare_serialized_messages(topics, 500 * 20);
   create_topics(rw_storage, topics);
 
-  rw_storage->write(serialized_messages);
+  auto lost_messages = rw_storage->write_messages(serialized_messages);
+  EXPECT_TRUE(lost_messages.empty()) << "Lost messages during write: " << lost_messages.size();
+
   uint64_t storage_bagfile_size = rw_storage->get_bagfile_size();
 
   size_t fs_bagfile_size = fs::file_size(full_bagfile_path);
@@ -150,7 +152,8 @@ TEST_P(Rosbag2StorageAPITests, get_bagfile_size_read_write_interface)
     " bagfile_size_from_storage = " << storage_bagfile_size;
 
   // Write messages one more time to make sure that storage_bagfile_size updating with each write
-  rw_storage->write(serialized_messages);
+  lost_messages = rw_storage->write_messages(serialized_messages);
+  EXPECT_TRUE(lost_messages.empty()) << "Lost messages during write: " << lost_messages.size();
   storage_bagfile_size = rw_storage->get_bagfile_size();
 
   fs_bagfile_size = fs::file_size(full_bagfile_path);


### PR DESCRIPTION
## Description

This PR adds a new `BaseWriteInterface::write_messages(msgs)` and `BaseWriteInterface::write(msg)` APIs, which return the operation's status.
This new API will be needed for the [Statistics about the number of lost and recorded messages](https://github.com/ros2/rosbag2/issues/2007) feature to be able to determine how many messages we lost on the storage level.
Note: The old API `BaseWriteInterface::write` is deprecated from now on and no longer used internally in Rosbag2.

- Relates # https://github.com/ros2/rosbag2/issues/2007

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow.

### Additional Information
Note: The new API was created instead of modifying the existing to avoid API breaking changes.
