### PR TITLE
Update README: Command of playing back multiple bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ A progress bar to track the playback progress will be displayed in the terminal 
 To play back multiple bags:
 
 ```
-$ ros2 bag play <bag1> -i <bag2> -i <bag3>
+$ ros2 bag play -i <bag1> -i <bag2> -i <bag3>
 ```
 
 Messages from all provided bags will be played in order, based on their original recording


### PR DESCRIPTION
## Description
This PR updates the README file on playing back multiple ROS bags.
Added missing `i` argument for the `ros2 bag play` CLI

Fixes # (issue)

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No

