### PR TITLE
[kilted] Follow-up on "Fix for multibag replay stagnation (#2158)"

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -381,6 +381,7 @@ protected:
 
   /// \brief Getter for the first of the currently stored storage options
   /// \return Reference to the first item in the StorageOptions vector
+  [[deprecated("Use rosabg2_transport::Player::get_all_storage_options() instead")]]
   ROSBAG2_TRANSPORT_PUBLIC
   const rosbag2_storage::StorageOptions & get_storage_options();
 

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -381,7 +381,6 @@ protected:
 
   /// \brief Getter for the first of the currently stored storage options
   /// \return Reference to the first item in the StorageOptions vector
-  [[deprecated("Use rosabg2_transport::Player::get_all_storage_options() instead")]]
   ROSBAG2_TRANSPORT_PUBLIC
   const rosbag2_storage::StorageOptions & get_storage_options();
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -241,7 +241,7 @@ public:
   size_t get_number_of_registered_on_play_msg_post_callbacks();
 
   /// \brief Getter for the first of the currently stored storage options
-  /// \return Copy of the first of the currently stored storage options
+  /// \return Reference to the first of the currently stored storage options
   const rosbag2_storage::StorageOptions & get_storage_options();
 
   /// \brief Getter for the currently stored storage options
@@ -435,6 +435,9 @@ private:
       return l->send_timestamp > r->send_timestamp;
     }
   } bag_message_chronological_send_timestamp_comparator;
+
+  // Note: The first_storage_options_ is used as a workaround for deprecated get_storage_options()
+  rosbag2_storage::StorageOptions first_storage_options_;
 };
 
 PlayerImpl::BagMessageComparator PlayerImpl::get_bag_message_comparator(const MessageOrder & order)
@@ -2178,10 +2181,12 @@ void PlayerImpl::publish_clock_update(const rclcpp::Time & time)
 const rosbag2_storage::StorageOptions & PlayerImpl::get_storage_options()
 {
   auto all_storage_options = get_all_storage_options();
-  if (all_storage_options.size() < 1) {
+  if (all_storage_options.empty()) {
     throw std::runtime_error("Storage options not available.");
   }
-  return all_storage_options[0];
+  first_storage_options_ = all_storage_options[0];
+  // Note: Use first_storage_options_ as return value to keep the reference valid
+  return first_storage_options_;
 }
 
 std::vector<rosbag2_storage::StorageOptions> PlayerImpl::get_all_storage_options()


### PR DESCRIPTION
## Description

- Fix for returning a dangling reference from the "Player::get_storage_options()" method
- Also deprecate "Player::get_storage_options()" method in favor of the "get_all_storage_options()"

Fixes # (issue) N/A

### Is this user-facing behavior change?
No. Because the method is in a protected section and was used only in the unit tests before.

### Did you use Generative AI?
Not in this case. :smile: 

### Additional Information
Note:  The 'get_storage_options()' is a method of the Player class and resides in the protected section. It was originally designed to be used in the unit tests and was recently superseded by the `Player::get_all_storage_options()` method