### PR TITLE
Bugfix for deadlocks in Rosbag2 player when calling stop API

### DIFF
--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_play_end_to_end.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "rosbag2_interfaces/srv/resume.hpp"
+#include "rosbag2_interfaces/srv/stop.hpp"
 #include "rosbag2_test_common/process_execution_helpers.hpp"
 #include "rosbag2_test_common/subscription_manager.hpp"
 #include "rosbag2_test_common/tested_storage_ids.hpp"
@@ -40,6 +41,7 @@ class PlayEndToEndTestFixture : public Test, public WithParamInterface<std::stri
 {
 public:
   using Resume = rosbag2_interfaces::srv::Resume;
+  using Stop = rosbag2_interfaces::srv::Stop;
 
   PlayEndToEndTestFixture()
   : sub_qos_(rclcpp::QoS{10}
@@ -49,8 +51,9 @@ public:
     // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
     bags_path_ = (fs::path(_SRC_RESOURCES_DIR_PATH) / GetParam()).generic_string();
     sub_ = std::make_unique<SubscriptionManager>();
-    client_node_ = std::make_shared<rclcpp::Node>("test_record_client");
+    client_node_ = std::make_shared<rclcpp::Node>("test_player_client");
     cli_resume_ = client_node_->create_client<Resume>("/rosbag2_player/resume");
+    cli_stop_ = client_node_->create_client<Stop>("/rosbag2_player/stop");
     exec_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     exec_->add_node(client_node_);
     spin_thread_ = std::thread(
@@ -109,6 +112,7 @@ public:
   std::unique_ptr<SubscriptionManager> sub_;
   rclcpp::Node::SharedPtr client_node_;
   rclcpp::Client<Resume>::SharedPtr cli_resume_;
+  rclcpp::Client<Stop>::SharedPtr cli_stop_;
   std::thread spin_thread_;
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
   const std::chrono::seconds service_call_timeout_ {10};
@@ -158,6 +162,31 @@ TEST_P(PlayEndToEndTestFixture, play_end_to_end_test) {
           &test_msgs::msg::Arrays::string_values,
           ElementsAre("Complex Hello1", "Complex Hello2", "Complex Hello3")))));
   EXPECT_TRUE(wait_until_completion(process_id));
