### PR TITLE
Address flakiness in the recorder's tests with a small cache size

### DIFF
--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -631,7 +631,7 @@ TEST_P(SequentialCompressionWriterTest, split_event_calls_callback_with_file_com
 TEST_F(SequentialCompressionWriterTest, snapshot_writes_to_new_file_with_file_compression)
 {
   tmp_dir_storage_options_.max_bagfile_size = 0;
-  tmp_dir_storage_options_.max_cache_size = 200;
+  tmp_dir_storage_options_.max_cache_size = 700;
   tmp_dir_storage_options_.snapshot_mode = true;
 
   initializeFakeFileStorage();

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -520,7 +520,7 @@ TEST_F(SequentialWriterTest, do_not_use_cache_if_cache_size_is_zero) {
 TEST_F(SequentialWriterTest, snapshot_mode_write_on_trigger)
 {
   storage_options_.max_bagfile_size = 0;
-  storage_options_.max_cache_size = 200;
+  storage_options_.max_cache_size = 700;
   storage_options_.snapshot_mode = true;
 
   // Expect a single write call when the snapshot is triggered
@@ -552,7 +552,7 @@ TEST_F(SequentialWriterTest, snapshot_mode_write_on_trigger)
 TEST_F(SequentialWriterTest, snapshot_mode_not_triggered_no_storage_write)
 {
   storage_options_.max_bagfile_size = 0;
-  storage_options_.max_cache_size = 200;
+  storage_options_.max_cache_size = 700;
   storage_options_.snapshot_mode = true;
 
   // Storage should never be written to when snapshot mode is enabled
@@ -598,10 +598,10 @@ TEST_F(SequentialWriterTest, snapshot_mode_zero_cache_size_throws_exception)
 TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
 {
   storage_options_.max_bagfile_size = 0;
-  storage_options_.max_cache_size = 200;
+  storage_options_.max_cache_size = 700;
   storage_options_.snapshot_mode = true;
   const rcutils_time_point_value_t first_msg_timestamp = 100;
-  const size_t num_msgs_to_write = 100;
+  const size_t num_msgs_to_write = 150;
   const std::string topic_name = "test_topic";
   std::string msg_content = "Hello";
   const size_t serialized_msg_buffer_length = msg_content.length();
@@ -700,7 +700,7 @@ TEST_F(SequentialWriterTest, snapshot_writes_to_new_file_with_bag_split)
 TEST_F(SequentialWriterTest, snapshot_can_be_called_twice)
 {
   storage_options_.max_bagfile_size = 0;
-  storage_options_.max_cache_size = 200;
+  storage_options_.max_cache_size = 700;
   storage_options_.snapshot_mode = true;
   const size_t num_msgs_to_write = 100;
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -582,7 +582,7 @@ TEST_P(RecordFixture, record_fails_gracefully_if_plugin_for_given_encoding_does_
 }
 
 TEST_P(RecordFixture, record_end_to_end_test_with_cache) {
-  auto max_cache_size = 10;
+  auto max_cache_size = 700;
   auto topic_name = "/rosbag2_cache_test_topic";
 
   auto message = get_messages_strings()[0];

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -71,7 +71,7 @@ public:
     rosbag2_transport::RecordOptions record_options =
     {false, false, false, false, {test_topic_}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
     storage_options_.snapshot_mode = snapshot_mode_;
-    storage_options_.max_cache_size = 200;
+    storage_options_.max_cache_size = 700;
     recorder_ = std::make_shared<rosbag2_transport::Recorder>(
       std::move(writer_), storage_options_, record_options, recorder_name_);
     recorder_->record();


### PR DESCRIPTION
## Description

 Address flakiness in the recorder's tests with a small cache size.
In many tests, we wrongly assumed that the `storage_options_.max_cache_size` is the number of messages. However, it is actually the number of bytes and needs to be adjusted accordingly.
Increase the cache size to at least 700 bytes to fit at least 3 messages in the cache.

- Fixes #2202

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Not at this time.

### Additional Information
N/A
