### PR TITLE
Use cache to try to determine the inner type for action introspection interfaces

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -172,6 +172,18 @@ private:
 
   std::unordered_map<DefinitionIdentifier,
     MessageSpec, DefinitionIdentifierHash> msg_specs_by_definition_identifier_;
+
+  /**
+   * \brief Topic name to inner action interface type cache.
+   *
+   * \note This cache is used to store the inner action interface type for a given topic name,
+   * because we can't convert CancelGoalEvent or Status action introspection interface types to
+   * action type directly. Therefore, we will use cache to try to determine the original action
+   * type for CancelGoalEvent, Status action introspection interface types by storing the action
+   * type from other action interface types corresponding to the same topic name and original
+   * action type.
+   */
+  std::unordered_map<std::string, std::string> topic_name_to_inner_action_interface_type_cache_;
 };
 
 ROSBAG2_CPP_PUBLIC

--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -174,16 +174,18 @@ private:
     MessageSpec, DefinitionIdentifierHash> msg_specs_by_definition_identifier_;
 
   /**
-   * \brief Topic name to inner action interface type cache.
+   * \brief Action name to inner action interface type cache.
    *
-   * \note This cache is used to store the inner action interface type for a given topic name,
+   * \note This cache is used to store the inner action interface type for a given action name,
    * because we can't convert CancelGoalEvent or Status action introspection interface types to
    * action type directly. Therefore, we will use cache to try to determine the original action
    * type for CancelGoalEvent, Status action introspection interface types by storing the action
-   * type from other action interface types corresponding to the same topic name and original
+   * type from other action interface types corresponding to the same action name and original
    * action type.
+   * The action name is the topic name without the postfix, e.g. for
+   * `/fibonacci/_action/send_goal/_service_event` the action name is `/fibonacci`.
    */
-  std::unordered_map<std::string, std::string> topic_name_to_inner_action_interface_type_cache_;
+  std::unordered_map<std::string, std::string> action_name_to_inner_action_interface_type_cache_;
 };
 
 ROSBAG2_CPP_PUBLIC

--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -73,19 +73,20 @@ public:
   rosbag2_storage::MessageDefinition get_full_text(const std::string & root_type);
 
   /**
-   * \brief Concatenate the message definition with its dependencies into a self-contained schema.
+   * \brief Try to get the message definition and concatenate it with its dependencies into a
+   * self-contained schema.
    * \details The format is different for MSG/SRV/ACTION and IDL definitions, and is described
    * fully in the docs/message_definition_encoding.md.
    * For SRV type, root_type must include a string '/srv/'.
    * For ACTION type, root_type must include a string '/action/'.
-   * Note: that for service or action introspection topics, the topic type will be extended to the
+   * \note That for service or action introspection topics, the topic type will be extended to the
    * inner original service or action type, respectively, before trying to find the
    * message definition.
    * \param[in] topic_name The topic name, which is used to determine the message definition format.
    * \param[in] root_type The root type of the message definition, which should be a fully qualified
    * datatype name.
-   * \throws DefinitionNotFoundError if one or more definition files are missing for the given
-   * package resource name.
+   * \throws DefinitionNotFoundError if one or more definition files are missing for the
+   * corresponding package resource name or if the package resource name cannot be determined.
    * \return A MessageDefinition object containing the encoded message definition and its
    * dependencies.
    */

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -238,8 +238,6 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
 {
   std::unordered_set<DefinitionIdentifier, DefinitionIdentifierHash> seen_deps;
 
-  std::string real_root_type = root_type;
-
   std::function<std::string(const DefinitionIdentifier &, int32_t)> append_recursive =
     [&](const DefinitionIdentifier & definition_identifier, int32_t depth) {
       if (depth <= 0) {
@@ -270,7 +268,11 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
     root_type == "action_msgs/srv/CancelGoal_Event";
   bool is_service_type = (!is_action_type && root_type.find("/srv/") != std::string::npos);
 
-  if (!is_service_type && !is_action_type) {  // Only msg and idl files
+  // Note: If the root_type is a service event type or one of the action interface types, we will
+  // try to convert it to the original service or action type respectively.
+  std::string real_root_type = root_type;
+
+  if (!is_service_type && !is_action_type) {  // Only for regular message types
     try {
       format = Format::MSG;
       result = append_recursive(DefinitionIdentifier(root_type, format), max_recursion_depth);
@@ -300,8 +302,23 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
     } else if (is_action_type) {
       format = Format::ACTION;
       if (!topic_name.empty() && is_topic_belong_to_action(topic_name, root_type)) {
-        // Convert action interface type to action type
-        real_root_type = rosbag2_cpp::get_action_type_for_info(root_type);
+        // Search for action type in cache first. Since we can't convert CancelGoalEvent or Status
+        // action introspection interface types to the corresponding action type directly, we are
+        // using cache to store the action type from other action introspection interface types
+        // corresponding to the same topic name and original action type.
+        auto it = topic_name_to_inner_action_interface_type_cache_.find(topic_name);
+        if (it != topic_name_to_inner_action_interface_type_cache_.end() && !it->second.empty()) {
+          real_root_type = it->second;
+        } else {
+          // Convert action interface type to action type
+          std::string action_type = rosbag2_cpp::get_action_type_for_info(root_type);
+          // Note: get_action_type_for_info(topic_type) will return empty string if the action
+          // type is CancelGoalEvent or Status.
+          if (!action_type.empty()) {
+            real_root_type = std::move(action_type);
+            topic_name_to_inner_action_interface_type_cache_[topic_name] = real_root_type;
+          }
+        }
       }
     }
     DefinitionIdentifier def_identifier{real_root_type, format};

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -306,8 +306,9 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
         // action introspection interface types to the corresponding action type directly, we are
         // using cache to store the action type from other action introspection interface types
         // corresponding to the same topic name and original action type.
-        auto it = topic_name_to_inner_action_interface_type_cache_.find(topic_name);
-        if (it != topic_name_to_inner_action_interface_type_cache_.end() && !it->second.empty()) {
+        std::string action_name = action_interface_name_to_action_name(topic_name);
+        auto it = action_name_to_inner_action_interface_type_cache_.find(action_name);
+        if (it != action_name_to_inner_action_interface_type_cache_.end() && !it->second.empty()) {
           real_root_type = it->second;
         } else {
           // Convert action interface type to action type
@@ -316,7 +317,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
           // type is CancelGoalEvent or Status.
           if (!action_type.empty()) {
             real_root_type = std::move(action_type);
-            topic_name_to_inner_action_interface_type_cache_[topic_name] = real_root_type;
+            action_name_to_inner_action_interface_type_cache_[action_name] = real_root_type;
           }
         }
       }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -138,6 +138,26 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_msg)
     check_result(result);
   }
 
+  // Known limitation:
+  // The get_full_text_ext(..) can return action definition for action interface 'cancel_goal' and
+  // 'status' only if it was a prior successful call to the get_full_text_ext(..) for the same
+  // action name.
+  // Check action interface cancel_goal
+  {
+    auto result = source.get_full_text_ext(
+      "action_msgs/srv/CancelGoal_Event",
+      "/complex_action_msg/_action/cancel_goal/_service_event");
+    check_result(result);
+  }
+
+  // Check action interface status
+  {
+    auto result = source.get_full_text_ext(
+      "action_msgs/msg/GoalStatusArray",
+      "/complex_action_msg/_action/status");
+    check_result(result);
+  }
+
   // Check action interface get_result
   {
     auto result = source.get_full_text_ext(
@@ -153,11 +173,6 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_msg)
       "/complex_action_msg/_action/feedback");
     check_result(result);
   }
-
-  // Known limitation
-  // get_full_text_ext() cannot return action definition for action interface 'cancel_goal' and
-  // 'status'.
-  // This issue will be resolved in future versions.
 }
 
 TEST(test_local_message_definition_source, can_find_action_deps_in_idl)
@@ -198,6 +213,26 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_idl)
     check_result(result);
   }
 
