### PR TITLE
Enable `rosbag2_performance_benchmarking` package to be built by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,7 @@ jobs:
           {
             "build": {
               "cmake-args": [
-                "-DCMAKE_CXX_FLAGS=\"-Werror\"",
-                "-DBUILD_ROSBAG2_BENCHMARKS=1"
+                "-DCMAKE_CXX_FLAGS=\"-Werror\""
               ],
               "packages-up-to": [
                 "mcap_vendor",

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(rosbag2_performance_benchmarking)
 
-option(BUILD_ROSBAG2_BENCHMARKS "Build rosbag2 performance benchmarks" OFF)
-
-if(NOT BUILD_ROSBAG2_BENCHMARKS)
-  return()
-endif()
+option(ENABLE_ROSBAG2_BENCHMARK_TESTS "Enables rosbag2 performance benchmark tests" OFF)
 
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
@@ -93,7 +89,7 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}
 )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND ENABLE_ROSBAG2_BENCHMARK_TESTS)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(benchmark_publishers
   rosbag2_storage::rosbag2_storage
   ${rosbag2_performance_benchmarking_msgs_TARGETS}
   ${sensor_msgs_TARGETS}
-  yaml-cpp
+  yaml-cpp::yaml-cpp
 )
 
 target_link_libraries(results_writer

--- a/rosbag2_performance/rosbag2_performance_benchmarking/README.md
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/README.md
@@ -26,6 +26,7 @@ For human friendly output, a postprocess report generation tool can be used. Lau
 ```bash
 scripts/report_gen.py -i <BENCHMARK_RESULT_DIR>
 ```
+
 #### Binaries
 
 These are used in the launch file:
@@ -45,12 +46,25 @@ In the case of the `benchmark_publishers` binary, a pool of threads is created t
 the number of threads is equal to the number of publishers. It is possible to change the number of threads
 using the optional `number_of_threads` parameter.
 
-## Building
+## Running builtin Rosbag2 benchmark tests on CI or local setup
 
-To build the package in the rosbag2 build process, make sure to turn `BUILD_ROSBAG2_BENCHMARKS` flag on (e.g. `colcon build --cmake-args -DBUILD_ROSBAG2_BENCHMARKS=1`)
+The package contains a set of builtin tests that can be run to verify the performance of the
+Rosbag2 recorder. However, these tests excluded from the build by default, so you need to enable
+them by setting the `ENABLE_ROSBAG2_BENCHMARK_TESTS` CMake flag to `ON` when building the package.
+To enable and run the rosbag2 benchmark tests with colcon, you need to:
+First build the package with the `ENABLE_ROSBAG2_BENCHMARK_TESTS` CMake option enabled:
 
-If you already built rosbag2, you can use `packages-select` option to build benchmarks.
-Example: `colcon build --packages-select rosbag2_performance_benchmarking --cmake-args -DBUILD_ROSBAG2_BENCHMARKS=1`.
+```bash
+colcon build --packages-select rosbag2_performance_benchmarking --cmake-args -DENABLE_ROSBAG2_BENCHMARK_TESTS=1
+```
+
+Then, you can run the tests using the `colcon test` command.
+
+```bash
+colcon test --packages-select rosbag2_performance_benchmarking
+```
+
+This will execute the tests defined in the "rosbag2_performance_benchmarking/test/benchmark_test.py".
 
 ## General knowledge: I/O benchmarking
 

--- a/rosbag2_performance/rosbag2_performance_benchmarking/README.md
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/README.md
@@ -49,7 +49,7 @@ using the optional `number_of_threads` parameter.
 ## Running builtin Rosbag2 benchmark tests on CI or local setup
 
 The package contains a set of builtin tests that can be run to verify the performance of the
-Rosbag2 recorder. However, these tests excluded from the build by default, so you need to enable
+Rosbag2 recorder. However, these tests are excluded from the build by default, so you need to enable
 them by setting the `ENABLE_ROSBAG2_BENCHMARK_TESTS` CMake flag to `ON` when building the package.
 To enable and run the rosbag2 benchmark tests with colcon, you need to:
 First build the package with the `ENABLE_ROSBAG2_BENCHMARK_TESTS` CMake option enabled:

--- a/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CMakeLists.txt
@@ -2,12 +2,6 @@ cmake_minimum_required(VERSION 3.20)
 
 project(rosbag2_performance_benchmarking_msgs)
 
-option(BUILD_ROSBAG2_BENCHMARKS "Build rosbag2 performance benchmarks" OFF)
-
-if(NOT BUILD_ROSBAG2_BENCHMARKS)
-  return()
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 


### PR DESCRIPTION
## Description

- This PR enables `rosbag2_performance_benchmarking` package to be built by default.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes #2037

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes, I used GitHub Copilot, Claude Sonnet 3.7 Thinking to help with writing comments and updates in the readme file.

### Additional Information
Note: the tests from the `rosbag2_performance_benchmarking` package are excluded from the build by default and should be explicitly enabled during the build time via ``--cmake-args -DENABLE_ROSBAG2_BENCHMARK_TESTS=1`

- This PR replaces https://github.com/ros2/rosbag2/pull/2073

