### PR TITLE
Fix: Add null pointer check for reader_imp in the Reader constructor

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -29,7 +29,7 @@ namespace rosbag2_cpp
 Reader::Reader(std::unique_ptr<reader_interfaces::BaseReaderInterface> reader_impl)
 : reader_impl_(std::move(reader_impl))
 {
-   if (!reader_impl_) {
+  if (!reader_impl_) {
     throw std::invalid_argument("Reader implementation is a nullptr.");
   }
 }

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -28,7 +28,11 @@ namespace rosbag2_cpp
 
 Reader::Reader(std::unique_ptr<reader_interfaces::BaseReaderInterface> reader_impl)
 : reader_impl_(std::move(reader_impl))
-{}
+{
+   if (!reader_impl_) {
+    throw std::invalid_argument("Reader implementation is a nullptr.");
+  }
+}
 
 Reader::~Reader()
 {
@@ -48,10 +52,6 @@ void Reader::open(
   const rosbag2_storage::StorageOptions & storage_options,
   const ConverterOptions & converter_options)
 {
-  if (!reader_impl_) {
-    throw std::runtime_error("Reader implementation is not initialized. "
-                             "Check the constructor and initialization logic.");
-  }
   reader_impl_->open(storage_options, converter_options);
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reader.cpp
@@ -48,6 +48,10 @@ void Reader::open(
   const rosbag2_storage::StorageOptions & storage_options,
   const ConverterOptions & converter_options)
 {
+  if (!reader_impl_) {
+    throw std::runtime_error("Reader implementation is not initialized. "
+                             "Check the constructor and initialization logic.");
+  }
   reader_impl_->open(storage_options, converter_options);
 }
 


### PR DESCRIPTION
Fix: Add a null pointer check for reader_imp in the Reader constructor.

~~The fix adds a null pointer check to the open() method. If reader_impl_ is null, it now throws a std::runtime_error with a descriptive message, preventing the crash and providing clear feedback to the user.~~

Fixes #2117