### PR TITLE
Add RecorderEventNotifier class

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -577,6 +577,14 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_player_progress_bar test/rosbag2_transport/test_player_progress_bar.cpp)
   target_link_libraries(test_player_progress_bar ${PROJECT_NAME})
+
+  ament_add_gmock(test_recorder_event_notifier
+    test/rosbag2_transport/test_recorder_event_notifier.cpp)
+  target_link_libraries(test_recorder_event_notifier
+    ${PROJECT_NAME}
+    rosbag2_test_common::rosbag2_test_common
+    ${rosbag2_interfaces_TARGETS}
+  )
 endif()
 
 ament_package()

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -45,6 +45,7 @@ find_package(yaml-cpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_transport/bag_rewrite.cpp
+  src/rosbag2_transport/recorder_event_notifier.cpp
   src/rosbag2_transport/player.cpp
   src/rosbag2_transport/play_options.cpp
   src/rosbag2_transport/player_progress_bar.cpp

--- a/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
@@ -12,24 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #ifndef ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_HPP_
 #define ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_HPP_
 
-
 #include <vector>
+#include <memory>
 #include <string>
 
 #include "rclcpp/node.hpp"
 
 #include "rosbag2_cpp/bag_events.hpp"
-#include "rclcpp/logging.hpp"
-
-#include "rosbag2_interfaces/msg/write_split_event.hpp"
 #include "rosbag2_transport/visibility_control.hpp"
+
+#ifdef _WIN32
+#  pragma warning(push)
+// Suppress warning "rosbag2_transport::RecorderEventNotifier::pimpl_': class 'std::unique_ptr>'
+// needs to have dll-interface to be used by clients of class
+// 'rosbag2_transport::RecorderEventNotifier'"
+// Justification:
+// 1. We never inline code in the header that actually calls methods on RecorderEventNotifierImpl.
+// 2. While the `RecorderEventNotifierImpl` is defined in the `recorder_event_notifier_impl.hpp`
+// file, we include it only in the `recorder_event_notifier.cpp` file, and it does not leak into the
+// external API.
+// 3. The pimpl design pattern imply that implementation details are hidden and shouldn't be
+// exposed with the dll-interface.
+#  pragma warning(disable:4251)
+#endif
 
 namespace rosbag2_transport
 {
+class RecorderEventNotifierImpl;
 
 class ROSBAG2_TRANSPORT_PUBLIC RecorderEventNotifier
 {
@@ -65,28 +77,13 @@ public:
   void reset_total_num_messages_lost_in_recorder();
 
 private:
-  void event_publisher_thread_main();
-
-  rclcpp::Node * node;
-
-  // Variables for event publishing
-  rclcpp::Publisher<rosbag2_interfaces::msg::WriteSplitEvent>::SharedPtr split_event_pub_;
-  std::atomic<bool> event_publisher_thread_should_exit_ = false;
-  std::atomic<bool> write_split_has_occurred_ = false;
-  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info_;
-  std::mutex event_publisher_thread_mutex_;
-  std::condition_variable event_publisher_thread_wake_cv_;
-  std::thread event_publisher_thread_;
-  std::chrono::milliseconds msgs_lost_statistics_update_period_{1000};  // 1 second
-
-  std::mutex per_topic_messages_lost_statistics_mutex_;
-  // Stores the number of messages lost per topic in the transport and recorder layers.
-  std::unordered_map<std::string, std::pair<size_t, size_t>> per_topic_messages_lost_statistics_;
-
-  std::atomic<size_t> total_num_messages_lost_in_transport_{0};
-  std::atomic<size_t> total_num_messages_lost_in_recorder_{0};
+  std::unique_ptr<RecorderEventNotifierImpl> pimpl_;
 };
 
 }  // namespace rosbag2_transport
+
+#ifdef _WIN32
+#  pragma warning(pop)
+#endif
 
 #endif  // ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_HPP_

--- a/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
@@ -58,7 +58,8 @@ public:
   /// statistics. A value of 0.0 means that the statistics will not be published.
   /// \note Event notifier will not publish statistics if there are no messages lost since the last
   /// time it was published.
-  /// \throws std::invalid_argument if the update rate is negative.
+  /// \throws std::invalid_argument if the update rate is negative or if the update rate more than
+  /// or equal 1000.00 Hz.
   void set_messages_lost_statistics_max_publishing_rate(float update_rate_hz);
 
   /// \brief Callback for when a bag split occurs in the recorder.

--- a/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
@@ -52,6 +52,15 @@ public:
   /// \brief Destructor for the RecorderEventNotifier class.
   virtual ~RecorderEventNotifier();
 
+  /// \brief Set the maximum update rate for messages lost statistics.
+  /// \details This controls how often the statistics about messages lost are published.
+  /// \param update_rate_hz Maximum publishing rate in times per second (Hz) for messages lost
+  /// statistics. A value of 0.0 means that the statistics will not be published.
+  /// \note Event notifier will not publish statistics if there are no messages lost since the last
+  /// time it was published.
+  /// \throws std::invalid_argument if the update rate is negative.
+  void set_messages_lost_statistics_max_publishing_rate(float update_rate_hz);
+
   /// \brief Callback for when a bag split occurs in the recorder.
   void on_bag_split_in_recorder(const rosbag2_cpp::bag_events::BagSplitInfo & bag_split_info);
 

--- a/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
@@ -73,11 +73,13 @@ public:
     const std::string & topic_name,
     const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info);
 
-  /// \brief Get the number of messages lost on the transport layer.
-  [[nodiscard]] size_t get_total_num_messages_lost_in_transport() const;
+  /// \brief Getter for the total number of messages lost in transport.
+  /// \return The total number of messages lost in transport.
+  [[nodiscard]] uint64_t get_total_num_messages_lost_in_transport() const;
 
-  /// \brief Get the number of messages lost in the recorder.
-  [[nodiscard]] size_t get_total_num_messages_lost_in_recorder() const;
+  /// \brief Getter for the total number of messages lost in recorder.
+  /// \return The total number of messages lost in recorder.
+  [[nodiscard]] uint64_t get_total_num_messages_lost_in_recorder() const;
 
   /// \brief Reset the counters for messages lost in transport.
   void reset_total_num_messages_lost_in_transport();

