### PR TITLE
Rolling 0.34.0 release

### DIFF
--- a/lz4_cmake_module/CHANGELOG.rst
+++ b/lz4_cmake_module/CHANGELOG.rst
@@ -1,12 +1,11 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package rosbag2_performance_benchmarking_msgs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package lz4_cmake_module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 0.34.0 (2025-12-23)
 -------------------
-* Enable `rosbag2_performance_benchmarking` package to be built by default (`#2093 <https://github.com/ros2/rosbag2/issues/2093>`_)
-* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
-* Contributors: Michael Orlov, mosfet80
+* Removed lz4 vendor package (`#2165 <https://github.com/ros2/rosbag2/issues/2165>`_)
+* Contributors: Alejandro Hernández Cordero
 
 0.33.0 (2025-04-25)
 -------------------
@@ -14,16 +13,16 @@ Changelog for package rosbag2_performance_benchmarking_msgs
 0.32.0 (2025-04-18)
 -------------------
 
-0.31.0 (2025-02-02)
+0.31.0 (2025-02-03)
 -------------------
 
 0.30.0 (2024-11-26)
 -------------------
 
-0.29.0 (2024-09-03)
+0.29.0 (2024-09-04)
 -------------------
 
-0.28.0 (2024-06-17)
+0.28.0 (2024-06-21)
 -------------------
 
 0.27.0 (2024-04-30)
@@ -35,33 +34,26 @@ Changelog for package rosbag2_performance_benchmarking_msgs
 0.26.0 (2024-04-16)
 -------------------
 
-0.25.0 (2024-03-27)
+0.25.0 (2024-03-28)
 -------------------
 
-0.24.0 (2023-07-11)
+0.24.0 (2023-07-12)
 -------------------
 
-0.23.0 (2023-04-28)
+0.23.0 (2023-04-29)
 -------------------
 
 0.22.0 (2023-04-18)
 -------------------
-* Add tests for rosbag2_performance_benchmarking pkg (`#1268 <https://github.com/ros2/rosbag2/issues/1268>`_)
-* Contributors: Michael Orlov
 
-0.21.0 (2023-04-12)
+0.21.0 (2023-04-13)
 -------------------
 
 0.20.0 (2023-02-14)
 -------------------
-* Skip ament_package() call when not building rosbag2_performance_benchmarking (`#1242 <https://github.com/ros2/rosbag2/issues/1242>`_)
-* Contributors: Shane Loretz
 
 0.19.0 (2023-01-13)
 -------------------
-* [rolling] Bump to 0.19.0 (`#1232 <https://github.com/ros2/rosbag2/issues/1232>`_)
-* Add option to specify a message type (`#1153 <https://github.com/ros2/rosbag2/issues/1153>`_)
-* Contributors: Audrow Nash, carlossvg
 
 0.18.0 (2022-11-15)
 -------------------

