### PR TITLE
Add input[output]_serialization_format to the RecordOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ output_bags:
   services: []
   all_actions: false
   actions: []
-  rmw_serialization_format: ""  # defaults to using the format of the input topic
+  input_serialization_format: ""   # defaults to using the format of the input topic
+  output_serialization_format: ""  # defaults to using the format of the input topic
   regex: ""
   exclude_regex: ""
   exclude_topics: []

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -146,7 +146,7 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
     # Core config
     parser.add_argument(
         '-f', '--serialization-format', default='', choices=serialization_choices,
-        help='The rmw serialization format in which the messages are saved, defaults to the '
+        help='The serialization format in which the messages are saved, defaults to the '
              'rmw currently in use.')
     parser.add_argument(
         '-b', '--max-bag-size', type=int, default=0,
@@ -381,7 +381,7 @@ class RecordVerb(VerbExtension):
         record_options.actions = args.actions if args.actions else []
 
         record_options.exclude_topic_types = args.exclude_topic_types
-        record_options.rmw_serialization_format = args.serialization_format
+        record_options.output_serialization_format = args.serialization_format
         record_options.topic_polling_interval = datetime.timedelta(
             milliseconds=args.polling_interval)
         record_options.regex = args.regex

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -116,8 +116,10 @@ class RecordOptions:
     ignore_leaf_topics: bool
     include_hidden_topics: bool
     include_unpublished_topics: bool
+    input_serialization_format: str
     is_discovery_disabled: bool
     node_prefix: str
+    output_serialization_format: str
     regex: str
     rmw_serialization_format: str
     services: List[str]

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -578,8 +578,18 @@ public:
     rclcpp::init(arguments.argc(), arguments.argv(),
                  rclcpp::InitOptions(), rclcpp::SignalHandlerOptions::None);
 
-    if (record_options.rmw_serialization_format.empty()) {
-      record_options.rmw_serialization_format = std::string(rmw_get_serialization_format());
+    if (!record_options.rmw_serialization_format.empty() &&
+      record_options.output_serialization_format.empty())
+    {
+      record_options.output_serialization_format = record_options.rmw_serialization_format;
+      PyErr_WarnEx(PyExc_DeprecationWarning,
+                   "The rmw_serialization_format option is deprecated and will be removed in a "
+                   "future release.\nPlease use output_serialization_format instead.",
+                   1
+      );
+    }
+    if (record_options.output_serialization_format.empty()) {
+      record_options.output_serialization_format = std::string(rmw_get_serialization_format());
     }
     auto writer = rosbag2_transport::ReaderWriterFactory::make_writer(record_options);
 
@@ -680,8 +690,18 @@ public:
     RecordOptions & record_options,
     const std::string & node_name)
   {
-    if (record_options.rmw_serialization_format.empty()) {
-      record_options.rmw_serialization_format = std::string(rmw_get_serialization_format());
+    if (!record_options.rmw_serialization_format.empty() &&
+      record_options.output_serialization_format.empty())
+    {
+      record_options.output_serialization_format = record_options.rmw_serialization_format;
+      PyErr_WarnEx(PyExc_DeprecationWarning,
+                   "The rmw_serialization_format option is deprecated and will be removed in a "
+                   "future release.\nPlease use output_serialization_format instead.",
+                   1
+      );
+    }
+    if (record_options.output_serialization_format.empty()) {
+      record_options.output_serialization_format = std::string(rmw_get_serialization_format());
     }
     auto writer = rosbag2_transport::ReaderWriterFactory::make_writer(record_options);
 
@@ -911,6 +931,8 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("topic_types", &RecordOptions::topic_types)
   .def_readwrite("exclude_topic_types", &RecordOptions::exclude_topic_types)
   .def_readwrite("rmw_serialization_format", &RecordOptions::rmw_serialization_format)
+  .def_readwrite("input_serialization_format", &RecordOptions::input_serialization_format)
+  .def_readwrite("output_serialization_format", &RecordOptions::output_serialization_format)
   .def_readwrite("topic_polling_interval", &RecordOptions::topic_polling_interval)
   .def_readwrite("regex", &RecordOptions::regex)
   .def_readwrite("exclude_regex", &RecordOptions::exclude_regex)

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_cpp_get_service_info.cpp
@@ -211,7 +211,7 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_services_only
   storage_options.storage_id = storage_id;
   storage_options.uri = bag_path_str;
   rosbag2_transport::RecordOptions record_options =
-  {false, true, false, false, {}, {}, {}, {}, {"/rosout"}, {}, {}, {}, "cdr", 100ms};
+  {false, true, false, false, {}, {}, {}, {}, {"/rosout"}, {}, {}, {}, {}, {}, "cdr", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer), storage_options, record_options);
   recorder->record();
@@ -292,7 +292,7 @@ TEST_P(Rosbag2CPPGetServiceInfoTest, get_service_info_for_bag_with_topics_and_se
   storage_options.storage_id = storage_id;
   storage_options.uri = bag_path_str;
   rosbag2_transport::RecordOptions record_options =
-  {true, true, false, false, {}, {}, {}, {}, {"/rosout"}, {}, {}, {}, "cdr", 100ms};
+  {true, true, false, false, {}, {}, {}, {}, {"/rosout"}, {}, {}, {}, {}, {}, "cdr", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer), storage_options, record_options);
   recorder->record();

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -42,7 +42,10 @@ public:
   std::vector<std::string> exclude_topic_types;
   std::vector<std::string> exclude_service_events;  // service event topics list
   std::vector<std::string> exclude_actions;         // actions name list
+  // rmw_serialization_format deprecated. Use output_serialization_format instead
   std::string rmw_serialization_format;
+  std::string input_serialization_format;
+  std::string output_serialization_format;
   std::chrono::milliseconds topic_polling_interval{100};
   std::string regex = "";
   std::string exclude_regex = "";

--- a/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
@@ -114,6 +114,12 @@ setup_topic_filtering(
     rosbag2_transport::TopicFilter topic_filter{record_options, nullptr, true};
     auto filtered_topics_and_types = topic_filter.filter_topics(input_topics);
 
+    std::string output_serialization_format = record_options.output_serialization_format;
+    // Fall back to the deprecated rmw_serialization_format if output format is unspecified
+    if (!record_options.rmw_serialization_format.empty() && output_serialization_format.empty()) {
+      output_serialization_format = record_options.rmw_serialization_format;
+    }
+
     // Done filtering - set up writer
     for (const auto & [topic_name, topic_type] : filtered_topics_and_types) {
       rosbag2_storage::TopicMetadata topic_metadata;
@@ -121,10 +127,10 @@ setup_topic_filtering(
       topic_metadata.type = topic_type;
 
       // Take source serialization format for the topic if output format is unspecified
-      if (record_options.rmw_serialization_format.empty()) {
+      if (output_serialization_format.empty()) {
         topic_metadata.serialization_format = input_topics_serialization_format[topic_name];
       } else {
-        topic_metadata.serialization_format = record_options.rmw_serialization_format;
+        topic_metadata.serialization_format = output_serialization_format;
       }
 
       topic_metadata.offered_qos_profiles = input_topics_qos_profiles[topic_name];

--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -319,6 +319,11 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
   record_options.rmw_serialization_format =
     node.declare_parameter<std::string>("record.rmw_serialization_format", "cdr");
 
+  record_options.input_serialization_format =
+    node.declare_parameter<std::string>("record.input_serialization_format", "cdr");
+  record_options.output_serialization_format =
+    node.declare_parameter<std::string>("record.output_serialization_format", "cdr");
+
   record_options.topic_polling_interval = param_utils::get_duration_from_node_param(
     node, "record.topic_polling_interval",
     0, 1000000).to_chrono<std::chrono::milliseconds>();

--- a/rosbag2_transport/src/rosbag2_transport/readers_manager_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/readers_manager_impl.hpp
@@ -50,7 +50,7 @@ public:
     earliest_timestamp_ = std::numeric_limits<rcutils_time_point_value_t>::max();
     latest_timestamp_ = std::numeric_limits<rcutils_time_point_value_t>::min();
     for (auto & [reader, options] : readers_with_options_) {
-      reader->open(options, {"", rmw_get_serialization_format()});
+      reader->open(options, {rmw_get_serialization_format(), rmw_get_serialization_format()});
       if (reader->has_next()) {
         next_messages_cache_.emplace_back(reader->read_next());
       }

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -37,6 +37,8 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
   node["services"] = record_options.services;
   node["actions"] = record_options.actions;
   node["rmw_serialization_format"] = record_options.rmw_serialization_format;
+  node["input_serialization_format"] = record_options.input_serialization_format;
+  node["output_serialization_format"] = record_options.output_serialization_format;
   node["topic_polling_interval"] = record_options.topic_polling_interval;
   node["regex"] = record_options.regex;
   node["exclude_regex"] = record_options.exclude_regex;
@@ -79,6 +81,10 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<std::vector<std::string>>(node, "actions", record_options.actions);
   optional_assign<std::string>(
     node, "rmw_serialization_format", record_options.rmw_serialization_format);
+  optional_assign<std::string>(
+    node, "input_serialization_format", record_options.input_serialization_format);
+  optional_assign<std::string>(
+    node, "output_serialization_format", record_options.output_serialization_format);
 
   optional_assign<std::chrono::milliseconds>(
     node, "topic_polling_interval", record_options.topic_polling_interval);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -133,7 +133,6 @@ private:
   std::unique_ptr<TopicFilter> topic_filter_;
   rclcpp::Event::SharedPtr discovery_graph_event_;
   std::future<void> discovery_future_;
-  std::string serialization_format_;
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides_;
   std::unordered_set<std::string> topic_unknown_types_;
   rclcpp::Service<rosbag2_interfaces::srv::IsPaused>::SharedPtr srv_is_paused_;
@@ -269,15 +268,33 @@ void RecorderImpl::record()
   }
   paused_ = record_options_.start_paused;
   topic_qos_profile_overrides_ = record_options_.topic_qos_profile_overrides;
-  if (record_options_.rmw_serialization_format.empty()) {
-    throw std::runtime_error("No serialization format specified!");
+  // Check serialization format options
+  if (!record_options_.rmw_serialization_format.empty() &&
+    record_options_.output_serialization_format.empty())
+  {
+    RCLCPP_WARN(node->get_logger(),
+      "The rmw_serialization_format option is deprecated and will be removed in a future release.\n"
+      "Please use output_serialization_format instead.");
+    record_options_.output_serialization_format = record_options_.rmw_serialization_format;
+  }
+  if (record_options_.input_serialization_format.empty()) {
+    record_options_.input_serialization_format = rmw_get_serialization_format();
+    RCLCPP_WARN(node->get_logger(),
+      "No input serialization format specified, using default rmw serialization format: '%s'.",
+      record_options_.input_serialization_format.c_str());
+  }
+  if (record_options_.output_serialization_format.empty()) {
+    record_options_.output_serialization_format = rmw_get_serialization_format();
+    RCLCPP_WARN(node->get_logger(),
+      "No output serialization format specified, using rmw serialization format. '%s'.",
+      record_options_.output_serialization_format.c_str());
   }
   subscriptions_.clear();
   event_notifier_->reset_total_num_messages_lost_in_transport();
   event_notifier_->reset_total_num_messages_lost_in_recorder();
   writer_->open(
     storage_options_,
-    {rmw_get_serialization_format(), record_options_.rmw_serialization_format});
+    {record_options_.input_serialization_format, record_options_.output_serialization_format});
 
   // Only expose snapshot service when mode is enabled
   if (storage_options_.snapshot_mode) {
@@ -343,7 +360,6 @@ void RecorderImpl::record()
     };
   writer_->add_event_callbacks(callbacks);
 
-  serialization_format_ = record_options_.rmw_serialization_format;
   RCLCPP_INFO(node->get_logger(), "Listening for topics...");
   if (!record_options_.use_sim_time) {
     subscribe_topics(get_requested_or_available_topics());
@@ -522,7 +538,7 @@ void RecorderImpl::subscribe_topics(
         0u,
         topic_with_type.first,
         topic_with_type.second,
-        serialization_format_,
+        record_options_.input_serialization_format,
         offered_qos_profiles_for_topic(endpoint_infos),
         type_description_hash_for_topic(endpoint_infos),
       });

--- a/rosbag2_transport/test/resources/recorder_node_params.yaml
+++ b/rosbag2_transport/test/resources/recorder_node_params.yaml
@@ -13,7 +13,8 @@ recorder_params_node:
       exclude_topic_types: ["sensor_msgs/msg/Image"]
       services: ["service", "other_service"]
       actions: ["action", "other_action"]
-      rmw_serialization_format: "cdr"
+      input_serialization_format: "cdr"
+      output_serialization_format: "cdr"
       topic_polling_interval:
         sec: 0
         nsec: 10000000

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
@@ -221,6 +221,8 @@ TEST_P(ComposableRecorderTests, recorder_can_parse_parameters_from_file) {
   std::vector<std::string> services {"/service/_service_event", "/other_service/_service_event"};
   EXPECT_EQ(record_options.services, services);
   EXPECT_EQ(record_options.rmw_serialization_format, "cdr");
+  EXPECT_EQ(record_options.input_serialization_format, "cdr");
+  EXPECT_EQ(record_options.output_serialization_format, "cdr");
   EXPECT_TRUE(record_options.topic_polling_interval == 0.01s);
   EXPECT_EQ(record_options.regex, "[xyz]/topic");
   EXPECT_EQ(record_options.exclude_regex, "(.*)");

--- a/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
@@ -194,7 +194,7 @@ TEST_F(RecordIntegrationTestFixture, test_keyboard_controls)
   auto keyboard_handler = std::make_shared<MockKeyboardHandler>();
 
   rosbag2_transport::RecordOptions record_options =
-  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   record_options.start_paused = true;
 
   auto recorder = std::make_shared<Recorder>(

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -47,7 +47,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
 
   rosbag2_transport::RecordOptions record_options =
   {false, false, false, false, {string_topic, array_topic},
-    {}, {}, {}, {}, {}, {}, {}, "rmw_format", 50ms};
+    {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", "rmw_format", 50ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -140,7 +140,10 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
     test_topic, basic_type_message, num_messages_to_publish, rclcpp::QoS{rclcpp::KeepAll()}, 50ms);
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {test_topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 50ms};
+  {
+    false, false, false, false, {test_topic}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format",
+    "rmw_format", 50ms
+  };
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -224,7 +227,7 @@ TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)
   pub_manager.setup_publisher(topic, string_message, 2);
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -289,7 +292,7 @@ TEST_F(RecordIntegrationTestFixture, records_sensor_data)
   pub_manager.setup_publisher(topic, string_message, 2, rclcpp::SensorDataQoS());
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -333,7 +336,7 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   pub_manager.run_publishers();
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -379,7 +382,7 @@ TEST_F(RecordIntegrationTestFixture, mixed_qos_subscribes) {
     topic, profile_transient_local);
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -428,7 +431,7 @@ TEST_F(RecordIntegrationTestFixture, duration_and_noncompatibility_policies_mixe
   auto publisher_liveliness = create_pub(profile_liveliness);
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, false, false, false, {topic}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -470,7 +473,10 @@ TEST_F(RecordIntegrationTestFixture, write_split_callback_is_called)
   }
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {string_topic}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {
+    false, false, false, false, {string_topic}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format",
+    10ms
+  };
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all.cpp
@@ -62,7 +62,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_topics_are
       RecorderEventNotifier::get_default_write_split_topic_name(),
       RecorderEventNotifier::get_default_messages_lost_topic_name(),
     },
-    {}, {}, {}, "rmw_format", 100ms
+    {}, {}, {}, {}, {}, "rmw_format", 100ms
   };
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
@@ -111,7 +111,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_services_a
     "test_service_2");
 
   rosbag2_transport::RecordOptions record_options =
-  {false, true, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, true, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<MockRecorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -159,7 +159,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_multiple_actions_ar
     "test_action_2");
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, true, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {false, false, true, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<MockRecorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();
@@ -229,7 +229,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_topic_service_actio
       RecorderEventNotifier::get_default_write_split_topic_name(),
       RecorderEventNotifier::get_default_messages_lost_topic_name(),
     },
-    {}, {}, {}, "rmw_format", 100ms
+    {}, {}, {}, {}, {}, "rmw_format", 100ms
   };
   auto recorder = std::make_shared<MockRecorder>(
     std::move(writer_), storage_options_, record_options);
@@ -292,7 +292,7 @@ TEST_F(RecordIntegrationTestFixture, cancel_event_messages_from_action_are_recor
       RecorderEventNotifier::get_default_write_split_topic_name(),
       RecorderEventNotifier::get_default_messages_lost_topic_name(),
     },
-    {}, {}, {}, "rmw_format", 100ms
+    {}, {}, {}, {}, {}, "rmw_format", 100ms
   };
   auto recorder = std::make_shared<MockRecorder>(
     std::move(writer_), storage_options_, record_options);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_ignore_leaf_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_ignore_leaf_topics.cpp
@@ -52,7 +52,7 @@ TEST_F(RecordIntegrationTestFixture, published_messages_from_two_topics_ignore_l
   pub_manager.setup_publisher(string_topic, string_message, 2);
 
   rosbag2_transport::RecordOptions record_options =
-  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   record_options.ignore_leaf_topics = true;
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_include_unpublished_topics.cpp
@@ -36,7 +36,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_false_ignore
     string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
 
   rosbag2_transport::RecordOptions record_options =
-  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   record_options.include_unpublished_topics = false;
   auto recorder = std::make_shared<MockRecorder>(writer_, storage_options_, record_options);
   recorder->record();
@@ -55,7 +55,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_include_unpublished_true_include
     string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
 
   rosbag2_transport::RecordOptions record_options =
-  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   record_options.include_unpublished_topics = true;
   auto recorder = std::make_shared<MockRecorder>(writer_, storage_options_, record_options);
   recorder->record();
@@ -76,7 +76,7 @@ TEST_F(
     string_topic, 10, [](test_msgs::msg::Strings::ConstSharedPtr) {});
 
   rosbag2_transport::RecordOptions record_options =
-  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {true, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   record_options.include_unpublished_topics = false;
   auto recorder = std::make_shared<MockRecorder>(writer_, storage_options_, record_options);
   recorder->record();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_no_discovery.cpp
@@ -38,7 +38,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_without_discovery_ignores_later_
   string_message->string_value = "Hello World";
 
   rosbag2_transport::RecordOptions record_options =
-  {true, false, false, true, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  {true, false, false, true, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
   auto recorder = std::make_shared<rosbag2_transport::Recorder>(
     std::move(writer_), storage_options_, record_options);
   recorder->record();

--- a/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_all_use_sim_time.cpp
@@ -97,7 +97,7 @@ TEST_F(RecordIntegrationTestFixture, record_all_with_sim_time)
 
   rosbag2_transport::RecordOptions record_options =
   {
-    false, false, false, false, {string_topic, clock_topic}, {}, {}, {}, {}, {}, {}, {},
+    false, false, false, false, {string_topic, clock_topic}, {}, {}, {}, {}, {}, {}, {}, {}, {},
     "rmw_format", 100ms
   };
   record_options.use_sim_time = true;

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -33,6 +33,8 @@ TEST(record_options, test_yaml_serialization)
   original.exclude_service_events = {"exclude_service1", "exclude_service2"};
   original.exclude_actions = {"exclude_action1", "exclude_action2"};
   original.rmw_serialization_format = "cdr";
+  original.input_serialization_format = "cdr";
+  original.output_serialization_format = "cdr";
   original.topic_polling_interval = std::chrono::milliseconds{200};
   original.regex = "[xyz]/topic";
   original.exclude_regex = "[x]/topic";
@@ -64,6 +66,8 @@ TEST(record_options, test_yaml_serialization)
   CHECK(exclude_service_events);
   CHECK(exclude_actions);
   CHECK(rmw_serialization_format);
+  CHECK(input_serialization_format);
+  CHECK(output_serialization_format);
   #undef CHECK
 }
 
@@ -73,7 +77,8 @@ TEST(record_options, test_yaml_decode_for_all_and_exclude)
     "  all: true\n"
     "  all_topics: false\n"
     "  topics: []\n"
-    "  rmw_serialization_format: \"\"  # defaults to using the format of the input topic\n"
+    "  input_serialization_format: \"\"  # defaults to using the format of the input topic\n"
+    "  output_serialization_format: \"\"  # defaults to using the format of the input topic\n"
     "  regex: \"[xyz]/topic\"\n"
     "  exclude: \"[x]/topic\"\n";
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -65,7 +65,7 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
   ASSERT_FALSE(std::regex_match(b4, re));
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   record_options.regex = regex;
 
   // TODO(karsten1987) Refactor this into publication manager
@@ -138,7 +138,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
   ASSERT_TRUE(std::regex_match(e1, exclude));
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   record_options.regex = regex;
   record_options.exclude_regex = topics_regex_to_exclude;
 
@@ -214,7 +214,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_topic_topic_recording)
   ASSERT_TRUE(e1 == topics_exclude);
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   record_options.regex = regex;
   record_options.exclude_topics.emplace_back(topics_exclude);
 
@@ -277,7 +277,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_service_recording)
   std::string b2 = "/namespace_before/not_nice";
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   record_options.regex = regex;
   record_options.exclude_regex = services_regex_to_exclude;
 
@@ -359,7 +359,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_service_service_recording
   std::string b2 = "/namespace_before/not_nice";
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   record_options.regex = regex;
   record_options.exclude_service_events.emplace_back(services_exclude);
 
@@ -441,7 +441,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_action_recording)
   std::string b2 = "/namespace_before/not_nice";
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   record_options.regex = regex;
   record_options.exclude_regex = actions_regex_to_exclude;
 
@@ -541,7 +541,7 @@ TEST_F(RecordIntegrationTestFixture, regex_and_exclude_actions_action_recording)
   std::string b2 = "/namespace_before/not_nice";
 
   rosbag2_transport::RecordOptions record_options =
-  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
   record_options.regex = regex;
   record_options.exclude_actions = action_exclude;
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -69,7 +69,10 @@ public:
     client_node_ = std::make_shared<rclcpp::Node>("test_record_client");
 
     rosbag2_transport::RecordOptions record_options =
-    {false, false, false, false, {test_topic_}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+    {
+      false, false, false, false, {test_topic_}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+      "rmw_format", 100ms
+    };
     storage_options_.snapshot_mode = snapshot_mode_;
     storage_options_.max_cache_size = 700;
     recorder_ = std::make_shared<rosbag2_transport::Recorder>(


### PR DESCRIPTION
## Description

This PR adds a new `input[output]_serialization_format` fields to the `RecordOptions` in replacement of the `RecordOptions::rmw_serialization_format`. The new options parameters are needed to avoid possible conversion to the CDR serialization if incoming messages are originally serialized in a different format, which is currently made by default. 

These changes needed to facilitate:
>  4.  -  [ ] Rosbag2 recorder has an option to avoid conversion to the CDR serialization format if the topic has a different serialization format.

from the #2214

The newly added `RecorderOption` fields explicitly specify input and output serialization formats for the messages the recorder processes. 
Please note that if `input_serialization_format` and `output_serialization_format` are different, the Rosbag2 recorder will try to find a plugin and use it for conversion from one serialization format to another.

- Relates #2214

### Is this user-facing behavior change?
Note: The former `RecordOptions::rmw_serialization_format` wasn't removed, but rather a deprecation message was added in the log if it is used.
While the backward compatibility on the API level is preserved, it is advised to use the newly added `RecordOptions::output_serialization_format` instead of the `RecordOptions::rmw_serialization_format` since the latter is expected to be removed after the next ROS 2 distro release.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-4.1 in my workflow

### Additional Information
Note: The former `RecordOptions::rmw_serialization_format` wasn't removed, but rather a deprecation message was added in the log if it is used.

This PR can't be backported since it introduces ABI-breaking changes.