### PR TITLE
Add callbacks for messages loss statistics

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -434,6 +434,10 @@ void SequentialCompressionWriter::write(
           "from compression queue because it is full. Queue size: " <<
           compressor_message_queue_.size());
       compressor_message_queue_.pop();
+      // Process message lost event
+      auto info = std::make_shared<std::vector<rosbag2_cpp::bag_events::MessagesLostInfo>>();
+      info->emplace_back(rosbag2_cpp::bag_events::MessagesLostInfo{message->topic_name, 1});
+      this->on_messages_lost(std::move(info));
     }
 
     // If no message should be dropped and the queue has still messages,

--- a/rosbag2_cpp/include/rosbag2_cpp/bag_events.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/bag_events.hpp
@@ -38,7 +38,24 @@ enum class BagEvent
   WRITE_SPLIT,
   /// Reading of the input bag file has gone over a split, opening the next file.
   READ_SPLIT,
+  /// The Writer has lost messages on the storage side or due to a cache overflow.
+  MESSAGES_LOST,
 };
+
+
+/**
+ * \brief The information structure passed to callbacks for the MESSAGES_LOST event.
+ * \details This structure contains the topic name and the number of messages lost for that topic.
+ */
+struct MessagesLostInfo
+{
+  /// The name of the topic for which messages were lost.
+  std::string topic_name;
+  /// The number of messages lost for that topic.
+  uint64_t num_messages_lost;
+};
+
+using MessagesLostCallback = std::function<void(const std::vector<MessagesLostInfo> &)>;
 
 /**
  * \brief The information structure passed to callbacks for the WRITE_SPLIT and READ_SPLIT events.
@@ -60,6 +77,9 @@ struct WriterEventCallbacks
 {
   /// The callback to call for the WRITE_SPLIT event.
   BagSplitCallbackType write_split_callback;
+
+  /// The callback to call for the MESSAGES_LOST event.
+  MessagesLostCallback messages_lost_callback;
 };
 
 /**

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/circular_message_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/circular_message_cache.hpp
@@ -57,7 +57,10 @@ public:
   ~CircularMessageCache() override;
 
   /// Puts msg into circular buffer, replacing the oldest msg when buffer is full
-  void push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
+  /// \return True if message was successfully pushed, otherwise false.
+  /// NOTE: This will always return true, since the circular buffer by design drops old messages
+  /// when the buffer is full.
+  bool push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
 
   /// Get current buffer to consume.
   /// Locks consumer buffer until release_consumer_buffer is called.

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache.hpp
@@ -76,7 +76,8 @@ public:
   ~MessageCache() override;
 
   /// Puts msg into primary buffer. With full cache, msg is ignored and counted as lost
-  void push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
+  /// \return True if message was successfully pushed, false if the buffer is full.
+  bool push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
 
   /// Gets a consumer buffer.
   /// In this greedy implementation, swap buffers before providing the buffer.

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_interface.hpp
@@ -41,7 +41,8 @@ public:
   virtual ~MessageCacheInterface() {}
 
   /// Push a bag message into the producer buffer.
-  virtual void push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) = 0;
+  /// \return True if message was successfully pushed, false if the buffer is full.
+  virtual bool push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) = 0;
 
   /// \brief Get a pointer to the buffer that can be used for consuming the cached messages.
   /// This call locks access to the buffer, `swap_buffers` and `get_consumer_buffer` will block

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -238,9 +238,12 @@ public:
     return *writer_impl_;
   }
 
-  /*
+  /**
    * \brief Add callbacks for events that may occur during bag writing.
+   *
    * \param callbacks the structure containing the callback to add for each event.
+   * \throws std::runtime_error if none of the write_split_callback and messages_lost_callback
+   * callbacks are set.
    */
   void add_event_callbacks(bag_events::WriterEventCallbacks & callbacks);
 

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -200,10 +200,22 @@ protected:
   get_writeable_message(
     std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message);
 
