### PR TITLE
Update `statistics_about_lost_and_recorded_messages.md` design document

### DIFF
--- a/docs/design/statistics_about_lost_and_recorded_messages.md
+++ b/docs/design/statistics_about_lost_and_recorded_messages.md
@@ -93,7 +93,6 @@ post-processing.
            event on a DDS transport layer.
          - `messages_lost_in_recorder` (uint64_t): The number of messages lost since the last 
            event in the Rosbag2 recorder.
-         - `bytes_written` (uint64_t): The total number of bytes written on this topic.
       3. The messages lost event shall not be published more often than the user-specified event 
          update rate to avoid excessive resource usage.
       4. The Messages lost event shall **not** include topics with zero number of lost messages.


### PR DESCRIPTION
## Description

This PR updates `statistics_about_lost_and_recorded_messages.md` design document by removing mention of the `bytes_written`  field from the proposed `rosbag2_interfaces::msg::MessagesLostEvent` message type.

Rationale: When a message loss happens on the transport layer, we may not have up-to-date information about written bytes on some specified topic, and it may affect performance if we try to get it from the underlying writer class. The user may still get `bytes_written` information when requesting a number of lost messages via the service request.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Relates:
-  #2006,
-  #2007 

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.

### Additional Information
N/A
