### PR TITLE
Bugfix for callback not called in writer for MESSAGES_LOST event

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -206,6 +206,12 @@ public:
    */
   void add_event_callbacks(bag_events::ReaderEventCallbacks & callbacks);
 
+  /**
+   * \brief Check if a callback is registered for the given event.
+   * \return True if there is any callback registered for the event, false otherwise.
+   */
+  [[nodiscard]] bool has_callback_for_event(bag_events::BagEvent event) const;
+
 private:
   std::unique_ptr<reader_interfaces::BaseReaderInterface> reader_impl_;
 };

--- a/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader_interfaces/base_reader_interface.hpp
@@ -67,6 +67,11 @@ public:
   virtual void seek(const rcutils_time_point_value_t & timestamp) = 0;
 
   virtual void add_event_callbacks(const bag_events::ReaderEventCallbacks & callbacks) = 0;
+
+  /// \brief Checks if a callback is registered for the given event.
+  /// \param event Type of event to check for registered callbacks.
+  /// \return True if there is any callback registered for the event, false otherwise.
+  [[nodiscard]] virtual bool has_callback_for_event(bag_events::BagEvent event) const = 0;
 };
 
 }  // namespace reader_interfaces

--- a/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/readers/sequential_reader.hpp
@@ -128,7 +128,7 @@ public:
    * \brief Check if a callback is registered for the given event.
    * \return True if there is any callback registered for the event, false otherwise.
    */
-  bool has_callback_for_event(const bag_events::BagEvent event) const;
+  [[nodiscard]] bool has_callback_for_event(bag_events::BagEvent event) const override;
 
 protected:
   /**

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -247,6 +247,12 @@ public:
    */
   void add_event_callbacks(bag_events::WriterEventCallbacks & callbacks);
 
+  /**
+   * \brief Check if a callback is registered for the given event.
+   * \return True if there is any callback registered for the event, false otherwise.
+   */
+  [[nodiscard]] bool has_callback_for_event(bag_events::BagEvent event) const;
+
 private:
   std::mutex writer_mutex_;
   std::unique_ptr<rosbag2_cpp::writer_interfaces::BaseWriterInterface> writer_impl_;

--- a/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
@@ -64,6 +64,12 @@ public:
   virtual void split_bagfile() = 0;
 
   virtual void add_event_callbacks(const bag_events::WriterEventCallbacks & callbacks) = 0;
+
+  /**
+   * \brief Check if a callback is registered for the given event.
+   * \return True if there is any callback registered for the event, false otherwise.
+   */
+  [[nodiscard]] virtual bool has_callback_for_event(bag_events::BagEvent event) const = 0;
 };
 
 }  // namespace writer_interfaces

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -141,6 +141,12 @@ public:
    */
   void split_bagfile() override;
 
+  /**
+   * \brief Check if a callback is registered for the given event.
+   * \return True if there is any callback registered for the event, false otherwise.
+   */
+  [[nodiscard]] bool has_callback_for_event(bag_events::BagEvent event) const override;
+
 protected:
   std::string base_folder_;
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory_;

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -107,4 +107,9 @@ void Reader::add_event_callbacks(bag_events::ReaderEventCallbacks & callbacks)
   reader_impl_->add_event_callbacks(callbacks);
 }
 
+bool Reader::has_callback_for_event(bag_events::BagEvent event) const
+{
+  return reader_impl_->has_callback_for_event(event);
+}
+
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -367,7 +367,7 @@ void SequentialReader::add_event_callbacks(const bag_events::ReaderEventCallback
   }
 }
 
-bool SequentialReader::has_callback_for_event(const bag_events::BagEvent event) const
+bool SequentialReader::has_callback_for_event(bag_events::BagEvent event) const
 {
   return callback_manager_.has_callback_for_event(event);
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -172,4 +172,9 @@ void Writer::add_event_callbacks(bag_events::WriterEventCallbacks & callbacks)
   writer_impl_->add_event_callbacks(callbacks);
 }
 
+bool Writer::has_callback_for_event(bag_events::BagEvent event) const
+{
+  return writer_impl_->has_callback_for_event(event);
+}
+
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -625,11 +625,15 @@ void SequentialWriter::add_event_callbacks(const bag_events::WriterEventCallback
     callback_manager_.add_event_callback(
       callbacks.write_split_callback,
       bag_events::BagEvent::WRITE_SPLIT);
-  } else if (callbacks.messages_lost_callback) {
+  }
+
+  if (callbacks.messages_lost_callback) {
     callback_manager_.add_event_callback(
       callbacks.messages_lost_callback,
       bag_events::BagEvent::MESSAGES_LOST);
-  } else {
+  }
+
+  if (!callbacks.messages_lost_callback && !callbacks.write_split_callback) {
     throw std::runtime_error("No valid callback provided");
   }
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -638,5 +638,10 @@ void SequentialWriter::add_event_callbacks(const bag_events::WriterEventCallback
   }
 }
 