+  /**
+   * \brief Helper method to process lost messages events.
+   * \note This method is expected to be called from a multiple threads.
+   * \param msgs_lost_info The information about lost messages to be processed.
+   */
+  void on_messages_lost(std::shared_ptr<std::vector<bag_events::MessagesLostInfo>> msgs_lost_info);
+
 private:
-  /// Helper method to write messages while also updating tracked metadata.
+  /**
+   * \brief Helper method to write messages while also updating tracked metadata.
+   * \param messages The list of messages to write.
+   */
   void write_messages(
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages);
+
+  std::mutex lost_messages_callbacks_mutex_;
   bool is_first_message_ {true};
   std::atomic_bool is_open_{false};
 

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
@@ -40,10 +40,13 @@ CircularMessageCache::~CircularMessageCache()
   cache_condition_var_.notify_one();
 }
 
-void CircularMessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
+bool CircularMessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
   std::lock_guard<std::mutex> cache_lock(producer_buffer_mutex_);
   producer_buffer_->push(msg);
+  // Always return true since circular message cache drops old messages by design and it
+  // shouldn't be counted as a lost messages.
+  return true;
 }
 
 std::shared_ptr<CacheBufferInterface> CircularMessageCache::get_consumer_buffer()

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache.cpp
@@ -44,7 +44,7 @@ MessageCache::~MessageCache()
   log_dropped();
 }
 
-void MessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
+bool MessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
   // While pushing, we keep track of inserted and dropped messages as well
   bool pushed = false;
@@ -58,6 +58,8 @@ void MessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMess
   }
 
   notify_data_ready();
+
+  return pushed;
 }
 
 std::shared_ptr<CacheBufferInterface> MessageCache::get_consumer_buffer()

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -424,15 +424,25 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
 
   auto converted_msg = get_writeable_message(message);
 
+  bool message_lost = false;
   if (storage_options_.max_cache_size == 0u) {
     // If cache size is set to zero, we write to storage directly
     if (storage_->write_message(converted_msg)) {
       metadata_.files.back().message_count++;
       topic_information->message_count++;
+    } else {
+      message_lost = true;
     }
   } else {
     // Otherwise, use cache buffer
-    message_cache_->push(converted_msg);
+    message_lost = !message_cache_->push(converted_msg);
+  }
+
+  if (message_lost) {
+    // Process message lost event
+    auto msgs_lost_info = std::make_shared<std::vector<bag_events::MessagesLostInfo>>();
+    msgs_lost_info->emplace_back(bag_events::MessagesLostInfo{message->topic_name, 1});
+    on_messages_lost(std::move(msgs_lost_info));
   }
 }
 
@@ -579,6 +589,32 @@ void SequentialWriter::write_messages(
       topic_info_it->second.message_count++;
     }
   }
+
+  // Notify about lost messages via callback
+  if (!lost_messages_idx.empty()) {
+    std::unordered_map<std::string, size_t> lost_messages_count;
+    for (const auto & lost_message_index : lost_messages_idx) {
+      const auto & topic_name = messages[lost_message_index]->topic_name;
+      lost_messages_count[topic_name]++;
+    }
+    auto msgs_lost_info = std::make_shared<std::vector<bag_events::MessagesLostInfo>>();
+    msgs_lost_info->reserve(lost_messages_count.size());
+    for (const auto & [topic_name, count] : lost_messages_count) {
+      msgs_lost_info->emplace_back(bag_events::MessagesLostInfo{topic_name, count});
+    }
+    on_messages_lost(std::move(msgs_lost_info));
+  }
+}
+
+void SequentialWriter::on_messages_lost(
+  std::shared_ptr<std::vector<bag_events::MessagesLostInfo>> msgs_lost_info)
+{
+  if (!msgs_lost_info->empty()) {
+    std::lock_guard<std::mutex> lock(lost_messages_callbacks_mutex_);
+    callback_manager_.execute_callbacks(
+      bag_events::BagEvent::MESSAGES_LOST,
+      std::move(msgs_lost_info));
+  }
 }
 
 void SequentialWriter::add_event_callbacks(const bag_events::WriterEventCallbacks & callbacks)