--- a/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
@@ -1,0 +1,92 @@
+// Copyright 2025 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_HPP_
+#define ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_HPP_
+
+
+#include <vector>
+#include <string>
+
+#include "rclcpp/node.hpp"
+
+#include "rosbag2_cpp/bag_events.hpp"
+#include "rclcpp/logging.hpp"
+
+#include "rosbag2_interfaces/msg/write_split_event.hpp"
+#include "rosbag2_transport/visibility_control.hpp"
+
+namespace rosbag2_transport
+{
+
+class ROSBAG2_TRANSPORT_PUBLIC RecorderEventNotifier
+{
+public:
+  /// \brief Constructor for the RecorderEventNotifier class.
+  explicit RecorderEventNotifier(rclcpp::Node * node);
+
+  /// \brief Destructor for the RecorderEventNotifier class.
+  virtual ~RecorderEventNotifier();
+
+  /// \brief Callback for when a bag split occurs in the recorder.
+  void on_bag_split_in_recorder(const rosbag2_cpp::bag_events::BagSplitInfo & bag_split_info);
+
+  /// \brief Callback for when messages are lost in recorder.
+  void on_messages_lost_in_recorder(
+    const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info);
+
+  /// \brief Callback for when messages are lost in transport.
+  void on_messages_lost_in_transport(
+    const std::string & topic_name,
+    const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info);
+
+  /// \brief Get the number of messages lost on the transport layer.
+  [[nodiscard]] size_t get_total_num_messages_lost_in_transport() const;
+
+  /// \brief Get the number of messages lost in the recorder.
+  [[nodiscard]] size_t get_total_num_messages_lost_in_recorder() const;
+
+  /// \brief Reset the counters for messages lost in transport.
+  void reset_total_num_messages_lost_in_transport();
+
+  /// \brief Reset the counters for messages lost in recorder.
+  void reset_total_num_messages_lost_in_recorder();
+
+private:
+  void event_publisher_thread_main();
+
+  rclcpp::Node * node;
+
+  // Variables for event publishing
+  rclcpp::Publisher<rosbag2_interfaces::msg::WriteSplitEvent>::SharedPtr split_event_pub_;
+  std::atomic<bool> event_publisher_thread_should_exit_ = false;
+  std::atomic<bool> write_split_has_occurred_ = false;
+  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info_;
+  std::mutex event_publisher_thread_mutex_;
+  std::condition_variable event_publisher_thread_wake_cv_;
+  std::thread event_publisher_thread_;
+  std::chrono::milliseconds msgs_lost_statistics_update_period_{1000};  // 1 second
+
+  std::mutex per_topic_messages_lost_statistics_mutex_;
+  // Stores the number of messages lost per topic in the transport and recorder layers.
+  std::unordered_map<std::string, std::pair<size_t, size_t>> per_topic_messages_lost_statistics_;
+
+  std::atomic<size_t> total_num_messages_lost_in_transport_{0};
+  std::atomic<size_t> total_num_messages_lost_in_recorder_{0};
+};
+
+}  // namespace rosbag2_transport
+
+#endif  // ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -166,6 +166,8 @@ RecorderImpl::RecorderImpl(
   keyboard_handler_(std::move(keyboard_handler)),
   event_notifier_(std::make_unique<RecorderEventNotifier>(node))
 {
+  event_notifier_->set_messages_lost_statistics_max_publishing_rate(0.0f);  // Disable by default
+
   if (record_options_.use_sim_time && record_options_.is_discovery_disabled) {
     throw std::runtime_error(
             "use_sim_time and is_discovery_disabled both set, but are incompatible settings. "

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -244,13 +244,13 @@ void RecorderImpl::stop()
 
   if (num_messages_lost_on_transport > 0) {
     RCLCPP_WARN(node->get_logger(),
-                "Number of messages lost on the transport layer: %zu",
+                "Number of messages lost on the transport layer: %lu",
                 num_messages_lost_on_transport);
   }
 
   if (num_messages_lost_in_recorder > 0) {
     RCLCPP_WARN(node->get_logger(),
-                "Number of messages lost in the recorder: %zu",
+                "Number of messages lost in the recorder: %lu",
                 num_messages_lost_in_recorder);
   }
 }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -45,6 +45,7 @@
 #include "rosbag2_transport/config_options_from_node_params.hpp"
 #include "rosbag2_transport/reader_writer_factory.hpp"
 #include "rosbag2_transport/topic_filter.hpp"
+#include "rosbag2_transport/recorder_event_notifier.hpp"
 
 namespace rosbag2_transport
 {
@@ -127,16 +128,6 @@ private:
 
   void warn_if_new_qos_for_subscribed_topic(const std::string & topic_name);
 
-  void event_publisher_thread_main();
-  bool event_publisher_thread_should_wake();
-
-  void on_messages_lost_in_recorder(
-    const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info);
-
-  void on_messages_lost_in_transport(
-    const std::string & topic_name,
-    const rclcpp::QOSMessageLostInfo & msgs_lost_info);
-
   rclcpp::Node * node;
   std::unique_ptr<TopicFilter> topic_filter_;
   std::future<void> discovery_future_;
@@ -158,17 +149,7 @@ private:
   KeyboardHandler::callback_handle_t toggle_paused_key_callback_handle_ =
     KeyboardHandler::invalid_handle;
 
-  // Variables for event publishing
-  rclcpp::Publisher<rosbag2_interfaces::msg::WriteSplitEvent>::SharedPtr split_event_pub_;
-  std::atomic<bool> event_publisher_thread_should_exit_ = false;
-  std::atomic<bool> write_split_has_occurred_ = false;
-  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info_;
-  std::mutex event_publisher_thread_mutex_;
-  std::condition_variable event_publisher_thread_wake_cv_;
-  std::thread event_publisher_thread_;
-
-  std::atomic<size_t> num_messages_lost_on_transport_{0};
-  std::atomic<size_t> num_messages_lost_in_recorder_{0};
+  std::unique_ptr<RecorderEventNotifier> event_notifier_;
 };
 
 RecorderImpl::RecorderImpl(
@@ -182,7 +163,8 @@ RecorderImpl::RecorderImpl(
   record_options_(record_options),
   node(owner),
   paused_(record_options.start_paused),
-  keyboard_handler_(std::move(keyboard_handler))
+  keyboard_handler_(std::move(keyboard_handler)),
+  event_notifier_(std::make_unique<RecorderEventNotifier>(node))
 {
   if (record_options_.use_sim_time && record_options_.is_discovery_disabled) {
     throw std::runtime_error(
@@ -252,26 +234,22 @@ void RecorderImpl::stop()
   subscriptions_.clear();
   writer_->close();  // Call writer->close() to finalize current bag file and write metadata
 
-  {
-    std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-    event_publisher_thread_should_exit_ = true;
-  }
-  event_publisher_thread_wake_cv_.notify_all();
-  if (event_publisher_thread_.joinable()) {
-    event_publisher_thread_.join();
-  }
   in_recording_ = false;
   RCLCPP_INFO(node->get_logger(), "Recording stopped");
 
-  if (num_messages_lost_on_transport_.load() > 0) {
+  auto num_messages_lost_in_recorder = event_notifier_->get_total_num_messages_lost_in_recorder();
+  auto num_messages_lost_on_transport = event_notifier_->get_total_num_messages_lost_in_transport();
+
+  if (num_messages_lost_on_transport > 0) {
     RCLCPP_WARN(node->get_logger(),
-      "Number of messages lost on the transport layer: %zu",
-        num_messages_lost_on_transport_.load());
+                "Number of messages lost on the transport layer: %zu",
+                num_messages_lost_on_transport);
   }
 
-  if (num_messages_lost_in_recorder_.load() > 0) {
+  if (num_messages_lost_in_recorder > 0) {
     RCLCPP_WARN(node->get_logger(),
-      "Number of messages lost in the recorder: %zu", num_messages_lost_in_recorder_.load());
+                "Number of messages lost in the recorder: %zu",
+                num_messages_lost_in_recorder);
   }
 }
 
@@ -290,8 +268,8 @@ void RecorderImpl::record()
     throw std::runtime_error("No serialization format specified!");
   }
   subscriptions_.clear();
-  num_messages_lost_in_recorder_.store(0);
-  num_messages_lost_on_transport_.store(0);
+  event_notifier_->reset_total_num_messages_lost_in_transport();
+  event_notifier_->reset_total_num_messages_lost_in_recorder();
   writer_->open(
     storage_options_,
     {rmw_get_serialization_format(), record_options_.rmw_serialization_format});
@@ -349,29 +327,14 @@ void RecorderImpl::record()
       response->paused = is_paused();
     });
 
-  split_event_pub_ =
-    node->create_publisher<rosbag2_interfaces::msg::WriteSplitEvent>("events/write_split", 1);
-
-  // Start the thread that will publish events
-  {
-    std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-    event_publisher_thread_should_exit_ = false;
-    event_publisher_thread_ = std::thread(&RecorderImpl::event_publisher_thread_main, this);
-  }
-
   rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
   callbacks.write_split_callback =
     [this](rosbag2_cpp::bag_events::BagSplitInfo & info) {
-      {
-        std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-        bag_split_info_ = info;
-        write_split_has_occurred_ = true;
-      }
-      event_publisher_thread_wake_cv_.notify_all();
+      event_notifier_->on_bag_split_in_recorder(info);
     };
   callbacks.messages_lost_callback =
     [this](const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info) {
-      on_messages_lost_in_recorder(msgs_lost_info);
+      event_notifier_->on_messages_lost_in_recorder(msgs_lost_info);
     };
   writer_->add_event_callbacks(callbacks);
 
@@ -390,70 +353,6 @@ void RecorderImpl::record()
   } else {
     RCLCPP_INFO(node->get_logger(), "Recording...");
   }
-}
-
-void RecorderImpl::on_messages_lost_in_recorder(
-  const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info)
-{
-  if (!msgs_lost_info.empty()) {
-    // Log lost messages in recorder
-    std::string log_text("Recorder lost messages per topic: ");
-    for (const auto & info : msgs_lost_info) {
-      num_messages_lost_in_recorder_.fetch_add(info.num_messages_lost);
-      log_text += "\n\t" + info.topic_name + ": " + std::to_string(info.num_messages_lost);
-    }
-    RCLCPP_DEBUG(node->get_logger(), "%s", log_text.c_str());
-    // TODO(morlov): Call EventNotifier->on_messages_lost_in_recorder(msgs_lost_info);
-  }
-}
-
-void RecorderImpl::on_messages_lost_in_transport(
-  const std::string & topic_name,
-  const rclcpp::QOSMessageLostInfo & msgs_lost_info)
-{
-  num_messages_lost_on_transport_.fetch_add(msgs_lost_info.total_count);
-  RCLCPP_DEBUG(
-    node->get_logger(),
-    "Messages lost on transport layer for topic '%s'. Total lost: %lu",
-    topic_name.c_str(), msgs_lost_info.total_count);
-  // TODO(morlov): Call EventNotifier->on_messages_lost_in_transport(topic_name, msgs_lost_info);
-}
-
-void RecorderImpl::event_publisher_thread_main()
-{
-  RCLCPP_INFO(node->get_logger(), "Event publisher thread: Starting");
-  while (!event_publisher_thread_should_exit_.load()) {
-    std::unique_lock<std::mutex> lock(event_publisher_thread_mutex_);
-    event_publisher_thread_wake_cv_.wait(
-      lock,
-      [this] {return event_publisher_thread_should_wake();});
-
-    if (write_split_has_occurred_) {
-      write_split_has_occurred_ = false;
-
-      auto message = rosbag2_interfaces::msg::WriteSplitEvent();
-      message.closed_file = bag_split_info_.closed_file;
-      message.opened_file = bag_split_info_.opened_file;
-      message.node_name = node->get_fully_qualified_name();
-      try {
-        split_event_pub_->publish(message);
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR_STREAM(
-          node->get_logger(),
-          "Failed to publish message on '/events/write_split' topic. \nError: " << e.what());
-      } catch (...) {
-        RCLCPP_ERROR_STREAM(
-          node->get_logger(),
-          "Failed to publish message on '/events/write_split' topic.");
-      }
-    }
-  }
-  RCLCPP_INFO(node->get_logger(), "Event publisher thread: Exiting");
-}
-
-bool RecorderImpl::event_publisher_thread_should_wake()
-{
-  return write_split_has_occurred_ || event_publisher_thread_should_exit_;
 }
 
 const rosbag2_cpp::Writer & RecorderImpl::get_writer_handle()
@@ -639,7 +538,7 @@ RecorderImpl::create_subscription(
   rclcpp::SubscriptionOptions sub_options;
   sub_options.event_callbacks.message_lost_callback =
     [this, topic_name](const rclcpp::QOSMessageLostInfo & msgs_lost_info) {
-      this->on_messages_lost_in_transport(topic_name, msgs_lost_info);
+      this->event_notifier_->on_messages_lost_in_transport(topic_name, msgs_lost_info);
     };
 
 #ifdef _WIN32

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
@@ -16,147 +16,61 @@
 #include "rclcpp/node.hpp"
 
 #include "rosbag2_transport/recorder_event_notifier.hpp"
+#include "recorder_event_notifier_impl.hpp"
 
 namespace rosbag2_transport
 {
 
 RecorderEventNotifier::RecorderEventNotifier(rclcpp::Node * node)
-: node(node)
 {
-  if (!node) {
-    throw std::invalid_argument("Node pointer cannot be null");
-  }
-  split_event_pub_ =
-    node->create_publisher<rosbag2_interfaces::msg::WriteSplitEvent>("events/write_split", 1);
-
-  // Start the thread that will publish events
-  {
-    std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-    event_publisher_thread_should_exit_ = false;
-    event_publisher_thread_ = std::thread(&RecorderEventNotifier::event_publisher_thread_main,
-        this);
-  }
+  pimpl_ = std::make_unique<RecorderEventNotifierImpl>(node);
 }
 
 RecorderEventNotifier::~RecorderEventNotifier()
 {
-  if (event_publisher_thread_.joinable()) {
-    {
-      std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-      event_publisher_thread_should_exit_ = true;
-    }
-    event_publisher_thread_wake_cv_.notify_all();
-    event_publisher_thread_.join();
-  }
+  // Explicitly reset the pimpl_ to ensure the destructor of RecorderEventNotifierImpl is called
+  // only once.
+  pimpl_.reset();
 }
 
-void RecorderEventNotifier::event_publisher_thread_main()
-{
-  RCLCPP_INFO(node->get_logger(), "Event publisher thread: Started");
-  while (!event_publisher_thread_should_exit_.load()) {
-    std::unique_lock<std::mutex> pub_thread_lock(event_publisher_thread_mutex_);
-
-    event_publisher_thread_wake_cv_.wait_for(pub_thread_lock, msgs_lost_statistics_update_period_,
-      [this]() {
-        return write_split_has_occurred_ || event_publisher_thread_should_exit_;
-        }
-    );
-
-    if (write_split_has_occurred_) {
-      write_split_has_occurred_ = false;
-      auto message = rosbag2_interfaces::msg::WriteSplitEvent();
-      message.closed_file = bag_split_info_.closed_file;
-      message.opened_file = bag_split_info_.opened_file;
-      message.node_name = node->get_fully_qualified_name();
-      try {
-        split_event_pub_->publish(message);
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR_STREAM(
-          node->get_logger(),
-          "Failed to publish message on '/events/write_split' topic. \nError: " << e.what());
-      } catch (...) {
-        RCLCPP_ERROR_STREAM(
-          node->get_logger(),
-          "Failed to publish message on '/events/write_split' topic.");
-      }
-    }
-
-//    {
-//      // TODO(morlov): Check if we need to publish statistics about messages lost events
-//      std::unique_lock<std::mutex> statistics_lock(per_topic_messages_lost_statistics_mutex_);
-//      for (const auto &[topic, lost_stats] : per_topic_messages_lost_statistics_) {
-//        const auto &[transport_lost, recorder_lost] = lost_stats;
-//        // Use topic, transport_lost, and recorder_lost to publish statistics if needed
-//      }
-//    }
-  }
-  RCLCPP_INFO(node->get_logger(), "Event publisher thread: Exited");
-}
 
 void RecorderEventNotifier::on_bag_split_in_recorder(
   const rosbag2_cpp::bag_events::BagSplitInfo & bag_split_info)
 {
-  {
-    std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-    bag_split_info_ = bag_split_info;
-    write_split_has_occurred_ = true;
-  }
-  event_publisher_thread_wake_cv_.notify_all();
+  pimpl_->on_bag_split_in_recorder(bag_split_info);
 }
 
 void RecorderEventNotifier::on_messages_lost_in_recorder(
   const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info)
 {
-  if (!msgs_lost_info.empty()) {
-    // Log lost messages in recorder
-    std::string log_text("Recorder lost messages per topic: ");
-    {
-      std::unique_lock<std::mutex> lock(per_topic_messages_lost_statistics_mutex_);
-      for (const auto & info : msgs_lost_info) {
-        total_num_messages_lost_in_recorder_.fetch_add(info.num_messages_lost);
-        per_topic_messages_lost_statistics_[info.topic_name].second += info.num_messages_lost;
-        log_text += "\n\t" + info.topic_name + ": " + std::to_string(info.num_messages_lost);
-      }
-    }
-    RCLCPP_DEBUG(node->get_logger(), "%s", log_text.c_str());
-  }
+  pimpl_->on_messages_lost_in_recorder(msgs_lost_info);
 }
 
 void RecorderEventNotifier::on_messages_lost_in_transport(
   const std::string & topic_name,
   const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info)
 {
-  total_num_messages_lost_in_transport_.fetch_add(qos_msgs_lost_info.total_count_change);
-  RCLCPP_DEBUG(
-    node->get_logger(),
-    "Messages lost on transport layer for topic '%s'. Total lost: %lu",
-    topic_name.c_str(), qos_msgs_lost_info.total_count);
-
-  {
-    std::unique_lock<std::mutex> lock(per_topic_messages_lost_statistics_mutex_);
-    per_topic_messages_lost_statistics_[topic_name].first += qos_msgs_lost_info.total_count_change;
-  }
+  pimpl_->on_messages_lost_in_transport(topic_name, qos_msgs_lost_info);
 }
 
 size_t RecorderEventNotifier::get_total_num_messages_lost_in_transport() const
 {
-  return total_num_messages_lost_in_transport_.load();
+  return pimpl_->get_total_num_messages_lost_in_transport();
 }
 
 size_t RecorderEventNotifier::get_total_num_messages_lost_in_recorder() const
 {
-  return total_num_messages_lost_in_recorder_.load();
+  return pimpl_->get_total_num_messages_lost_in_recorder();
 }
 
 void RecorderEventNotifier::reset_total_num_messages_lost_in_transport()
 {
-  total_num_messages_lost_in_transport_.store(0);
+  pimpl_->reset_total_num_messages_lost_in_transport();
 }
 
 void RecorderEventNotifier::reset_total_num_messages_lost_in_recorder()
 {
-  total_num_messages_lost_in_recorder_.store(0);
+  pimpl_->reset_total_num_messages_lost_in_recorder();
 }
-
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
@@ -57,12 +57,12 @@ void RecorderEventNotifier::on_messages_lost_in_transport(
   pimpl_->on_messages_lost_in_transport(topic_name, qos_msgs_lost_info);
 }
 
-size_t RecorderEventNotifier::get_total_num_messages_lost_in_transport() const
+uint64_t RecorderEventNotifier::get_total_num_messages_lost_in_transport() const
 {
   return pimpl_->get_total_num_messages_lost_in_transport();
 }
 
-size_t RecorderEventNotifier::get_total_num_messages_lost_in_recorder() const
+uint64_t RecorderEventNotifier::get_total_num_messages_lost_in_recorder() const
 {
   return pimpl_->get_total_num_messages_lost_in_recorder();
 }

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
@@ -33,6 +33,10 @@ RecorderEventNotifier::~RecorderEventNotifier()
   pimpl_.reset();
 }
 
+void RecorderEventNotifier::set_messages_lost_statistics_max_publishing_rate(float update_rate_hz)
+{
+  pimpl_->set_messages_lost_statistics_max_publishing_rate(update_rate_hz);
+}
 
 void RecorderEventNotifier::on_bag_split_in_recorder(
   const rosbag2_cpp::bag_events::BagSplitInfo & bag_split_info)

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
@@ -1,0 +1,162 @@
+// Copyright 2025 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node.hpp"
+
+#include "rosbag2_transport/recorder_event_notifier.hpp"
+
+namespace rosbag2_transport
+{
+
+RecorderEventNotifier::RecorderEventNotifier(rclcpp::Node * node)
+: node(node)
+{
+  if (!node) {
+    throw std::invalid_argument("Node pointer cannot be null");
+  }
+  split_event_pub_ =
+    node->create_publisher<rosbag2_interfaces::msg::WriteSplitEvent>("events/write_split", 1);
+
+  // Start the thread that will publish events
+  {
+    std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+    event_publisher_thread_should_exit_ = false;
+    event_publisher_thread_ = std::thread(&RecorderEventNotifier::event_publisher_thread_main,
+        this);
+  }
+}
+
+RecorderEventNotifier::~RecorderEventNotifier()
+{
+  if (event_publisher_thread_.joinable()) {
+    {
+      std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+      event_publisher_thread_should_exit_ = true;
+    }
+    event_publisher_thread_wake_cv_.notify_all();
+    event_publisher_thread_.join();
+  }
+}
+
+void RecorderEventNotifier::event_publisher_thread_main()
+{
+  RCLCPP_INFO(node->get_logger(), "Event publisher thread: Started");
+  while (!event_publisher_thread_should_exit_.load()) {
+    std::unique_lock<std::mutex> pub_thread_lock(event_publisher_thread_mutex_);
+
+    event_publisher_thread_wake_cv_.wait_for(pub_thread_lock, msgs_lost_statistics_update_period_,
+      [this]() {
+        return write_split_has_occurred_ || event_publisher_thread_should_exit_;
+        }
+    );
+
+    if (write_split_has_occurred_) {
+      write_split_has_occurred_ = false;
+      auto message = rosbag2_interfaces::msg::WriteSplitEvent();
+      message.closed_file = bag_split_info_.closed_file;
+      message.opened_file = bag_split_info_.opened_file;
+      message.node_name = node->get_fully_qualified_name();
+      try {
+        split_event_pub_->publish(message);
+      } catch (const std::exception & e) {
+        RCLCPP_ERROR_STREAM(
+          node->get_logger(),
+          "Failed to publish message on '/events/write_split' topic. \nError: " << e.what());
+      } catch (...) {
+        RCLCPP_ERROR_STREAM(
+          node->get_logger(),
+          "Failed to publish message on '/events/write_split' topic.");
+      }
+    }
+
+//    {
+//      // TODO(morlov): Check if we need to publish statistics about messages lost events
+//      std::unique_lock<std::mutex> statistics_lock(per_topic_messages_lost_statistics_mutex_);
+//      for (const auto &[topic, lost_stats] : per_topic_messages_lost_statistics_) {
+//        const auto &[transport_lost, recorder_lost] = lost_stats;
+//        // Use topic, transport_lost, and recorder_lost to publish statistics if needed
+//      }
+//    }
+  }
+  RCLCPP_INFO(node->get_logger(), "Event publisher thread: Exited");
+}
+
+void RecorderEventNotifier::on_bag_split_in_recorder(
+  const rosbag2_cpp::bag_events::BagSplitInfo & bag_split_info)
+{
+  {
+    std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+    bag_split_info_ = bag_split_info;
+    write_split_has_occurred_ = true;
+  }
+  event_publisher_thread_wake_cv_.notify_all();
+}
+
+void RecorderEventNotifier::on_messages_lost_in_recorder(
+  const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info)
+{
+  if (!msgs_lost_info.empty()) {
+    // Log lost messages in recorder
+    std::string log_text("Recorder lost messages per topic: ");
+    {
+      std::unique_lock<std::mutex> lock(per_topic_messages_lost_statistics_mutex_);
+      for (const auto & info : msgs_lost_info) {
+        total_num_messages_lost_in_recorder_.fetch_add(info.num_messages_lost);
+        per_topic_messages_lost_statistics_[info.topic_name].second += info.num_messages_lost;
+        log_text += "\n\t" + info.topic_name + ": " + std::to_string(info.num_messages_lost);
+      }
+    }
+    RCLCPP_DEBUG(node->get_logger(), "%s", log_text.c_str());
+  }
+}
+
+void RecorderEventNotifier::on_messages_lost_in_transport(
+  const std::string & topic_name,
+  const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info)
+{
+  total_num_messages_lost_in_transport_.fetch_add(qos_msgs_lost_info.total_count_change);
+  RCLCPP_DEBUG(
+    node->get_logger(),
+    "Messages lost on transport layer for topic '%s'. Total lost: %lu",
+    topic_name.c_str(), qos_msgs_lost_info.total_count);
+
+  {
+    std::unique_lock<std::mutex> lock(per_topic_messages_lost_statistics_mutex_);
+    per_topic_messages_lost_statistics_[topic_name].first += qos_msgs_lost_info.total_count_change;
+  }
+}
+
+size_t RecorderEventNotifier::get_total_num_messages_lost_in_transport() const
+{
+  return total_num_messages_lost_in_transport_.load();
+}
+
+size_t RecorderEventNotifier::get_total_num_messages_lost_in_recorder() const
+{
+  return total_num_messages_lost_in_recorder_.load();
+}
+
+void RecorderEventNotifier::reset_total_num_messages_lost_in_transport()
+{
+  total_num_messages_lost_in_transport_.store(0);
+}
+
+void RecorderEventNotifier::reset_total_num_messages_lost_in_recorder()
+{
+  total_num_messages_lost_in_recorder_.store(0);
+}
+
+
+}  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -219,7 +219,7 @@ private:
   std::mutex event_publisher_thread_mutex_;
   std::condition_variable event_publisher_thread_wake_cv_;
   std::thread event_publisher_thread_;
-  bool disable_publishing_msgs_lost_statistics_{false};
+  bool disable_publishing_msgs_lost_statistics_{true};
   std::chrono::milliseconds msgs_lost_stats_max_publishing_period_{1000};  // 1 second
 
   std::mutex per_topic_messages_lost_statistics_mutex_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -1,0 +1,198 @@
+// Copyright 2025 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_IMPL_HPP_
+#define ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_IMPL_HPP_
+
+#include <vector>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node.hpp"
+
+#include "rosbag2_interfaces/msg/write_split_event.hpp"
+#include "rosbag2_cpp/bag_events.hpp"
+#include "rosbag2_transport/recorder_event_notifier.hpp"
+
+namespace rosbag2_transport
+{
+class RecorderEventNotifierImpl
+{
+public:
+  explicit RecorderEventNotifierImpl(rclcpp::Node * node)
+  : node(node)
+  {
+    if (!node) {
+      throw std::invalid_argument("Node pointer cannot be null");
+    }
+    split_event_pub_ =
+      node->create_publisher<rosbag2_interfaces::msg::WriteSplitEvent>("events/write_split", 1);
+
+    // Start the thread that will publish events
+    {
+      std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+      event_publisher_thread_should_exit_ = false;
+      event_publisher_thread_ = std::thread(&RecorderEventNotifierImpl::event_publisher_thread_main,
+                                            this);
+    }
+  }
+
+  virtual ~RecorderEventNotifierImpl()
+  {
+    if (event_publisher_thread_.joinable()) {
+      {
+        std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+        event_publisher_thread_should_exit_ = true;
+      }
+      event_publisher_thread_wake_cv_.notify_all();
+      event_publisher_thread_.join();
+    }
+  }
+
+
+  void on_bag_split_in_recorder(const rosbag2_cpp::bag_events::BagSplitInfo & bag_split_info)
+  {
+    {
+      std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
+      bag_split_info_ = bag_split_info;
+      write_split_has_occurred_ = true;
+    }
+    event_publisher_thread_wake_cv_.notify_all();
+  }
+
+  void on_messages_lost_in_recorder(
+    const std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> & msgs_lost_info)
+  {
+    if (!msgs_lost_info.empty()) {
+      // Log lost messages in recorder
+      std::string log_text("Recorder lost messages per topic: ");
+      {
+        std::unique_lock<std::mutex> lock(per_topic_messages_lost_statistics_mutex_);
+        for (const auto & info : msgs_lost_info) {
+          total_num_messages_lost_in_recorder_.fetch_add(info.num_messages_lost);
+          per_topic_messages_lost_statistics_[info.topic_name].second += info.num_messages_lost;
+          log_text += "\n\t" + info.topic_name + ": " + std::to_string(info.num_messages_lost);
+        }
+      }
+      RCLCPP_DEBUG(node->get_logger(), "%s", log_text.c_str());
+    }
+  }
+
+  void on_messages_lost_in_transport(
+    const std::string & topic_name,
+    const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info)
+  {
+    total_num_messages_lost_in_transport_.fetch_add(qos_msgs_lost_info.total_count_change);
+    RCLCPP_DEBUG(
+      node->get_logger(),
+      "Messages lost on transport layer for topic '%s'. Total lost: %lu",
+      topic_name.c_str(), qos_msgs_lost_info.total_count);
+
+    {
+      std::unique_lock<std::mutex> lock(per_topic_messages_lost_statistics_mutex_);
+      per_topic_messages_lost_statistics_[topic_name].first +=
+        qos_msgs_lost_info.total_count_change;
+    }
+  }
+
+
+  [[nodiscard]] size_t get_total_num_messages_lost_in_transport() const
+  {
+    return total_num_messages_lost_in_transport_.load();
+  }
+
+  [[nodiscard]] size_t get_total_num_messages_lost_in_recorder() const
+  {
+    return total_num_messages_lost_in_recorder_.load();
+  }
+
+  void reset_total_num_messages_lost_in_transport()
+  {
+    total_num_messages_lost_in_transport_.store(0);
+  }
+
+  void reset_total_num_messages_lost_in_recorder()
+  {
+    total_num_messages_lost_in_recorder_.store(0);
+  }
+
+  void event_publisher_thread_main()
+  {
+    RCLCPP_INFO(node->get_logger(), "Event publisher thread: Started");
+    while (!event_publisher_thread_should_exit_.load()) {
+      std::unique_lock<std::mutex> pub_thread_lock(event_publisher_thread_mutex_);
+
+      event_publisher_thread_wake_cv_.wait_for(pub_thread_lock, msgs_lost_statistics_update_period_,
+        [this]() {
+          return write_split_has_occurred_ || event_publisher_thread_should_exit_;
+        }
+      );
+
+      if (write_split_has_occurred_) {
+        write_split_has_occurred_ = false;
+        auto message = rosbag2_interfaces::msg::WriteSplitEvent();
+        message.closed_file = bag_split_info_.closed_file;
+        message.opened_file = bag_split_info_.opened_file;
+        message.node_name = node->get_fully_qualified_name();
+        try {
+          split_event_pub_->publish(message);
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR_STREAM(
+            node->get_logger(),
+            "Failed to publish message on '/events/write_split' topic. \nError: " << e.what());
+        } catch (...) {
+          RCLCPP_ERROR_STREAM(
+            node->get_logger(),
+            "Failed to publish message on '/events/write_split' topic.");
+        }
+      }
+
+//    {
+//      // TODO(morlov): Check if we need to publish statistics about messages lost events
+//      std::unique_lock<std::mutex> statistics_lock(per_topic_messages_lost_statistics_mutex_);
+//      for (const auto &[topic, lost_stats] : per_topic_messages_lost_statistics_) {
+//        const auto &[transport_lost, recorder_lost] = lost_stats;
+//        // Use topic, transport_lost, and recorder_lost to publish statistics if needed
+//      }
+//    }
+    }
+    RCLCPP_INFO(node->get_logger(), "Event publisher thread: Exited");
+  }
+
+private:
+  rclcpp::Node * node;
+  rclcpp::Publisher<rosbag2_interfaces::msg::WriteSplitEvent>::SharedPtr split_event_pub_;
+  std::atomic<bool> event_publisher_thread_should_exit_ = false;
+  std::atomic<bool> write_split_has_occurred_ = false;
+  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info_;
+  std::mutex event_publisher_thread_mutex_;
+  std::condition_variable event_publisher_thread_wake_cv_;
+  std::thread event_publisher_thread_;
+  std::chrono::milliseconds msgs_lost_statistics_update_period_{1000};  // 1 second
+
+  std::mutex per_topic_messages_lost_statistics_mutex_;
+  // Stores the number of messages lost per topic in the transport and recorder layers.
+  std::unordered_map<std::string, std::pair<size_t, size_t>> per_topic_messages_lost_statistics_;
+
+  std::atomic<size_t> total_num_messages_lost_in_transport_{0};
+  std::atomic<size_t> total_num_messages_lost_in_recorder_{0};
+};
+
+}  // namespace rosbag2_transport
+
+#endif  // ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_IMPL_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -16,11 +16,16 @@
 #ifndef ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_IMPL_HPP_
 #define ROSBAG2_TRANSPORT__RECORDER_EVENT_NOTIFIER_IMPL_HPP_
 
-#include <vector>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
@@ -89,8 +94,7 @@ public:
   {
     {
       std::lock_guard<std::mutex> lock(event_publisher_thread_mutex_);
-      bag_split_info_ = bag_split_info;
-      write_split_has_occurred_ = true;
+      bag_split_info_queue_.push(bag_split_info);
     }
     event_publisher_thread_wake_cv_.notify_all();
   }
@@ -160,7 +164,7 @@ public:
         // If publishing of messages lost statistics is disabled, wait indefinitely
         event_publisher_thread_wake_cv_.wait(pub_thread_lock,
           [this]() {
-            return write_split_has_occurred_ || event_publisher_thread_should_exit_ ||
+            return !bag_split_info_queue_.empty() || event_publisher_thread_should_exit_ ||
                    !disable_publishing_msgs_lost_statistics_;
           });
       } else {
@@ -169,17 +173,17 @@ public:
           pub_thread_lock,
           msgs_lost_stats_max_publishing_period_,
           [this]() {
-            return write_split_has_occurred_ || event_publisher_thread_should_exit_ ||
+            return !bag_split_info_queue_.empty() || event_publisher_thread_should_exit_ ||
                    disable_publishing_msgs_lost_statistics_;
           }
         );
       }
 
