### PR TITLE
Bugfix for deadlock in multibag replay

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -1042,13 +1042,45 @@ rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr PlayerImpl::get_clock_pu
 
 bool PlayerImpl::wait_for_playback_to_start(std::chrono::duration<double> timeout)
 {
-  std::unique_lock<std::mutex> lk(ready_to_play_from_queue_mutex_);
+  using namespace std::chrono_literals;  // NOLINT
+  // Lambda for try_lock_with_timeout
+  auto try_lock_with_timeout =
+    [](std::mutex & mutex, std::chrono::duration<double> max_wait,
+    std::chrono::milliseconds poll_interval = 10ms) -> std::unique_lock<std::mutex>
+    {
+      auto start = std::chrono::steady_clock::now();
+      std::unique_lock<std::mutex> lock(mutex, std::defer_lock);  // Do not lock yet
+
+      if (max_wait.count() < 0) {
+      // If timeout is negative, wait indefinitely
+        lock.lock();
+        return lock;  // Lock acquired
+      } else {
+        while (std::chrono::steady_clock::now() - start < max_wait) {
+          if (lock.try_lock()) {
+            return lock;  // Lock acquired
+          }
+          std::this_thread::sleep_for(poll_interval);
+        }
+      }
+      return {};  // Return empty (non-owning) lock
+    };
+
+  auto start = std::chrono::steady_clock::now();
+  auto lock = try_lock_with_timeout(ready_to_play_from_queue_mutex_, timeout);
+  if (!lock.owns_lock()) {
+    return false;  // Timeout occurred, lock not acquired
+  }
+
   if (timeout.count() < 0) {
-    ready_to_play_from_queue_cv_.wait(lk, [this] {return is_ready_to_play_from_queue_;});
+    ready_to_play_from_queue_cv_.wait(lock, [this] {return is_ready_to_play_from_queue_;});
     return true;
   } else {
+    auto lock_duration = std::chrono::steady_clock::now() - start;
+    auto residual_time = timeout > lock_duration ?
+      timeout - lock_duration : std::chrono::microseconds(1);
     return ready_to_play_from_queue_cv_.wait_for(
-      lk, timeout, [this] {return is_ready_to_play_from_queue_;}
+      lock, residual_time, [this] {return is_ready_to_play_from_queue_;}
     );
   }
 }

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -315,8 +315,8 @@ private:
   void load_storage_content();
   bool is_storage_completely_loaded() const;
   void enqueue_up_to_boundary(
-    const size_t boundary,
-    const size_t message_queue_size) RCPPUTILS_TSA_REQUIRES(reader_mutex_);
+    size_t boundary,
+    size_t message_queue_size) RCPPUTILS_TSA_REQUIRES(reader_mutex_);
   void wait_for_filled_queue() const;
   void play_messages_from_queue();
   void prepare_publishers();
@@ -1118,17 +1118,31 @@ void PlayerImpl::load_storage_content()
   }
 }
 
-void PlayerImpl::enqueue_up_to_boundary(const size_t boundary, const size_t message_queue_size)
+void PlayerImpl::enqueue_up_to_boundary(size_t boundary, size_t message_queue_size)
 {
-  // Read messages from input bags in a round robin way
+  // Read messages from input bags in a round-robin way
   size_t input_bag_index = 0u;
-  for (size_t i = message_queue_size; i < boundary; i++) {
+  while (message_queue_size < boundary) {
     const auto & reader = readers_with_options_[input_bag_index].first;
-    // We are supposed to have at least one bag with messages to read
     if (reader->has_next()) {
+      ++message_queue_size;
       message_queue_.push(reader->read_next());
     }
     input_bag_index = (input_bag_index + 1) % readers_with_options_.size();
+
+    if (input_bag_index == 0) {
+      // If we have gone through all readers, check if we have no more messages
+      const bool no_more_messages = std::all_of(
+        readers_with_options_.cbegin(),
+        readers_with_options_.cend(),
+        [](const auto & reader_options) {return !reader_options.first->has_next();});
+
+      if (no_more_messages) {
+        // If we have no more messages, we shall stop reading and exit the loop to avoid endless
+        // cycle.
+        break;
+      }
+    }
   }
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -402,6 +402,80 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
           ElementsAre(40.0f, 2.0f, 0.0f)))));
 }
 
