### PR TITLE
Support relative includes for IDL in local message definition

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -107,7 +107,9 @@ public:
 private:
   struct MessageSpec
   {
-    MessageSpec(Format format, std::string text, const std::string & package_context);
+    MessageSpec(
+      Format format, std::string text, const std::string & package_context,
+      const std::string & namespace_hint);
     const std::set<std::string> dependencies;
     const std::string text;
     Format format{Format::UNKNOWN};
@@ -188,8 +190,8 @@ ROSBAG2_CPP_PUBLIC
 std::set<std::string> parse_definition_dependencies(
   LocalMessageDefinitionSource::Format format,
   const std::string & text,
-  const std::string & package_context);
-
+  const std::string & package_context,
+  const std::string & namespace_hint);
 }  // namespace rosbag2_cpp
 
 #ifdef _WIN32

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -136,7 +136,8 @@ static std::set<std::string> parse_msg_dependencies(
 /// to the specified package context.
 /// \param text The IDL definition text to parse.
 /// \param package_context The package context to use for relative type references.
-/// \param namespace_hint An optional namespace hint to infix for relative type references (e.g. "msg").
+/// \param namespace_hint An optional namespace hint to infix for relative type references
+/// (e.g. "msg").
 /// \return A set of message type dependencies in the format "package_name/msg/TypeName".
 static std::set<std::string> parse_idl_dependencies(
   const std::string & text,

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -53,19 +53,17 @@ public:
 };
 
 /// \brief This regular expression is designed to parse ROS topic type strings into their package
-/// name and type name components.
-/// \details  The regex requires a format like package_name/[path/]TypeName or
-///  package_name/[path/][msg|srv|action]/TypeName where both package_name and TypeName consist of
-///  alphanumeric characters and underscores.
-/// Breaking down this regex:
+/// name, optional middle path, and type name components.
+/// \details The regex requires a format like package_name/[path/]TypeName where package_name and
+/// TypeName consist of alphanumeric characters and underscores.
+/// Breaking down this regex (^([a-zA-Z0-9_]+)/?(.*)/([a-zA-Z0-9_]+)$):
 /// ^ - Ensures matching starts at beginning of string
 /// ([a-zA-Z0-9_]+) - First capture group: matches the package name
 /// (e.g., "std_msgs", "sensor_msgs")
-/// (?:/[a-zA-Z0-9_]+)* - Allows for any number of additional path segments (like /nested_sub_dir)
-/// / - Matches a literal forward slash
-/// (?:msg/|srv/|action/)? - Non-capturing group that optionally matches "msg/", "srv/", or
-/// "action/"
-/// ([a-zA-Z0-9_]+) - Second capture group: matches the type name (e.g., "String", "LaserScan")
+/// /? - Optionally matches a forward slash after the package name
+/// (.*) - Second capture group: matches any middle path segments (e.g., "msg", "srv/nested", etc.)
+/// / - Matches a literal forward slash before the type name
+/// ([a-zA-Z0-9_]+) - Third capture group: matches the type name (e.g., "String", "LaserScan")
 /// $ - Ensures matching ends at the end of string
 /// The regex processes ROS topic types in these formats:
 /// package_name/TypeName (e.g., "std_msgs/String")
@@ -81,16 +79,29 @@ public:
 ///  std_msgs/String.msg - file extensions are not allowed
 ///  std msgs/String - spaces are not allowed
 ///  std_msgs/@String - special characters other than alphanumeric and underscore are not allowed
+///  String - missing package name separator
 static const std::regex PACKAGE_TYPENAME_REGEX{
-  R"(^([a-zA-Z0-9_]+)(?:/[a-zA-Z0-9_]+)*/(?:msg/|srv/|action/)?([a-zA-Z0-9_]+)$)"};
-
+  R"(^([a-zA-Z0-9_]+)/?(.*)/([a-zA-Z0-9_]+)$)"
+};
 // Match field types from .msg, .srv and .action definitions
 // ("foo_msgs/Bar" in "foo_msgs/Bar[] bar")
 static const std::regex MSG_FIELD_TYPE_REGEX{R"((?:^|\n)\s*([a-zA-Z0-9_/]+)(?:\[[^\]]*\])?\s+)"};
 
