### PR TITLE
Add a direct API for rosbag2_transport::Recorder

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -117,8 +117,101 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   virtual ~Recorder();
 
+  /// @brief Start recording.
+  /// The record() method will return almost immediately and recording will happen in background.
   ROSBAG2_TRANSPORT_PUBLIC
   void record();
+
+  /// @brief Add a new channel (topic) to the rosbag2 writer to be recorded.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::add_topic().
+  /// \note This method does not require the message definition. The recorder will try to find the
+  /// corresponding message definition by the given topic name and type.
+  /// @param topic_name The name of the topic.
+  /// @param topic_type The type of the topic.
+  /// @param serialization_format The serialization format of the topic.
+  /// @param type_description_hash REP-2011 type description hash of the topic.
+  /// @param offered_qos_profiles The list of offered QoS profiles for the topic if available.
+  ROSBAG2_TRANSPORT_PUBLIC
+  void add_channel(
+    const std::string & topic_name,
+    const std::string & topic_type,
+    const std::string & serialization_format = "memory_view",
+    const std::string & type_description_hash = "",
+    const std::vector<rclcpp::QoS> & offered_qos_profiles = {});
+
+  /// \brief Add a new channel (topic) to the rosbag2 writer to be recorded.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::add_topic().
+  /// \param topic_name The name of the topic.
+  /// \param topic_type The type of the topic.
+  /// \param message_definition_encoding The encoding technique used in
+  /// the `encoded_message_definition` e.g. "ros2idl", "ros2msg", "apex_json" or "unknown" if
+  /// encoded_message_definition is empty.
+  /// \param encoded_message_definition The fully encoded message definition for this type.
+  /// \param serialization_format The serialization format of the topic.
+  /// \param type_description_hash REP-2011 type description hash of the topic.
+  /// \param offered_qos_profiles The list of offered QoS profiles for the topic if available.
+  ROSBAG2_TRANSPORT_PUBLIC
+  void add_channel(
+    const std::string & topic_name,
+    const std::string & topic_type,
+    const std::string & message_definition_encoding,
+    const std::string & encoded_message_definition,
+    const std::string & serialization_format = "memory_view",
+    const std::string & type_description_hash = "",
+    const std::vector<rclcpp::QoS> & offered_qos_profiles = {});
+
+  /// @brief Write a serialized message to the bag file.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::write().
+  /// \note This method assumes that the topic has already been created via add_channel().
+  /// \note If recorder is in pause mode, this method will return without writing anything.
+  /// @param serialized_data The serialized message data to write.
+  /// @param topic_name The name of the topic the message belongs to.
+  /// @param pub_timestamp The original or publication timestamp of the message.
+  /// @param sequence_number An optional sequence number of the message. If non-zero, sequence
+  /// numbers should be unique per channel and increasing over time.
+  /// \throws std::runtime_error if topic has not been added via add_channel().
+  ROSBAG2_TRANSPORT_PUBLIC
+  void write_message(
+    std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+    const std::string & topic_name,
+    const rcutils_time_point_value_t & pub_timestamp,
+    uint32_t sequence_number = 0);
+
+  /// @brief Write a serialized message to the bag file with receive timestamp.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::write().
+  /// \note This method assumes that the topic has already been created via add_channel().
+  /// \note If recorder is in pause mode, this method will return without writing anything.
+  /// @param serialized_data The serialized message data to write.
+  /// @param topic_name The name of the topic the message belongs to.
+  /// @param pub_timestamp The original or publication timestamp of the message in nanoseconds.
+  /// @param recv_timestamp The timestamp of the message in nanoseconds when message was received.
+  /// @param sequence_number An optional sequence number of the message. If non-zero, sequence
+  /// numbers should be unique per channel and increasing over time.
+  /// \throws std::runtime_error if topic has not been added via add_channel().
+  ROSBAG2_TRANSPORT_PUBLIC
+  void write_message(
+    std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+    const std::string & topic_name,
+    const rcutils_time_point_value_t & pub_timestamp,
+    const rcutils_time_point_value_t & recv_timestamp,
+    uint32_t sequence_number = 0);
+
+  /// @brief Updates recorder about lost messages on transport layer.
+  /// @details This a direct recorder API and this method is expected to be called when messages
+  /// are lost in the transport layer.
+  /// The recorder may use this information for logging or metrics.
+  /// @param topic_name The name of the topic.
+  /// @param qos_msgs_lost_info Information about lost messages.
+  ROSBAG2_TRANSPORT_PUBLIC
+  void on_messages_lost_in_transport(
+    const std::string & topic_name,
+    const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info);
+
+  /// @brief Get total number of messages lost in transport layer.
+  /// @return Total number of messages lost in transport layer.
+  [[nodiscard]]
+  ROSBAG2_TRANSPORT_PUBLIC
+  uint64_t get_total_num_messages_lost_in_transport() const;
 
   /// @brief Stopping recording.
   /// @details The stop() is opposite to the record() operation. It will stop recording, dump

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -63,12 +63,98 @@ public:
 
   ~RecorderImpl();
 
