### PR TITLE
feat(storage): Add fifo storage plugin for real-time streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ venv/
 __pycache__/
 *.db3-*
 
+
+build/
+install/
+log/

--- a/rosbag2_storage_fifo_plugin/CMakeLists.txt
+++ b/rosbag2_storage_fifo_plugin/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.8)
+project(rosbag2_storage_fifo_plugin)
+
+set(CMAKE_CXX_STANDARD 17)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rosbag2_storage REQUIRED)
+find_package(rosbag2_storage_mcap REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
+find_package(mcap_vendor REQUIRED)
+find_package(pluginlib REQUIRED)
+
+add_library(
+  rosbag2_storage_fifo_plugin SHARED
+  src/fifo_storage.cpp
+)
+
+target_include_directories(rosbag2_storage_fifo_plugin PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(
+  rosbag2_storage_fifo_plugin
+  rclcpp
+  rosbag2_storage
+  rosbag2_storage_mcap
+  yaml_cpp_vendor
+  mcap_vendor
+  pluginlib
+)
+
+install(
+  TARGETS rosbag2_storage_fifo_plugin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+pluginlib_export_plugin_description_file(rosbag2_storage plugin_description.xml)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rosbag2_storage_fifo_plugin/README.md
+++ b/rosbag2_storage_fifo_plugin/README.md
@@ -1,0 +1,28 @@
+# rosbag2_storage_fifo_plugin
+
+This package provides a storage plugin for `rosbag2` that writes bag data as a real-time stream to a named pipe (FIFO) instead of a conventional file. This allows other applications to consume ROS 2 topic data live as it's being recorded.
+
+---
+
+## Features
+
+* **Real-time Streaming**: Data is available for consumption by other processes the moment it's recorded, without needing to wait for the bag file to be closed.
+* **MCAP Format Stream**: The data within the FIFO is serialized using the standard MCAP format, allowing for compatibility with existing MCAP tools and readers.
+* **Low Disk Overhead**: Since data is streamed directly to a consuming application, it minimizes the need for disk buffering and I/O on the recording machine.
+
+---
+
+## Usage
+
+Using this plugin requires a two-step process involving two separate terminals: one for the **reader** (the application that will consume the data) and one for the **writer** (the `ros2 bag record` command).
+
+The reader **must** be started before the writer, as the plugin will block until a reader connects to the FIFO.
+
+### 1. Start the Reader
+
+In your first terminal, start an application to read from the FIFO. The simplest way to test this is using `cat` to redirect the stream into a standard file. This command will wait until the recorder starts.
+
+```bash
+# Terminal 1: Start the reader
+# This will block until the recorder starts writing data.
+cat /Data/fifo/ros2_mcap.fifo > live_data.mcap

--- a/rosbag2_storage_fifo_plugin/include/rosbag2_storage_fifo_plugin/fifo_storage.hpp
+++ b/rosbag2_storage_fifo_plugin/include/rosbag2_storage_fifo_plugin/fifo_storage.hpp
@@ -1,0 +1,118 @@
+// Copyright 2024 Virginia Tech Transportation Institute - Jean Paul Talledo Vilela
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_STORAGE_FIFO_PLUGIN__FIFO_STORAGE_HPP_
+#define ROSBAG2_STORAGE_FIFO_PLUGIN__FIFO_STORAGE_HPP_
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "rclcpp/logging.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rosbag2_storage/bag_metadata.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/storage_filter.hpp"
+#include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
+#include "rosbag2_storage/storage_options.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
+
+// This is the correct header for Humble to look up message definitions
+#include "rosbag2_storage_mcap/message_definition_cache.hpp"
+
+#include "mcap/writer.hpp"
+#include "yaml-cpp/yaml.h"
+
+namespace rosbag2_storage_fifo_plugin
+{
+class FdWriter : public mcap::IWritable
+{
+public:
+  explicit FdWriter(int fd)
+  : fd_(fd), total_bytes_written_(0) {}
+
+  ~FdWriter() override = default;
+
+  void handleWrite(const std::byte * data, uint64_t size) override;
+  uint64_t size() const override;
+  void end() override {}
+
+private:
+  int fd_;
+  uint64_t total_bytes_written_;
+};
+
+class FifoStorage : public rosbag2_storage::storage_interfaces::ReadWriteInterface
+{
+public:
+  FifoStorage();
+  ~FifoStorage() override;
+
+  void open(
+    const rosbag2_storage::StorageOptions & storage_options,
+    rosbag2_storage::storage_interfaces::IOFlag io_flag =
+    rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
+
+  void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message) override;
+  void write(
+    const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
+  override;
+
+  void create_topic(const rosbag2_storage::TopicMetadata & topic) override;
+  void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
+  std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
+  rosbag2_storage::BagMetadata get_metadata() override;
+
+  bool has_next() override {return false;}
+  std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override {return nullptr;}
+  void seek(const rcutils_time_point_value_t & timestamp) override {(void) timestamp;}
+
+  uint64_t get_bagfile_size() const override;
+  std::string get_storage_identifier() const override;
+  std::string get_relative_file_path() const override;
+
+  void set_filter(const rosbag2_storage::StorageFilter & storage_filter) override;
+  void reset_filter() override;
+  uint64_t get_minimum_split_file_size() const override;
+
+private:
+  void create_fifo(const std::string & path);
+  void write_metadata_to_yaml_fifo();
+
+  std::string mcap_fifo_path_;
+  std::string yaml_fifo_path_;
+  int mcap_fifo_fd_ = -1;
+
+  std::unique_ptr<FdWriter> mcap_fd_writer_;
+  std::unique_ptr<mcap::McapWriter> mcap_writer_;
+  std::unique_ptr<rosbag2_storage_mcap::internal::MessageDefinitionCache> definition_cache_;
+
+  rosbag2_storage::BagMetadata metadata_{};
+  std::vector<rosbag2_storage::TopicMetadata> topics_;
+  std::unordered_map<std::string, mcap::ChannelId> topic_to_channel_id_;
+  std::unordered_map<std::string, uint64_t> message_counts_;
+
+  rcutils_time_point_value_t starting_time_ = 0;
+  rcutils_time_point_value_t last_timestamp_ = 0;
+  const std::string storage_identifier_ = "fifo";
+  rclcpp::Logger logger_;
+};
+}  // namespace rosbag2_storage_fifo_plugin
+
+#endif  // ROSBAG2_STORAGE_FIFO_PLUGIN__FIFO_STORAGE_HPP_

--- a/rosbag2_storage_fifo_plugin/package.xml
+++ b/rosbag2_storage_fifo_plugin/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbag2_storage_fifo_plugin</name>
+  <version>0.2.0</version>
+  <description>A rosbag2 storage plugin that writes to a FIFO stream.</description>
+  <maintainer email="jvilela@vtti.vt.edu">Jean Paul Talledo Vilela</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rosbag2_storage</depend>
+  <depend>rosbag2_storage_mcap</depend>
+  <depend>yaml_cpp_vendor</depend>
+  <depend>mcap_vendor</depend>
+  <depend>pluginlib</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <rosbag2_storage plugin="${prefix}/plugin_description.xml"/>
+  </export>
+</package>

--- a/rosbag2_storage_fifo_plugin/plugin_description.xml
+++ b/rosbag2_storage_fifo_plugin/plugin_description.xml
@@ -1,0 +1,9 @@
+<library path="rosbag2_storage_fifo_plugin">
+  <class
+    name="fifo"
+    type="rosbag2_storage_fifo_plugin::FifoStorage"
+    base_class_type="rosbag2_storage::storage_interfaces::ReadWriteInterface"
+  >
+    <description>A rosbag2 storage plugin that writes to a FIFO stream.</description>
+  </class>
+</library>

--- a/rosbag2_storage_fifo_plugin/src/fifo_storage.cpp
+++ b/rosbag2_storage_fifo_plugin/src/fifo_storage.cpp
@@ -1,0 +1,311 @@
+// Copyright 2024 Virginia Tech Transportation Institute - Jean Paul Talledo Vilela
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_storage_fifo_plugin/fifo_storage.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pluginlib/class_list_macros.hpp"
+
+namespace rosbag2_storage_fifo_plugin
+{
+
+// --- CONFIGURATION ---
+// Define the hardcoded base path for the FIFOs here for easy modification.
+const char * kFifoBasePath = "/Data/fifo";
+// --- END CONFIGURATION ---
+
+// FdWriter implementation from .hpp moved here for brevity in .hpp
+void FdWriter::handleWrite(const std::byte * data, uint64_t size)
+{
+  if (size == 0) {
+    return;
+  }
+  ssize_t bytes_written = ::write(fd_, data, size);
+  if (bytes_written < 0) {
+    throw std::runtime_error(std::string("Failed to write to FIFO: ") + strerror(errno));
+  }
+  if (static_cast<uint64_t>(bytes_written) != size) {
+    throw std::runtime_error("Partial write to FIFO, this should not happen.");
+  }
+  total_bytes_written_ += bytes_written;
+}
+
+uint64_t FdWriter::size() const
+{
+  return total_bytes_written_;
+}
+
+FifoStorage::FifoStorage()
+: logger_(rclcpp::get_logger("rosbag2_storage_fifo_plugin")),
+  mcap_writer_(nullptr)
+{
+  metadata_.storage_identifier = storage_identifier_;
+  definition_cache_ = std::make_unique<rosbag2_storage_mcap::internal::MessageDefinitionCache>();
+}
+
+FifoStorage::~FifoStorage()
+{
+  if (mcap_writer_) {
+    write_metadata_to_yaml_fifo();
+    mcap_writer_->close();
+  }
+  if (mcap_fifo_fd_ != -1) {
+    ::close(mcap_fifo_fd_);
+  }
+}
+
+void FifoStorage::create_fifo(const std::string & path)
+{
+  struct stat st;
+  if (stat(path.c_str(), &st) == 0) {
+    if (!S_ISFIFO(st.st_mode)) {
+      throw std::runtime_error("File exists at FIFO path but is not a FIFO: " + path);
+    }
+    return;
+  }
+
+  if (mkfifo(path.c_str(), 0666) == -1) {
+    if (errno != EEXIST) {
+      throw std::runtime_error(
+              "Failed to create FIFO: " + std::string(strerror(errno)) + " at " + path);
+    }
+  }
+}
+
+void FifoStorage::open(
+  const rosbag2_storage::StorageOptions & storage_options,
+  rosbag2_storage::storage_interfaces::IOFlag io_flag)
+{
+  (void)storage_options;  // Explicitly ignore the path from the -o argument
+
+  if (io_flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
+    throw std::runtime_error("FifoStorage is a write-only storage implementation.");
+  }
+
+  // Create the hardcoded base directory
+  std::filesystem::create_directories(kFifoBasePath);
+
+  // Construct the FIFO paths using the hardcoded base path
+  mcap_fifo_path_ = std::string(kFifoBasePath) + "/ros2_mcap.fifo";
+  yaml_fifo_path_ = std::string(kFifoBasePath) + "/ros2_yaml.fifo";
+
+  create_fifo(mcap_fifo_path_);
+  create_fifo(yaml_fifo_path_);
+
+  RCLCPP_INFO(logger_, "MCAP FIFO is at: %s", mcap_fifo_path_.c_str());
+  RCLCPP_INFO(logger_, "Waiting for a reader to connect...");
+
+  mcap_fifo_fd_ = ::open(mcap_fifo_path_.c_str(), O_WRONLY);
+  if (mcap_fifo_fd_ == -1) {
+    throw std::runtime_error(
+            "Failed to open MCAP FIFO for writing: " + std::string(strerror(errno)));
+  }
+  RCLCPP_INFO(logger_, "Reader connected to MCAP FIFO.");
+
+  mcap_fd_writer_ = std::make_unique<FdWriter>(mcap_fifo_fd_);
+  mcap::McapWriterOptions options("ros2");
+  mcap_writer_ = std::make_unique<mcap::McapWriter>();
+  mcap_writer_->open(*mcap_fd_writer_, options);
+}
+
+void FifoStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
+{
+  if (!mcap_writer_) {
+    throw std::runtime_error("MCAP writer is not open. Call open() first.");
+  }
+
+  if (starting_time_ == 0) {
+    starting_time_ = message->time_stamp;
+  }
+  last_timestamp_ = message->time_stamp;
+  message_counts_[message->topic_name]++;
+
+  mcap::Message msg;
+  msg.channelId = topic_to_channel_id_[message->topic_name];
+  msg.sequence = 0;
+  msg.logTime = mcap::Timestamp(message->time_stamp);
+  msg.publishTime = msg.logTime;
+  msg.data = reinterpret_cast<const std::byte *>(message->serialized_data->buffer);
+  msg.dataSize = message->serialized_data->buffer_length;
+
+  auto status = mcap_writer_->write(msg);
+  if (!status.ok()) {
+    throw std::runtime_error("Failed to write message to MCAP FIFO: " + status.message);
+  }
+}
+
+void FifoStorage::write(
+  const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
+{
+  for (const auto & message : messages) {
+    write(message);
+  }
+}
+
+void FifoStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
+{
+  if (topic_to_channel_id_.count(topic.name)) {
+    return;
+  }
+
+  if (!mcap_writer_) {
+    throw std::runtime_error("MCAP writer is not open. Call open() first.");
+  }
+
+  topics_.push_back(topic);
+  message_counts_[topic.name] = 0;
+
+  const auto definition_pair = definition_cache_->get_full_text(topic.type);
+  const std::string & schema_text = definition_pair.second;
+
+  mcap::Schema schema(topic.type, "ros2msg", schema_text);
+  mcap_writer_->addSchema(schema);
+
+  mcap::Channel channel(topic.name, "cdr", schema.id);
+  mcap_writer_->addChannel(channel);
+  topic_to_channel_id_[topic.name] = channel.id;
+}
+
+void FifoStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
+{
+  (void)topic;
+}
+
+std::vector<rosbag2_storage::TopicMetadata> FifoStorage::get_all_topics_and_types()
+{
+  return topics_;
+}
+
+std::string FifoStorage::get_storage_identifier() const
+{
+  return storage_identifier_;
+}
+
+std::string FifoStorage::get_relative_file_path() const
+{
+  return mcap_fifo_path_;
+}
+
+uint64_t FifoStorage::get_bagfile_size() const
+{
+  if (mcap_fd_writer_) {
+    return mcap_fd_writer_->size();
+  }
+  return 0;
+}
+
+rosbag2_storage::BagMetadata FifoStorage::get_metadata()
+{
+  metadata_.relative_file_paths = {get_relative_file_path()};
+  metadata_.topics_with_message_count.clear();
+  uint64_t total_messages = 0;
+
+  for (const auto & topic : topics_) {
+    rosbag2_storage::TopicInformation info{};
+    info.topic_metadata = topic;
+    info.message_count = message_counts_[topic.name];
+    metadata_.topics_with_message_count.push_back(info);
+    total_messages += info.message_count;
+  }
+
+  metadata_.message_count = total_messages;
+  metadata_.starting_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
+    std::chrono::nanoseconds(starting_time_));
+  if (last_timestamp_ > starting_time_) {
+    metadata_.duration = std::chrono::nanoseconds(last_timestamp_ - starting_time_);
+  } else {
+    metadata_.duration = std::chrono::nanoseconds(0);
+  }
+
+  return metadata_;
+}
+
+void FifoStorage::set_filter(const rosbag2_storage::StorageFilter & storage_filter)
+{
+  (void)storage_filter;
+}
+
+void FifoStorage::reset_filter()
+{
+}
+
+uint64_t FifoStorage::get_minimum_split_file_size() const
+{
+  return 0;
+}
+
+void FifoStorage::write_metadata_to_yaml_fifo()
+{
+  auto current_metadata = get_metadata();
+  YAML::Emitter out;
+  out << YAML::BeginMap;
+  out << YAML::Key << "rosbag2_bagfile_information";
+  out << YAML::Value << YAML::BeginMap;
+  out << YAML::Key << "version" << YAML::Value << 5;
+  out << YAML::Key << "storage_identifier" << YAML::Value << current_metadata.storage_identifier;
+  out << YAML::Key << "relative_file_paths" << YAML::Value << YAML::Flow <<
+    current_metadata.relative_file_paths;
+  out << YAML::Key << "duration" << YAML::Value << YAML::BeginMap;
+  out << YAML::Key << "nanoseconds" << YAML::Value << current_metadata.duration.count();
+  out << YAML::EndMap;
+  out << YAML::Key << "starting_time" << YAML::Value << YAML::BeginMap;
+  out << YAML::Key << "nanoseconds_since_epoch" << YAML::Value <<
+    std::chrono::duration_cast<std::chrono::nanoseconds>(
+    current_metadata.starting_time.time_since_epoch()).count();
+  out << YAML::EndMap;
+  out << YAML::Key << "message_count" << YAML::Value << current_metadata.message_count;
+  out << YAML::Key << "topics_with_message_count" << YAML::Value << YAML::BeginSeq;
+  for (const auto & topic_info : current_metadata.topics_with_message_count) {
+    out << YAML::BeginMap;
+    out << YAML::Key << "topic_metadata" << YAML::Value << YAML::BeginMap;
+    out << YAML::Key << "name" << YAML::Value << topic_info.topic_metadata.name;
+    out << YAML::Key << "type" << YAML::Value << topic_info.topic_metadata.type;
+    out << YAML::Key << "serialization_format" << YAML::Value <<
+      topic_info.topic_metadata.serialization_format;
+    out << YAML::Key << "offered_qos_profiles" << YAML::Value <<
+      topic_info.topic_metadata.offered_qos_profiles;
+    out << YAML::EndMap;
+    out << YAML::Key << "message_count" << YAML::Value << topic_info.message_count;
+    out << YAML::EndMap;
+  }
+  out << YAML::EndSeq;
+  out << YAML::EndMap;
+  out << YAML::EndMap;
+
+  int yaml_fd = ::open(yaml_fifo_path_.c_str(), O_WRONLY | O_NONBLOCK);
+  if (yaml_fd != -1) {
+    RCLCPP_INFO(logger_, "Writing metadata to YAML FIFO.");
+    ssize_t written = ::write(yaml_fd, out.c_str(), out.size());
+    if (written < 0) {
+      RCLCPP_WARN(logger_, "Could not write metadata to YAML FIFO: %s", strerror(errno));
+    }
+    ::close(yaml_fd);
+  } else {
+    RCLCPP_WARN(
+      logger_,
+      "Could not open YAML FIFO to write metadata. A reader may not be present.");
+  }
+}
+
+}  // namespace rosbag2_storage_fifo_plugin
+
+PLUGINLIB_EXPORT_CLASS(
+  rosbag2_storage_fifo_plugin::FifoStorage,
+  rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -29,10 +29,13 @@ add_library(${PROJECT_NAME} SHARED
   src/mcap_storage.cpp
   src/message_definition_cache.cpp
 )
+
+# This section is corrected to export the proper include path
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  $<INSTALL_INTERFACE:include>
 )
+
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_STORAGE_MCAP_BUILDING_DLL")
 ament_target_dependencies(${PROJECT_NAME}
@@ -79,6 +82,12 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
+)
+
+# This correctly installs the header files for other packages to use
+install(
+  DIRECTORY include/
+  DESTINATION include
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Description
This pull request introduces a new storage plugin, rosbag2_storage_fifo_plugin, designed for real-time streaming of rosbag2 data.

Instead of writing to a conventional file, this plugin writes to a named pipe (FIFO) at a predictable, hardcoded path. This allows external applications to connect to the FIFO and consume ROS topic data live, as it's being recorded.

Key Features:

Real-time Streaming: Provides immediate access to recorded data for other processes.

MCAP Stream Format: The data within the FIFO is serialized using the MCAP format for compatibility with existing tools.

Predictable Path: The FIFO path is hardcoded to /Data/fifo/ to allow external applications to know the connection point before the recorder starts.

Documentation: A detailed README.md is included with usage, configuration, and limitations.

This PR also includes necessary fixes to the rosbag2_storage_mcap build system that were discovered during development and are required to build this new plugin from source against the humble branch.


Is this user-facing behavior change?
Yes. This PR adds a new storage option that users can select with --storage fifo.

Users can now stream rosbag2 data in real-time to other applications by reading from a predictable FIFO path (/Data/fifo/ros2_mcap.fifo). This new workflow requires a consumer application to be started before running ros2 bag record, as the plugin will block until a reader is connected.

Did you use Generative AI?
Yes, Generating the README.md file

Additional Information
This PR also implicitly includes two necessary bug fixes for the rosbag2_storage_mcap package on the humble branch to enable building from source:

Added a missing install(DIRECTORY include/ ...) rule to its CMakeLists.txt to ensure headers are installed.

Corrected the exported INSTALL_INTERFACE path in target_include_directories to fix compilation errors in downstream packages.
