### PR TITLE
Bugfix: `prosbag2_performance_benchmarking` outputs incorrect results for topics with frequency more than 1 kHz

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/benchmark_publishers.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/benchmark_publishers.cpp
@@ -59,7 +59,7 @@ private:
   {
     std::shared_ptr<msg_utils::ProducerBase> msg_producer;
     std::promise<void> promise_finished;
-    std::chrono::milliseconds period{0};
+    std::chrono::microseconds period{0};
     size_t produced_messages = 0;
     size_t max_messages = 0;
 
@@ -118,8 +118,9 @@ private:
 
     producer->msg_producer = msg_utils::create(producer_config.message_type, *this, topic, config);
     producer->max_messages = producer_config.max_count;
-    producer->period = std::chrono::milliseconds(
-      producer_config.frequency ? 1000 / producer_config.frequency : 1);
+    // Note: The std::chrono::microseconds::period::den == 1,000,000
+    producer->period = std::chrono::microseconds(producer_config.frequency ?
+      std::chrono::microseconds::period::den / producer_config.frequency : 1);
 
     if (producer->max_messages > 0) {
       thread_pool_.queue(

--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
@@ -53,7 +53,7 @@ bool wait_for_subscriptions_from_node_parameters(rclcpp::Node & node)
 {
   const std::string parameters_ns = "publishers";
   node.declare_parameter<bool>(parameters_ns + ".wait_for_subscriptions", true);
-  bool wait_for_subscriptions;
+  bool wait_for_subscriptions = true;
   node.get_parameter(parameters_ns + ".wait_for_subscriptions", wait_for_subscriptions);
   return wait_for_subscriptions;
 }


### PR DESCRIPTION
## Description

Bugfix for the issue when `prosbag2_performance_benchmarking` outputs incorrect results for topics with frequency more than 1 kHz.

### RCA
- The publishers in `prosbag2_performance_benchmarking` producers can't keep up with more than 1 kHz frequency.

### Fix explanation:
  - Use microseconds for the producer's `period` variable.
  - Also, a supplemental fix for the warning about the possible use of an uninitialized variable.

- Fixes # (issue) N/A

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow.

### Additional Information

This PR can be backported to the other already released ROS 2 distros.