@@ -587,6 +623,12 @@ void SequentialWriter::add_event_callbacks(const bag_events::WriterEventCallback
     callback_manager_.add_event_callback(
       callbacks.write_split_callback,
       bag_events::BagEvent::WRITE_SPLIT);
+  } else if (callbacks.messages_lost_callback) {
+    callback_manager_.add_event_callback(
+      callbacks.messages_lost_callback,
+      bag_events::BagEvent::MESSAGES_LOST);
+  } else {
+    throw std::runtime_error("No valid callback provided");
   }
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/mock_message_cache.hpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/mock_message_cache.hpp
@@ -36,6 +36,24 @@ public:
   }
 
   MOCK_METHOD0(log_dropped, void());
+  MOCK_METHOD1(mock_push, bool(std::shared_ptr<const rosbag2_storage::SerializedBagMessage>));
+
+  bool push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override
+  {
+    if (use_mock_push_) {
+      return mock_push(msg);
+    } else {
+      return rosbag2_cpp::cache::MessageCache::push(msg);
+    }
+  }
+
+  void use_mock_push(bool enable_mock_push)
+  {
+    use_mock_push_ = enable_mock_push;
+  }
+
+private:
+  bool use_mock_push_ = false;
 };
 
 #endif  // ROSBAG2_CPP__MOCK_MESSAGE_CACHE_HPP_

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -154,6 +154,7 @@ public:
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
   std::string fake_storage_uri_;
   const std::string bag_base_dir_ = "test_bag";
+  size_t num_messages_to_lose_ = 0;
 };
 
 std::shared_ptr<rosbag2_storage::SerializedBagMessage> make_test_msg()