+  // Known limitation:
+  // The get_full_text_ext(..) can return action definition for action interface 'cancel_goal' and
+  // 'status' only if it was a prior successful call to the get_full_text_ext(..) for the same
+  // action name.
+  // Check action interface cancel_goal
+  {
+    auto result = source.get_full_text_ext(
+      "action_msgs/srv/CancelGoal_Event",
+      "/complex_action_idl/_action/cancel_goal/_service_event");
+    check_result(result);
+  }
+
+  // Check action interface status
+  {
+    auto result = source.get_full_text_ext(
+      "action_msgs/msg/GoalStatusArray",
+      "/complex_action_idl/_action/status");
+    check_result(result);
+  }
+
   // Check action interface get_result
   {
     auto result = source.get_full_text_ext(
@@ -213,11 +248,6 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_idl)
       "/complex_action_idl/_action/feedback");
     check_result(result);
   }
-
-  // Known limitation
-  // get_full_text_ext() cannot return action definition for action interface 'cancel_goal' and
-  // 'status'.
-  // This issue will be resolved in future versions.
 }
 
 TEST(test_local_message_definition_source, can_find_idl_deps)


### PR DESCRIPTION
## Description

- This PR will help address the issue when `get_full_text_ext(..)` cannot return full inner message definitions for the action interface `cancel_goal` and `status` message types.
- This PR adds cache to map short action name to the inner action interface type in the `LocalMessageDefinitionSource::get_full_text_ext(root_type, topic_name)` to help determine the inner type for action introspection interfaces when trying to get the full message definition in a text form.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes #1966

### Is this user-facing behavior change?
No.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes. The GitHub Copilot, GPT-4.1 was used to help with Doxygen comments.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
- This PR is not backportable since it adds a new class member variable 
```cpp
  std::unordered_map<std::string, std::string> topic_name_to_inner_action_interface_type_cache_;
```
into the `rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp` header file.
Making changes to be ABI incompatible.
<!--
If applicable, provide any additional context or details about the changes.
-->

### Known limitations:
- The `get_full_text_ext(topic_type, topic_name)` can return action message definition for action interface types `action_msgs/srv/CancelGoal_Event` and `action_msgs/msg/GoalStatusArray` only if it was a prior successful call to the get_full_text_ext(topic_type, topic_name) for the same action name. 
For instance, if it was a prior call to the: 
```cpp
get_full_text_ext("rosbag2_test_msgdefs/action/ComplexActionMsg_SendGoal_Event",
  "/complex_action_msg/_action/send_goal/_service_event");
```