+}
+
+TEST_P(PlayEndToEndTestFixture, player_gracefully_exit_with_stop_service_call) {
+  sub_->add_subscription<test_msgs::msg::Arrays>("/array_topic", 1, sub_qos_);
+  sub_->add_subscription<test_msgs::msg::BasicTypes>("/test_topic", 1, sub_qos_);
+
+  // Start ros2 bag play in pause and loop mode. Loop mode is needed to ensure that the player
+  // does not exit after playing the bag once, so we can test the stop service call.
+  auto process_id = start_execution("ros2 bag play -p -l " + bags_path_ + "/cdr_test");
+  auto cleanup_process_handle = rcpputils::make_scope_exit(
+    [process_id]() {
+      stop_execution(process_id);
+    });
+
+  EXPECT_TRUE(sub_->spin_and_wait_for_matched({"/test_topic", "/array_topic"}));
+  auto subscription_future = sub_->spin_subscriptions();
+
+  ASSERT_TRUE(cli_resume_->wait_for_service(service_call_timeout_));
+  ASSERT_TRUE(cli_stop_->wait_for_service(service_call_timeout_));
+  // Send resume service call for player
+  successful_service_request<Resume>(cli_resume_);
+  subscription_future.get();
+  successful_service_request<Stop>(cli_stop_);
+  // Wait for the process to finish gracefully after the stop service call
+  EXPECT_TRUE(wait_until_completion(process_id, std::chrono::seconds(5)));
 }
 
 TEST_P(PlayEndToEndTestFixture, play_fails_gracefully_if_bag_does_not_exist) {

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -545,16 +545,20 @@ PlayerImpl::PlayerImpl(
 
 PlayerImpl::~PlayerImpl()
 {
-  // Force to stop playback to avoid hangout in case of unexpected exception or when smart
-  // pointer to the player object goes out of scope
-  stop();
-
-  // remove callbacks on key_codes to prevent race conditions
+  // Remove callbacks from keyboard_handler_ to prevent race conditions.
   // Note: keyboard_handler handles locks between removing & executing callbacks
   if (keyboard_handler_) {
     for (auto cb_handle : keyboard_callbacks_) {
       keyboard_handler_->delete_key_press_callback(cb_handle);
     }
+  }
+
+  // Force to stop playback to avoid hangout in case of unexpected exception or when smart
+  // pointer to the player object goes out of scope
+  stop();
+
+  if (playback_thread_.joinable()) {
+    playback_thread_.join();
   }
   // closes readers
   std::lock_guard<std::mutex> lk(reader_mutex_);
@@ -581,17 +585,19 @@ bool PlayerImpl::is_storage_completely_loaded() const
 
 bool PlayerImpl::play()
 {
-  {
-    rcpputils::unique_lock<std::mutex> is_in_playback_lk(is_in_playback_mutex_);
-    if (is_in_playback_.exchange(true)) {
-      RCLCPP_WARN_STREAM(
-        owner_->get_logger(),
-        "Trying to play() while in playback, dismissing request.");
-      progress_bar_->update(clock_->is_paused() ? PlayerStatus::PAUSED : PlayerStatus::RUNNING);
-      return false;
-    }
+  rcpputils::unique_lock<std::mutex> is_in_playback_lk(is_in_playback_mutex_);
+  if (is_in_playback_.exchange(true)) {
+    RCLCPP_WARN_STREAM(
+      owner_->get_logger(),
+      "Trying to play() while in playback, dismissing request.");
+    progress_bar_->update(clock_->is_paused() ? PlayerStatus::PAUSED : PlayerStatus::RUNNING);
+    return false;
   }
 
+  // May need to join the previous thread if we are calling play() a second time
+  if (playback_thread_.joinable()) {
+    playback_thread_.join();
+  }
   stop_playback_ = false;
 
   rclcpp::Duration delay(0, 0);
@@ -605,10 +611,6 @@ bool PlayerImpl::play()
 
   RCLCPP_INFO_STREAM(owner_->get_logger(), "Playback until timestamp: " << play_until_timestamp_);
 
-  // May need to join the previous thread if we are calling play() a second time
-  if (playback_thread_.joinable()) {
-    playback_thread_.join();
-  }
   playback_thread_ = std::thread(
     [&, delay]() {
       try {
@@ -694,7 +696,7 @@ bool PlayerImpl::play()
         playback_finished_cv_.notify_all();
       }
 
-      // If we get here and still have/just got a play next request, make sure to notify
+      // If we get here and still have/just got a play next request, make sure to notify play_next()
       // After that, requests will be automatically rejected since is_in_playback_ is false
       if (play_next_.exchange(false)) {
         std::lock_guard<std::mutex> lk(finished_play_next_mutex_);
@@ -723,11 +725,7 @@ bool PlayerImpl::wait_for_playback_to_finish(std::chrono::duration<double> timeo
 void PlayerImpl::stop()
 {
   rcpputils::unique_lock<std::mutex> is_in_playback_lk(is_in_playback_mutex_);
-  if (!is_in_playback_) {
-    if (playback_thread_.joinable()) {
-      playback_thread_.join();
-    }
-  } else {
+  if (is_in_playback_) {
     RCLCPP_INFO_STREAM(owner_->get_logger(), "Stopping playback.");
     stop_playback_ = true;
     // Temporary stop playback in play_messages_from_queue() and block play_next() and seek() or
@@ -751,9 +749,10 @@ void PlayerImpl::stop()
     // Wait for playback thread to finish. Make sure that we have unlocked
     // is_in_playback_mutex_, otherwise playback_thread_ will wait forever at the end
     is_in_playback_lk.unlock();
-    if (playback_thread_.joinable()) {
-      playback_thread_.join();
-    }
+    wait_for_playback_to_finish(std::chrono::seconds(-1));
+  } else {
+    RCLCPP_DEBUG_STREAM(owner_->get_logger(),
+      "Trying to stop when playback is not running. Dismissing stop request.");
   }
 }
 
@@ -820,25 +819,23 @@ rosbag2_storage::SerializedBagMessageSharedPtr PlayerImpl::take_next_message_fro
 
 bool PlayerImpl::play_next()
 {
-  if (!is_in_playback_) {
-    RCLCPP_WARN_STREAM(owner_->get_logger(), "Called play next, but player is not playing.");
-    return false;
-  }
-  if (!clock_->is_paused()) {
-    RCLCPP_WARN_STREAM(owner_->get_logger(), "Called play next, but not in paused state.");
-    progress_bar_->update(PlayerStatus::RUNNING);
-    return false;
-  }
+  // First check if we can proceed with playing next message
+  {
+    rcpputils::unique_lock<std::mutex> is_in_playback_lk(is_in_playback_mutex_);
+    if (!is_in_playback_) {
+      RCLCPP_WARN_STREAM(owner_->get_logger(), "Called play next, but player is not playing.");
+      return false;
+    }
+    if (!clock_->is_paused()) {
+      RCLCPP_WARN_STREAM(owner_->get_logger(), "Called play next, but not in paused state.");
+      progress_bar_->update(PlayerStatus::RUNNING);
+      return false;
+    }
+  }  // Release is_in_playback_mutex_ before proceeding to avoid deadlock with
+     // playback_thread_ which is waiting for this mutex to be released at the end.
 
   // Use RCLCPP_DEBUG_STREAM to avoid delays in the burst mode
   RCLCPP_DEBUG_STREAM(owner_->get_logger(), "Playing next message.");
-
-  // Wait for player to be ready for playback messages from queue i.e. wait for Player:play() to
-  // be called if not yet and queue to be filled with messages.
-  {
-    std::unique_lock<std::mutex> lk(ready_to_play_from_queue_mutex_);
-    ready_to_play_from_queue_cv_.wait(lk, [this] {return is_ready_to_play_from_queue_;});
-  }
 
   // Request to play next
   play_next_ = true;


### PR DESCRIPTION
## Description

This PR fixes potential deadlocks in the Rosbag2 player when running from CLI `ros2 bag play` or from Python API and when trying to stop playback via service call from another process or thread.

Please refer to the https://github.com/ros2/rosbag2/issues/2056#issuecomment-3015973746 for the detailed root cause analysis.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes #2056

### Is this user-facing behavior change?
No.
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
- This PR doesn't contain API/ABI breaking changes and can be backported.
