### PR TITLE
Use pybind11 from deb or pixi

### DIFF
--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -42,7 +42,6 @@ set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 # Find python before pybind11
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
-find_package(pybind11_vendor REQUIRED)
 find_package(pybind11 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})

--- a/rosbag2_py/package.xml
+++ b/rosbag2_py/package.xml
@@ -19,7 +19,7 @@
 
   <build_depend>python3-dev</build_depend>
 
-  <depend>pybind11_vendor</depend>
+  <depend>pybind11-dev</depend>
   <depend>rosbag2_compression</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>


### PR DESCRIPTION
This PR will make changes to use pybind11 from deb or pixi instead of the `pybind11_vendor` package.

- Related with https://github.com/ros2/ros2/pull/1740