### PR TITLE
Log reasoning for not found message definition only in debug log

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -65,8 +65,6 @@ public:
    * docs/message_definition_encoding.md
    * For SRV type, root_type must include a string '/srv/'.
    * For ACTION type, root_type must include a string '/action/'.
-   * Throws DefinitionNotFoundError if one or more definition files are missing for the given
-   * package resource name.
    */
   [[deprecated("Use get_full_text_ext() instead, which allows specifying the topic name and "
      "provides more flexibility in how the message definition is constructed.")]]
@@ -85,8 +83,6 @@ public:
    * \param[in] topic_name The topic name, which is used to determine the message definition format.
    * \param[in] root_type The root type of the message definition, which should be a fully qualified
    * datatype name.
-   * \throws DefinitionNotFoundError if one or more definition files are missing for the
-   * corresponding package resource name or if the package resource name cannot be determined.
    * \return A MessageDefinition object containing the encoded message definition and its
    * dependencies.
    */

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -235,7 +235,7 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
       "resource_content : \n%s for package: '%s' ,\n share_dir: '%s'\n, topic_type: '%s'",
       resource_content.c_str(), package_name.c_str(), share_dir_path.c_str(), topic_type.c_str());
   } else {
-    ROSBAG2_CPP_LOG_WARN(
+    ROSBAG2_CPP_LOG_DEBUG(
       "Failed to get information about rosidl_interfaces resources from ament_index for package "
       "'%s'", package_name.c_str());
     throw DefinitionNotFoundError(definition_identifier.topic_type());
@@ -257,7 +257,7 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   }
 
   if (relative_file_path_str.empty()) {
-    ROSBAG2_CPP_LOG_WARN(
+    ROSBAG2_CPP_LOG_DEBUG(
       "Message definition file '%s' not found in the resource content for package: '%s'",
       file_name.c_str(), package_name.c_str());
     throw DefinitionNotFoundError(definition_identifier.topic_type());
@@ -265,7 +265,7 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   std::string msg_definition_path_str = (share_dir_path / relative_file_path_str).generic_string();
   std::ifstream file{msg_definition_path_str};
   if (!file.good()) {
-    ROSBAG2_CPP_LOG_WARN("Message definition not found in the %s for package: '%s'",
+    ROSBAG2_CPP_LOG_DEBUG("Message definition not found in the %s for package: '%s'",
       msg_definition_path_str.c_str(), package_name.c_str());
     throw DefinitionNotFoundError(definition_identifier.topic_type());
   }
@@ -335,29 +335,26 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
       // delimiter. All dependent .msg definitions are preceded by a two-line delimiter:
       result = append_recursive(DefinitionIdentifier(root_type, format), max_recursion_depth);
     } catch (const DefinitionNotFoundError & err) {
-      ROSBAG2_CPP_LOG_WARN("No .msg definition for %s, falling back to IDL", err.what());
+      ROSBAG2_CPP_LOG_DEBUG("No .msg definition for %s, falling back to IDL", err.what());
       format = Format::IDL;
       try {
         DefinitionIdentifier root_definition_identifier(root_type, format);
         result = (delimiter(root_definition_identifier) +
           append_recursive(root_definition_identifier, max_recursion_depth));
-      } catch (const DefinitionNotFoundError & err) {
-        ROSBAG2_CPP_LOG_WARN("No .idl definition found for topic type %s, "
-          "definition will be left empty in bag", err.what());
+      } catch (const DefinitionNotFoundError & idl_search_error) {
+        ROSBAG2_CPP_LOG_DEBUG("No .idl definition found for topic type %s.",
+                              idl_search_error.what());
         format = Format::UNKNOWN;
-        throw;
       }
     } catch (const TypenameNotUnderstoodError & err) {
-      ROSBAG2_CPP_LOG_WARN(
-        "Message type name '%s' not understood by type definition search, "
-        "definition will be left empty in bag.", err.what());
+      ROSBAG2_CPP_LOG_DEBUG(
+        "Message type name '%s' not understood by type definition search.", err.what());
       format = Format::UNKNOWN;
     }
   } else {
     // The service and action dependencies could be either in the msg or idl files.
     // Therefore, will try to search dependencies in MSG files first then in IDL files
     // via two separate recursive searches for each dependency.
-    format = Format::UNKNOWN;
     if (is_service_type) {
       format = Format::SRV;
       if (!topic_name.empty() && is_service_event_topic(topic_name, root_type)) {
@@ -387,43 +384,60 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
         }
       }
     }
-    DefinitionIdentifier def_identifier{real_root_type, format};
-    (void)seen_deps.insert(def_identifier).second;
-    result = delimiter(def_identifier);
-    const MessageSpec & spec = load_message_spec(def_identifier);
-    result += spec.text;
-    for (const auto & dep_name : spec.dependencies) {
-      DefinitionIdentifier dep(dep_name, Format::MSG);
-      bool inserted = seen_deps.insert(dep).second;
-      if (inserted) {
-        try {
-          result += "\n";
-          result += delimiter(dep);
-          result += append_recursive(dep, max_recursion_depth);
-          format = Format::MSG;
-        } catch (const DefinitionNotFoundError & err) {
-          ROSBAG2_CPP_LOG_WARN("No .msg definition for %s, falling back to IDL", err.what());
-          dep = DefinitionIdentifier(dep_name, Format::IDL);
-          inserted = seen_deps.insert(dep).second;
-          if (inserted) {
+    try {
+      DefinitionIdentifier def_identifier{real_root_type, format};
+      const MessageSpec & spec = load_message_spec(def_identifier);
+      (void)seen_deps.insert(def_identifier).second;
+      result = delimiter(def_identifier);
+      result += spec.text;
+      for (const auto & dep_name : spec.dependencies) {
+        DefinitionIdentifier dep(dep_name, Format::MSG);
+        bool inserted = seen_deps.insert(dep).second;
+        if (inserted) {
+          try {
             result += "\n";
             result += delimiter(dep);
             result += append_recursive(dep, max_recursion_depth);
-            format = Format::IDL;
+            format = Format::MSG;
+          } catch (const DefinitionNotFoundError & msg_search_err) {
+            ROSBAG2_CPP_LOG_DEBUG("No .msg definition for %s, falling back to IDL",
+                                  msg_search_err.what());
+            try {
+              dep = DefinitionIdentifier(dep_name, Format::IDL);
+              inserted = seen_deps.insert(dep).second;
+              if (inserted) {
+                result += "\n";
+                result += delimiter(dep);
+                result += append_recursive(dep, max_recursion_depth);
+                format = Format::IDL;
+              }
+            } catch (const DefinitionNotFoundError & idl_search_error) {
+              ROSBAG2_CPP_LOG_DEBUG("No .idl definition found for topic type %s.",
+                                    idl_search_error.what());
+              format = Format::UNKNOWN;
+            }
+          } catch (const TypenameNotUnderstoodError & err) {
+            ROSBAG2_CPP_LOG_DEBUG(
+              "Message type name '%s' not understood by type definition search.", err.what());
+            format = Format::UNKNOWN;
           }
-        } catch (const TypenameNotUnderstoodError & err) {
-          ROSBAG2_CPP_LOG_WARN(
-            "Message type name '%s' not understood by type definition search, "
-            "definition will be left empty in bag.", err.what());
-          format = Format::UNKNOWN;
         }
       }
+    } catch (const DefinitionNotFoundError & real_root_search_err) {
+      ROSBAG2_CPP_LOG_DEBUG("No message definition found for topic type %s.",
+                            real_root_search_err.what());
+      format = Format::UNKNOWN;
+    } catch (const TypenameNotUnderstoodError & err) {
+      ROSBAG2_CPP_LOG_DEBUG(
+        "Message type name '%s' not understood by type definition search.", err.what());
+      format = Format::UNKNOWN;
     }
   }
   rosbag2_storage::MessageDefinition out;
   switch (format) {
     case Format::UNKNOWN:
       out.encoding = "unknown";
+      result = "";
       break;
     case Format::MSG:
     case Format::SRV:

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -219,14 +219,21 @@ void SequentialWriter::create_topic(const rosbag2_storage::TopicMetadata & topic
     // nothing to do, topic already created
     return;
   }
-  rosbag2_storage::MessageDefinition definition;
-  try {
-    definition = message_definitions_.get_full_text_ext(topic_with_type.type, topic_with_type.name);
-  } catch (DefinitionNotFoundError &) {
+  rosbag2_storage::MessageDefinition definition =
+    message_definitions_.get_full_text_ext(topic_with_type.type, topic_with_type.name);
+
+  if (definition.encoded_message_definition.empty() ||
+    definition.encoding.empty() || definition.encoding == "unknown")
+  {
+    ROSBAG2_CPP_LOG_WARN("Message definition for topic '%s' with type '%s' not found. "
+      "Message definition will be left empty in bag.",
+      topic_with_type.name.c_str(), topic_with_type.type.c_str());
     definition =
       rosbag2_storage::MessageDefinition::empty_message_definition_for(topic_with_type.type);
   }
 
+  // Copy hash from topic_with_type to message definition
+  definition.type_hash = topic_with_type.type_description_hash;
   create_topic(topic_with_type, definition);
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -388,18 +388,22 @@ TEST(test_local_message_definition_source, no_crash_on_bad_name)
   ASSERT_EQ(result.encoding, "unknown");
 }
 
-TEST(test_local_message_definition_source, throw_definition_not_found_for_unknown_msg)
+TEST(test_local_message_definition_source, gracefully_handle_unknown_msg)
 {
   LocalMessageDefinitionSource source;
-  ASSERT_THROW(
+  rosbag2_storage::MessageDefinition result;
+  EXPECT_NO_THROW(
   {
-    source.get_full_text_ext("rosbag2_test_msgdefs/msg/UnknownMessage", "/unknown_msg_topic");
-  }, rosbag2_cpp::DefinitionNotFoundError);
+    result = source.get_full_text_ext("rosbag2_test_msgdefs/msg/UnknownMessage",
+      "/unknown_msg_topic");
+  });
+  EXPECT_EQ(result.encoding, "unknown");
 
-  // Throw DefinitionNotFoundError for not found message definition package name
-  ASSERT_THROW(
+  // No throw for not found message definition package name
+  EXPECT_NO_THROW(
   {
-    source.get_full_text_ext(
+    result = source.get_full_text_ext(
       "not_found_msgdefs_pkg/msg/UnknownMessage", "/not_found_msgdefs_pkg_topic");
-  }, rosbag2_cpp::DefinitionNotFoundError);
+  });
+  EXPECT_EQ(result.encoding, "unknown");
 }


### PR DESCRIPTION
## Description

Log reasoning for not-found message definition only in the debug log
- Rational: To avoid spamming in the log and confusing users with the debug info. 
Note that in some cases, a not-found message definition is a valid case since we may have a fallback.

- Fixes #2153

### Is this user-facing behavior change?
Yes. Users will not see spamming and confusing messages about not-found message definitions during recording.
However, the user will see one high-level message if we end up with a not-found message definition.
```cpp
   ROSBAG2_CPP_LOG_WARN("Message definition for topic '%s' with type '%s' not found. "
      "Message definition will be left empty in bag.",
      topic_with_type.name.c_str(), topic_with_type.type.c_str());
```

### Did you use Generative AI?
Yes, I am using GitHub Copilot, GPT-4.1, in my workflow

### Additional Information
N/A