### PR TITLE
Upstream minor fixes from Apex.AI

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_reader.cpp
@@ -346,6 +346,7 @@ public:
       // Check both timestamp and value to uniquely identify messages in expected order
       ASSERT_TRUE(reader.has_next());
       auto next = reader.read_next();
+      ASSERT_NE(next, nullptr);
       EXPECT_EQ(next->recv_timestamp, expect_timestamp);
 
       ASSERT_EQ(next->serialized_data->buffer_length, 4u);

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -498,6 +498,7 @@ protected:
     }
     install_signal_handlers();
     try {
+      exit_ = false;
       start_spin();
       player_->play();
 

--- a/rosbag2_storage/include/rosbag2_storage/qos.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/qos.hpp
@@ -57,6 +57,13 @@ public:
   /// \return string representation of this QoS profile.
   [[nodiscard]] std::string to_string() const;
 
+  static Rosbag2QoS EventQoS()
+  {
+    return Rosbag2QoS(rclcpp::QoS(3)
+             .reliable()
+             .durability_volatile());
+  }
+
   // Create an adaptive QoS profile to use for subscribing to a set of offers from publishers.
   /**
     * - Uses history keep last with the maximum depth from all publishers. If depth is 0, it

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -1634,8 +1634,7 @@ void PlayerImpl::prepare_publishers()
 
   // Create a publisher and callback for when encountering a split in the input
   split_event_pub_ = owner_->create_publisher<rosbag2_interfaces::msg::ReadSplitEvent>(
-    "events/read_split",
-    1);
+    "events/read_split", rosbag2_storage::Rosbag2QoS::EventQoS());
   rosbag2_cpp::bag_events::ReaderEventCallbacks callbacks;
   callbacks.read_split_callback =
     [this](rosbag2_cpp::bag_events::BagSplitInfo & info) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -451,17 +451,19 @@ void RecorderImpl::record()
     };
   writer_->add_event_callbacks(callbacks);
 
-  RCLCPP_INFO(node->get_logger(), "Listening for topics...");
   if (!record_options_.use_sim_time) {
     subscribe_topics(get_requested_or_available_topics());
   }
   if (!record_options_.is_discovery_disabled) {
     start_discovery();
+    RCLCPP_INFO(node->get_logger(), "Listening for topics...");
   }
   if (record_options_.start_paused) {
-    RCLCPP_INFO(
-      node->get_logger(), "Wait for recording: Press %s to start.",
-      enum_key_code_to_str(Recorder::kPauseResumeToggleKey).c_str());
+    if (!record_options_.disable_keyboard_controls) {
+      RCLCPP_INFO(
+        node->get_logger(), "Wait for recording: Press %s to start.",
+        enum_key_code_to_str(Recorder::kPauseResumeToggleKey).c_str());
+    }
   } else {
     RCLCPP_INFO(node->get_logger(), "Recording...");
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -35,6 +35,7 @@
 #include "rosbag2_interfaces/msg/messages_lost_event.hpp"
 #include "rosbag2_interfaces/msg/write_split_event.hpp"
 #include "rosbag2_cpp/bag_events.hpp"
+#include "rosbag2_storage/qos.hpp"
 #include "rosbag2_transport/rclcpp_publisher_wrapper.hpp"
 #include "rosbag2_transport/recorder_event_notifier.hpp"
 
@@ -62,14 +63,16 @@ public:
       split_event_pub_ = std::move(split_event_pub);
     } else {
       split_event_pub_ = RclcppPublisherWrapper<WriteSplitEvent>::make_shared(
-        node->create_publisher<WriteSplitEvent>(kDefaultWriteSplitTopicName, 1));
+        node->create_publisher<WriteSplitEvent>(kDefaultWriteSplitTopicName,
+                                                rosbag2_storage::Rosbag2QoS::EventQoS()));
     }
 
     if (msgs_lost_event_pub) {
       msgs_lost_event_pub_ = std::move(msgs_lost_event_pub);
     } else {
       msgs_lost_event_pub_ = RclcppPublisherWrapper<MessagesLostEvent>::make_shared(
-        node->create_publisher<MessagesLostEvent>(kDefaultMessagesLostTopicName, 1));
+        node->create_publisher<MessagesLostEvent>(kDefaultMessagesLostTopicName,
+                                                  rosbag2_storage::Rosbag2QoS::EventQoS()));
     }
 
     // Start the thread that will publish events

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -15,14 +15,14 @@
 
 #include <gmock/gmock.h>
 
-#include <thread>
-#include <memory>
-#include <string>
-#include <vector>
 #include <chrono>
-#include <utility>
-#include <queue>
+#include <memory>
 #include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "rosbag2_interfaces/msg/messages_lost_event.hpp"
 #include "rosbag2_interfaces/msg/messages_lost_event_topic_stat.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -566,7 +566,7 @@ TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
   // Simulate concurrent access to on_messages_lost_in_transport
   for (size_t i = 0; i < num_threads_for_each_event; i++) {
     // Simulate concurrent access to on_messages_lost_in_transport
-    threads.emplace_back([this, i]() {
+    threads.emplace_back([this, i, iterations_per_thread]() {
         for (size_t j = 0; j < iterations_per_thread; j++) {
           rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
           qos_msgs_lost_info.total_count_change = 1;
@@ -574,7 +574,7 @@ TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
         }
     });
     // Simulate concurrent access to on_messages_lost_in_recorder
-    threads.emplace_back([this, i]() {
+    threads.emplace_back([this, i, iterations_per_thread]() {
         for (size_t j = 0; j < iterations_per_thread; j++) {
           std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
             {"topic" + std::to_string(i), 1}

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -15,8 +15,14 @@
 
 #include <gmock/gmock.h>
 
-#include <iostream>
 #include <thread>
+#include <memory>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <utility>
+#include <queue>
+#include <mutex>
 
 #include "rosbag2_interfaces/msg/messages_lost_event.hpp"
 #include "rosbag2_interfaces/msg/messages_lost_event_topic_stat.hpp"
@@ -361,6 +367,7 @@ TEST_F(TestRecorderEventNotifier, event_notifier_respects_max_publishing_rate) {
   std::vector<WriteSplitEvent> published_write_split_events;
   std::vector<std::pair<std::chrono::steady_clock::time_point, MessagesLostEvent>>
     published_messages_lost_events;
+  std::mutex published_events_mutex;
 
   // Create shared_ptrs to the mock wrappers first
   auto write_split_pub_mock = std::make_shared<MockPublisherWrapper<WriteSplitEvent>>(
@@ -374,14 +381,16 @@ TEST_F(TestRecorderEventNotifier, event_notifier_respects_max_publishing_rate) {
   // Set up expectations on the shared_ptr mocks directly
   ON_CALL(*write_split_pub_mock, publish(::testing::_))
   .WillByDefault(::testing::Invoke(
-      [&published_write_split_events](const WriteSplitEvent & msg) {
+      [&published_write_split_events, &published_events_mutex](const WriteSplitEvent & msg) {
+        std::lock_guard<std::mutex> lock(published_events_mutex);
         published_write_split_events.push_back(msg);
       }
   ));
 
   EXPECT_CALL(*msgs_lost_pub_mock, publish(::testing::_))
   .WillRepeatedly(::testing::Invoke(
-      [&published_messages_lost_events](const MessagesLostEvent & msg) {
+      [&published_messages_lost_events, &published_events_mutex](const MessagesLostEvent & msg) {
+        std::lock_guard<std::mutex> lock(published_events_mutex);
         published_messages_lost_events.emplace_back(std::chrono::steady_clock::now(), msg);
       }
   ));
@@ -404,7 +413,9 @@ TEST_F(TestRecorderEventNotifier, event_notifier_respects_max_publishing_rate) {
 
   // Allow some time for the events to be processed
   std::this_thread::sleep_for(std::chrono::seconds(1));
+  notifier_.reset();  // Ensure all events are processed before assertions
 
+  std::lock_guard<std::mutex> lock(published_events_mutex);
   // Verify that no write split events were published
   EXPECT_TRUE(published_write_split_events.empty());
 
@@ -555,7 +566,7 @@ TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
   // Simulate concurrent access to on_messages_lost_in_transport
   for (size_t i = 0; i < num_threads_for_each_event; i++) {
     // Simulate concurrent access to on_messages_lost_in_transport
-    threads.emplace_back([this, i, iterations_per_thread]() {
+    threads.emplace_back([this, i]() {
         for (size_t j = 0; j < iterations_per_thread; j++) {
           rclcpp::QOSMessageLostInfo qos_msgs_lost_info;
           qos_msgs_lost_info.total_count_change = 1;
@@ -563,7 +574,7 @@ TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
         }
     });
     // Simulate concurrent access to on_messages_lost_in_recorder
-    threads.emplace_back([this, i, iterations_per_thread]() {
+    threads.emplace_back([this, i]() {
         for (size_t j = 0; j < iterations_per_thread; j++) {
           std::vector<rosbag2_cpp::bag_events::MessagesLostInfo> msgs_lost_info = {
             {"topic" + std::to_string(i), 1}


### PR DESCRIPTION
## Description

This PR upstream minor fixes we recently made in Apex.AI.

1. Adjust warnings in the `rosbag2_transport::Recorder class`
1. Address thread sanitizer warnings in `TestRecorderEventNotifier` (will make tests less flaky).
1. Follow-up on ros2/rosbag2#2150. Add `EventQoS` for event notifier publishers.
1. Fix: rosbag_py Player not init global exit flag before starting to play
   The rosbag_py Player was not resetting its global static exit flag upon start playing. This led to a situation where player instances created afterward could not start playing and would stop immediately.

Fixes # (issue) N/A

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.

### Additional Information
No API/ABI breaking changes so far.