-      if (write_split_has_occurred_) {
-        write_split_has_occurred_ = false;
+      while (!bag_split_info_queue_.empty()) {
+        const auto & bag_split_info = bag_split_info_queue_.front();
         auto message = rosbag2_interfaces::msg::WriteSplitEvent();
-        message.closed_file = bag_split_info_.closed_file;
-        message.opened_file = bag_split_info_.opened_file;
+        message.closed_file = bag_split_info.closed_file;
+        message.opened_file = bag_split_info.opened_file;
         message.node_name = node->get_fully_qualified_name();
         try {
           split_event_pub_->publish(message);
@@ -192,6 +196,7 @@ public:
             node->get_logger(),
             "Failed to publish message on '/events/write_split' topic.");
         }
+        bag_split_info_queue_.pop();
       }
 
 //    if (!disable_publishing_msgs_lost_statistics_) {
@@ -210,8 +215,7 @@ private:
   rclcpp::Node * node;
   rclcpp::Publisher<rosbag2_interfaces::msg::WriteSplitEvent>::SharedPtr split_event_pub_;
   std::atomic<bool> event_publisher_thread_should_exit_ = false;
-  std::atomic<bool> write_split_has_occurred_ = false;
-  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info_;
+  std::queue<rosbag2_cpp::bag_events::BagSplitInfo> bag_split_info_queue_;
   std::mutex event_publisher_thread_mutex_;
   std::condition_variable event_publisher_thread_wake_cv_;
   std::thread event_publisher_thread_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -64,6 +64,26 @@ public:
     }
   }
 
