### PR TITLE
Fix warning: initialize number_of_threads

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/src/config_utils.cpp
@@ -62,7 +62,7 @@ size_t get_number_of_threads_from_node_parameters(rclcpp::Node & node)
 {
   const std::string parameters_ns = "publishers";
   node.declare_parameter<int>(parameters_ns + ".number_of_threads", 0);
-  size_t number_of_threads;
+  size_t number_of_threads = 0;
   node.get_parameter(parameters_ns + ".number_of_threads", number_of_threads);
   return number_of_threads;
 }


### PR DESCRIPTION
## Description

This warning is showing in CI:

```
‘number_of_threads’ may be used uninitialized [-Wmaybe-uninitialized]
67 | return number_of_threads;
| ^~
```

Reference build: https://ci.ros2.org/job/nightly_linux_release/3565/gcc/source.88475f3e-1990-4c1e-a7c6-5d49b31055c8/#67


This should be backported to `kilted` branch (see [kilted warnings](https://build.ros2.org/job/Kci__nightly-release_ubuntu_noble_amd64/28/))