### PR TITLE
fix potential memory leak on make_empty_serialized_message().

### DIFF
--- a/rosbag2_storage/src/rosbag2_storage/ros_helper.cpp
+++ b/rosbag2_storage/src/rosbag2_storage/ros_helper.cpp
@@ -45,6 +45,7 @@ make_empty_serialized_message(size_t size)
   *msg = rcutils_get_zero_initialized_uint8_array();
   auto ret = rcutils_uint8_array_init(msg, size, &allocator);
   if (ret != RCUTILS_RET_OK) {
+    delete msg;
     throw std::runtime_error(
             "Error allocating resources for serialized message: " +
             std::string(rcutils_get_error_string().str));


### PR DESCRIPTION
## Description

when i was checking https://github.com/ros2/rosbag2/issues/2252, i just found this issue.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
