### PR TITLE
Follow-up on "Fix for multibag replay stagnation (#2158)"

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -380,9 +380,10 @@ protected:
   size_t get_number_of_registered_on_play_msg_post_callbacks();
 
   /// \brief Getter for the first of the currently stored storage options
-  /// \return Reference to the first item in the StorageOptions vector
+  /// \return Copy of the first item in the StorageOptions vector
+  [[deprecated("Use rosabg2_transport::Player::get_all_storage_options() instead")]]
   ROSBAG2_TRANSPORT_PUBLIC
-  const rosbag2_storage::StorageOptions & get_storage_options();
+  rosbag2_storage::StorageOptions get_storage_options();
 
   /// \brief Getter for the currently stored storage options
   /// \return Copy of the currently stored storage options

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -381,6 +381,7 @@ protected:
 
   /// \brief Getter for the first of the currently stored storage options
   /// \return Copy of the first item in the StorageOptions vector
+  // TODO(morlov): Remove this method in Rolling after Lyrical release
   [[deprecated("Use rosabg2_transport::Player::get_all_storage_options() instead")]]
   ROSBAG2_TRANSPORT_PUBLIC
   rosbag2_storage::StorageOptions get_storage_options();

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -242,7 +242,7 @@ public:
 
   /// \brief Getter for the first of the currently stored storage options
   /// \return Copy of the first of the currently stored storage options
-  const rosbag2_storage::StorageOptions & get_storage_options();
+  rosbag2_storage::StorageOptions get_storage_options();
 
   /// \brief Getter for the currently stored storage options
   /// \return Copy of the currently stored storage options
@@ -2179,10 +2179,10 @@ void PlayerImpl::publish_clock_update(const rclcpp::Time & time)
   }
 }
 
-const rosbag2_storage::StorageOptions & PlayerImpl::get_storage_options()
+rosbag2_storage::StorageOptions PlayerImpl::get_storage_options()
 {
   auto all_storage_options = get_all_storage_options();
-  if (all_storage_options.size() < 1) {
+  if (all_storage_options.empty()) {
     throw std::runtime_error("Storage options not available.");
   }
   return all_storage_options[0];
@@ -2448,7 +2448,7 @@ size_t Player::get_number_of_registered_on_play_msg_post_callbacks()
   return pimpl_->get_number_of_registered_on_play_msg_post_callbacks();
 }
 
-const rosbag2_storage::StorageOptions & Player::get_storage_options()
+rosbag2_storage::StorageOptions Player::get_storage_options()
 {
   return pimpl_->get_storage_options();
 }


### PR DESCRIPTION
## Description

- Return player storage options by value in the 'get_storage_options()' to avoid returning dangling references.
- Also deprecate usage of the  'get_storage_options()' method.

Fixes # (issue) N/A

### Is this user-facing behavior change?
No. Because the method is in a protected section and was used only in the unit tests before.

### Did you use Generative AI?
Not in this case. :smile: 

### Additional Information
Note:  The 'get_storage_options()' is a method of the Player class and resides in the protected section. It was originally designed to be used in the unit tests and was recently superseded by the `Player::get_all_storage_options()` method