+  void set_messages_lost_statistics_max_publishing_rate(float update_rate_hz)
+  {
+    {
+      std::unique_lock<std::mutex> pub_thread_lock(event_publisher_thread_mutex_);
+      if (update_rate_hz == 0.0f) {
+        disable_publishing_msgs_lost_statistics_ = true;
+        RCLCPP_DEBUG(node->get_logger(), "Messages lost statistics publishing is disabled");
+      } else if (update_rate_hz > 0.0f) {
+        disable_publishing_msgs_lost_statistics_ = false;
+        msgs_lost_stats_max_publishing_period_ =
+          std::chrono::milliseconds(static_cast<int>(1000 / update_rate_hz));
+        RCLCPP_DEBUG(node->get_logger(),
+                     "Messages lost statistics publishing update rate set to %ld ms",
+                     msgs_lost_stats_max_publishing_period_.count());
+      } else {
+        throw std::invalid_argument("Update rate must be non-negative");
+      }
+    }
+    event_publisher_thread_wake_cv_.notify_all();
+  }
 
   void on_bag_split_in_recorder(const rosbag2_cpp::bag_events::BagSplitInfo & bag_split_info)
   {
@@ -136,12 +156,24 @@ public:
     RCLCPP_INFO(node->get_logger(), "Event publisher thread: Started");
     while (!event_publisher_thread_should_exit_.load()) {
       std::unique_lock<std::mutex> pub_thread_lock(event_publisher_thread_mutex_);
-
-      event_publisher_thread_wake_cv_.wait_for(pub_thread_lock, msgs_lost_statistics_update_period_,
-        [this]() {
-          return write_split_has_occurred_ || event_publisher_thread_should_exit_;
-        }
-      );
+      if (disable_publishing_msgs_lost_statistics_) {
+        // If publishing of messages lost statistics is disabled, wait indefinitely
+        event_publisher_thread_wake_cv_.wait(pub_thread_lock,
+          [this]() {
+            return write_split_has_occurred_ || event_publisher_thread_should_exit_ ||
+                   !disable_publishing_msgs_lost_statistics_;
+          });
+      } else {
+        // Wait for either a write split event or the specified period for messages lost statistics
+        event_publisher_thread_wake_cv_.wait_for(
+          pub_thread_lock,
+          msgs_lost_stats_max_publishing_period_,
+          [this]() {
+            return write_split_has_occurred_ || event_publisher_thread_should_exit_ ||
+                   disable_publishing_msgs_lost_statistics_;
+          }
+        );
+      }
 
       if (write_split_has_occurred_) {
         write_split_has_occurred_ = false;
@@ -162,7 +194,7 @@ public:
         }
       }
 
-//    {
+//    if (!disable_publishing_msgs_lost_statistics_) {
 //      // TODO(morlov): Check if we need to publish statistics about messages lost events
 //      std::unique_lock<std::mutex> statistics_lock(per_topic_messages_lost_statistics_mutex_);
 //      for (const auto &[topic, lost_stats] : per_topic_messages_lost_statistics_) {
@@ -183,7 +215,8 @@ private:
   std::mutex event_publisher_thread_mutex_;
   std::condition_variable event_publisher_thread_wake_cv_;
   std::thread event_publisher_thread_;
-  std::chrono::milliseconds msgs_lost_statistics_update_period_{1000};  // 1 second
+  bool disable_publishing_msgs_lost_statistics_{false};
+  std::chrono::milliseconds msgs_lost_stats_max_publishing_period_{1000};  // 1 second
 
   std::mutex per_topic_messages_lost_statistics_mutex_;
   // Stores the number of messages lost per topic in the transport and recorder layers.

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -135,12 +135,12 @@ public:
   }
 
 