@@ -771,7 +772,7 @@ TEST_F(SequentialWriterTest, calls_callback_on_storage_message_lost_with_no_cach
   const size_t message_count = 10;
   const size_t expected_lost_messages = 4;
   const size_t expected_written_messages = message_count - expected_lost_messages;
-
+  num_messages_to_lose_ = expected_lost_messages;
   EXPECT_CALL(*storage_,
               write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
   .Times(message_count);
@@ -779,16 +780,18 @@ TEST_F(SequentialWriterTest, calls_callback_on_storage_message_lost_with_no_cach
   ON_CALL(*storage_,
     write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
   .WillByDefault(
-    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
-      static size_t curr_number_of_lost_messages = 0;
-      if (curr_number_of_lost_messages < expected_lost_messages) {
-        curr_number_of_lost_messages++;
-        return false;  // Simulate message loss
-      } else {
-        fake_storage_size_++;
-        return true;  // Simulate successful write
+    Invoke(
+      [this](const std::shared_ptr<const rosbag2_storage::SerializedBagMessage> &) -> bool {
+        static size_t curr_number_of_lost_messages = 0;
+        if (curr_number_of_lost_messages < num_messages_to_lose_) {
+          curr_number_of_lost_messages++;
+          return false;  // Simulate message loss
+        } else {
+          fake_storage_size_++;
+          return true;  // Simulate successful write
+        }
       }
-    }
+    )
   );
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
@@ -832,6 +835,7 @@ TEST_F(SequentialWriterTest, calls_callback_on_storage_messages_lost_with_cache)
   const size_t message_count = 10;
   const size_t expected_lost_messages = 5;
   const size_t expected_written_messages = message_count - expected_lost_messages;
+  num_messages_to_lose_ = expected_lost_messages;
 
   EXPECT_CALL(*storage_,
               write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
@@ -839,20 +843,22 @@ TEST_F(SequentialWriterTest, calls_callback_on_storage_messages_lost_with_cache)
 
   ON_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
   .WillByDefault(
-    [this](const rosbag2_storage::SerializedBagMessages & msgs)
-    {
-      static size_t curr_number_of_lost_messages = 0;
-      std::vector<size_t> lost_messages;
-      for (size_t i = 0; i < msgs.size(); i++) {
-        if (curr_number_of_lost_messages < expected_lost_messages) {
-          lost_messages.push_back(i);    // Simulate message loss
-          curr_number_of_lost_messages++;
-        } else {
-          fake_storage_size_++;
+    Invoke(
+      [this](const rosbag2_storage::SerializedBagMessages & msgs)
+      {
+        static size_t curr_number_of_lost_messages = 0;
+        std::vector<size_t> lost_messages;
+        for (size_t i = 0; i < msgs.size(); i++) {
+          if (curr_number_of_lost_messages < num_messages_to_lose_) {
+            lost_messages.push_back(i);    // Simulate message loss
+            curr_number_of_lost_messages++;
+          } else {
+            fake_storage_size_++;
+          }
         }
+        return lost_messages;
       }
-      return lost_messages;
-    }
+    )
   );
 
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
@@ -898,6 +904,7 @@ TEST_F(SequentialWriterTest, calls_callback_on_messages_loss_in_writer_cache)
 {
   const size_t message_count = 10;
   const size_t expected_lost_messages = 5;
+  num_messages_to_lose_ = expected_lost_messages;
 
   auto sequential_writer = std::make_unique<SequentialWriterForTest>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
@@ -928,18 +935,18 @@ TEST_F(SequentialWriterTest, calls_callback_on_messages_loss_in_writer_cache)
   ON_CALL(*mock_message_cache,
         mock_push(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
   .WillByDefault(
-    [&expected_lost_messages]
-    (std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message)
-    {
-      (void)serialized_message;  // Unused in this context
-      static size_t num_lost_messages_in_cache = 0;
-      if (num_lost_messages_in_cache < expected_lost_messages) {
-        num_lost_messages_in_cache++;
-        return false;
-      } else {
-        return true;
+    Invoke(
+      [this](const std::shared_ptr<const rosbag2_storage::SerializedBagMessage> &)-> bool
+      {
+        static size_t num_lost_messages_in_cache = 0;
+        if (num_lost_messages_in_cache < num_messages_to_lose_) {
+          num_lost_messages_in_cache++;
+          return false;
+        } else {
+          return true;
+        }
       }
-    }
+    )
   );
 
   auto mock_cache_consumer =

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -37,10 +37,33 @@
 #include "mock_metadata_io.hpp"
 #include "mock_storage.hpp"
 #include "mock_storage_factory.hpp"
+#include "mock_message_cache.hpp"
+#include "mock_cache_consumer.hpp"
 
 using namespace testing;  // NOLINT
 using rosbag2_test_common::ParametrizedTemporaryDirectoryFixture;
 namespace fs = std::filesystem;
+
+class SequentialWriterForTest : public rosbag2_cpp::writers::SequentialWriter
+{
+public:
+  SequentialWriterForTest(
+    std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
+    std::shared_ptr<rosbag2_cpp::SerializationFormatConverterFactoryInterface> converter_factory,
+    std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
+  :rosbag2_cpp::writers::SequentialWriter(
+      std::move(storage_factory), std::move(converter_factory), std::move(metadata_io)) {}
+
+  /// \brief Sets the message cache and cache consumer.
+  /// \note Needs to be called after the SequentialWriterForTest::open(..) method call.
+  void set_message_cache_and_cache_consumer(
+    std::shared_ptr<rosbag2_cpp::cache::MessageCacheInterface> message_cache,
+    std::unique_ptr<rosbag2_cpp::cache::CacheConsumer> cache_consumer)
+  {
+    message_cache_ = std::move(message_cache);
+    cache_consumer_ = std::move(cache_consumer);
+  }
+};
 
 class SequentialWriterTest : public Test
 {
@@ -741,6 +764,204 @@ TEST_F(SequentialWriterTest, snapshot_can_be_called_twice)
     ASSERT_STREQ(closed_files[i].c_str(), expected_closed.generic_string().c_str());
     ASSERT_STREQ(opened_files[i].c_str(), expected_opened.generic_string().c_str());
   }
+}
+
+TEST_F(SequentialWriterTest, calls_callback_on_storage_message_lost_with_no_cache)
+{
+  const size_t message_count = 10;
+  const size_t expected_lost_messages = 4;
+  const size_t expected_written_messages = message_count - expected_lost_messages;
+
+  EXPECT_CALL(*storage_,
+              write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .Times(message_count);
+
+  ON_CALL(*storage_,
+    write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .WillByDefault(
+    [this](std::shared_ptr<const rosbag2_storage::SerializedBagMessage>) {
+      static size_t curr_number_of_lost_messages = 0;
+      if (curr_number_of_lost_messages < expected_lost_messages) {
+        curr_number_of_lost_messages++;
+        return false;  // Simulate message loss
+      } else {
+        fake_storage_size_++;
+        return true;  // Simulate successful write
+      }
+    }
+  );
+
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+
+  storage_options_.max_cache_size = 0;  // Disable cache
+
+  size_t num_lost_messages = 0;
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  callbacks.messages_lost_callback =
+    [&num_lost_messages](const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> &
+    msgs_lost_info) {
+      for (const auto & info : msgs_lost_info) {
+        num_lost_messages += info.num_messages_lost;
+      }
+    };
+  writer_->add_event_callbacks(callbacks);
+
+  writer_->open(storage_options_, {"rmw_format", "rmw_format"});
+  writer_->create_topic({0u, "test_topic", "test_msgs/BasicTypes", "", {}, ""});
+
+  for (size_t i = 0; i < message_count; i++) {
+    writer_->write(message);
+  }
+  writer_->close();
+
+  EXPECT_EQ(num_lost_messages, expected_lost_messages);
+  EXPECT_EQ(fake_metadata_.message_count, expected_written_messages);
+  ASSERT_EQ(fake_metadata_.files.size(), 1u);
+  EXPECT_EQ(fake_metadata_.files[0].message_count, expected_written_messages);
+  ASSERT_EQ(fake_metadata_.topics_with_message_count.size(), 1u);
+  EXPECT_EQ(fake_metadata_.topics_with_message_count[0].message_count, expected_written_messages);
+}
+
+TEST_F(SequentialWriterTest, calls_callback_on_storage_messages_lost_with_cache)
+{
+  const size_t message_count = 10;
+  const size_t expected_lost_messages = 5;
+  const size_t expected_written_messages = message_count - expected_lost_messages;
+
+  EXPECT_CALL(*storage_,
+              write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .Times(0);    // No direct writes to storage
+
+  ON_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
+  .WillByDefault(
+    [this](const rosbag2_storage::SerializedBagMessages & msgs)
+    {
+      static size_t curr_number_of_lost_messages = 0;
+      std::vector<size_t> lost_messages;
+      for (size_t i = 0; i < msgs.size(); i++) {
+        if (curr_number_of_lost_messages < expected_lost_messages) {
+          lost_messages.push_back(i);    // Simulate message loss
+          curr_number_of_lost_messages++;
+        } else {
+          fake_storage_size_++;
+        }
+      }
+      return lost_messages;
+    }
+  );
+
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  auto message_to_write = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message_to_write->topic_name = "test_topic";
+  std::string msg_content = "Hello";
+  message_to_write->serialized_data =
+    rosbag2_storage::make_serialized_message(msg_content.c_str(), msg_content.length());
+
+  storage_options_.max_cache_size = 100 * 1024;  // Enable cache 100 KiB
+
+  size_t num_lost_messages = 0;
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  callbacks.messages_lost_callback =
+    [&num_lost_messages](
+    const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info) {
+      for (const auto & info : msgs_lost_info) {
+        num_lost_messages += info.num_messages_lost;
+      }
+    };
+  writer_->add_event_callbacks(callbacks);
+
+  writer_->open(storage_options_, {"rmw_format", "rmw_format"});
+  writer_->create_topic({0u, "test_topic", "test_msgs/BasicTypes", "", {}, ""});
+
+  for (size_t i = 0; i < message_count; i++) {
+    writer_->write(message_to_write);
+  }
+  writer_->close();
+
+  EXPECT_EQ(num_lost_messages, expected_lost_messages);
+  EXPECT_EQ(fake_metadata_.message_count, expected_written_messages);
+  ASSERT_EQ(fake_metadata_.files.size(), 1u);
+  EXPECT_EQ(fake_metadata_.files[0].message_count, expected_written_messages);
+  ASSERT_EQ(fake_metadata_.topics_with_message_count.size(), 1u);
+  EXPECT_EQ(fake_metadata_.topics_with_message_count[0].message_count, expected_written_messages);
+}
+
+TEST_F(SequentialWriterTest, calls_callback_on_messages_loss_in_writer_cache)
+{
+  const size_t message_count = 10;
+  const size_t expected_lost_messages = 5;
+
+  auto sequential_writer = std::make_unique<SequentialWriterForTest>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+
+  size_t num_lost_messages = 0;
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  callbacks.messages_lost_callback =
+    [&num_lost_messages](
+    const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info) {
+      for (const auto & info : msgs_lost_info) {
+        num_lost_messages += info.num_messages_lost;
+      }
+    };
+  sequential_writer->add_event_callbacks(callbacks);
+
+  storage_options_.max_cache_size = 100 * 1024;  // Enable cache 100 KiB
+  sequential_writer->open(storage_options_, {"rmw_format", "rmw_format"});
+
+  size_t consumed_message_count = 0;
+  auto mock_message_cache = std::make_shared<NiceMock<MockMessageCache>>(1024u);
+  auto write_messages_cb = [&consumed_message_count](
+    const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msgs) {
+      consumed_message_count += msgs.size();
+    };
+  mock_message_cache->use_mock_push(true);
+
+  // Simulate messages loss in the cache push method
+  ON_CALL(*mock_message_cache,
+        mock_push(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>()))
+  .WillByDefault(
+    [&expected_lost_messages]
+    (std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message)
+    {
+      (void)serialized_message;  // Unused in this context
+      static size_t num_lost_messages_in_cache = 0;
+      if (num_lost_messages_in_cache < expected_lost_messages) {
+        num_lost_messages_in_cache++;
+        return false;
+      } else {
+        return true;
+      }
+    }
+  );
+
+  auto mock_cache_consumer =
+    std::make_unique<NiceMock<MockCacheConsumer>>(mock_message_cache, write_messages_cb);
+
+  sequential_writer->set_message_cache_and_cache_consumer(
+    mock_message_cache, std::move(mock_cache_consumer));
+
+  sequential_writer->create_topic({0u, "test_topic", "test_msgs/BasicTypes", "", {}, ""});
+
+  auto message_to_write = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message_to_write->topic_name = "test_topic";
+  std::string msg_content = "Hello";
+  message_to_write->serialized_data =
+    rosbag2_storage::make_serialized_message(msg_content.c_str(), msg_content.length());
+
+  for (size_t i = 0; i < message_count; i++) {
+    sequential_writer->write(message_to_write);
+  }
+  sequential_writer->close();
+
+  EXPECT_EQ(num_lost_messages, expected_lost_messages);
 }
 
 TEST_F(SequentialWriterTest, split_event_calls_callback)

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -130,6 +130,13 @@ private:
   void event_publisher_thread_main();
   bool event_publisher_thread_should_wake();
 
+  void on_messages_lost_in_recorder(
+    const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info);
+
+  void on_messages_lost_in_transport(
+    const std::string & topic_name,
+    const rclcpp::QOSMessageLostInfo & msgs_lost_info);
+
   rclcpp::Node * node;
   std::unique_ptr<TopicFilter> topic_filter_;
   std::future<void> discovery_future_;
@@ -347,6 +354,10 @@ void RecorderImpl::record()
       }
       event_publisher_thread_wake_cv_.notify_all();
     };
+  callbacks.messages_lost_callback =
+    [this](const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info) {
+      on_messages_lost_in_recorder(msgs_lost_info);
+    };
   writer_->add_event_callbacks(callbacks);
 
   serialization_format_ = record_options_.rmw_serialization_format;
@@ -364,6 +375,31 @@ void RecorderImpl::record()
   } else {
     RCLCPP_INFO(node->get_logger(), "Recording...");
   }
+}
+
+void RecorderImpl::on_messages_lost_in_recorder(
+  const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info)
+{
+  if (!msgs_lost_info.empty()) {
+    // Log lost messages in recorder
+    std::string log_text("Recorder lost messages per topic: ");
+    for (const auto & info : msgs_lost_info) {
+      log_text += "\n\t" + info.topic_name + ": " + std::to_string(info.num_messages_lost);
+    }
+    RCLCPP_DEBUG(node->get_logger(), "%s", log_text.c_str());
+    // TODO(morlov): Call EventNotifier->on_messages_lost_in_recorder(msgs_lost_info);
+  }
+}
+
+void RecorderImpl::on_messages_lost_in_transport(
+  const std::string & topic_name,
+  const rclcpp::QOSMessageLostInfo & msgs_lost_info)
+{
+  RCLCPP_DEBUG(
+    node->get_logger(),
+    "Messages lost on transport layer for topic '%s'. Total lost: %lu",
+    topic_name.c_str(), msgs_lost_info.total_count);
+  // TODO(morlov): Call EventNotifier->on_messages_lost_in_transport(topic_name, msgs_lost_info);
 }
 
 void RecorderImpl::event_publisher_thread_main()
@@ -583,6 +619,12 @@ std::shared_ptr<rclcpp::GenericSubscription>
 RecorderImpl::create_subscription(
   const std::string & topic_name, const std::string & topic_type, const rclcpp::QoS & qos)
 {
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.event_callbacks.message_lost_callback =
+    [this, topic_name](const rclcpp::QOSMessageLostInfo & msgs_lost_info) {
+      this->on_messages_lost_in_transport(topic_name, msgs_lost_info);
+    };
+
 #ifdef _WIN32
   if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") !=
     std::string::npos)
@@ -598,7 +640,8 @@ RecorderImpl::create_subscription(
             std::move(message), topic_name, topic_type, node->now().nanoseconds(),
             0);
         }
-      });
+      },
+      sub_options);
   }
 #endif
 
@@ -614,7 +657,8 @@ RecorderImpl::create_subscription(
             std::move(message), topic_name, topic_type, node->now().nanoseconds(),
             mi.get_rmw_message_info().source_timestamp);
         }
-      });
+      },
+      sub_options);
   } else {
     return node->create_generic_subscription(
       topic_name,
@@ -628,7 +672,8 @@ RecorderImpl::create_subscription(
             mi.get_rmw_message_info().received_timestamp,
             mi.get_rmw_message_info().source_timestamp);
         }
-      });
+      },
+      sub_options);
   }
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -166,6 +166,9 @@ private:
   std::mutex event_publisher_thread_mutex_;
   std::condition_variable event_publisher_thread_wake_cv_;
   std::thread event_publisher_thread_;
