### PR TITLE
Make sure test topic is discovered by recorder in rosbag2_py test

### DIFF
--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -185,7 +185,7 @@ def test_recorder_api(tmp_path, storage_id):
 
     record_options = rosbag2_py.RecordOptions()
     record_options.start_paused = False
-    record_options.topics = ['/topic']
+    record_options.topics = ['/test_recorder_api_node/topic']
     record_options.is_discovery_disabled = False
     record_options.topic_polling_interval = datetime.timedelta(milliseconds=10)
     record_options.disable_keyboard_controls = True
@@ -201,7 +201,11 @@ def test_recorder_api(tmp_path, storage_id):
     ctx = rclpy.Context()
     ctx.init()
     node = rclpy.create_node('test_recorder_api_node', context=ctx)
-    pub = node.create_publisher(String, 'topic', QoSProfile(depth=10))
+    pub = node.create_publisher(String, '~/topic', QoSProfile(depth=10))
+    # Wait for the recorder to discover the topic
+    assert wait_for(
+        lambda: pub.get_subscription_count() > 0,
+        timeout=rclpy.duration.Duration(seconds=10))
     resume_client = node.create_client(Resume, '/rosbag2_recorder_test/resume')
     executor = rclpy.executors.SingleThreadedExecutor(context=ctx)
     executor.add_node(node)
@@ -241,7 +245,7 @@ def test_recorder_api(tmp_path, storage_id):
         topic_info.topic_metadata.name
         for topic_info in metadata.topics_with_message_count
     ]
-    assert '/topic' in bag_topics, str(bag_topics)
+    assert '/test_recorder_api_node/topic' in bag_topics, str(bag_topics)
 
 
 def test_player_unconfigured():


### PR DESCRIPTION
## Description

Fixes #2128

Wait for the test publisher to have a matching subscription (from the recorder) before proceeding. Since `/topic` is pretty generic, use a relative topic (`~/topic`) to avoid interference.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

The failed assertion is meant to check that `/topic` is part of the bag's metadata: https://github.com/ros2/rosbag2/blob/bc37cdf1d3d56cb957b47670808362eae836049b/rosbag2_py/test/test_transport.py#L244

I believe a topic is added/written to the bag's metadata when the recorder subscribes to a given topic and gets the writer to create the topic: https://github.com/ros2/rosbag2/blob/bc37cdf1d3d56cb957b47670808362eae836049b/rosbag2_transport/src/rosbag2_transport/recorder.cpp#L616

The recorder can subscribe to topics through 2 mechanisms:

1. When `record()` is called, the recorder calls `node->get_topic_names_and_types()` to get the complete list of available topics, filters that through the topic filter (which here only has `'/topic'`), and then subscribes to the filtered list of topics: https://github.com/ros2/rosbag2/blob/bc37cdf1d3d56cb957b47670808362eae836049b/rosbag2_transport/src/rosbag2_transport/recorder.cpp#L381
2. During topics discovery (internal thread), the recorder does the same thing, but only subscribes to new (filtered) topics if there are any: https://github.com/ros2/rosbag2/blob/bc37cdf1d3d56cb957b47670808362eae836049b/rosbag2_transport/src/rosbag2_transport/recorder.cpp#L556-L561

I did not realize that `record_options.topics = ['/topic']` does not mean that the recorder would subscribe to `/topic` right away. In practice, the recorder may not ever see/discover `/topic` (1) when it starts recording or (2) through discovery (which is currently set to check new topics every 10 ms). There's nothing that really waits for that in the test. We can see in the [recorder logs](https://ci.ros2.org/job/nightly_linux_repeated/3925/consoleText) that it never subscribes to `/topic`:

```
4: [INFO] [1754041428.596433436] [rosbag2_recorder_test]: Listening for topics...
4: [INFO] [1754041428.596451720] [rosbag2_recorder_test]: Event publisher thread: Starting
4: [INFO] [1754041428.596546845] [rosbag2_recorder_test]: Recording...
4: [INFO] [1754041428.608936342] [rosbag2_recorder_test]: Resuming recording.
4: [INFO] [1754041428.608975205] [rosbag2_recorder_test]: Pausing recording.
4: [INFO] [1754041428.616810237] [rosbag2_recorder_test]: Pausing recording.
4: [INFO] [1754041428.617514287] [rosbag2_recorder_test]: Event publisher thread: Exiting
4: [INFO] [1754041428.617568461] [rosbag2_recorder_test]: Recording stopped
```

The C++ tests in `rosbag2_transport` properly deal with this, because they can easily mock the underlying writer and wait until it receives and writes messages: https://github.com/ros2/rosbag2/blob/bc37cdf1d3d56cb957b47670808362eae836049b/rosbag2_transport/test/rosbag2_transport/test_record.cpp#L76-L80

However, this isn't really (easily) possible from Python/`rosbag2_py`. This test shouldn't really fully test the functionality, since it's already tested by `rosbag2_transport` anyway.