### PR TITLE
Check for nullptrs when pushing new messages to the message cache

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/cache/circular_message_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/circular_message_cache.hpp
@@ -58,8 +58,8 @@ public:
 
   /// Puts msg into circular buffer, replacing the oldest msg when buffer is full
   /// \return True if message was successfully pushed, otherwise false.
-  /// NOTE: This will always return true, since the circular buffer by design drops old messages
-  /// when the buffer is full.
+  /// NOTE: Unless message is null or too large for the buffer, this will always return true
+  /// since the circular buffer by design drops old messages when the buffer is full.
   bool push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
 
   /// Get current buffer to consume.

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_circular_buffer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/message_cache_circular_buffer.hpp
@@ -54,8 +54,12 @@ public:
   explicit MessageCacheCircularBuffer(size_t max_cache_size);
 
   /**
-  * If buffer size has some space left, we push the message regardless of its size,
-  *  but if this results in exceeding buffer size, we begin dropping old messages.
+  * \brief Pushes a SerializedBagMessage into the cache buffer.
+  * \details If buffer size has some space left, we push the message regardless of its size,
+  * but if this results in exceeding buffer size, we begin dropping old messages.
+  * \param msg SerializedBagMessage to add to the buffer.
+  * \return True if message was successfully pushed. Returns false if msg is null or if msg size
+  * exceeds max buffer size.
   */
   bool push(CacheBufferInterface::buffer_element_t msg) override;
 

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
@@ -42,15 +42,8 @@ CircularMessageCache::~CircularMessageCache()
 
 bool CircularMessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
-  if (msg == nullptr) {
-    return false;
-  }
-
   std::lock_guard<std::mutex> cache_lock(producer_buffer_mutex_);
-  producer_buffer_->push(msg);
-  // Always return true since circular message cache drops old messages by design and it
-  // shouldn't be counted as a lost messages.
-  return true;
+  return producer_buffer_->push(msg);
 }
 
 std::shared_ptr<CacheBufferInterface> CircularMessageCache::get_consumer_buffer()

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/circular_message_cache.cpp
@@ -42,6 +42,10 @@ CircularMessageCache::~CircularMessageCache()
 
 bool CircularMessageCache::push(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
+  if (msg == nullptr) {
+    return false;
+  }
+
   std::lock_guard<std::mutex> cache_lock(producer_buffer_mutex_);
   producer_buffer_->push(msg);
   // Always return true since circular message cache drops old messages by design and it

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
@@ -32,6 +32,10 @@ MessageCacheCircularBuffer::MessageCacheCircularBuffer(size_t max_cache_size)
 
 bool MessageCacheCircularBuffer::push(CacheBufferInterface::buffer_element_t msg)
 {
+  if (msg == nullptr) {
+    return false;
+  }
+
   // Drop message if it exceeds the buffer size
   if (msg->serialized_data->buffer_length > max_bytes_size_) {
     ROSBAG2_CPP_LOG_WARN_STREAM("Last message exceeds snapshot buffer size. Dropping message!");

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
@@ -32,13 +32,14 @@ MessageCacheCircularBuffer::MessageCacheCircularBuffer(size_t max_cache_size)
 
 bool MessageCacheCircularBuffer::push(CacheBufferInterface::buffer_element_t msg)
 {
-  if (msg == nullptr) {
+  if (!msg || !msg->serialized_data) {
+    ROSBAG2_CPP_LOG_ERROR("Attempted to push null message into circular buffer. Dropping message!");
     return false;
   }
 
   // Drop message if it exceeds the buffer size
   if (msg->serialized_data->buffer_length > max_bytes_size_) {
-    ROSBAG2_CPP_LOG_WARN_STREAM("Last message exceeds snapshot buffer size. Dropping message!");
+    ROSBAG2_CPP_LOG_WARN("Last message exceeds snapshot buffer size. Dropping message!");
     return false;
   }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
@@ -133,3 +133,12 @@ TEST_F(CircularMessageCacheTest, circular_message_cache_ensure_empty) {
   EXPECT_THAT(circular_message_cache->get_consumer_buffer()->size(), Eq(0u));
   circular_message_cache->release_consumer_buffer();
 }
+
+TEST_F(CircularMessageCacheTest, circular_message_cache_rejects_null_message) {
+  auto circular_message_cache_ = std::make_shared<rosbag2_cpp::cache::CircularMessageCache>(
+  cache_size_);
+
+  bool result = true;
+  ASSERT_NO_THROW(result = circular_message_cache_->push(nullptr));
+  EXPECT_FALSE(result);
+}

--- a/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
+
 #include <chrono>
 #include <numeric>
 #include <memory>
@@ -23,13 +23,11 @@
 #include <vector>
 #include <thread>
 
-#include "rosbag2_cpp/cache/message_cache_circular_buffer.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
 #include "mock_cache_consumer.hpp"
 #include "mock_message_cache.hpp"
-
 
 using namespace testing;  // NOLINT
 
@@ -106,19 +104,4 @@ TEST_F(MessageCacheTest, message_cache_writes_full_producer_buffer) {
 
   mock_cache_consumer->stop();
   EXPECT_EQ(consumed_message_count, message_count - should_be_dropped_count);
-}
-
-class MessageCacheCircularBufferTest : public testing::Test {
-protected:
-  MessageCacheCircularBufferTest()
-  : buffer_(1024) {}
-  rosbag2_cpp::cache::MessageCacheCircularBuffer buffer_;
-};
-
-TEST_F(MessageCacheCircularBufferTest, PushNullptrCausesCrash) {
-  bool result = true;
-  ASSERT_NO_THROW({
-    result = buffer_.push(nullptr);
-  });
-  EXPECT_FALSE(result);
 }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_message_cache.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-
+#include <gtest/gtest.h>
 #include <chrono>
 #include <numeric>
 #include <memory>
@@ -23,11 +23,13 @@
 #include <vector>
 #include <thread>
 
+#include "rosbag2_cpp/cache/message_cache_circular_buffer.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
 #include "mock_cache_consumer.hpp"
 #include "mock_message_cache.hpp"
+
 
 using namespace testing;  // NOLINT
 
@@ -104,4 +106,19 @@ TEST_F(MessageCacheTest, message_cache_writes_full_producer_buffer) {
 
   mock_cache_consumer->stop();
   EXPECT_EQ(consumed_message_count, message_count - should_be_dropped_count);
+}
+
+class MessageCacheCircularBufferTest : public testing::Test {
+protected:
+  MessageCacheCircularBufferTest()
+  : buffer_(1024) {}
+  rosbag2_cpp::cache::MessageCacheCircularBuffer buffer_;
+};
+
+TEST_F(MessageCacheCircularBufferTest, PushNullptrCausesCrash) {
+  bool result = true;
+  ASSERT_NO_THROW({
+    result = buffer_.push(nullptr);
+  });
+  EXPECT_FALSE(result);
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Adds a simple check to the message cache circular buffer when pushing nullptr messages.
Changed CircularMessageCache to report when dropping messages (null or too large for buffer).

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes #2115

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

As it only adds a check if the message is a nullptr, this should not change any normal runtime behavior as this should always trigger a segmentation fault or at minimum UB.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
