### PR TITLE
Fixes in the rosbag2_performance_benchmarking message data generator

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/msg_utils/helpers.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/msg_utils/helpers.cpp
@@ -22,6 +22,7 @@ namespace helpers
 {
 void generate_data(rosbag2_performance_benchmarking_msgs::msg::ByteArray & array, size_t size)
 {
+  array.data.clear();
   array.data.reserve(size);
   for (auto i = 0u; i < size; ++i) {
     array.data.emplace_back(std::rand() % 255);
@@ -30,18 +31,22 @@ void generate_data(rosbag2_performance_benchmarking_msgs::msg::ByteArray & array
 
 void generate_data(sensor_msgs::msg::Image & msg, size_t size)
 {
-  // TODO(carlossvg): calculate message base size to set total size
-  msg.data.reserve(size);
-  for (auto i = 0u; i < size; ++i) {
+  msg.data.clear();
+  auto msg_type_size = sizeof(msg);
+  auto data_size = (size > msg_type_size) ? size - msg_type_size : 0;
+  msg.data.reserve(data_size);
+  for (auto i = 0u; i < data_size; ++i) {
     msg.data.emplace_back(std::rand() % 255);
   }
 }
 
 void generate_data(sensor_msgs::msg::PointCloud2 & msg, size_t size)
 {
-  // TODO(carlossvg): calculate message base size to set total size
-  msg.data.reserve(size);
-  for (auto i = 0u; i < size; ++i) {
+  msg.data.clear();
+  auto msg_type_size = sizeof(msg);
+  auto data_size = (size > msg_type_size) ? size - msg_type_size : 0;
+  msg.data.reserve(data_size);
+  for (auto i = 0u; i < data_size; ++i) {
     msg.data.emplace_back(std::rand() % 255);
   }
 }

--- a/rosbag2_performance/rosbag2_performance_benchmarking/test/benchmark_test.py
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/test/benchmark_test.py
@@ -332,9 +332,6 @@ class BenchmarkResultsChecker:
 
 
 def generate_test_description():
-    proc_env = os.environ.copy()
-    proc_env['PYTHONUNBUFFERED'] = '1'
-
     config_path = os.path.join(
         ament_index_python.get_package_share_directory('rosbag2_performance_benchmarking'),
         'config'
@@ -375,7 +372,7 @@ def generate_test_description():
             process = launch.actions.ExecuteProcess(
                 cmd=['ros2', 'launch', 'rosbag2_performance_benchmarking',
                      'benchmark_launch.py'] + args,
-                env=proc_env,
+                additional_env={'PYTHONUNBUFFERED': '1'},
                 output='screen'
             )
             benchmark_processes.append(process)


### PR DESCRIPTION
## Description

- Fixes in the rosbag2_performance_benchmarking `msg_utils::helpers::generate_data`
  1. Clear data before generating a new data
  2. Correctly calculate the size need for the payload
 - Also, supplemental bugfix: "Don't override process env variable with 'PYTHONUNBUFFERED=1'"
    - In the previous implementation, the process environment variable was overridden with the 'PYTHONUNBUFFERED=1' value.
    - While it was not causing any failure in the default usage, it could cause unexpected behavior if the user needed to specify custom values for the process environment variables before running `rosbag2_performance_benchmarking` tests. For instance to enable some extended logging on the RMW or transport layer.
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue) N/A

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow.

### Additional Information

This PR can be backported to the already released ROS 2 distros.