+
+  std::atomic<size_t> num_messages_lost_on_transport_{0};
+  std::atomic<size_t> num_messages_lost_in_recorder_{0};
 };
 
 RecorderImpl::RecorderImpl(
@@ -259,6 +262,17 @@ void RecorderImpl::stop()
   }
   in_recording_ = false;
   RCLCPP_INFO(node->get_logger(), "Recording stopped");
+
+  if (num_messages_lost_on_transport_.load() > 0) {
+    RCLCPP_INFO(node->get_logger(),
+      "Number of messages lost on the transport layer: %zu",
+        num_messages_lost_on_transport_.load());
+  }
+
+  if (num_messages_lost_in_recorder_.load() > 0) {
+    RCLCPP_INFO(node->get_logger(),
+      "Number of messages lost in the recorder: %zu", num_messages_lost_in_recorder_.load());
+  }
 }
 
 void RecorderImpl::record()
@@ -275,8 +289,9 @@ void RecorderImpl::record()
   if (record_options_.rmw_serialization_format.empty()) {
     throw std::runtime_error("No serialization format specified!");
   }
-
   subscriptions_.clear();
+  num_messages_lost_in_recorder_.store(0);
+  num_messages_lost_on_transport_.store(0);
   writer_->open(
     storage_options_,
     {rmw_get_serialization_format(), record_options_.rmw_serialization_format});
