### PR TITLE
fix CMAKE deprecation

### DIFF
--- a/liblz4_vendor/CMakeLists.txt
+++ b/liblz4_vendor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(liblz4_vendor)
 
 find_package(ament_cmake REQUIRED)

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 project(mcap_vendor LANGUAGES C CXX)
 
 ## Dependencies

--- a/rosbag2/CMakeLists.txt
+++ b/rosbag2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2)
 
 find_package(ament_cmake REQUIRED)

--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_compression)
 
 # Default to C99

--- a/rosbag2_compression_zstd/CMakeLists.txt
+++ b/rosbag2_compression_zstd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_compression_zstd)
 
 # Default to C99

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_cpp)
 
 add_definitions(-D_SRC_REINDEX_DIR_PATH="${CMAKE_CURRENT_SOURCE_DIR}/test/rosbag2_cpp/reindex_test_bags")

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_examples_cpp)
 
 # Default to C99

--- a/rosbag2_interfaces/CMakeLists.txt
+++ b/rosbag2_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_interfaces)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_performance_benchmarking)
 
 option(BUILD_ROSBAG2_BENCHMARKS "Build rosbag2 performance benchmarks" OFF)

--- a/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(rosbag2_performance_benchmarking_msgs)
 

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_storage)
 
 # Default to C99

--- a/rosbag2_storage_default_plugins/CMakeLists.txt
+++ b/rosbag2_storage_default_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_storage_default_plugins)
 
 find_package(ament_cmake REQUIRED)

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_storage_mcap)
 
 # Set Release build if no build type was specified

--- a/rosbag2_storage_sqlite3/CMakeLists.txt
+++ b/rosbag2_storage_sqlite3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_storage_sqlite3)
 
 # Default to C99

--- a/rosbag2_test_common/CMakeLists.txt
+++ b/rosbag2_test_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_test_common)
 
 # Default to C99

--- a/rosbag2_test_msgdefs/CMakeLists.txt
+++ b/rosbag2_test_msgdefs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_test_msgdefs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rosbag2_tests/CMakeLists.txt
+++ b/rosbag2_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_tests)
 
 add_definitions(-D_SRC_RESOURCES_DIR_PATH="${CMAKE_CURRENT_SOURCE_DIR}/resources")

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosbag2_transport)
 
 # Default to C99

--- a/sqlite3_vendor/CMakeLists.txt
+++ b/sqlite3_vendor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(sqlite3_vendor)
 
 find_package(ament_cmake REQUIRED)

--- a/sqlite3_vendor/patches/0001-add-cmakelists.patch
+++ b/sqlite3_vendor/patches/0001-add-cmakelists.patch
@@ -2,7 +2,7 @@ diff -uNr a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt	1969-12-31 16:00:00.000000000 -0800
 +++ b/CMakeLists.txt	2022-11-16 16:44:12.322210922 -0800
 @@ -0,0 +1,12 @@
-+cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.20)
 +project(sqlite3)
 +set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # for Linux, since the library will be used in a shared lib
 +add_library(sqlite3 sqlite3.c)

--- a/zstd_vendor/CMakeLists.txt
+++ b/zstd_vendor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(zstd_vendor)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

cmake version < then 3.10 is deprecated

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