+  /// @brief Start recording.
+  /// The record() method will return almost immediately and recording will happen in background.
   void record();
+
+  /// @brief Add a new channel (topic) to the rosbag2 writer to be recorded.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::add_topic().
+  /// \note This method does not require the message definition. The recorder will try to find the
+  /// corresponding message definition by the given topic name and type.
+  /// @param topic_name The name of the topic.
+  /// @param topic_type The type of the topic.
+  /// @param serialization_format The serialization format of the topic.
+  /// @param type_description_hash REP-2011 type description hash of the topic.
+  /// @param offered_qos_profiles The list of offered QoS profiles for the topic.
+  void add_channel(
+    const std::string & topic_name,
+    const std::string & topic_type,
+    const std::string & serialization_format = "memory_view",
+    const std::string & type_description_hash = "",
+    const std::vector<rclcpp::QoS> & offered_qos_profiles = {});
+
+  /// \brief Add a new channel (topic) to the rosbag2 writer to be recorded.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::add_topic().
+  /// \param topic_name The name of the topic.
+  /// \param topic_type The type of the topic.
+  /// \param message_definition_encoding The encoding technique used in
+  /// the `encoded_message_definition` e.g. "ros2idl", "ros2msg", "apex_json" or "unknown" if
+  /// encoded_message_definition is empty.
+  /// \param encoded_message_definition The fully encoded message definition for this type.
+  /// \param serialization_format The serialization format of the topic.
+  /// \param type_description_hash REP-2011 type description hash of the topic.
+  /// \param offered_qos_profiles The list of offered QoS profiles for the topic.
+  void add_channel(
+    const std::string & topic_name,
+    const std::string & topic_type,
+    const std::string & message_definition_encoding,
+    const std::string & encoded_message_definition,
+    const std::string & serialization_format = "memory_view",
+    const std::string & type_description_hash = "",
+    const std::vector<rclcpp::QoS> & offered_qos_profiles = {});
+
+  /// @brief Write a serialized message to the bag file.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::write().
+  /// \note This method assumes that the topic has already been created via add_channel().
+  /// \note If recorder is in pause mode, this method will return without writing anything.
+  /// \note This overload uses only publication timestamp. The received timestamp will be taken
+  /// from the underlying node's clock at the time of writing.
+  /// @param serialized_data The serialized message data to write.
+  /// @param topic_name The name of the topic the message belongs to.
+  /// @param pub_timestamp The original or publication timestamp of the message in nanoseconds.
+  /// @param sequence_number An optional sequence number of the message. If non-zero, sequence
+  /// numbers should be unique per channel and increasing over time.
+  /// \throws std::runtime_error if topic has not been added via add_channel().
+  void write_message(
+    std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+    const std::string & topic_name,
+    const rcutils_time_point_value_t & pub_timestamp,
+    uint32_t sequence_number = 0);
+
+  /// @brief Write a serialized message to the bag file with receive timestamp.
+  /// \details This is a direct Recorder API equivalent to the rosbag2_cpp::Writer::write().
+  /// \note This method assumes that the topic has already been created via add_channel().
+  /// \note If recorder is in pause mode, this method will return without writing anything.
+  /// @param serialized_data The serialized message data to write.
+  /// @param topic_name The name of the topic the message belongs to.
+  /// @param pub_timestamp The original or publication timestamp of the message in nanoseconds.
+  /// @param recv_timestamp The timestamp of the message in nanoseconds when message was received.
+  /// @param sequence_number An optional sequence number of the message. If non-zero, sequence
+  /// numbers should be unique per channel and increasing over time.
+  /// \throws std::runtime_error if topic has not been added via add_channel().
+  void write_message(
+    std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+    const std::string & topic_name,
+    const rcutils_time_point_value_t & pub_timestamp,
+    const rcutils_time_point_value_t & recv_timestamp,
+    uint32_t sequence_number = 0);
+
+
+  /// @brief Updates recorder about lost messages on transport layer.
+  /// @details This a direct recorder API and this method is expected to be called when messages
+  /// are lost in the transport layer.
+  /// The recorder may use this information for logging or metrics.
+  /// @param topic_name The name of the topic.
+  /// @param qos_msgs_lost_info Information about lost messages.
+  void on_messages_lost_in_transport(
+    const std::string & topic_name,
+    const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info);
 
   /// @brief Stopping recording and closing writer.
   /// The record() can be called again after stop().
   void stop();
 
