### PR TITLE
Fix for data races in tests with MockSequentialWriter

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -62,6 +62,7 @@ public:
 
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message) override
   {
+    std::lock_guard<std::mutex> lock(messages_mutex_);
     if (!snapshot_mode_) {
       messages_.push_back(message);
     } else {
@@ -76,6 +77,7 @@ public:
 
   bool take_snapshot() override
   {
+    std::lock_guard<std::mutex> lock(messages_mutex_);
     std::swap(snapshot_buffer_, messages_);
     snapshot_buffer_.clear();
     return true;
@@ -106,26 +108,52 @@ public:
     return callback_manager_.has_callback_for_event(event);
   }
 
-  const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & get_messages()
+  size_t get_number_of_recorded_messages() const
   {
-    return messages_;
+    std::lock_guard<std::mutex> lock(messages_mutex_);
+    return messages_.size();
   }
 
-  const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &
-  get_snapshot_buffer()
+  std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> get_messages()
   {
-    return snapshot_buffer_;
+    std::lock_guard<std::mutex> lock(messages_mutex_);
+    auto copy_of_messages = messages_;
+    return copy_of_messages;
   }
 
-  const std::unordered_map<std::string, size_t> & messages_per_topic()
+  size_t get_snapshot_buffer_size() const
   {
-    return messages_per_topic_;
+    std::lock_guard<std::mutex> lock(messages_mutex_);
+    return snapshot_buffer_.size();
   }
 
-  const std::unordered_map<
+  std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> get_snapshot_buffer()
+  {
+    std::lock_guard<std::mutex> lock(messages_mutex_);
+    auto copy_of_snapshot_buffer = snapshot_buffer_;
+    return copy_of_snapshot_buffer;
+  }
+
+  std::unordered_map<std::string, size_t> messages_per_topic()
+  {
+    std::lock_guard<std::mutex> lock(messages_mutex_);
+    auto copy_of_messages_per_topic = messages_per_topic_;
+    return copy_of_messages_per_topic;
+  }
+
+  size_t get_messages_per_topic(const std::string & topic_name) const
+  {
+    std::lock_guard<std::mutex> lock(messages_mutex_);
+    if (messages_per_topic_.find(topic_name) != messages_per_topic_.end()) {
+      return messages_per_topic_.at(topic_name);
+    }
+    return 0;
+  }
+
+  std::unordered_map<
     std::string,
     std::pair<rosbag2_storage::TopicMetadata, rosbag2_storage::MessageDefinition>
-  > & get_topics()
+  > get_topics()
   {
     return topics_;
   }
@@ -154,6 +182,7 @@ private:
   std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> snapshot_buffer_;
   std::unordered_map<std::string, size_t> messages_per_topic_;
   size_t messages_per_file_ = 0;
+  mutable std::mutex messages_mutex_;
   bool snapshot_mode_ = false;
   rosbag2_cpp::bag_events::EventCallbackManager callback_manager_;
   size_t file_number_ = 0;

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -75,7 +75,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
     auto ret = rosbag2_test_common::wait_until_condition(
       [ =, &mock_writer]() {
-        return mock_writer.get_messages().size() >= expected_messages;
+        return mock_writer.get_number_of_recorded_messages() >= expected_messages;
       },
       std::chrono::seconds(5));
     EXPECT_TRUE(ret) << "failed to capture expected messages in time" <<
@@ -166,7 +166,7 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
   constexpr size_t expected_messages = 4;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
@@ -240,7 +240,7 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   constexpr size_t expected_messages = 2;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
@@ -305,7 +305,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
   constexpr size_t expected_messages = 2;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
@@ -347,7 +347,7 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   size_t expected_messages = num_latched_messages;
   auto ret = rosbag2_test_common::wait_until_condition(
     [&mock_writer, &expected_messages]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
@@ -461,8 +461,10 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
     };
   writer_->add_event_callbacks(callbacks);
 
-  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
-  mock_writer.set_max_messages_per_file(5);
+  {
+    auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer_->get_implementation_handle());
+    mock_writer.set_max_messages_per_file(5);
+  }
 
   rosbag2_transport::RecordOptions record_options =
   {false, false, false, false, {string_topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
@@ -473,7 +475,7 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
   auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
   auto & writer = recorder->get_writer_handle();
-  mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
 
   size_t expected_messages = mock_writer.max_messages_per_file() + 1;
 
@@ -487,7 +489,7 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
 
   auto ret = rosbag2_test_common::wait_until_condition(
     [&mock_writer, &expected_messages]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -82,7 +82,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
   constexpr size_t expected_messages = 4;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -140,7 +140,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_services_a
   constexpr size_t expected_messages = 4;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -191,7 +191,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_actions_ar
   constexpr size_t expected_messages = 16;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -270,7 +270,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_topic_service_actio
   constexpr size_t expected_messages = 1 + 2 + 8;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -317,7 +317,7 @@ TEST_F(RecordIntegrationTestFixture, cancel_event_messages_from_action_are_recor
   constexpr size_t expected_messages = 8;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() > expected_messages;
+      return mock_writer.get_number_of_recorded_messages() > expected_messages;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_ignore_leaf_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_ignore_leaf_topics.cpp
@@ -71,7 +71,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_two_topics_ignore_l
   constexpr size_t expected_messages = 2;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
@@ -57,7 +57,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_without_discovery_ignores_later_
   constexpr size_t expected_messages = 0;
   rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() > expected_messages;
+      return mock_writer.get_number_of_recorded_messages() > expected_messages;
     },
     std::chrono::seconds(2));
   // We can't EXPECT anything here, since there may be some messages from rosout

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -91,9 +91,9 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   // publishes /clock messages every 100ms until shutdown
   auto clock_pub = ClockPublisher(std::chrono::milliseconds(100), time_value);
-
+  constexpr size_t expected_string_messages = 5;
   rosbag2_test_common::PublicationManager pub_manager;
-  pub_manager.setup_publisher(string_topic, string_message, 5);
+  pub_manager.setup_publisher(string_topic, string_message, expected_string_messages);
 
   rosbag2_transport::RecordOptions record_options =
   {
@@ -105,7 +105,6 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
     std::move(writer_), storage_options_, record_options);
   recorder->record();
 
-  constexpr size_t expected_messages = 10;
   std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> recorded_messages;
   std::unordered_map<std::string, size_t> messages_per_topic;
 
@@ -113,11 +112,11 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
   {
     auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
 
-    ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
-
     ASSERT_TRUE(recorder->wait_for_topic_to_be_discovered(string_topic));
 
     ASSERT_TRUE(recorder->topic_available_for_recording(string_topic));
+
+    ASSERT_TRUE(pub_manager.wait_for_matched(string_topic.c_str()));
 
     pub_manager.run_publishers();
 
@@ -127,19 +126,19 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
     auto ret = rosbag2_test_common::wait_until_condition(
       [ =, &mock_writer]() {
-        return mock_writer.get_messages().size() >= expected_messages;
+        return mock_writer.get_messages_per_topic(string_topic) == expected_string_messages;
       },
       std::chrono::seconds(5));
     ASSERT_TRUE(ret) << "failed to capture expected messages in time. " <<
-      "recorded messages = " << recorded_messages.size();
+      "recorded messages = " << mock_writer.get_messages_per_topic(string_topic);
     recorded_messages = mock_writer.get_messages();
     messages_per_topic = mock_writer.messages_per_topic();
   }
 
   ASSERT_EQ(messages_per_topic.count(string_topic), 1u);
-  EXPECT_EQ(messages_per_topic[string_topic], 5u);
+  EXPECT_EQ(messages_per_topic[string_topic], expected_string_messages);
 
-  EXPECT_THAT(recorded_messages, SizeIs(Ge(expected_messages)));
+  EXPECT_THAT(recorded_messages, SizeIs(Ge(expected_string_messages)));
 
   std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr> string_messages;
   for (const auto & message : recorded_messages) {

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -94,7 +94,7 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
   constexpr size_t expected_messages = 3;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
@@ -169,7 +169,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
   constexpr size_t expected_messages = 3;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
@@ -245,7 +245,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_topic_topic_recording)
   constexpr size_t expected_messages = 3;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   auto recorded_messages = mock_writer.get_messages();
@@ -329,7 +329,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_service_recording)
   constexpr size_t expected_messages = 4;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -411,7 +411,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_service_service_recording
   constexpr size_t expected_messages = 4;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_messages;
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -494,7 +494,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_action_recording)
   constexpr size_t expected_at_least_messages_size = 16;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_at_least_messages_size;
+      return mock_writer.get_number_of_recorded_messages() >= expected_at_least_messages_size;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";
@@ -594,7 +594,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_actions_action_recording)
   constexpr size_t expected_at_least_messages_size = 16;
   auto ret = rosbag2_test_common::wait_until_condition(
     [ =, &mock_writer]() {
-      return mock_writer.get_messages().size() >= expected_at_least_messages_size;
+      return mock_writer.get_number_of_recorded_messages() >= expected_at_least_messages_size;
     },
     std::chrono::seconds(5));
   EXPECT_TRUE(ret) << "failed to capture expected messages in time";

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -169,20 +169,20 @@ TEST_F(RecordSrvsSnapshotTest, trigger_snapshot)
 {
   auto & writer = recorder_->get_writer_handle();
   auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
-  EXPECT_THAT(mock_writer.get_messages().size(), Eq(0u));
+  EXPECT_THAT(mock_writer.get_number_of_recorded_messages(), Eq(0u));
 
   // Wait for messages to be appeared in snapshot_buffer
   std::chrono::duration<int> timeout = std::chrono::seconds(10);
   using clock = std::chrono::steady_clock;
   auto start = clock::now();
-  while (mock_writer.get_snapshot_buffer().empty()) {
+  while (mock_writer.get_snapshot_buffer_size() == 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
     EXPECT_LE((clock::now() - start), timeout) << "Failed to capture messages in time";
   }
-  EXPECT_THAT(mock_writer.get_messages().size(), Eq(0u));
+  EXPECT_THAT(mock_writer.get_number_of_recorded_messages(), Eq(0u));
 
   successful_service_request<Snapshot>(cli_snapshot_);
-  EXPECT_THAT(mock_writer.get_messages().size(), Ne(0u));
+  EXPECT_THAT(mock_writer.get_number_of_recorded_messages(), Ne(0u));
 }
 
 TEST_F(RecordSrvsTest, split_bagfile)
@@ -204,7 +204,7 @@ TEST_F(RecordSrvsTest, split_bagfile)
   std::chrono::duration<int> timeout = std::chrono::seconds(10);
   using clock = std::chrono::steady_clock;
   auto start = clock::now();
-  while (mock_writer.get_messages().empty()) {
+  while (mock_writer.get_number_of_recorded_messages() == 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
     EXPECT_LE((clock::now() - start), timeout) << "Failed to capture messages in time";
   }


### PR DESCRIPTION
## Description

Fix for data races in tests with MockSequentialWriter

- Use a mutex to protect access to the inner `messages_` in the `MockSequentialWriter` and add a new `get_number_of_recorded_messages()` method to be used instead of the `mock_writer.get_messages().size()`
- Use 'get_messages_per_topic(topic_name)' in `record_all_with_sim_time` Rationale: To better settle expectations in the test and reduce possible flakiness.
- Change `MockSequentialWriter` getters API to return by value instead of by const reference. 
  Rationale: To avoid possible data races in tests in the future.

- Fixes #2191

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow

### Additional Information
Can be backported into the other ROS 2 distros