### PR TITLE
Follow-up on "Add cache for topic filter #1486"

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
@@ -102,7 +102,15 @@ protected:
 
   /// Cache for topic_selected_by_lists_or_regex results
   /// The key is a concatenation of topic name and topic type to avoid ambiguity
+  /// \note Uses kTypeNameDelimiter_ as delimiter between topic name and topic type in the key
   std::unordered_map<std::string, bool> topic_selected_by_lists_or_regex_cache_;
+
+  /// Delimiter used for concatenating topic name and topic type in the cache key
+  /// Using a special character to avoid collisions with topic names and types. i.e. without
+  /// delimiter topic name "/motor" and type "controlsystem_msgs/msg/Foo" would create the same
+  /// key as a topic name "/motorcontrol" and type "system_msgs/msg/Foo". The '&' character is not
+  /// allowed in ROS topic names and types, so it is safe to use as delimiter.
+  static constexpr const char * kTopicNameTypeDelimiter_ = "&";
 
   /// Cache for type_is_known results
   std::unordered_map<std::string, bool> known_topic_types_cache_;

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -303,12 +303,15 @@ bool TopicFilter::take_topic(
   bool topic_selected = false;
   // Check cache first
   auto lists_or_regex_cache_it =
-    topic_selected_by_lists_or_regex_cache_.find(topic_name + topic_type);
+    topic_selected_by_lists_or_regex_cache_.find(
+      topic_name + kTopicNameTypeDelimiter_ + topic_type);
+
   if (lists_or_regex_cache_it != topic_selected_by_lists_or_regex_cache_.end()) {
     topic_selected = lists_or_regex_cache_it->second;
   } else {
     topic_selected = topic_selected_by_lists_or_regex(topic_name, topic_type);
-    topic_selected_by_lists_or_regex_cache_[topic_name + topic_type] = topic_selected;
+    topic_selected_by_lists_or_regex_cache_[topic_name + kTopicNameTypeDelimiter_ + topic_type] =
+      topic_selected;
   }
 
   if (!topic_selected) {

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -48,6 +48,12 @@ public:
     return topic_selected_by_lists_or_regex_cache_;
   }
 
+  // Getter for the delimiter constant
+  static std::string get_topic_name_and_type_delimiter()
+  {
+    return kTopicNameTypeDelimiter_;
+  }
+
   std::unordered_map<std::string, bool> & get_known_topic_types_cache()
   {
     return known_topic_types_cache_;
@@ -713,26 +719,32 @@ TEST_F(TestTopicFilter, test_topic_selected_by_lists_or_regex_caching) {
   record_options.all_topics = true;
   TopicFilterForTest filter{record_options, nullptr, true};
 
+  const std::string topic_name1 = "/planning1";
+  const std::string topic_name2 = "/planning2";
+  const std::string topic_type = "planning_topic_type";
+  const std::string topic_name_type_delimiter = filter.get_topic_name_and_type_delimiter();
+
   // Initial cache should be empty
   EXPECT_TRUE(filter.get_topic_selected_by_lists_or_regex_cache().empty());
 
   // First take_topic call should add to cache
   // Note: We are not using topic_selected_by_lists_or_regex(...) directly here because the caching
   // for the selected topics implemented in the take_topic(...)
-  EXPECT_TRUE(filter.take_topic("/planning1", {"planning_topic_type"}));
+  EXPECT_TRUE(filter.take_topic(topic_name1, {topic_type}));
   EXPECT_EQ(filter.get_topic_selected_by_lists_or_regex_cache().size(), 1);
   auto find_in_cache_it =
-    filter.get_topic_selected_by_lists_or_regex_cache().find("/planning1planning_topic_type");
+    filter.get_topic_selected_by_lists_or_regex_cache().find(
+      topic_name1 + topic_name_type_delimiter + topic_type);
   ASSERT_TRUE(find_in_cache_it != filter.get_topic_selected_by_lists_or_regex_cache().end());
   ASSERT_TRUE(find_in_cache_it->second);
 
   // Second call with same parameters should use cache
   find_in_cache_it->second = false;  // Modify cached value to test that cache being used
-  EXPECT_FALSE(filter.take_topic("/planning1", {"planning_topic_type"}));
+  EXPECT_FALSE(filter.take_topic(topic_name1, {topic_type}));
   EXPECT_EQ(filter.get_topic_selected_by_lists_or_regex_cache().size(), 1);  // Cache size unchanged
 
   // Call with different parameters should add new entry
-  EXPECT_TRUE(filter.take_topic("/planning2", {"planning_topic_type"}));
+  EXPECT_TRUE(filter.take_topic(topic_name2, {topic_type}));
   EXPECT_EQ(filter.get_topic_selected_by_lists_or_regex_cache().size(), 2);
 }
 
@@ -822,12 +834,13 @@ TEST_F(TestTopicFilter, topic_selected_by_lists_or_regex_action_topics) {
 }
 
 TEST_F(TestTopicFilter, take_topic_uses_cache) {
-  const std::string topic_name = "/planning_service";
-  const std::string topic_type = "planning_topic_type";
-
   rosbag2_transport::RecordOptions record_options{};
   record_options.all_topics = true;
   TopicFilterForTest filter{record_options, nullptr, false};
+
+  const std::string topic_name = "/planning_service";
+  const std::string topic_type = "planning_topic_type";
+  const std::string topic_name_type_delimiter = filter.get_topic_name_and_type_delimiter();
 
   // Initial caches should be empty
   EXPECT_TRUE(filter.get_topic_selected_by_lists_or_regex_cache().empty());
@@ -850,7 +863,8 @@ TEST_F(TestTopicFilter, take_topic_uses_cache) {
 
   // Check that topic_selected_by_lists_or_regex_cache is used
   auto find_in_selected_topics_cache_it =
-    filter.get_topic_selected_by_lists_or_regex_cache().find(topic_name + topic_type);
+    filter.get_topic_selected_by_lists_or_regex_cache().find(
+     topic_name + topic_name_type_delimiter + topic_type);
   ASSERT_TRUE(find_in_selected_topics_cache_it !=
               filter.get_topic_selected_by_lists_or_regex_cache().end());
   EXPECT_TRUE(find_in_selected_topics_cache_it->second);


### PR DESCRIPTION
## Description

Add topic name and type delimiter for the `topic_selected_by_lists_or_regex_cache_` hash map key.

Rationale: 
  To avoid possible collisions. i.e., without a delimiter, the topic name "/motor" and type "controlsystem_msgs/msg/Foo" would create the same key as a topic name "/motorcontrol" and type "system_msgs/msg/Foo".

 - Fixes #1486

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
I used GitHub Copilot, GPT-4.1 to help with Doxygen comments

### Additional Information
N/A