+  /// Get a const reference to the underlying rosbag2 writer.
   const rosbag2_cpp::Writer & get_writer_handle();
 
   /// Pause the recording.
@@ -150,6 +236,7 @@ private:
   KeyboardHandler::callback_handle_t toggle_paused_key_callback_handle_ =
     KeyboardHandler::invalid_handle;
 
+public:
   std::unique_ptr<RecorderEventNotifier> event_notifier_;
 };
 
@@ -545,6 +632,89 @@ void RecorderImpl::subscribe_topics(
   }
 }
 
+void RecorderImpl::add_channel(
+  const std::string & topic_name,
+  const std::string & topic_type,
+  const std::string & serialization_format,
+  const std::string & type_description_hash,
+  const std::vector<rclcpp::QoS> & offered_qos_profiles)
+{
+  rosbag2_storage::TopicMetadata topic_with_type{
+    0u,
+    topic_name,
+    topic_type,
+    serialization_format,
+    offered_qos_profiles,
+    type_description_hash,
+  };
+  writer_->create_topic(topic_with_type);
+}
+
+void RecorderImpl::add_channel(
+  const std::string & topic_name,
+  const std::string & topic_type,
+  const std::string & message_definition_encoding,
+  const std::string & encoded_message_definition,
+  const std::string & serialization_format,
+  const std::string & type_description_hash,
+  const std::vector<rclcpp::QoS> & offered_qos_profiles)
+{
+  rosbag2_storage::TopicMetadata topic_with_type{
+    0u,
+    topic_name,
+    topic_type,
+    serialization_format,
+    offered_qos_profiles,
+    type_description_hash,
+  };
+  rosbag2_storage::MessageDefinition message_definition{
+    topic_type,
+    message_definition_encoding,
+    encoded_message_definition,
+    type_description_hash
+  };
+  writer_->create_topic(topic_with_type, message_definition);
+}
+
+void RecorderImpl::write_message(
+  std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+  const std::string & topic_name,
+  const rcutils_time_point_value_t & pub_timestamp,
+  uint32_t sequence_number)
+{
+  write_message(
+    std::move(serialized_data),
+    topic_name,
+    pub_timestamp,
+    node->now().nanoseconds(),
+    sequence_number);
+}
+
+void RecorderImpl::write_message(
+  std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+  const std::string & topic_name,
+  const rcutils_time_point_value_t & pub_timestamp,
+  const rcutils_time_point_value_t & recv_timestamp,
+  uint32_t sequence_number)
+{
+  if (!paused_.load()) {
+    auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+    bag_message->serialized_data = std::move(serialized_data);
+    bag_message->topic_name = topic_name;
+    bag_message->recv_timestamp = recv_timestamp;
+    bag_message->send_timestamp = pub_timestamp;
+    bag_message->sequence_number = sequence_number;
+    writer_->write(bag_message);
+  }
+}
+
+void RecorderImpl::on_messages_lost_in_transport(
+  const std::string & topic_name,
+  const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info)
+{
+  event_notifier_->on_messages_lost_in_transport(topic_name, qos_msgs_lost_info);
+}
+
 void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 {
   if (subscriptions_.find(topic.name) != subscriptions_.end()) {
@@ -579,7 +749,7 @@ RecorderImpl::create_subscription(
   rclcpp::SubscriptionOptions sub_options;
   sub_options.event_callbacks.message_lost_callback =
     [this, topic_name](const rclcpp::QOSMessageLostInfo & msgs_lost_info) {
-      this->event_notifier_->on_messages_lost_in_transport(topic_name, msgs_lost_info);
+      on_messages_lost_in_transport(topic_name, msgs_lost_info);
     };
 
 #ifdef _WIN32
@@ -817,6 +987,63 @@ Recorder::~Recorder() = default;
 void Recorder::record()
 {
   pimpl_->record();
+}
+
+void Recorder::add_channel(
+  const std::string & topic_name,
+  const std::string & topic_type,
+  const std::string & serialization_format,
+  const std::string & type_description_hash,
+  const std::vector<rclcpp::QoS> & offered_qos_profiles)
+{
+  pimpl_->add_channel(
+    topic_name, topic_type, serialization_format, type_description_hash, offered_qos_profiles);
+}
+
+void Recorder::add_channel(
+  const std::string & topic_name,
+  const std::string & topic_type,
+  const std::string & message_definition_encoding,
+  const std::string & encoded_message_definition,
+  const std::string & serialization_format,
+  const std::string & type_description_hash,
+  const std::vector<rclcpp::QoS> & offered_qos_profiles)
+{
+  pimpl_->add_channel(
+    topic_name, topic_type, message_definition_encoding, encoded_message_definition,
+    serialization_format, type_description_hash, offered_qos_profiles);
+}
+
+void Recorder::write_message(
+  std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+  const std::string & topic_name,
+  const rcutils_time_point_value_t & pub_timestamp,
+  uint32_t sequence_number)
+{
+  pimpl_->write_message(
+    std::move(serialized_data), topic_name, pub_timestamp, sequence_number);
+}
+
+void Recorder::write_message(
+  std::shared_ptr<rcutils_uint8_array_t> serialized_data,
+  const std::string & topic_name,
+  const rcutils_time_point_value_t & pub_timestamp,
+  const rcutils_time_point_value_t & recv_timestamp,
+  uint32_t sequence_number)
+{
+  pimpl_->write_message(
+    std::move(serialized_data), topic_name, pub_timestamp, recv_timestamp, sequence_number);
+}
+
+void Recorder::on_messages_lost_in_transport(
+  const std::string & topic_name, const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info)
+{
+  pimpl_->on_messages_lost_in_transport(topic_name, qos_msgs_lost_info);
+}
+
+uint64_t Recorder::get_total_num_messages_lost_in_transport() const
+{
+  return pimpl_->event_notifier_->get_total_num_messages_lost_in_transport();
 }
 
 void Recorder::stop()

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -150,6 +150,11 @@ public:
     const std::string & topic_name,
     const rclcpp::QOSMessageLostInfo & qos_msgs_lost_info);
 
+  /// @brief Get total number of messages lost in transport layer.
+  /// @return Total number of messages lost in transport layer.
+  [[nodiscard]]
+  uint64_t get_total_num_messages_lost_in_transport() const;
+
   /// @brief Stopping recording and closing writer.
   /// The record() can be called again after stop().
   void stop();
@@ -236,7 +241,6 @@ private:
   KeyboardHandler::callback_handle_t toggle_paused_key_callback_handle_ =
     KeyboardHandler::invalid_handle;
 
-public:
   std::unique_ptr<RecorderEventNotifier> event_notifier_;
 };
 
@@ -715,6 +719,11 @@ void RecorderImpl::on_messages_lost_in_transport(
   event_notifier_->on_messages_lost_in_transport(topic_name, qos_msgs_lost_info);
 }
 
+uint64_t RecorderImpl::get_total_num_messages_lost_in_transport() const
+{
+  return event_notifier_->get_total_num_messages_lost_in_transport();
+}
+
 void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 {
   if (subscriptions_.find(topic.name) != subscriptions_.end()) {
@@ -1043,7 +1052,7 @@ void Recorder::on_messages_lost_in_transport(
 
 uint64_t Recorder::get_total_num_messages_lost_in_transport() const
 {
-  return pimpl_->event_notifier_->get_total_num_messages_lost_in_transport();
+  return pimpl_->get_total_num_messages_lost_in_transport();
 }
 
 void Recorder::stop()

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <rosbag2_storage/ros_helper.hpp>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -530,4 +531,250 @@ TEST_F(RecordIntegrationTestFixture, toggle_paused_do_pause_resume)
   test_output = testing::internal::GetCapturedStderr();
   EXPECT_TRUE(recorder->is_paused());
   EXPECT_TRUE(test_output.find("Pausing recording.") != std::string::npos);
+}
+
+TEST_F(RecordIntegrationTestFixture, add_channel_creates_topic_in_writer)
+{
+  rosbag2_transport::RecordOptions record_options{};
+  record_options.is_discovery_disabled = true;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  std::string topic_name = "/test_channel";
+  std::string topic_type = "rosbag2_test_msgdefs/ComplexMsg";
+  std::string serialization_format = "cdr";
+
+  recorder->record();
+
+  recorder->add_channel(topic_name, topic_type, serialization_format);
+
+  EXPECT_THAT(recorder->subscriptions().size(), 0u);
+
+  auto & writer = recorder->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  auto recorded_topics = mock_writer.get_topics();
+
+  EXPECT_EQ(recorded_topics.count(topic_name), 1u);
+  EXPECT_EQ(recorded_topics.at(topic_name).first.name, topic_name);
+  EXPECT_EQ(recorded_topics.at(topic_name).first.type, topic_type);
+  EXPECT_EQ(recorded_topics.at(topic_name).first.serialization_format, serialization_format);
+
+  recorder->stop();
+}
+
+TEST_F(RecordIntegrationTestFixture, add_channel_with_message_definition)
+{
+  rosbag2_transport::RecordOptions record_options{};
+  record_options.is_discovery_disabled = true;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  std::string topic_name = "/test_channel_with_def";
+  std::string topic_type = "test_msgs/msg/BasicTypes";
+  std::string message_definition_encoding = "ros2idl";
+  std::string encoded_message_definition = "string test_field";
+  std::string serialization_format = "cdr";
+
+  recorder->record();
+
+  recorder->add_channel(topic_name, topic_type, message_definition_encoding,
+                        encoded_message_definition, serialization_format);
+
+  auto & writer = recorder->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  auto recorded_topics = mock_writer.get_topics();
+
+  EXPECT_EQ(recorded_topics.count(topic_name), 1u);
+  EXPECT_EQ(recorded_topics.at(topic_name).first.name, topic_name);
+  EXPECT_EQ(recorded_topics.at(topic_name).first.type, topic_type);
+  EXPECT_EQ(recorded_topics.at(topic_name).second.encoding, message_definition_encoding);
+  EXPECT_EQ(
+    recorded_topics.at(topic_name).second.encoded_message_definition,
+    encoded_message_definition
+  );
+  recorder->stop();
+}
+
+TEST_F(RecordIntegrationTestFixture, write_message_writes_to_bag)
+{
+  rosbag2_transport::RecordOptions record_options{};
+  const std::string serialization_format = "memory_view";
+  record_options.input_serialization_format = serialization_format;
+  record_options.output_serialization_format = serialization_format;
+  record_options.is_discovery_disabled = true;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  const std::string topic_name = "/direct_write_topic";
+  const std::string topic_type = "test_msgs/msg/Strings";
+
+  // Add channel first
+  recorder->add_channel(topic_name, topic_type, serialization_format);
+
+  recorder->record();
+
+  const uint32_t num_messages = 5U;
+  const rcutils_time_point_value_t initial_timestamp = 1234567890;
+
+  for (uint32_t i = 0; i < num_messages; i++) {
+    // Create serialized message
+    uint64_t msg_content_uint64_value = i * 1000;
+    auto serialized_data =
+      rosbag2_storage::make_serialized_message(&msg_content_uint64_value,
+                                               sizeof(msg_content_uint64_value));
+
+    rcutils_time_point_value_t timestamp = initial_timestamp + (i * 200);
+    uint32_t sequence_number = i;
+    recorder->write_message(serialized_data, topic_name, timestamp, timestamp + 1, sequence_number);
+  }
+
+  auto & writer = recorder->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  ASSERT_EQ(mock_writer.get_number_of_recorded_messages(), num_messages);
+
+  auto recorded_messages = mock_writer.get_messages();
+  ASSERT_EQ(recorded_messages.size(), num_messages);
+
+  for (uint32_t i = 0; i < num_messages; i++) {
+    EXPECT_EQ(recorded_messages[i]->topic_name, topic_name);
+    EXPECT_EQ(recorded_messages[i]->send_timestamp, initial_timestamp + (i * 200));
+    EXPECT_EQ(recorded_messages[i]->recv_timestamp, initial_timestamp + (i * 200) + 1);
+    EXPECT_EQ(recorded_messages[i]->sequence_number, i);
+
+    uint64_t recorded_message_value =
+      *(reinterpret_cast<uint64_t *>(recorded_messages[i]->serialized_data->buffer));
+    EXPECT_EQ(recorded_message_value, i * 1000);
+  }
+
+  recorder->stop();
+}
+
+TEST_F(RecordIntegrationTestFixture, write_message_uses_recv_timestamp_from_node_clock)
+{
+  rosbag2_transport::RecordOptions record_options{};
+  const std::string serialization_format = "memory_view";
+  record_options.input_serialization_format = serialization_format;
+  record_options.output_serialization_format = serialization_format;
+  record_options.is_discovery_disabled = true;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  const std::string topic_name = "/direct_write_topic";
+  const std::string topic_type = "test_msgs/msg/Strings";
+
+  // Add channel first
+  recorder->add_channel(topic_name, topic_type, serialization_format);
+
+  recorder->record();
+
+  const uint32_t num_messages = 5u;
+  const rcutils_time_point_value_t initial_timestamp = 1234567890;
+
+  for (uint32_t i = 0; i < num_messages; i++) {
+    // Create serialized message
+    uint64_t msg_content_uint64_value = i * 1000;
+    auto serialized_data =
+      rosbag2_storage::make_serialized_message(&msg_content_uint64_value,
+                                               sizeof(msg_content_uint64_value));
+
+    rcutils_time_point_value_t timestamp = initial_timestamp + (i * 200);
+    uint32_t sequence_number = i;
+    recorder->write_message(serialized_data, topic_name, timestamp, sequence_number);
+  }
+
+  auto & writer = recorder->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  ASSERT_EQ(mock_writer.get_number_of_recorded_messages(), num_messages);
+
+  auto recorded_messages = mock_writer.get_messages();
+  ASSERT_EQ(recorded_messages.size(), num_messages);
+
+  for (uint32_t i = 0; i < num_messages; i++) {
+    EXPECT_EQ(recorded_messages[i]->topic_name, topic_name);
+    EXPECT_EQ(recorded_messages[i]->send_timestamp, initial_timestamp + (i * 200));
+    // recv_timestamp should be set by the node's clock, so it should be different from
+    // send_timestamp or zero.
+    EXPECT_NE(recorded_messages[i]->recv_timestamp, recorded_messages[i]->send_timestamp);
+    EXPECT_NE(recorded_messages[i]->recv_timestamp, 0);
+    EXPECT_EQ(recorded_messages[i]->sequence_number, i);
+
+    uint64_t recorded_message_value =
+      *(reinterpret_cast<uint64_t *>(recorded_messages[i]->serialized_data->buffer));
+    EXPECT_EQ(recorded_message_value, i * 1000);
+  }
+
+  recorder->stop();
+}
+
+TEST_F(RecordIntegrationTestFixture, write_message_does_not_write_when_paused)
+{
+  rosbag2_transport::RecordOptions record_options{};
+  const std::string serialization_format = "memory_view";
+  record_options.input_serialization_format = serialization_format;
+  record_options.output_serialization_format = serialization_format;
+  record_options.is_discovery_disabled = true;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  // Create serialized message
+  uint64_t msg_content_uint64_value = 12345;
+  auto serialized_data = rosbag2_storage::make_serialized_message(&msg_content_uint64_value,
+                                                                  sizeof(msg_content_uint64_value));
+
+  recorder->record();
+
+  const std::string topic_name = "/paused_write_topic";
+  const std::string topic_type = "test_msgs/msg/Strings";
+  recorder->add_channel(topic_name, topic_type, serialization_format, "unknown", "");
+
+  // Pause recording
+  recorder->pause();
+  ASSERT_TRUE(recorder->is_paused());
+
+  // Try to write message while paused
+  rcutils_time_point_value_t timestamp = 1234567890;
+  uint32_t sequence_number = 42;
+  recorder->write_message(serialized_data, topic_name, timestamp, sequence_number);
+
+  auto & writer = recorder->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  auto recorded_messages = mock_writer.get_messages();
+
+  // No messages should be recorded while paused
+  EXPECT_EQ(recorded_messages.size(), 0u);
+
+  recorder->stop();
+}
+
+TEST_F(RecordIntegrationTestFixture, on_messages_lost_in_transport_updates_statistics)
+{
+  rosbag2_transport::RecordOptions record_options{};
+  record_options.is_discovery_disabled = true;
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  std::string topic_name = "/lost_topic";
+  std::string topic_type = "test_msgs/msg/BasicTypes";
+  std::string serialization_format = "cdr";
+
+  recorder->record();
+  recorder->add_channel(topic_name, topic_type, serialization_format);
+
+  rclcpp::QOSMessageLostInfo lost_info;
+  lost_info.total_count = 5;
+  lost_info.total_count_change = 3;
+
+  recorder->on_messages_lost_in_transport(topic_name, lost_info);
+  lost_info.total_count++;
+  lost_info.total_count_change = 1;
+  recorder->on_messages_lost_in_transport(topic_name, lost_info);
+
+  EXPECT_EQ(recorder->get_total_num_messages_lost_in_transport(), 4u);
+
+  recorder->stop();
 }


### PR DESCRIPTION
## Description
This PR adds a direct API for rosbag2_transport::Recorder to enable direct use of the recorder without creating any subscriptions. For instance, from device drivers.

- This PR depends on https://github.com/ros2/rosbag2/pull/2215

Added direct recorder API add_channel(..) and write_message(..)
Added direct write_message(..) API with recv_timestamp 
Added direct `on_messages_lost_in_transport(..)` API
   Note: The `on_messages_lost_in_transport(..)` method is expected to be called when messages are lost in the transport layer.
Added `get_total_num_messages_lost_in_transport()` getter method.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes #2214

### Is this user-facing behavior change?
No. However, the new API will become available

### Did you use Generative AI?
Yes, I am using GitHub Copilot, GPT-5 in my workflow, mostly to help with writing tests and documentation.

### Additional Information
This PR will be difficult to backport since it depends on the non-backportable other PR #2215