--- a/mcap_vendor/CHANGELOG.rst
+++ b/mcap_vendor/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package mcap_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Removed lz4 vendor package (`#2165 <https://github.com/ros2/rosbag2/issues/2165>`_)
+* Replace zstd_vendor with zstd_cmake_module (`#2166 <https://github.com/ros2/rosbag2/issues/2166>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Backporting Missing cstdint Include (`#2008 <https://github.com/ros2/rosbag2/issues/2008>`_)
+* Contributors: Alejandro Hernández Cordero, David Anthony, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/ros2bag/CHANGELOG.rst
+++ b/ros2bag/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package ros2bag
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* add rosbag2_storage_default_plugins to exec_depend of ros2bag. (`#2227 <https://github.com/ros2/rosbag2/issues/2227>`_)
+* Add input[output]_serialization_format to the RecordOptions (`#2215 <https://github.com/ros2/rosbag2/issues/2215>`_)
+* Add messages lost notification on a predefined topic during recording (`#2150 <https://github.com/ros2/rosbag2/issues/2150>`_)
+* Expose more of the player/recorder API through Python (`#2062 <https://github.com/ros2/rosbag2/issues/2062>`_)
+* fix setuptools deprecations (`#2087 <https://github.com/ros2/rosbag2/issues/2087>`_)
+* Change Python player and recorder to be more as a classes (`#2047 <https://github.com/ros2/rosbag2/issues/2047>`_)
+* Contributors: Christophe Bedard, Michael Orlov, Tomoya Fujita, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2/CHANGELOG.rst
+++ b/rosbag2/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Contributors: mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/rosbag2_compression/CHANGELOG.rst
+++ b/rosbag2_compression/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package rosbag2_compression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Make topics persistent between writer's close() and open() API calls. (`#2229 <https://github.com/ros2/rosbag2/issues/2229>`_)
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Add callbacks for messages loss statistics (`#2039 <https://github.com/ros2/rosbag2/issues/2039>`_)
+* Add new messages write API in BaseWriteInterface, with return status of operation (`#2030 <https://github.com/ros2/rosbag2/issues/2030>`_)
+* Contributors: Michael Orlov, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Bugfix: `ros2 bag convert` dropping messages with compression mode message (`#1975 <https://github.com/ros2/rosbag2/issues/1975>`_)

--- a/rosbag2_compression_zstd/CHANGELOG.rst
+++ b/rosbag2_compression_zstd/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_compression_zstd
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Replace zstd_vendor with zstd_cmake_module (`#2166 <https://github.com/ros2/rosbag2/issues/2166>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Contributors: Alejandro Hernández Cordero, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/rosbag2_cpp/CHANGELOG.rst
+++ b/rosbag2_cpp/CHANGELOG.rst
@@ -2,6 +2,28 @@
 Changelog for package rosbag2_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Updated deprecated ament_index_cpp API (`#2268 <https://github.com/ros2/rosbag2/issues/2268>`_)
+* Make topics persistent between writer's close() and open() API calls. (`#2229 <https://github.com/ros2/rosbag2/issues/2229>`_)
+* Check for nullptrs when pushing new messages to the message cache (`#2219 <https://github.com/ros2/rosbag2/issues/2219>`_)
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_)
+* Log reasoning for not found message definition only in debug log (`#2183 <https://github.com/ros2/rosbag2/issues/2183>`_)
+* minor error checks for rosbag2_cpp (`#2127 <https://github.com/ros2/rosbag2/issues/2127>`_)
+* Fix: Add null pointer check for reader_imp in the Reader constructor (`#2135 <https://github.com/ros2/rosbag2/issues/2135>`_)
+* Use rclcpp typesupport helpers in rosbag2_cpp (`#2017 <https://github.com/ros2/rosbag2/issues/2017>`_)
+* Bugfix for callback not called in writer for MESSAGES_LOST event (`#2105 <https://github.com/ros2/rosbag2/issues/2105>`_)
+* Minor performance improvements in the recorder's MessageCache (`#2104 <https://github.com/ros2/rosbag2/issues/2104>`_)
+* Fix reindex duration bug when bag file durations overlap (`#2036 <https://github.com/ros2/rosbag2/issues/2036>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Add support for searching message definitions in nested subdirectories (`#2055 <https://github.com/ros2/rosbag2/issues/2055>`_)
+* Add callbacks for messages loss statistics (`#2039 <https://github.com/ros2/rosbag2/issues/2039>`_)
+* Use cache to try to determine the inner type for action introspection interfaces (`#2052 <https://github.com/ros2/rosbag2/issues/2052>`_)
+* Fix service/action message definition issue (`#2041 <https://github.com/ros2/rosbag2/issues/2041>`_)
+* Add new messages write API in BaseWriteInterface, with return status of operation (`#2030 <https://github.com/ros2/rosbag2/issues/2030>`_)
+* Improvements in message publishing timings (`#2025 <https://github.com/ros2/rosbag2/issues/2025>`_)
+* Contributors: Alejandro Hernández Cordero, Barry Xu, Chui Vanfleet, José Faria, Michael Orlov, Tomoya Fujita, YuJin Hong, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2_examples/rosbag2_examples_cpp/CHANGELOG.rst
+++ b/rosbag2_examples/rosbag2_examples_cpp/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package rosbag2_examples_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Update subscription callback signatures (`#2225 <https://github.com/ros2/rosbag2/issues/2225>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Add examples for compressing bag files (`#1956 <https://github.com/ros2/rosbag2/issues/1956>`_)
+* Contributors: Maxime Fleury, mini-1235, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/rosbag2_examples/rosbag2_examples_py/CHANGELOG.rst
+++ b/rosbag2_examples/rosbag2_examples_py/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_examples_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* fix setuptools deprecation (`#2092 <https://github.com/ros2/rosbag2/issues/2092>`_)
+* Add examples for compressing bag files (`#1956 <https://github.com/ros2/rosbag2/issues/1956>`_)
+* Contributors: Maxime Fleury, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2_interfaces/CHANGELOG.rst
+++ b/rosbag2_interfaces/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Add messages lost notification on a predefined topic during recording (`#2150 <https://github.com/ros2/rosbag2/issues/2150>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Contributors: Michael Orlov, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CHANGELOG.rst
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package rosbag2_performance_benchmarking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Fix warning: initialize number_of_threads (`#2121 <https://github.com/ros2/rosbag2/issues/2121>`_)
+* Enable `rosbag2_performance_benchmarking` package to be built by default (`#2093 <https://github.com/ros2/rosbag2/issues/2093>`_)
+* Fixes in the rosbag2_performance_benchmarking message data generator (`#2078 <https://github.com/ros2/rosbag2/issues/2078>`_)
+* Fix for failure in the benchmark_launch when using Process.wait twice (`#2076 <https://github.com/ros2/rosbag2/issues/2076>`_)
+* Bugfix: `prosbag2_performance_benchmarking` outputs incorrect results for topics with frequency more than 1 kHz (`#2077 <https://github.com/ros2/rosbag2/issues/2077>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Contributors: Cristóbal Arroyo, Michael Orlov, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2_py/CHANGELOG.rst
+++ b/rosbag2_py/CHANGELOG.rst
@@ -2,6 +2,20 @@
 Changelog for package rosbag2_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Add input[output]_serialization_format to the RecordOptions (`#2215 <https://github.com/ros2/rosbag2/issues/2215>`_)
+* Use pybind11 from deb or pixi (`#2154 <https://github.com/ros2/rosbag2/issues/2154>`_)
+* Add messages lost notification on a predefined topic during recording (`#2150 <https://github.com/ros2/rosbag2/issues/2150>`_)
+* Make sure test topic is discovered by recorder in rosbag2_py test (`#2132 <https://github.com/ros2/rosbag2/issues/2132>`_)
+* Fix env var CMake list append in rosbag2_py with clang (`#2116 <https://github.com/ros2/rosbag2/issues/2116>`_)
+* Add public API to get player's starting time and playback duration (`#2095 <https://github.com/ros2/rosbag2/issues/2095>`_)
+* Expose more of the player/recorder API through Python (`#2062 <https://github.com/ros2/rosbag2/issues/2062>`_)
+* Add send_timestamp to python interface for reading serialized messages (`#2061 <https://github.com/ros2/rosbag2/issues/2061>`_)
+* Change Python player and recorder to be more as a classes (`#2047 <https://github.com/ros2/rosbag2/issues/2047>`_)
+* Fix service/action message definition issue (`#2041 <https://github.com/ros2/rosbag2/issues/2041>`_)
+* Contributors: Alejandro Hernández Cordero, Barry Xu, Christophe Bedard, Michael Orlov, Om Shivam Verma
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2_storage/CHANGELOG.rst
+++ b/rosbag2_storage/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package rosbag2_storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* fix memory leak on make_empty_serialized_message(). (`#2253 <https://github.com/ros2/rosbag2/issues/2253>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Add new messages write API in BaseWriteInterface, with return status of operation (`#2030 <https://github.com/ros2/rosbag2/issues/2030>`_)
+* Bugfix: Undefined behavior in the `rosbag2_storage` and `rosbag2_storage_sqlite3` packages (`#1997 <https://github.com/ros2/rosbag2/issues/1997>`_)
+* Contributors: Michael Orlov, Tomoya Fujita, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Use DDS queue depth for subscriptions as a maximum value across publishers (`#1960 <https://github.com/ros2/rosbag2/issues/1960>`_)

--- a/rosbag2_storage_default_plugins/CHANGELOG.rst
+++ b/rosbag2_storage_default_plugins/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_storage_default_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Contributors: mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/rosbag2_storage_mcap/CHANGELOG.rst
+++ b/rosbag2_storage_mcap/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package rosbag2_storage_mcap
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Bugfix for MCAPStorage::seek(time) advance in time is current (`#2157 <https://github.com/ros2/rosbag2/issues/2157>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Add new messages write API in BaseWriteInterface, with return status of operation (`#2030 <https://github.com/ros2/rosbag2/issues/2030>`_)
+* Update index.ros.org/p/ links for rosbag2_storage_mcap (`#2034 <https://github.com/ros2/rosbag2/issues/2034>`_)
+* Contributors: Christophe Bedard, Michael Orlov, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/rosbag2_storage_sqlite3/CHANGELOG.rst
+++ b/rosbag2_storage_sqlite3/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package rosbag2_storage_default_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Removed sqlite3_vendor (`#2164 <https://github.com/ros2/rosbag2/issues/2164>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Add new messages write API in BaseWriteInterface, with return status of operation (`#2030 <https://github.com/ros2/rosbag2/issues/2030>`_)
+* Bugfix: Undefined behavior in the `rosbag2_storage` and `rosbag2_storage_sqlite3` packages (`#1997 <https://github.com/ros2/rosbag2/issues/1997>`_)
+* Contributors: Alejandro Hernández Cordero, Michael Orlov, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2_test_common/CHANGELOG.rst
+++ b/rosbag2_test_common/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package rosbag2_test_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Update subscription callback signatures (`#2225 <https://github.com/ros2/rosbag2/issues/2225>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Address flakiness in tests where need to spin a node (`#2001 <https://github.com/ros2/rosbag2/issues/2001>`_)
+* Contributors: Michael Orlov, mini-1235, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2_test_msgdefs/CHANGELOG.rst
+++ b/rosbag2_test_msgdefs/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_test_msgdefs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Add support for searching message definitions in nested subdirectories (`#2055 <https://github.com/ros2/rosbag2/issues/2055>`_)
+* Contributors: Michael Orlov, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 

--- a/rosbag2_tests/CHANGELOG.rst
+++ b/rosbag2_tests/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package rosbag2_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Add input[output]_serialization_format to the RecordOptions (`#2215 <https://github.com/ros2/rosbag2/issues/2215>`_)
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_)
+* Use rclcpp typesupport helpers in rosbag2_cpp (`#2017 <https://github.com/ros2/rosbag2/issues/2017>`_)
+* Expose more of the player/recorder API through Python (`#2062 <https://github.com/ros2/rosbag2/issues/2062>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+  cmake version < then 3.10 is deprecated
+* Bugfixes for deadlocks in Rosbag2 player when calling stop API (`#2057 <https://github.com/ros2/rosbag2/issues/2057>`_)
+* Add new messages write API in BaseWriteInterface, with return status of operation (`#2030 <https://github.com/ros2/rosbag2/issues/2030>`_)
+* Address flakiness in tests where need to spin a node (`#2001 <https://github.com/ros2/rosbag2/issues/2001>`_)
+* Contributors: Christophe Bedard, Michael Orlov, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_)

--- a/rosbag2_transport/CHANGELOG.rst
+++ b/rosbag2_transport/CHANGELOG.rst
@@ -2,6 +2,43 @@
 Changelog for package rosbag2_transport
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.34.0 (2025-12-23)
+-------------------
+* Fix macOS build: Disable thread-safety annotations in locked_priority_queue.hpp (`#2245 <https://github.com/ros2/rosbag2/issues/2245>`_)
+* Fix for C++ Recorder failure on stop() -> record() due to reusing the bag name (`#2224 <https://github.com/ros2/rosbag2/issues/2224>`_)
+* Add a direct API for rosbag2_transport::Recorder (`#2221 <https://github.com/ros2/rosbag2/issues/2221>`_)
+* Add input[output]_serialization_format to the RecordOptions (`#2215 <https://github.com/ros2/rosbag2/issues/2215>`_)
+* Enable RMW communication isolation in rosbag2_transport tests (`#2190 <https://github.com/ros2/rosbag2/issues/2190>`_)
+* Add topic name and type delimiter for the hash map key (`#2210 <https://github.com/ros2/rosbag2/issues/2210>`_)
+* Add cache for topic filter to avoid performance burden on discovery (`#1486 <https://github.com/ros2/rosbag2/issues/1486>`_)
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_)
+* Reduce CPU overhead in the Rosbag2 recorder discovery (`#2201 <https://github.com/ros2/rosbag2/issues/2201>`_)
+* Fix for possible data races in PlayerProgressBar class (`#2194 <https://github.com/ros2/rosbag2/issues/2194>`_)
+* Fix for data races in tests with MockSequentialWriter (`#2192 <https://github.com/ros2/rosbag2/issues/2192>`_)
+* Make the player respect the original messages' order with the same timestamp (`#2172 <https://github.com/ros2/rosbag2/issues/2172>`_)
+* Follow-up on "Fix for multibag replay stagnation (`#2158 <https://github.com/ros2/rosbag2/issues/2158>`_)" (`#2181 <https://github.com/ros2/rosbag2/issues/2181>`_)
+* Bugfix: Player can't play with read_ahead_queue_size equal 1 (`#2174 <https://github.com/ros2/rosbag2/issues/2174>`_)
+  Co-authored-by: Christophe Bedard <bedard.christophe@gmail.com>
+* Fixes for multiple race conditions in player (`#2171 <https://github.com/ros2/rosbag2/issues/2171>`_)
+* Fix for multibag replay stagnation (`#2158 <https://github.com/ros2/rosbag2/issues/2158>`_)
+* Bugfix for MCAPStorage::seek(time) advance in time is current (`#2157 <https://github.com/ros2/rosbag2/issues/2157>`_)
+* Add messages lost notification on a predefined topic during recording (`#2150 <https://github.com/ros2/rosbag2/issues/2150>`_)
+* Add RecorderEventNotifier class (`#2144 <https://github.com/ros2/rosbag2/issues/2144>`_)
+* Bugfix for deadlock in multibag replay (`#2143 <https://github.com/ros2/rosbag2/issues/2143>`_)
+* Use rclcpp typesupport helpers in rosbag2_cpp (`#2017 <https://github.com/ros2/rosbag2/issues/2017>`_)
+* Bugfix for callback not called in writer for MESSAGES_LOST event (`#2105 <https://github.com/ros2/rosbag2/issues/2105>`_)
+* Add public API to get player's starting time and playback duration (`#2095 <https://github.com/ros2/rosbag2/issues/2095>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
+* Bugfixes for deadlocks in Rosbag2 player when calling stop API (`#2057 <https://github.com/ros2/rosbag2/issues/2057>`_)
+* Add callbacks for messages loss statistics (`#2039 <https://github.com/ros2/rosbag2/issues/2039>`_)
+* Skip flaky `can_record_again_after_stop` test (`#2031 <https://github.com/ros2/rosbag2/issues/2031>`_)
+* Bugfix: No output in cout if progress bar is disabled (`#2024 <https://github.com/ros2/rosbag2/issues/2024>`_)
+* Improvements in message publishing timings (`#2025 <https://github.com/ros2/rosbag2/issues/2025>`_)
+* Fix for flaky `playing_respects_delay` test (`#2016 <https://github.com/ros2/rosbag2/issues/2016>`_)
+* Address flakiness in tests where need to spin a node (`#2001 <https://github.com/ros2/rosbag2/issues/2001>`_)
+* Avoid sending non-existent cancel requests (`#2005 <https://github.com/ros2/rosbag2/issues/2005>`_)
+* Contributors: Barry Xu, Dhruv Patel, Michael Orlov, Scott K Logan, mosfet80
+
 0.33.0 (2025-04-25)
 -------------------
 * Fix a maybe-uninitialized warning in player_action_client.cpp (`#1969 <https://github.com/ros2/rosbag2/issues/1969>`_)

--- a/zstd_cmake_module/CHANGELOG.rst
+++ b/zstd_cmake_module/CHANGELOG.rst
@@ -1,12 +1,11 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package rosbag2_performance_benchmarking_msgs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package zstd_cmake_module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 0.34.0 (2025-12-23)
 -------------------
-* Enable `rosbag2_performance_benchmarking` package to be built by default (`#2093 <https://github.com/ros2/rosbag2/issues/2093>`_)
-* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_)
-* Contributors: Michael Orlov, mosfet80
+* Replace zstd_vendor with zstd_cmake_module (`#2166 <https://github.com/ros2/rosbag2/issues/2166>`_)
+* Contributors: Alejandro Hernández Cordero
 
 0.33.0 (2025-04-25)
 -------------------
@@ -14,16 +13,16 @@ Changelog for package rosbag2_performance_benchmarking_msgs
 0.32.0 (2025-04-18)
 -------------------
 
-0.31.0 (2025-02-02)
+0.31.0 (2025-02-03)
 -------------------
 
 0.30.0 (2024-11-26)
 -------------------
 
-0.29.0 (2024-09-03)
+0.29.0 (2024-09-04)
 -------------------
 
-0.28.0 (2024-06-17)
+0.28.0 (2024-06-21)
 -------------------
 
 0.27.0 (2024-04-30)
@@ -35,33 +34,26 @@ Changelog for package rosbag2_performance_benchmarking_msgs
 0.26.0 (2024-04-16)
 -------------------
 
-0.25.0 (2024-03-27)
+0.25.0 (2024-03-28)
 -------------------
 
-0.24.0 (2023-07-11)
+0.24.0 (2023-07-12)
 -------------------
 
-0.23.0 (2023-04-28)
+0.23.0 (2023-04-29)
 -------------------
 
 0.22.0 (2023-04-18)
 -------------------
-* Add tests for rosbag2_performance_benchmarking pkg (`#1268 <https://github.com/ros2/rosbag2/issues/1268>`_)
-* Contributors: Michael Orlov
 
-0.21.0 (2023-04-12)
+0.21.0 (2023-04-13)
 -------------------
 
 0.20.0 (2023-02-14)
 -------------------
-* Skip ament_package() call when not building rosbag2_performance_benchmarking (`#1242 <https://github.com/ros2/rosbag2/issues/1242>`_)
-* Contributors: Shane Loretz
 
 0.19.0 (2023-01-13)
 -------------------
-* [rolling] Bump to 0.19.0 (`#1232 <https://github.com/ros2/rosbag2/issues/1232>`_)
-* Add option to specify a message type (`#1153 <https://github.com/ros2/rosbag2/issues/1153>`_)
-* Contributors: Audrow Nash, carlossvg
 
 0.18.0 (2022-11-15)
 -------------------


### PR DESCRIPTION
Rolling 0.34.0 release.

As soon as this PR is reviewed, I will squash commits, merge on the Rolling branch, fix the tag, and then do a bloom release for the Rosbag2 repo.