### PR TITLE
Update index.ros.org/p/ links for rosbag2_storage_mcap

### DIFF
--- a/rosbag2_storage_mcap/README.md
+++ b/rosbag2_storage_mcap/README.md
@@ -3,10 +3,7 @@
 This package provides a [storage plugin](https://github.com/ros2/rosbag2#storage-format-plugin-architecture) for rosbag2 which extends it with support for the [MCAP](https://mcap.dev) file format.
 
 
-[![ROS Foxy version](https://img.shields.io/ros/v/foxy/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros2-rosbag2/#foxy)
-[![ROS Galactic version](https://img.shields.io/ros/v/galactic/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros2-rosbag2/#galactic)
-[![ROS Humble version](https://img.shields.io/ros/v/humble/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros2-rosbag2/#humble)
-[![ROS Rolling version](https://img.shields.io/ros/v/rolling/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros2-rosbag2/#rolling)
+[![ROS Rolling version](https://img.shields.io/ros/v/rolling/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/)
 
 ## ⚠️ Move from `ros-tooling` organization
 


### PR DESCRIPTION
## Description

`index.ros.org/p/$pkg/` links with the GitHub repo at the end no longer work and result in a 404.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

Consider backporting this to non-EOL distro branches.