-  [[nodiscard]] size_t get_total_num_messages_lost_in_transport() const
+  [[nodiscard]] uint64_t get_total_num_messages_lost_in_transport() const
   {
     return total_num_messages_lost_in_transport_.load();
   }
 
-  [[nodiscard]] size_t get_total_num_messages_lost_in_recorder() const
+  [[nodiscard]] uint64_t get_total_num_messages_lost_in_recorder() const
   {
     return total_num_messages_lost_in_recorder_.load();
   }
@@ -224,10 +224,11 @@ private:
 
   std::mutex per_topic_messages_lost_statistics_mutex_;
   // Stores the number of messages lost per topic in the transport and recorder layers.
-  std::unordered_map<std::string, std::pair<size_t, size_t>> per_topic_messages_lost_statistics_;
+  std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
+  per_topic_messages_lost_statistics_;
 
-  std::atomic<size_t> total_num_messages_lost_in_transport_{0};
-  std::atomic<size_t> total_num_messages_lost_in_recorder_{0};
+  std::atomic<uint64_t> total_num_messages_lost_in_transport_{0};
+  std::atomic<uint64_t> total_num_messages_lost_in_recorder_{0};
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -77,6 +77,9 @@ public:
         disable_publishing_msgs_lost_statistics_ = true;
         RCLCPP_DEBUG(node->get_logger(), "Messages lost statistics publishing is disabled");
       } else if (update_rate_hz > 0.0f) {
+        if (update_rate_hz >= 1000.0f) {
+          throw std::invalid_argument("Update rate must be less than 1000 Hz");
+        }
         disable_publishing_msgs_lost_statistics_ = false;
         msgs_lost_stats_max_publishing_period_ =
           std::chrono::milliseconds(static_cast<int>(1000 / update_rate_hz));

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -145,6 +145,11 @@ TEST_F(TestRecorderEventNotifier, set_statistics_publishing_rate)
   ASSERT_NO_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(0.0f));
   ASSERT_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(-10.0f),
                std::invalid_argument);
