### PR TITLE
[jazzy] Fix for issue when inner message definition not found for service events

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -211,8 +211,6 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
 {
   std::unordered_set<DefinitionIdentifier, DefinitionIdentifierHash> seen_deps;
 
-  std::string real_root_type = root_type;
-
   std::function<std::string(const DefinitionIdentifier &, int32_t)> append_recursive =
     [&](const DefinitionIdentifier & definition_identifier, int32_t depth) {
       if (depth <= 0) {
@@ -236,15 +234,16 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
   std::string result;
   Format format = Format::UNKNOWN;
   int32_t max_recursion_depth = ROSBAG2_CPP_LOCAL_MESSAGE_DEFINITION_SOURCE_MAX_RECURSION_DEPTH;
+  std::string service_root_type;
 
   if (root_type.find("/srv/") == std::string::npos) {  // Normal topic type
     try {
       format = Format::MSG;
-      result = append_recursive(DefinitionIdentifier(real_root_type, format), max_recursion_depth);
+      result = append_recursive(DefinitionIdentifier(root_type, format), max_recursion_depth);
     } catch (const DefinitionNotFoundError & err) {
       ROSBAG2_CPP_LOG_WARN("No .msg definition for %s, falling back to IDL", err.what());
       format = Format::IDL;
-      DefinitionIdentifier root_definition_identifier(real_root_type, format);
+      DefinitionIdentifier root_definition_identifier(root_type, format);
       result = (delimiter(root_definition_identifier) +
         append_recursive(root_definition_identifier, max_recursion_depth));
     } catch (const TypenameNotUnderstoodError & err) {
@@ -261,12 +260,13 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
 
     // Convert service event type to service type
     std::regex srv_event_type_postfix_regex{R"(_Event$)"};
+    service_root_type = root_type;
     if (std::regex_search(root_type, srv_event_type_postfix_regex)) {
-      real_root_type = std::regex_replace(
-        root_type, srv_event_type_postfix_regex, "");
+      service_root_type = std::regex_replace(
+        service_root_type, srv_event_type_postfix_regex, "");
     }
 
-    DefinitionIdentifier def_identifier{real_root_type, format};
+    DefinitionIdentifier def_identifier{service_root_type, format};
     (void)seen_deps.insert(def_identifier).second;
     result = delimiter(def_identifier);
     const MessageSpec & spec = load_message_spec(def_identifier);
@@ -316,7 +316,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
   }
 
   out.encoded_message_definition = result;
-  out.topic_type = real_root_type;
+  out.topic_type = (format == Format::SRV) ? service_root_type : root_type;
   return out;
 }
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -211,6 +211,8 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
 {
   std::unordered_set<DefinitionIdentifier, DefinitionIdentifierHash> seen_deps;
 
+  std::string real_root_type = root_type;
+
   std::function<std::string(const DefinitionIdentifier &, int32_t)> append_recursive =
     [&](const DefinitionIdentifier & definition_identifier, int32_t depth) {
       if (depth <= 0) {
@@ -235,14 +237,14 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
   Format format = Format::UNKNOWN;
   int32_t max_recursion_depth = ROSBAG2_CPP_LOCAL_MESSAGE_DEFINITION_SOURCE_MAX_RECURSION_DEPTH;
 
-  if (root_type.find("/srv/") == std::string::npos) {  // Not a service
+  if (root_type.find("/srv/") == std::string::npos) {  // Normal topic type
     try {
       format = Format::MSG;
-      result = append_recursive(DefinitionIdentifier(root_type, format), max_recursion_depth);
+      result = append_recursive(DefinitionIdentifier(real_root_type, format), max_recursion_depth);
     } catch (const DefinitionNotFoundError & err) {
       ROSBAG2_CPP_LOG_WARN("No .msg definition for %s, falling back to IDL", err.what());
       format = Format::IDL;
-      DefinitionIdentifier root_definition_identifier(root_type, format);
+      DefinitionIdentifier root_definition_identifier(real_root_type, format);
       result = (delimiter(root_definition_identifier) +
         append_recursive(root_definition_identifier, max_recursion_depth));
     } catch (const TypenameNotUnderstoodError & err) {
@@ -251,12 +253,20 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
         "definition will be left empty in bag.", err.what());
       format = Format::UNKNOWN;
     }
-  } else {
+  } else {  // Service event topic type
     // The service dependencies could be either in the msg or idl files. Therefore, will try to
     // search service dependencies in MSG files first then in IDL files via two separate recursive
     // searches for each dependency.
-    format = Format::UNKNOWN;
-    DefinitionIdentifier def_identifier{root_type, Format::SRV};
+    format = Format::SRV;
+
+    // Convert service event type to service type
+    std::regex srv_event_type_postfix_regex{R"(_Event$)"};
+    if (std::regex_search(root_type, srv_event_type_postfix_regex)) {
+      real_root_type = std::regex_replace(
+        root_type, srv_event_type_postfix_regex, "");
+    }
+
+    DefinitionIdentifier def_identifier{real_root_type, format};
     (void)seen_deps.insert(def_identifier).second;
     result = delimiter(def_identifier);
     const MessageSpec & spec = load_message_spec(def_identifier);
@@ -306,7 +316,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
   }
 
   out.encoded_message_definition = result;
-  out.topic_type = root_type;
+  out.topic_type = real_root_type;
   return out;
 }
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -65,7 +65,7 @@ TEST(test_local_message_definition_source, can_find_msg_deps)
 TEST(test_local_message_definition_source, can_find_srv_deps_in_msg)
 {
   LocalMessageDefinitionSource source;
-  auto result = source.get_full_text("rosbag2_test_msgdefs/srv/ComplexSrvMsg");
+  auto result = source.get_full_text("rosbag2_test_msgdefs/srv/ComplexSrvMsg_Event");
   ASSERT_EQ(result.encoding, "ros2msg");
   ASSERT_EQ(
     result.encoded_message_definition,
@@ -83,7 +83,7 @@ TEST(test_local_message_definition_source, can_find_srv_deps_in_msg)
 TEST(test_local_message_definition_source, can_find_srv_deps_in_idl)
 {
   LocalMessageDefinitionSource source;
-  auto result = source.get_full_text("rosbag2_test_msgdefs/srv/ComplexSrvIdl");
+  auto result = source.get_full_text("rosbag2_test_msgdefs/srv/ComplexSrvIdl_Event");
   ASSERT_EQ(result.encoding, "ros2idl");
   ASSERT_EQ(
     result.encoded_message_definition,


### PR DESCRIPTION
## Description

- Fixes service message definition issue (#1966) only for Jazzy.   

Since rosbag2 for Jazzy only supports services, I didn't make the fixing based on #2041. Instead, I used a simpler method to fix the issue.

### Is this user-facing behavior change?

### Did you use Generative AI?

No

### Additional Information

No
