### PR TITLE
[draft] merge the remapping argument into Player's NodeOption.

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -2167,7 +2167,17 @@ Player::Player(
   const rclcpp::NodeOptions & node_options)
 : rclcpp::Node(
     node_name,
-    rclcpp::NodeOptions(node_options).arguments(play_options.topic_remapping_options))
+    // Merge existing arguments with topic remapping options
+    rclcpp::NodeOptions(node_options).arguments(
+      [&, node_options]() {
+        auto args = node_options.arguments();
+        args.insert(args.end(),
+          play_options.topic_remapping_options.begin(),
+          play_options.topic_remapping_options.end());
+        return args;
+      }()
+    )
+)
 {
   std::shared_ptr<KeyboardHandler> keyboard_handler;
   if (!play_options.disable_keyboard_controls) {
@@ -2202,7 +2212,17 @@ Player::Player(
   const rclcpp::NodeOptions & node_options)
 : rclcpp::Node(
     node_name,
-    rclcpp::NodeOptions(node_options).arguments(play_options.topic_remapping_options))
+    // Merge existing arguments with topic remapping options
+    rclcpp::NodeOptions(node_options).arguments(
+      [&, node_options]() {
+        auto args = node_options.arguments();
+        args.insert(args.end(),
+          play_options.topic_remapping_options.begin(),
+          play_options.topic_remapping_options.end());
+        return args;
+      }()
+    )
+)
 {
   std::vector<reader_storage_options_pair_t> readers_with_options{};
   readers_with_options.emplace_back(std::move(reader), storage_options);
@@ -2231,10 +2251,21 @@ Player::Player(
   const rclcpp::NodeOptions & node_options)
 : rclcpp::Node(
     node_name,
-    rclcpp::NodeOptions(node_options).arguments(play_options.topic_remapping_options)),
+    // Merge existing arguments with topic remapping options
+    rclcpp::NodeOptions(node_options).arguments(
+      [&, node_options]() {
+        auto args = node_options.arguments();
+        args.insert(args.end(),
+          play_options.topic_remapping_options.begin(),
+          play_options.topic_remapping_options.end());
+        return args;
+      }()
+    )
+),
   pimpl_(std::make_unique<PlayerImpl>(
       this, std::move(readers_with_options), std::move(keyboard_handler), play_options))
-{}
+{
+}
 
 Player::~Player() = default;
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #2088 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes, with this PR, Player constructor honors the NodeOption argument to append play_option.arguments.
in other word, `play_option.arguments` does not overwrite the argument for the NodeOption.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes, Copilot Claude Sonnet 4.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