-// match field types from `.idl` definitions ("foo_msgs/msg/bar" in #include <foo_msgs/msg/Bar.idl>)
+
+/// \brief This regex is designed to parse IDL include statements to extract
+/// message type dependencies.
+/// \details Breaking down this regex:
+/// (?:^|\n) - Ensures matching starts at the beginning of the string or after a newline
+/// #include\s+ - Matches the literal string "#include" followed by one or more whitespace
+/// characters
+/// (?:\"|<) - Non-capturing group that matches either a double quote (") or a less-than sign (<)
+/// ([a-zA-Z0-9_\/]+\/)? - Optional first capture group that matches the package path
+/// (e.g., "foo_msgs/msg/") ending with a forward slash
+/// ([a-zA-Z0-9_]+) - Second capture group that matches the type name (e.g., "Bar")
+/// \.idl - Matches the literal string ".idl"
+/// (?:\"|>) - Non-capturing group that matches either a double quote (") or a greater-than sign (>)
 static const std::regex IDL_FIELD_TYPE_REGEX{
-  R"((?:^|\n)#include\s+(?:"|<)([a-zA-Z0-9_/]+)\.idl(?:"|>))"};
+  R"((?:^|\n)#include\s+(?:\"|<)([a-zA-Z0-9_\/]+\/)?([a-zA-Z0-9_]+)\.idl(?:"|>))"};
 
 static const std::unordered_set<std::string> PRIMITIVE_TYPES{
   "bool", "byte", "char", "float32", "float64", "int8", "uint8",
@@ -106,26 +117,59 @@ static std::set<std::string> parse_msg_dependencies(
     iter != std::sregex_iterator(); ++iter)
   {
     std::string type = (*iter)[1];
-    if (PRIMITIVE_TYPES.find(type) != PRIMITIVE_TYPES.end()) {
+    if (PRIMITIVE_TYPES.count(type)) {
       continue;
     }
     if (type.find('/') == std::string::npos) {
-      dependencies.insert(package_context + '/' + std::move(type));
+      dependencies.emplace(package_context + '/' + std::move(type));
     } else {
-      dependencies.insert(std::move(type));
+      dependencies.emplace(type);
     }
   }
   return dependencies;
 }
 
-static std::set<std::string> parse_idl_dependencies(const std::string & text)
+/// \brief Parse IDL definition text to extract message type dependencies.
+/// \details This function scans the provided IDL text for include statements
+/// and extracts the message type dependencies. It supports both absolute and relative
+/// type references. If a type is referenced without a package path, it is assumed to belong
+/// to the specified package context.
+/// \param text The IDL definition text to parse.
+/// \param package_context The package context to use for relative type references.
+/// \param namespace_hint An optional namespace hint to infix for relative type references (e.g. "msg").
+/// \return A set of message type dependencies in the format "package_name/msg/TypeName".
+static std::set<std::string> parse_idl_dependencies(
+  const std::string & text,
+  const std::string & package_context = "",
+  const std::string & namespace_hint = "")
 {
   std::set<std::string> dependencies;
 
   for (std::sregex_iterator iter(text.begin(), text.end(), IDL_FIELD_TYPE_REGEX);
     iter != std::sregex_iterator(); ++iter)
   {
-    dependencies.insert((*iter)[1]);
+    const auto & pkg_path_capturing_group = (*iter)[1];
+    const auto & type_name_capturing_group = (*iter)[2];
+
+    if (pkg_path_capturing_group.matched && type_name_capturing_group.matched) {
+      // If there is a path component, include it
+      // Remove trailing "/" and append type name "foo_msgs/msg/" → "foo_msgs/msg/Bar"
+      const auto & pkg_path_str = pkg_path_capturing_group.str();
+      const auto & type_name_str = type_name_capturing_group.str();
+      std::string dep = pkg_path_str.substr(0, pkg_path_str.length() - 1) + '/' + type_name_str;
+      dependencies.emplace(dep);
+    } else if (type_name_capturing_group.matched) {
+      const auto & type_name_str = type_name_capturing_group.str();
+      // No path: use current package context
+      // "" → "current_package/Bar"
+      std::string dep;
+      if (!namespace_hint.empty()) {
+        dep = package_context + '/' + namespace_hint + '/' + type_name_str;
+      } else {
+        dep = package_context + '/' + type_name_str;
+      }
+      dependencies.emplace(dep);
+    }
   }
   return dependencies;
 }
@@ -133,13 +177,14 @@ static std::set<std::string> parse_idl_dependencies(const std::string & text)
 std::set<std::string> parse_definition_dependencies(
   LocalMessageDefinitionSource::Format format,
   const std::string & text,
-  const std::string & package_context)
+  const std::string & package_context,
+  const std::string & namespace_hint)
 {
   switch (format) {
     case LocalMessageDefinitionSource::Format::MSG:
       return parse_msg_dependencies(text, package_context);
     case LocalMessageDefinitionSource::Format::IDL:
-      return parse_idl_dependencies(text);
+      return parse_idl_dependencies(text, package_context, namespace_hint);
     case LocalMessageDefinitionSource::Format::SRV:
     case LocalMessageDefinitionSource::Format::ACTION:
       {
@@ -147,7 +192,7 @@ std::set<std::string> parse_definition_dependencies(
         if (!dep.empty()) {
           return dep;
         } else {
-          return parse_idl_dependencies(text);
+          return parse_idl_dependencies(text, package_context, namespace_hint);
         }
       }
     default:
@@ -199,10 +244,10 @@ std::string LocalMessageDefinitionSource::delimiter(
 
 LocalMessageDefinitionSource::MessageSpec::MessageSpec(
   Format format, std::string text,
-  const std::string & package_context)
-: dependencies(parse_definition_dependencies(format, text, package_context))
-  , text(std::move(text))
-  , format(format)
+  const std::string & package_context, const std::string & namespace_hint)
+: dependencies(parse_definition_dependencies(format, text, package_context, namespace_hint)),
+  text(std::move(text)),
+  format(format)
 {
 }
 
@@ -219,9 +264,11 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   if (!std::regex_match(topic_type, match, PACKAGE_TYPENAME_REGEX) || match.size() < 3) {
     throw TypenameNotUnderstoodError(topic_type);
   }
-  std::string package_name = match[1].str();
-  const std::string file_name =
-    match[2].str() + extension_for_format(definition_identifier.format());
+  const std::string package_name{match[1].str()};
+  const std::string subdir{match[2].str()};
+  const std::string type_name{match[3].str()};
+  const std::string type_name_with_extension =
+    type_name + extension_for_format(definition_identifier.format());
   fs::path share_dir_path;
   // Get the resource content and prefix path from ament_index
   auto result = ament_index_cpp::get_resource("rosidl_interfaces", package_name);
@@ -245,7 +292,7 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
     if (!line.empty()) {
       fs::path curr_relative_file_path(line);
       // Find the first line that ends with the filename we're looking for
-      if (curr_relative_file_path.filename() == file_name) {
+      if (curr_relative_file_path.filename() == type_name_with_extension) {
         relative_file_path_str = curr_relative_file_path.generic_string();
         break;
       }
@@ -255,7 +302,7 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   if (relative_file_path_str.empty()) {
     ROSBAG2_CPP_LOG_DEBUG(
       "Message definition file '%s' not found in the resource content for package: '%s'",
-      file_name.c_str(), package_name.c_str());
+      type_name_with_extension.c_str(), package_name.c_str());
     throw DefinitionNotFoundError(definition_identifier.topic_type());
   }
   std::string msg_definition_path_str = (share_dir_path / relative_file_path_str).generic_string();
@@ -271,7 +318,8 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
   std::string contents{std::istreambuf_iterator(file), {}};
   const MessageSpec & spec = msg_specs_by_definition_identifier_.emplace(
     definition_identifier,
-    MessageSpec(definition_identifier.format(), std::move(contents), package_name)).first->second;
+    MessageSpec(definition_identifier.format(), std::move(contents), package_name,
+      subdir)).first->second;
 
   // "References and pointers to data stored in the container are only invalidated by erasing that
   // element, even when the corresponding iterator is invalidated."
@@ -340,6 +388,10 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
       } catch (const DefinitionNotFoundError & idl_search_error) {
         ROSBAG2_CPP_LOG_DEBUG("No .idl definition found for topic type %s.",
                               idl_search_error.what());
+        format = Format::UNKNOWN;
+      } catch (const TypenameNotUnderstoodError & err) {
+        ROSBAG2_CPP_LOG_DEBUG(
+          "Message type name '%s' not understood by type definition search.", err.what());
         format = Format::UNKNOWN;
       }
     } catch (const TypenameNotUnderstoodError & err) {
@@ -410,6 +462,10 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
             } catch (const DefinitionNotFoundError & idl_search_error) {
               ROSBAG2_CPP_LOG_DEBUG("No .idl definition found for topic type %s.",
                                     idl_search_error.what());
+              format = Format::UNKNOWN;
+            } catch (const TypenameNotUnderstoodError & err) {
+              ROSBAG2_CPP_LOG_DEBUG(
+                "Message type name '%s' not understood by type definition search.", err.what());
               format = Format::UNKNOWN;
             }
           } catch (const TypenameNotUnderstoodError & err) {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -41,19 +41,45 @@ module rosbag2_test_msgdefs {
 
   )r";
   std::set<std::string> dependencies = parse_definition_dependencies(
-    LocalMessageDefinitionSource::Format::IDL, sample, "");
-  ASSERT_THAT(
+    LocalMessageDefinitionSource::Format::IDL, sample, "", "");
+  EXPECT_THAT(
     dependencies, UnorderedElementsAre(
       "rosbag2_test_msgdefs/msg/BasicIdlA",
       "rosbag2_test_msgdefs/msg/BasicIdlB"));
+}
+
+TEST(test_local_message_definition_source, can_find_relative_idl_includes)
+{
+  const char sample[] =
+    R"r(
+#include "BasicIdlA.idl"
+
+#include <rosbag2_test_msgdefs/msg/BasicIdlB.idl>
+
+module rosbag2_test_msgdefs {
+  module msg {
+    struct ComplexIdl {
+      rosbag2_test_msgdefs::msg::BasicIdlA a;
+      rosbag2_test_msgdefs::msg::BasicIdlB b;
+    };
+  };
+};
+
+  )r";
+  std::set<std::string> dependencies = parse_definition_dependencies(
+    LocalMessageDefinitionSource::Format::IDL, sample, "rosbag2_test_msgdefs", "msg");
+  EXPECT_THAT(
+    dependencies, UnorderedElementsAre(
+    "rosbag2_test_msgdefs/msg/BasicIdlA",
+    "rosbag2_test_msgdefs/msg/BasicIdlB"));
 }
 
 TEST(test_local_message_definition_source, can_find_msg_deps)
 {
   LocalMessageDefinitionSource source;
   auto result = source.get_full_text_ext("rosbag2_test_msgdefs/ComplexMsg", "/complex_msg_topic");
-  ASSERT_EQ(result.encoding, "ros2msg");
-  ASSERT_EQ(
+  EXPECT_EQ(result.encoding, "ros2msg");
+  EXPECT_EQ(
     result.encoded_message_definition,
     "rosbag2_test_msgdefs/BasicMsg b\n"
     "\n"
@@ -68,10 +94,10 @@ TEST(test_local_message_definition_source, can_find_msg_definition_in_nested_sub
   auto result =
     source.get_full_text_ext("rosbag2_test_msgdefs/msg/nested_sub_dir/AnotherBasicMsg",
                              "/basic_msg_topic");
-  ASSERT_EQ(result.encoding, "ros2msg");
+  EXPECT_EQ(result.encoding, "ros2msg");
   // Note: By design The top-level message definition for MSG format is present first, with no
   // delimiter. All dependent .msg definitions are preceded by a two-line delimiter:
-  ASSERT_EQ(result.encoded_message_definition, "float32 c\n");
+  EXPECT_EQ(result.encoded_message_definition, "float32 c\n");
 }
 
 TEST(test_local_message_definition_source, can_find_action_definition_in_nested_subfolder)
@@ -80,8 +106,8 @@ TEST(test_local_message_definition_source, can_find_action_definition_in_nested_
   auto result =
     source.get_full_text_ext("rosbag2_test_msgdefs/nested_sub_dir/action/BasicMsg",
                              "/basic_action_msg/_action/send_goal");
-  ASSERT_EQ(result.encoding, "ros2msg");
-  ASSERT_EQ(result.encoded_message_definition,
+  EXPECT_EQ(result.encoding, "ros2msg");
+  EXPECT_EQ(result.encoded_message_definition,
     "================================================================================\n"
     "ACTION: rosbag2_test_msgdefs/nested_sub_dir/action/BasicMsg\n"
     "string goal\n"
@@ -97,8 +123,8 @@ TEST(test_local_message_definition_source, can_find_srv_deps_in_msg)
   LocalMessageDefinitionSource source;
   auto result = source.get_full_text_ext("rosbag2_test_msgdefs/srv/ComplexSrvMsg_Event",
     "/complex_srv_msg_topic/_service_event");
-  ASSERT_EQ(result.encoding, "ros2msg");
-  ASSERT_EQ(
+  EXPECT_EQ(result.encoding, "ros2msg");
+  EXPECT_EQ(
     result.encoded_message_definition,
     "================================================================================\n"
     "SRV: rosbag2_test_msgdefs/srv/ComplexSrvMsg\n"
@@ -116,8 +142,8 @@ TEST(test_local_message_definition_source, can_find_srv_deps_in_idl)
   LocalMessageDefinitionSource source;
   auto result = source.get_full_text_ext("rosbag2_test_msgdefs/srv/ComplexSrvIdl_Event",
     "/complex_srv_idl_topic/_service_event");
-  ASSERT_EQ(result.encoding, "ros2idl");
-  ASSERT_EQ(
+  EXPECT_EQ(result.encoding, "ros2idl");
+  EXPECT_EQ(
     result.encoded_message_definition,
     "================================================================================\n"
     "SRV: rosbag2_test_msgdefs/srv/ComplexSrvIdl\n"
@@ -142,8 +168,8 @@ TEST(test_local_message_definition_source, can_find_srv_deps_in_idl)
 TEST(test_local_message_definition_source, can_find_action_deps_in_msg)
 {
   auto check_result = [](const rosbag2_storage::MessageDefinition & result) {
-      ASSERT_EQ(result.encoding, "ros2msg");
-      ASSERT_EQ(
+      EXPECT_EQ(result.encoding, "ros2msg");
+      EXPECT_EQ(
         result.encoded_message_definition,
         "================================================================================\n"
         "ACTION: rosbag2_test_msgdefs/action/ComplexActionMsg\n"
@@ -208,8 +234,8 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_msg)
 TEST(test_local_message_definition_source, can_find_action_deps_in_idl)
 {
   auto check_result = [](const rosbag2_storage::MessageDefinition & result) {
-      ASSERT_EQ(result.encoding, "ros2idl");
-      ASSERT_EQ(
+      EXPECT_EQ(result.encoding, "ros2idl");
+      EXPECT_EQ(
         result.encoded_message_definition,
         "================================================================================\n"
         "ACTION: rosbag2_test_msgdefs/action/ComplexActionIdl\n"
@@ -285,8 +311,8 @@ TEST(test_local_message_definition_source, can_find_idl_deps)
   LocalMessageDefinitionSource source;
   auto result = source.get_full_text_ext(
     "rosbag2_test_msgdefs/msg/ComplexIdl", "/complex_idl_topic");
-  ASSERT_EQ(result.encoding, "ros2idl");
-  ASSERT_EQ(
+  EXPECT_EQ(result.encoding, "ros2idl");
+  EXPECT_EQ(
     result.encoded_message_definition,
     "================================================================================\n"
     "IDL: rosbag2_test_msgdefs/msg/ComplexIdl\n"
@@ -311,13 +337,44 @@ TEST(test_local_message_definition_source, can_find_idl_deps)
     "};\n");
 }
 
+TEST(test_local_message_definition_source, can_find_relative_idl_deps)
+{
+  LocalMessageDefinitionSource source;
+  auto result = source.get_full_text_ext(
+    "rosbag2_test_msgdefs/msg/ComplexWithRelativeDep", "/complex_idl_topic");
+  EXPECT_EQ(result.encoding, "ros2idl");
+  EXPECT_EQ(
+    result.encoded_message_definition,
+    "================================================================================\n"
+    "IDL: rosbag2_test_msgdefs/msg/ComplexWithRelativeDep\n"
+    "#include \"BasicIdl.idl\"\n"
+    "\n"
+    "module rosbag2_test_msgdefs {\n"
+    "  module msg {\n"
+    "    struct ComplexWithRelativeDep {\n"
+    "      rosbag2_test_msgdefs::msg::BasicIdl a;\n"
+    "    };\n"
+    "  };\n"
+    "};\n"
+    "\n"
+    "================================================================================\n"
+    "IDL: rosbag2_test_msgdefs/msg/BasicIdl\n"
+    "module rosbag2_test_msgdefs {\n"
+    "  module msg {\n"
+    "    struct BasicIdl {\n"
+    "        float x;\n"
+    "    };\n"
+    "  };\n"
+    "};\n");
+}
+
 TEST(test_local_message_definition_source, can_resolve_msg_with_idl_deps)
 {
   LocalMessageDefinitionSource source;
   auto result = source.get_full_text_ext(
     "rosbag2_test_msgdefs/msg/ComplexMsgDependsOnIdl", "/complex_msg_depends_on_idl_topic");
-  ASSERT_EQ(result.encoding, "ros2idl");
-  ASSERT_EQ(
+  EXPECT_EQ(result.encoding, "ros2idl");
+  EXPECT_EQ(
     result.encoded_message_definition,
     "================================================================================\n"
     "IDL: rosbag2_test_msgdefs/msg/ComplexMsgDependsOnIdl\n"
@@ -352,40 +409,40 @@ TEST(test_local_message_definition_source, no_crash_on_bad_name)
   rosbag2_storage::MessageDefinition result;
 
   // The following type names are not valid, but it should not crash
-  ASSERT_NO_THROW(
+  EXPECT_NO_THROW(
   {
     // The typename without preceding package name
     result = source.get_full_text_ext("/msg/String", "/msg_topic");
   });
-  ASSERT_EQ(result.encoding, "unknown");
+  EXPECT_EQ(result.encoding, "unknown");
 
-  ASSERT_NO_THROW(
+  EXPECT_NO_THROW(
   {
     // Missing the actual type name after format specifier
     result = source.get_full_text_ext("std_msgs/msg/", "/msg_topic");
   });
-  ASSERT_EQ(result.encoding, "unknown");
+  EXPECT_EQ(result.encoding, "unknown");
 
-  ASSERT_NO_THROW(
+  EXPECT_NO_THROW(
   {
     // Missing package name before the first slash
     result = source.get_full_text_ext("/String", "/msg_topic");
   });
-  ASSERT_EQ(result.encoding, "unknown");
+  EXPECT_EQ(result.encoding, "unknown");
 
-  ASSERT_NO_THROW(
+  EXPECT_NO_THROW(
   {
     // Hyphens are not allowed in package names
     result = source.get_full_text_ext("std-msgs/String", "/msg_topic");
   });
-  ASSERT_EQ(result.encoding, "unknown");
+  EXPECT_EQ(result.encoding, "unknown");
 
-  ASSERT_NO_THROW(
+  EXPECT_NO_THROW(
   {
     // File extensions are not allowed
     result = source.get_full_text_ext("std_msgs/String.msg", "/msg_topic");
   });
-  ASSERT_EQ(result.encoding, "unknown");
+  EXPECT_EQ(result.encoding, "unknown");
 }
 
 TEST(test_local_message_definition_source, gracefully_handle_unknown_msg)

--- a/rosbag2_test_msgdefs/CMakeLists.txt
+++ b/rosbag2_test_msgdefs/CMakeLists.txt
@@ -15,6 +15,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/nested_sub_dir/AnotherBasicMsg.msg"
   "msg/ComplexMsg.msg"
   "msg/ComplexMsgDependsOnIdl.msg"
+  "msg/ComplexWithRelativeDep.idl"
   "srv/BasicSrv.srv"
   "srv/ComplexSrvMsg.srv"
   "srv/ComplexSrvIdl.srv"

--- a/rosbag2_test_msgdefs/msg/ComplexWithRelativeDep.idl
+++ b/rosbag2_test_msgdefs/msg/ComplexWithRelativeDep.idl
@@ -1,0 +1,9 @@
+#include "BasicIdl.idl"
+
+module rosbag2_test_msgdefs {
+  module msg {
+    struct ComplexWithRelativeDep {
+      rosbag2_test_msgdefs::msg::BasicIdl a;
+    };
+  };
+};


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This MR fixes relative includes for IDL format. If the user has an IDL file that is in the same directory
as the parent message, and the parent message is being recorded, rosbag2 will crash without reporting
an error. This is avoided by adding a new `namespace_hint` parameter, modifying the regex used to search
for includes, and applying that information when there is no package nor namespace provided for dependency
collection.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

Not backportable. Has  a breaking public API change
```cpp
ROSBAG2_CPP_PUBLIC
std::set<std::string> parse_definition_dependencies(
  LocalMessageDefinitionSource::Format format,
  const std::string & text,
  const std::string & package_context,
  const std::string & namespace_hint);
```