### PR TITLE
Fix env var CMake list append in rosbag2_py with clang

### DIFF
--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -145,7 +145,7 @@ if(BUILD_TESTING)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Work around a rtti bug when using class_loader from a
     # python extension built with libc++.
-    set(set_env_vars "${set_env_vars} ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL=True")
+    list(APPEND set_env_vars "ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL=True")
   endif()
 
   ament_add_pytest_test(test_sequential_reader_py


### PR DESCRIPTION
## Description

When clang is used, an extra env var
(`ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL=True`) is added to a list of env vars. However, it is not properly appended and results in being added as-is to the value of the existing env var, `ROSBAG2_PY_TEST_RESOURCES_DIR`:

```
ROSBAG2_PY_TEST_RESOURCES_DIR=/home/christophe.bedard/ros2_ws/src/ros2/rosbag2/rosbag2_py/test/resources ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL=True
```

We can see this in the test runner script output:

```
4: -- run_test.py: extra environment variables:
4:  - PYTHONDONTWRITEBYTECODE=1
4:  - ROSBAG2_PY_TEST_RESOURCES_DIR=/home/christophe.bedard/ros2_ws/src/ros2/rosbag2/rosbag2_py/test/resources ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL=True
```

This makes tests that use `ROSBAG2_PY_TEST_RESOURCES_DIR` fail, since that is obviously not a valid path.

With the fix, we get:

```
4: -- run_test.py: extra environment variables:
4:  - PYTHONDONTWRITEBYTECODE=1
4:  - ROSBAG2_PY_TEST_RESOURCES_DIR=/home/christophe.bedard/ros2_ws/src/ros2/rosbag2/rosbag2_py/test/resources
4:  - ROSBAG2_PY_TEST_WITH_RTLD_GLOBAL=True
```

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

Using `--mixin clang` didn't work on my Ubuntu 24.04 system, because I have `clang[++]-18` but not `clang[++]`. So I used: `--cmake-args -DCMAKE_C_COMPILER=/usr/bin/clang-18 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-18`.