### PR TITLE
Bugfix for incorrect MCAPStorage::seek(timestamp) when timestamp is current

### DIFF
--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -851,9 +851,7 @@ void MCAPStorage::reset_filter()
 
 void MCAPStorage::seek(const rcutils_time_point_value_t & time_stamp)
 {
-  if (time_stamp != last_read_time_point_) {
-    last_read_message_offset_ = std::nullopt;
-  }
+  last_read_message_offset_ = std::nullopt;
   last_read_time_point_ = time_stamp;
   reset_iterator();
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -183,6 +183,37 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_with_timestamp_later_than_in_last_messag
   ASSERT_THAT(replayed_topic1, SizeIs(expected_number_of_messages));
 }
 
+TEST_P(RosBag2PlaySeekTestFixture, reader_can_correctly_do_seek) {
+  reader_->open(storage_options_);
+  const auto first_msg_timestamp = start_time_ms_ * 1000000;
+  const auto second_msg_timestamp = (start_time_ms_ + message_spacing_ms_) * 1000000;
+  const auto third_msg_timestamp = (start_time_ms_ + message_spacing_ms_ * 2) * 1000000;
+  ASSERT_TRUE(reader_->has_next());
+  auto msg = reader_->read_next();
+  EXPECT_EQ(msg->recv_timestamp, first_msg_timestamp);  // First message timestamp
+
+  // Jump on third message (1200 ms)
+  reader_->seek(third_msg_timestamp);
+  ASSERT_TRUE(reader_->has_next());
+  msg = reader_->read_next();
+  EXPECT_EQ(msg->recv_timestamp, third_msg_timestamp);
+
+  // Jump back on second message (1100 ms)
+  reader_->seek(second_msg_timestamp);
+  ASSERT_TRUE(reader_->has_next());
+  msg = reader_->read_next();
+  EXPECT_EQ(msg->recv_timestamp, second_msg_timestamp);
+  ASSERT_TRUE(reader_->has_next());
+  msg = reader_->read_next();
+  EXPECT_EQ(msg->recv_timestamp, third_msg_timestamp);
+
+  // Jump on third message (1200 ms) where timestamp is exactly the same as previous read message
+  reader_->seek(third_msg_timestamp);
+  ASSERT_TRUE(reader_->has_next());
+  msg = reader_->read_next();
+  EXPECT_EQ(msg->recv_timestamp, third_msg_timestamp);
+}
+
 TEST_P(RosBag2PlaySeekTestFixture, seek_forward) {
   const size_t expected_number_of_messages = num_msgs_in_bag_ - 1;
   auto player = std::make_shared<MockPlayer>(std::move(reader_), storage_options_, play_options_);


### PR DESCRIPTION
## Description

 Bugfix for the situation when `read_next()` returns a message with a timestamp bigger than the timestamp of the prior `seek(timestamp)` call. It was a possible message lost when `seek(timestamp)` was called with a timestamp equal to the current timestamp in the mcap storage.

The seek(timestamp) shall adhere `>=` condition even when target timestamp is equal to the current timestamp in the storage.

- Fixes #2155 

### Is this user-facing behavior change?
Yes. It will fix a problem with missed messages after the `seek(timestamp)` operation.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1, in my workflow. in particular to help with unit tests and documentation.

### Additional Information
This PR can be backported to the other distros.