### PR TITLE
Minor performance improvements in the recorder's MessageCache

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache.cpp
@@ -51,13 +51,14 @@ bool MessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMess
   {
     std::lock_guard<std::mutex> lock(producer_buffer_mutex_);
     pushed = producer_buffer_->push(msg);
+    data_ready_ = true;  // Don't use notify_data_ready() here for the sake of performance.
   }
+  // Notify the consumer that data is ready
+  cache_condition_var_.notify_one();
 
   if (!pushed) {
     messages_dropped_per_topic_[msg->topic_name]++;
   }
-
-  notify_data_ready();
 
   return pushed;
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_buffer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_buffer.cpp
@@ -26,6 +26,7 @@ namespace cache
 MessageCacheBuffer::MessageCacheBuffer(size_t max_cache_size)
 : max_bytes_size_(max_cache_size)
 {
+  buffer_.reserve(512);  // Reserve some space to avoid reallocations. 16x512 = 8192 bytes.
 }
 
 bool MessageCacheBuffer::push(CacheBufferInterface::buffer_element_t msg)


### PR DESCRIPTION
## Description

- This PR introduces minor performance improvements in the recorder's MessageCache
1. Avoid extra mutex lock when pushing a message to the cache buffer.
2. Reserve some space for the cache buffer in the constructor to avoid memory re-allocations in the runtime.

Fixes # (issue) N/A

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.

### Additional Information
This PR can be backported to the already released ROS 2 distros.