+TEST_F(RosBag2PlayTestFixture, can_play_when_one_bag_has_fewer_messages_than_other_bags)
+{
+  auto msg = get_messages_basic_types()[0];
+  msg->int32_value = 42;
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {1u, "topic1", "test_msgs/msg/BasicTypes", "", {}, ""},
+    {2u, "topic2", "test_msgs/msg/BasicTypes", "", {}, ""},
+  };
+
+  std::vector<std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>> messages_list{};
+
+  messages_list.emplace_back(
+    std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>{
+    serialize_test_message("topic1", 1, 1, msg)
+    }
+  );
+  for (size_t i = 0; i < 5; i++) {
+    messages_list.back().emplace_back(
+      serialize_test_message(i % 2 ? "topic1" : "topic2",
+        // Translate nanoseconds to milliseconds before incrementing value
+                             messages_list.back().back()->recv_timestamp / 1000000 + 3,
+                             messages_list.back().back()->send_timestamp / 1000000 + 3,
+                             msg));
+  }
+
+  messages_list.emplace_back(
+    std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>{
+    serialize_test_message("topic1", 2, 1, msg)
+    }
+  );
+  // Add more messages to the last bag to make it have more messages than the first one
+  for (size_t i = 0; i < 15; i++) {
+    messages_list.back().emplace_back(
+      serialize_test_message(i % 2 ? "topic1" : "topic2",
+        // Translate nanoseconds to milliseconds before incrementing value
+                             messages_list.back().back()->recv_timestamp / 1000000 + 3,
+                             messages_list.back().back()->send_timestamp / 1000000 + 3,
+                             msg));
+  }
+
+  std::vector<rosbag2_transport::Player::reader_storage_options_pair_t> bags{};
+  std::size_t total_messages = 0u;
+  for (const auto & curr_bag_messages : messages_list) {
+    auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+    total_messages += curr_bag_messages.size();
+    prepared_mock_reader->prepare(curr_bag_messages, topic_types);
+    bags.emplace_back(
+      std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader)), storage_options_);
+  }
+  ASSERT_GT(total_messages, 0u);
+
+  // Note: For the sake of the checking corner cases, the read_ahead_queue_size is set to a value
+  // that is larger than the number of messages in the first bag, but smaller than the total number
+  // of messages in all bags.
+  play_options_.read_ahead_queue_size = 17;
+  play_options_.message_order = MessageOrder::RECEIVED_TIMESTAMP;
+  auto player = std::make_shared<rosbag2_transport::Player>(std::move(bags), play_options_);
+  std::size_t num_played_messages = 0u;
+  rcutils_time_point_value_t last_timestamp = 0;
+  const auto callback = [&](std::shared_ptr<rosbag2_storage::SerializedBagMessage> msg) {
+    // Make sure messages are played in order
+      const auto timestamp = msg->recv_timestamp;
+      EXPECT_LE(last_timestamp, timestamp);
+      last_timestamp = timestamp;
+      num_played_messages++;
+    };
+  player->add_on_play_message_pre_callback(callback);
+  player->play();
+  ASSERT_TRUE(player->wait_for_playback_to_start(10s));
+  ASSERT_TRUE(player->wait_for_playback_to_finish(10s));
+  EXPECT_EQ(total_messages, num_played_messages);
+}
+
 TEST_P(RosBag2PlayTestFixtureMessageOrder, recorded_msgs_are_played_for_all_topics_from_three_bags)
 {
   auto msg = get_messages_basic_types()[0];
@@ -439,10 +513,10 @@ TEST_P(RosBag2PlayTestFixtureMessageOrder, recorded_msgs_are_played_for_all_topi
     serialize_test_message("topic2", 15, 7, msg)});
   std::vector<rosbag2_transport::Player::reader_storage_options_pair_t> bags{};
   std::size_t total_messages = 0u;
-  for (std::size_t i = 0u; i < messages_list.size(); i++) {
+  for (const auto & curr_bag_messages : messages_list) {
     auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
-    total_messages += messages_list[i].size();
-    prepared_mock_reader->prepare(messages_list[i], topic_types);
+    total_messages += curr_bag_messages.size();
+    prepared_mock_reader->prepare(curr_bag_messages, topic_types);
     bags.emplace_back(
       std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader)), storage_options_);
   }
@@ -450,6 +524,7 @@ TEST_P(RosBag2PlayTestFixtureMessageOrder, recorded_msgs_are_played_for_all_topi
 
   const rosbag2_transport::MessageOrder message_order = GetParam();
   play_options_.message_order = message_order;
+  play_options_.read_ahead_queue_size = total_messages - 3;
   auto player = std::make_shared<rosbag2_transport::Player>(std::move(bags), play_options_);
   std::size_t num_played_messages = 0u;
   rcutils_time_point_value_t last_timetamp = 0;
@@ -473,7 +548,8 @@ TEST_P(RosBag2PlayTestFixtureMessageOrder, recorded_msgs_are_played_for_all_topi
     };
   player->add_on_play_message_pre_callback(callback);
   player->play();
-  player->wait_for_playback_to_finish();
+  ASSERT_TRUE(player->wait_for_playback_to_start(10s));
+  ASSERT_TRUE(player->wait_for_playback_to_finish(10s));
   EXPECT_EQ(total_messages, num_played_messages);
 }
 


### PR DESCRIPTION
## Description

Fix for freeze on start in the Rosbag2 player when replaying from multiple bags.

This PR fixes a deadlock in the player when waiting on the queue to be filled with multibag replay when one of the bag have fewer messages than `PlayOptions::read_ahead_queue_size / num_bags`

Details about fix:
Increment `message_queue_size counter` only when we really push a message to the queue. Also, check if we have no more messages in the `enqueue_up_to_boundary(..)` to avoid an endless cycle at the end of playback`.

- Fixes #2142

### Is this user-facing behavior change?
Yes. The potential deadlock will be eliminated

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow.

### Additional Information
This PR can be backported to the Kilted and Jazzy