+bool SequentialWriter::has_callback_for_event(bag_events::BagEvent event) const
+{
+  return callback_manager_.has_callback_for_event(event);
+}
+
 }  // namespace writers
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -574,19 +574,21 @@ void SequentialWriter::write_messages(
   }
   metadata_.files.back().message_count += written_messages_count;
   metadata_.message_count += written_messages_count;
-  std::lock_guard<std::mutex> lock(topics_info_mutex_);
-  // Update message count for each topic in metadata
-  for (size_t i = 0; i < messages.size(); i++) {
-    // If some messages were lost, we need to skip them
-    if (!lost_messages_idx.empty()) {
-      auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
-      if (is_lost) {
-        continue;  // Skip lost messages
+
+  {  // Update message count for each topic in metadata
+    std::lock_guard<std::mutex> lock(topics_info_mutex_);
+    for (size_t i = 0; i < messages.size(); i++) {
+      // If some messages were lost, we need to skip them
+      if (!lost_messages_idx.empty()) {
+        auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
+        if (is_lost) {
+          continue;  // Skip lost messages
+        }
       }
-    }
-    auto topic_info_it = topics_names_to_info_.find(messages[i]->topic_name);
-    if (topic_info_it != topics_names_to_info_.end()) {
-      topic_info_it->second.message_count++;
+      auto topic_info_it = topics_names_to_info_.find(messages[i]->topic_name);
+      if (topic_info_it != topics_names_to_info_.end()) {
+        topic_info_it->second.message_count++;
+      }
     }
   }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -210,6 +210,7 @@ TEST_F(SequentialReaderTest, next_file_calls_callback) {
       callback_called = true;
     };
   reader_->add_event_callbacks(callbacks);
+  ASSERT_TRUE(reader_->has_callback_for_event(rosbag2_cpp::bag_events::BagEvent::READ_SPLIT));
 
   reader_->open(default_storage_options_, {"", storage_serialization_format_});
   // Calling read_next() 6 times should trigger the read-split event callback

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -1066,6 +1066,37 @@ TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
   EXPECT_TRUE(opened_file.empty());
 }
 
+TEST_F(SequentialWriterTest, all_event_callbacks_can_be_installed) {
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  bool is_split_callback_called = false;
+  bool is_messages_lost_callback_called = false;
+  callbacks.write_split_callback =
+    [&is_split_callback_called](rosbag2_cpp::bag_events::BagSplitInfo &) {
+      is_split_callback_called = true;
+    };
+  callbacks.messages_lost_callback =
+    [&is_messages_lost_callback_called](
+    const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> &) {
+      is_messages_lost_callback_called = true;
+    };
+  writer_->add_event_callbacks(callbacks);
+  EXPECT_TRUE(writer_->has_callback_for_event(rosbag2_cpp::bag_events::BagEvent::WRITE_SPLIT));
+  EXPECT_TRUE(writer_->has_callback_for_event(rosbag2_cpp::bag_events::BagEvent::MESSAGES_LOST));
+}
+
+TEST_F(SequentialWriterTest, add_event_callbacks_throws_if_callbacks_are_not_set) {
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  EXPECT_THROW(writer_->add_event_callbacks(callbacks);, std::runtime_error);
+}
+
 TEST_P(ParametrizedTemporaryDirectoryFixture, split_bag_metadata_has_full_duration) {
   const std::vector<std::pair<rcutils_time_point_value_t, uint32_t>> fake_messages {
     {100, 1},

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -132,6 +132,11 @@ public:
     }
   }
 
+  bool has_callback_for_event(rosbag2_cpp::bag_events::BagEvent event) const override
+  {
+    return callback_manager_.has_callback_for_event(event);
+  }
+
   void prepare(
     std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages,
     std::vector<rosbag2_storage::TopicMetadata> topics)

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -101,6 +101,11 @@ public:
     }
   }
 
+  bool has_callback_for_event(rosbag2_cpp::bag_events::BagEvent event) const override
+  {
+    return callback_manager_.has_callback_for_event(event);
+  }
+
   const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & get_messages()
   {
     return messages_;


### PR DESCRIPTION
## Description

Bugfix for callback not called in writer for MESSAGES_LOST event

Note: There was a mistake in the if-else logic, and the `MESSAGES_LOST` event callback was omitted to install if `WRITE_SPLIT` event callback, also provisioned.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue) N/A

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow.

### Additional Information
This PR can't be backported because:
1. It is applied bugfix to the code that exists only on Rolling
2. It has ABI-breaking changes by adding virtual methods to the header files..
