### PR TITLE
Fix missing blanks in help text

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -108,11 +108,11 @@ class RecordVerb(VerbExtension):
         )
         parser.add_argument(
             '--max-cache-size', type=int, default=100*1024*1024,
-            help='maximum size (in bytes) of messages to hold in each buffer of cache.'
+            help='maximum size (in bytes) of messages to hold in each buffer of cache. '
                  'Default is 100 mebibytes. The cache is handled through double buffering, '
-                 'which means that in pessimistic case up to twice the parameter value of memory'
-                 'is needed. A rule of thumb is to cache an order of magitude corresponding to'
-                 'about one second of total recorded data volume.'
+                 'which means that in pessimistic case up to twice the parameter value of memory '
+                 'is needed. A rule of thumb is to cache an order of magitude corresponding to '
+                 'about one second of total recorded data volume. '
                  'If the value specified is 0, then every message is directly written to disk.'
         )
         parser.add_argument(


### PR DESCRIPTION
## Description

Fix missing blanks in the help text of `ros2 bag record -h`
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

(No Issue is found on this.)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

None
<!--
If applicable, provide any additional context or details about the changes.
-->