+  ASSERT_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(1000.0f),
+               std::invalid_argument);
+  ASSERT_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(1000.001f),
+               std::invalid_argument);
+  ASSERT_NO_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(999.999f));
 }
 
 TEST_F(TestRecorderEventNotifier, handle_empty_messages_lost_in_recorder)

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -1,0 +1,251 @@
+// Copyright 2025 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <gmock/gmock.h>
+
+#include <iostream>
+#include <thread>
+
+#include "rosbag2_interfaces/msg/write_split_event.hpp"
+#include "rosbag2_transport/recorder_event_notifier.hpp"
+#include "rosbag2_test_common/subscription_manager.hpp"
+
+using namespace ::testing;          // NOLINT
+using namespace rosbag2_transport;  // NOLINT
+using namespace rosbag2_test_common;  // NOLINT
+
+class TestRecorderEventNotifier : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override
+  {
+    node_ = std::make_unique<rclcpp::Node>("test_recorder_event_notifier");
+    notifier_ = std::make_unique<RecorderEventNotifier>(node_.get());
+  }
+
+  std::unique_ptr<rclcpp::Node> node_;
+  std::unique_ptr<RecorderEventNotifier> notifier_;
+};
+
+TEST_F(TestRecorderEventNotifier, default_ctor_dtor)
+{
+  // Destructor should not throw
+  ASSERT_NO_THROW(notifier_.reset());
+}
+
+TEST_F(TestRecorderEventNotifier, handle_bag_split_event)
+{
+  // Disable statistics publishing
+  notifier_->set_messages_lost_statistics_max_publishing_rate(0.0f);
+  const size_t expected_number_of_messages = 2;
+  const std::string topic_name = "events/write_split";
+  auto sub = std::make_unique<SubscriptionManager>();
+  rclcpp::QoS sub_qos(rclcpp::QoS{10}.reliability(rclcpp::ReliabilityPolicy::Reliable));
+  // Create a subscription to the write_split event
+  sub->add_subscription<rosbag2_interfaces::msg::WriteSplitEvent>(
+    topic_name, expected_number_of_messages, sub_qos
+  );
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(sub->spin_and_wait_for_matched({topic_name}, std::chrono::seconds(30), 1));
+  auto await_received_messages = sub->spin_subscriptions(std::chrono::seconds(30));
+
+  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info1;
+  bag_split_info1.closed_file = "closed_file1.bag";
+  bag_split_info1.opened_file = "opened_file2.bag";
+
+  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info2;
+  bag_split_info2.closed_file = "closed_file2.bag";
+  bag_split_info2.opened_file = "";
+
+  ASSERT_NO_THROW(notifier_->on_bag_split_in_recorder(bag_split_info1));
+  ASSERT_NO_THROW(notifier_->on_bag_split_in_recorder(bag_split_info2));
+
+  await_received_messages.get();
+  auto received_split_event_messages =
+    sub->get_received_messages<rosbag2_interfaces::msg::WriteSplitEvent>(topic_name);
+  ASSERT_THAT(received_split_event_messages, SizeIs(expected_number_of_messages));
+
+  EXPECT_THAT(received_split_event_messages[0]->closed_file, Eq(bag_split_info1.closed_file));
+  EXPECT_THAT(received_split_event_messages[0]->opened_file, Eq(bag_split_info1.opened_file));
+  EXPECT_THAT(received_split_event_messages[1]->closed_file, Eq(bag_split_info2.closed_file));
+  EXPECT_THAT(received_split_event_messages[1]->opened_file, Eq(bag_split_info2.opened_file));
+}
+
+TEST_F(TestRecorderEventNotifier, messages_lost_in_transport_correctly_accumulated)
+{
+  rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
+  qos_msgs_lost_info.total_count = 20;
+  qos_msgs_lost_info.total_count_change = 5;
+  ASSERT_NO_THROW(notifier_->on_messages_lost_in_transport("topic1", qos_msgs_lost_info));
+  ASSERT_NO_THROW(notifier_->on_messages_lost_in_transport("topic2", qos_msgs_lost_info));
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), 10u);
+}
+
+TEST_F(TestRecorderEventNotifier, messages_lost_in_recorder_correctly_accumulated)
+{
+  std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
+    {"topic1", 3},
+    {"topic3", 9}
+  };
+  notifier_->on_messages_lost_in_recorder(msgs_lost_info);
+  notifier_->on_messages_lost_in_recorder(msgs_lost_info);
+
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), 24u);
+}
+
+TEST_F(TestRecorderEventNotifier, reset_messages_lost_counters)
+{
+  std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
+    {"topic1", 5}
+  };
+  notifier_->on_messages_lost_in_recorder(msgs_lost_info);
+
+  rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
+  qos_msgs_lost_info.total_count_change = 3;
+  ASSERT_NO_THROW(notifier_->on_messages_lost_in_transport("topic2", qos_msgs_lost_info));
+
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), 5u);
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), 3u);
+
+  notifier_->reset_total_num_messages_lost_in_recorder();
+  notifier_->reset_total_num_messages_lost_in_transport();
+
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), 0u);
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), 0u);
+}
+
+TEST_F(TestRecorderEventNotifier, set_statistics_publishing_rate)
+{
+  ASSERT_NO_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(1.0f));
+  ASSERT_NO_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(0.0f));
+  ASSERT_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(-1.0f),
+               std::invalid_argument);
+  ASSERT_NO_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(0.0f));
+  ASSERT_THROW(notifier_->set_messages_lost_statistics_max_publishing_rate(-10.0f),
+               std::invalid_argument);
+}
+
+TEST_F(TestRecorderEventNotifier, handle_empty_messages_lost_in_recorder)
+{
+  std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {};
+  ASSERT_NO_THROW(notifier_->on_messages_lost_in_recorder(msgs_lost_info));
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), 0u);
+}
+
+TEST_F(TestRecorderEventNotifier, zero_messages_lost)
+{
+  rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
+  qos_msgs_lost_info.total_count = 0;
+  qos_msgs_lost_info.total_count_change = 0;
+  ASSERT_NO_THROW(notifier_->on_messages_lost_in_transport("topic1", qos_msgs_lost_info));
+
+  std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
+    {"topic1", 0}
+  };
+  ASSERT_NO_THROW(notifier_->on_messages_lost_in_recorder(msgs_lost_info));
+
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), 0u);
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), 0u);
+}
+
+TEST_F(TestRecorderEventNotifier, large_message_counts)
+{
+  rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
+  qos_msgs_lost_info.total_count = 1000000;
+  qos_msgs_lost_info.total_count_change = 1000000;
+  notifier_->on_messages_lost_in_transport("topic1", qos_msgs_lost_info);
+
+  std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
+    {"topic1", 2000000}
+  };
+  notifier_->on_messages_lost_in_recorder(msgs_lost_info);
+
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), 1000000u);
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), 2000000u);
+}
+
+TEST_F(TestRecorderEventNotifier, reset_between_message_loss_notifications)
+{
+  rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
+  qos_msgs_lost_info.total_count = 1000000;
+  qos_msgs_lost_info.total_count_change = 10;
+  notifier_->on_messages_lost_in_transport("topic1", qos_msgs_lost_info);
+
+  std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
+    {"topic1", 5}
+  };
+  notifier_->on_messages_lost_in_recorder(msgs_lost_info);
+
+  notifier_->reset_total_num_messages_lost_in_transport();
+  notifier_->reset_total_num_messages_lost_in_recorder();
+
+  qos_msgs_lost_info.total_count_change = 7;
+  notifier_->on_messages_lost_in_transport("topic2", qos_msgs_lost_info);
+
+  msgs_lost_info = {{"topic2", 3}};
+  notifier_->on_messages_lost_in_recorder(msgs_lost_info);
+
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), 7u);
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), 3u);
+}
+
+TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
+{
+  constexpr size_t num_threads_for_each_event = 10;
+  constexpr size_t iterations_per_thread = 1000;
+  constexpr size_t expected_transport_lost = num_threads_for_each_event * iterations_per_thread;
+  constexpr size_t expected_recorder_lost = num_threads_for_each_event * iterations_per_thread;
+
+  std::vector<std::thread> threads;
+
+  // Simulate concurrent access to on_messages_lost_in_transport
+  for (size_t i = 0; i < num_threads_for_each_event; i++) {
+    // Simulate concurrent access to on_messages_lost_in_transport
+    threads.emplace_back([this, i]() {
+        for (size_t j = 0; j < iterations_per_thread; j++) {
+          rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
+          qos_msgs_lost_info.total_count_change = 1;
+          notifier_->on_messages_lost_in_transport("topic" + std::to_string(i), qos_msgs_lost_info);
+        }
+    });
+    // Simulate concurrent access to on_messages_lost_in_recorder
+    threads.emplace_back([this, i]() {
+        for (size_t j = 0; j < iterations_per_thread; j++) {
+          std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
+            {"topic" + std::to_string(i), 1}
+          };
+          notifier_->on_messages_lost_in_recorder(msgs_lost_info);
+        }
+    });
+  }
+
+  for (auto & thread : threads) {
+    thread.join();
+  }
+
+  // Verify that the total counts are consistent
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), expected_transport_lost);
+  EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), expected_recorder_lost);
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -223,7 +223,7 @@ TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
   // Simulate concurrent access to on_messages_lost_in_transport
   for (size_t i = 0; i < num_threads_for_each_event; i++) {
     // Simulate concurrent access to on_messages_lost_in_transport
-    threads.emplace_back([this, i]() {
+    threads.emplace_back([this, i, iterations_per_thread]() {
         for (size_t j = 0; j < iterations_per_thread; j++) {
           rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
           qos_msgs_lost_info.total_count_change = 1;
@@ -231,7 +231,7 @@ TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
         }
     });
     // Simulate concurrent access to on_messages_lost_in_recorder
-    threads.emplace_back([this, i]() {
+    threads.emplace_back([this, i, iterations_per_thread]() {
         for (size_t j = 0; j < iterations_per_thread; j++) {
           std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
             {"topic" + std::to_string(i), 1}


### PR DESCRIPTION
## Description

Add recorder event notifier class, which will be responsible for sending events on predefined topics about bag split and statistics about messages lost on transport and inner recorder level.

This PR is needed as part of the #2007 
>  2. Incremental statistics about the number of messages lost and bytes written on a per-topic basis should be published on a specific topic when messages are lost.

The `RecorderEventNotifier` class implemented as an extended replacement of the Messages Lost Notifier described in the 
[statistics_about_lost_and_recorded_messages.md](https://github.com/ros2/rosbag2/blob/7f304136062740cc718502dc4a855f79aa0571a3/docs/design/statistics_about_lost_and_recorded_messages.md?plain=1#L76C1-L108) design document.
```markdown
### 4. Messages Lost Notifier

   Will need to add a new `MessagesLostNotifier` class to the `rosbag2_transport::recorder` that 
   will publish on a predefined topic, incremental statistics about the number of lost messages 
   and bytes written on a per-topic basis when messages lost happened.
   - To facilitate this, the Rosbag2 recorder shall satisfy the following requirements:
      1. The messages lost event shall be published from the Rosbag2 recorder on a dedicated topic.
      e.g., `/events/rosbag2_messages_lost`
      2. The messages lost event shall include per-topic statistics with the number of lost 
        messages. The message type could be named as `rosbag2_interfaces::msg::MessagesLostEvent`
        and defined in the `rosbag2_interfaces` package. The message type will be similar to the 
        `rosbag2_interfaces::msg::WriteSplitEvent` message type and shall contain the following 
         fields:
         - `node_name` (string): The name of the node that is recording.
         - Array of the following fields:
         - `topic_name` (string): The name of the topic on which the messages were lost.
         - `messages_lost_in_transport` (uint64_t): The number of messages lost since the last 
           event on a DDS transport layer.
         - `messages_lost_in_recorder` (uint64_t): The number of messages lost since the last 
           event in the Rosbag2 recorder.
```

Besides the functionality for the message lost notification on a dedicated topic, the `RecorderEventNotifier` also encapsulates functionality for other event notifications, such as notifications about bag split. 
Notice that notifications about bag splits were built into the `RecorderImpl` class itself. Now that functionality was moved with minimum changes to the `RecorderEventNotifier` class. A queue was added for the bag_split events to avoid missing notifications when events happened one-to-one, with minimum delay.

**Note: In this PR, the `RecorderEventNotifier` doesn't implement the core functionality of the `Messages Lost Notifier` described in the [statistics_about_lost_and_recorded_messages.md](https://github.com/ros2/rosbag2/blob/rolling/docs/design/statistics_about_lost_and_recorded_messages.md) design document. However, it is a one-to-one replacement of the current implementation for the logic of what we have in the `RecorderImpl` class. That was made on purpose to be able to backport this PR to Kilted and Jazzy with minimum changes to reduce divergencies in the code base.
We will be able to backport the part related to the moving bag split event notification and callbacks for messages lost in the transport layer. However, the part related to the callbacks from the writer about lost messages will be omitted since the underlying API in the writer is missing.
The rest of the missing functionality for the `Messages Lost Notifier` will be implemented in follow-up PRs.**


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue) N/A
- Relates  #2007

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes, I am using GitHub Copilot, GPT-4.1 in my workflow.

### Additional Information
- Can be backported. Please refer to the notes above.
- It was considered to make one universal `EventNotifier` class for Player and Recorder. However, this design option was not accepted because events are very specific to the Player and Recorder classes, and it will be a cleaner implementation if they are split into separate classes. Having a common `EventNotifierBase` class also will not give much benefits, but rather will introduce extra layers of dependencies, which is unnecessary in this particular case.
