### PR TITLE
Fix macOS build: Disable thread-safety annotations in locked_priority_queue.hpp

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/locked_priority_queue.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/locked_priority_queue.hpp
@@ -25,6 +25,13 @@
 #include "rcpputils/thread_safety_annotations.hpp"
 #include "rcpputils/unique_lock.hpp"
 
+#ifdef __APPLE__
+// On macOS, thread-safety annotations break compilation; make them no-op
+#pragma push_macro("RCPPUTILS_TSA_GUARDED_BY")
+#undef RCPPUTILS_TSA_GUARDED_BY
+#define RCPPUTILS_TSA_GUARDED_BY(x)
+#endif
+
 /// \brief `std::priority_queue` wrapper with locks and stable sorting.
 /// \details This class wraps a `std::priority_queue` and provides locking for thread-safe
 ///   access. It uses std::vector as underlying container for the `std::priority_queue` and
@@ -143,5 +150,9 @@ private:
 
   size_t insert_sequence_number_{0} RCPPUTILS_TSA_GUARDED_BY(queue_mutex_);
 };
+
+#ifdef __APPLE__
+#pragma pop_macro("RCPPUTILS_TSA_GUARDED_BY")
+#endif
 
 #endif  // ROSBAG2_TRANSPORT__LOCKED_PRIORITY_QUEUE_HPP_

--- a/rosbag2_transport/src/rosbag2_transport/locked_priority_queue.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/locked_priority_queue.hpp
@@ -26,7 +26,7 @@
 #include "rcpputils/unique_lock.hpp"
 
 #ifdef __APPLE__
-// On macOS, thread-safety annotations break compilation; make them no-op
+// no-op: Clang on macOS does not support thread-safety annotations
 #pragma push_macro("RCPPUTILS_TSA_GUARDED_BY")
 #undef RCPPUTILS_TSA_GUARDED_BY
 #define RCPPUTILS_TSA_GUARDED_BY(x)


### PR DESCRIPTION
## Description

On macOS, thread-safety annotations in `rcpputils` cause compilation
failures in `rosbag2_transport` due to Clang not supporting function-style
macro definitions on the command line.


### Error
```
error: expected ';' at end of declaration list
size_t insert_sequence_number_{0} RCPPUTILS_TSA_GUARDED_BY(queue_mutex_);
                                     ^
```

### Changes in this PR:
- Disables `RCPPUTILS_TSA_GUARDED_BY(x)` on Apple platforms via an `#ifdef`.
- Allows `rosbag2_transport` and other packages depending on `LockedPriorityQueue`
  to build successfully on macOS.
- Keeps Linux behavior unchanged.

### Testing
- Successfully built `rcpputils` and `rosbag2_transport` on macOS (Apple Clang).
- Verified Linux build is unaffected.