@@ -384,6 +399,7 @@ void RecorderImpl::on_messages_lost_in_recorder(
     // Log lost messages in recorder
     std::string log_text("Recorder lost messages per topic: ");
     for (const auto & info : msgs_lost_info) {
+      num_messages_lost_in_recorder_.fetch_add(info.num_messages_lost);
       log_text += "\n\t" + info.topic_name + ": " + std::to_string(info.num_messages_lost);
     }
     RCLCPP_DEBUG(node->get_logger(), "%s", log_text.c_str());
@@ -395,6 +411,7 @@ void RecorderImpl::on_messages_lost_in_transport(
   const std::string & topic_name,
   const rclcpp::QOSMessageLostInfo & msgs_lost_info)
 {
+  num_messages_lost_on_transport_.fetch_add(msgs_lost_info.total_count);
   RCLCPP_DEBUG(
     node->get_logger(),
     "Messages lost on transport layer for topic '%s'. Total lost: %lu",

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -264,13 +264,13 @@ void RecorderImpl::stop()
   RCLCPP_INFO(node->get_logger(), "Recording stopped");
 
   if (num_messages_lost_on_transport_.load() > 0) {
-    RCLCPP_INFO(node->get_logger(),
+    RCLCPP_WARN(node->get_logger(),
       "Number of messages lost on the transport layer: %zu",
         num_messages_lost_on_transport_.load());
   }
 
   if (num_messages_lost_in_recorder_.load() > 0) {
-    RCLCPP_INFO(node->get_logger(),
+    RCLCPP_WARN(node->get_logger(),
       "Number of messages lost in the recorder: %zu", num_messages_lost_in_recorder_.load());
   }
 }


### PR DESCRIPTION
## Description

This PR adds `rosbag2_cpp::bag_events::messages_lost_callback` to the `rosbag2_cpp::Wtiter` class to be able to determine messages lost in the Rosbag2 recorder, either in the message's cache or on the storage level from the upper `rosbag2_transport` layer. 
Also adds   `RecorderImpl::on_messages_lost_in_transport` callback linked to the `rclcpp::SubscriptionOptions::event_callbacks::message_lost_callback` for each newly created subscription in the Rosbag2 recorder class.

### Relates:
-  #2006
-  #2007 

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1, in my workflow.

### Additional Information

- This PR also modifies public `rosbag2_cpp::cache::MessageCacheInterface::(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)` API by returning the boolean value, the result of the operation. It will return false if the push is unsuccessful due to the cache overflow.

### Notes for reviewers
- The `RecorderImpl::on_messages_lost_in_transport` is not covered by the unit tests currently for the following reasons:
  1. It is pretty trivial for a while, and just one assignment operator in the method, which is creating a new subscription.
  2. It is very difficult (almost impossible) to deterministically simulate the messages lost on the transport layer for integration tests.
  3. It is not possible to refer to the `RecorderImpl` from unit tests while its definition and declaration are solely in the `player.cpp` file. We can move it to the private header file located in the `src` subfolder for better testability. But it would be better to do it in a separate PR.
