### PR TITLE
Kilted 0.32.1 release

### DIFF
--- a/liblz4_vendor/CHANGELOG.rst
+++ b/liblz4_vendor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package liblz4_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/mcap_vendor/CHANGELOG.rst
+++ b/mcap_vendor/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package mcap_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Backporting Missing cstdint Include (`#2008 <https://github.com/ros2/rosbag2/issues/2008>`_) (`#2199 <https://github.com/ros2/rosbag2/issues/2199>`_)
+* mcap_vendor: update to v1.4.2 (`#2070 <https://github.com/ros2/rosbag2/issues/2070>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: james-rms, mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/ros2bag/CHANGELOG.rst
+++ b/ros2bag/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package ros2bag
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* add rosbag2_storage_default_plugins to exec_depend of ros2bag. (`#2227 <https://github.com/ros2/rosbag2/issues/2227>`_) (`#2230 <https://github.com/ros2/rosbag2/issues/2230>`_)
+* Expose more of the player/recorder API through Python (`#2062 <https://github.com/ros2/rosbag2/issues/2062>`_) (`#2099 <https://github.com/ros2/rosbag2/issues/2099>`_)
+* Change Python player and recorder to be more as a classes (`#2047 <https://github.com/ros2/rosbag2/issues/2047>`_) (`#2053 <https://github.com/ros2/rosbag2/issues/2053>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add actions replay feature (`#1955 <https://github.com/ros2/rosbag2/issues/1955>`_)

--- a/rosbag2/CHANGELOG.rst
+++ b/rosbag2/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_compression/CHANGELOG.rst
+++ b/rosbag2_compression/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package rosbag2_compression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* [kilted] Make topics persistent between writer's close() and open() API calls. (backport `#2229 <https://github.com/ros2/rosbag2/issues/2229>`_) (`#2242 <https://github.com/ros2/rosbag2/issues/2242>`_)
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_) (`#2206 <https://github.com/ros2/rosbag2/issues/2206>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Bugfix: `ros2 bag convert` dropping messages with compression mode message (`#1975 <https://github.com/ros2/rosbag2/issues/1975>`_) (`#1984 <https://github.com/ros2/rosbag2/issues/1984>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_compression_zstd/CHANGELOG.rst
+++ b/rosbag2_compression_zstd/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_compression_zstd
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_cpp/CHANGELOG.rst
+++ b/rosbag2_cpp/CHANGELOG.rst
@@ -2,6 +2,24 @@
 Changelog for package rosbag2_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* [kilted] Make topics persistent between writer's close() and open() API calls. (backport `#2229 <https://github.com/ros2/rosbag2/issues/2229>`_) (`#2242 <https://github.com/ros2/rosbag2/issues/2242>`_)
+* [kilted] Check for nullptrs when pushing new messages to the message cache (backport `#2219 <https://github.com/ros2/rosbag2/issues/2219>`_) (`#2222 <https://github.com/ros2/rosbag2/issues/2222>`_)
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_) (`#2206 <https://github.com/ros2/rosbag2/issues/2206>`_)
+* [kilted] Log reasoning for not found message definition only in debug log (backport `#2183 <https://github.com/ros2/rosbag2/issues/2183>`_) (`#2185 <https://github.com/ros2/rosbag2/issues/2185>`_)
+* Use rclcpp typesupport helpers in rosbag2_cpp (`#2017 <https://github.com/ros2/rosbag2/issues/2017>`_) (`#2129 <https://github.com/ros2/rosbag2/issues/2129>`_)
+* Fix: Add null pointer check for reader_imp in the Reader constructor (`#2135 <https://github.com/ros2/rosbag2/issues/2135>`_) (`#2139 <https://github.com/ros2/rosbag2/issues/2139>`_)
+* minor error checks for rosbag2_cpp (`#2127 <https://github.com/ros2/rosbag2/issues/2127>`_) (`#2145 <https://github.com/ros2/rosbag2/issues/2145>`_)
+* Fix reindex duration bug when bag file durations overlap (`#2036 <https://github.com/ros2/rosbag2/issues/2036>`_) (`#2106 <https://github.com/ros2/rosbag2/issues/2106>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Add support for searching message definitions in nested subdirectories (`#2055 <https://github.com/ros2/rosbag2/issues/2055>`_) (`#2063 <https://github.com/ros2/rosbag2/issues/2063>`_)
+* Fix service/action message definition issue (`#2041 <https://github.com/ros2/rosbag2/issues/2041>`_) (`#2051 <https://github.com/ros2/rosbag2/issues/2051>`_)
+* Improvements in message publishing timings (`#2025 <https://github.com/ros2/rosbag2/issues/2025>`_) (`#2026 <https://github.com/ros2/rosbag2/issues/2026>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Address clang warning in the `TimeControllerClock::wakeup()` (`#1962 <https://github.com/ros2/rosbag2/issues/1962>`_) (`#1978 <https://github.com/ros2/rosbag2/issues/1978>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add support for finding action types message definitions in the `LocalMessageDefinitionSource`

--- a/rosbag2_examples/rosbag2_examples_cpp/CHANGELOG.rst
+++ b/rosbag2_examples/rosbag2_examples_cpp/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_examples_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_examples/rosbag2_examples_py/CHANGELOG.rst
+++ b/rosbag2_examples/rosbag2_examples_py/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_examples_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Add a simple example showing how to convert bags to the csv file (`#1974 <https://github.com/ros2/rosbag2/issues/1974>`_) (`#1981 <https://github.com/ros2/rosbag2/issues/1981>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_interfaces/CHANGELOG.rst
+++ b/rosbag2_interfaces/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_performance/rosbag2_performance_benchmarking/CHANGELOG.rst
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog for package rosbag2_performance_benchmarking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Fix warning: initialize number_of_threads (`#2121 <https://github.com/ros2/rosbag2/issues/2121>`_) (`#2122 <https://github.com/ros2/rosbag2/issues/2122>`_)
+* Bugfix: `prosbag2_performance_benchmarking` outputs incorrect results for topics with frequency more than 1 kHz (`#2077 <https://github.com/ros2/rosbag2/issues/2077>`_) (`#2079 <https://github.com/ros2/rosbag2/issues/2079>`_)
+* Fixes in the rosbag2_performance_benchmarking message data generator (`#2078 <https://github.com/ros2/rosbag2/issues/2078>`_) (`#2083 <https://github.com/ros2/rosbag2/issues/2083>`_)
+* Enable `rosbag2_performance_benchmarking` package to be built by default (`#2093 <https://github.com/ros2/rosbag2/issues/2093>`_) (`#2096 <https://github.com/ros2/rosbag2/issues/2096>`_)
+* Fix for failure in the benchmark_launch when using Process.wait twice (`#2076 <https://github.com/ros2/rosbag2/issues/2076>`_) (`#2081 <https://github.com/ros2/rosbag2/issues/2081>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CHANGELOG.rst
+++ b/rosbag2_performance/rosbag2_performance_benchmarking_msgs/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_performance_benchmarking_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Enable `rosbag2_performance_benchmarking` package to be built by default (`#2093 <https://github.com/ros2/rosbag2/issues/2093>`_) (`#2096 <https://github.com/ros2/rosbag2/issues/2096>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_py/CHANGELOG.rst
+++ b/rosbag2_py/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog for package rosbag2_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Make sure test topic is discovered by recorder in rosbag2_py test (`#2132 <https://github.com/ros2/rosbag2/issues/2132>`_) (`#2134 <https://github.com/ros2/rosbag2/issues/2134>`_)
+* Add public API to get player's starting time and playback duration (`#2095 <https://github.com/ros2/rosbag2/issues/2095>`_) (`#2101 <https://github.com/ros2/rosbag2/issues/2101>`_)
+* Expose more of the player/recorder API through Python (`#2062 <https://github.com/ros2/rosbag2/issues/2062>`_) (`#2099 <https://github.com/ros2/rosbag2/issues/2099>`_)
+* Change Python player and recorder to be more as a classes (`#2047 <https://github.com/ros2/rosbag2/issues/2047>`_) (`#2053 <https://github.com/ros2/rosbag2/issues/2053>`_)
+* Fix service/action message definition issue (`#2041 <https://github.com/ros2/rosbag2/issues/2041>`_) (`#2051 <https://github.com/ros2/rosbag2/issues/2051>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Bugfix: `ros2 bag convert` dropping messages with compression mode message (`#1975 <https://github.com/ros2/rosbag2/issues/1975>`_) (`#1984 <https://github.com/ros2/rosbag2/issues/1984>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add message sequence number to the messages write API (`#1961 <https://github.com/ros2/rosbag2/issues/1961>`_)

--- a/rosbag2_storage/CHANGELOG.rst
+++ b/rosbag2_storage/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package rosbag2_storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix memory leak on make_empty_serialized_message(). (`#2253 <https://github.com/ros2/rosbag2/issues/2253>`_) (`#2259 <https://github.com/ros2/rosbag2/issues/2259>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Bugfix: Undefined behavior in the `rosbag2_storage` and `rosbag2_storage_sqlite3` packages (`#1997 <https://github.com/ros2/rosbag2/issues/1997>`_) (`#1998 <https://github.com/ros2/rosbag2/issues/1998>`_)
+* Use DDS queue depth for subscriptions as a maximum value across publishers (`#1960 <https://github.com/ros2/rosbag2/issues/1960>`_) (`#1979 <https://github.com/ros2/rosbag2/issues/1979>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add message sequence number to the messages write API (`#1961 <https://github.com/ros2/rosbag2/issues/1961>`_)

--- a/rosbag2_storage_default_plugins/CHANGELOG.rst
+++ b/rosbag2_storage_default_plugins/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_storage_default_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/rosbag2_storage_mcap/CHANGELOG.rst
+++ b/rosbag2_storage_mcap/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_storage_mcap
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Bugfix for MCAPStorage::seek(time) advance in time is current (`#2157 <https://github.com/ros2/rosbag2/issues/2157>`_) (`#2159 <https://github.com/ros2/rosbag2/issues/2159>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add message sequence number to the messages write API (`#1961 <https://github.com/ros2/rosbag2/issues/1961>`_)

--- a/rosbag2_storage_sqlite3/CHANGELOG.rst
+++ b/rosbag2_storage_sqlite3/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package rosbag2_storage_default_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Bugfix: Undefined behavior in the `rosbag2_storage` and `rosbag2_storage_sqlite3` packages (`#1997 <https://github.com/ros2/rosbag2/issues/1997>`_) (`#1998 <https://github.com/ros2/rosbag2/issues/1998>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add actions replay feature (`#1955 <https://github.com/ros2/rosbag2/issues/1955>`_)

--- a/rosbag2_test_common/CHANGELOG.rst
+++ b/rosbag2_test_common/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package rosbag2_test_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Address flakiness in tests where need to spin a node (`#2001 <https://github.com/ros2/rosbag2/issues/2001>`_) (`#2018 <https://github.com/ros2/rosbag2/issues/2018>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Use DDS queue depth for subscriptions as a maximum value across publishers (`#1960 <https://github.com/ros2/rosbag2/issues/1960>`_) (`#1979 <https://github.com/ros2/rosbag2/issues/1979>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add actions replay feature (`#1955 <https://github.com/ros2/rosbag2/issues/1955>`_)

--- a/rosbag2_test_msgdefs/CHANGELOG.rst
+++ b/rosbag2_test_msgdefs/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_test_msgdefs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Add support for searching message definitions in nested subdirectories (`#2055 <https://github.com/ros2/rosbag2/issues/2055>`_) (`#2063 <https://github.com/ros2/rosbag2/issues/2063>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add support for finding action types message definitions in the `LocalMessageDefinitionSource`

--- a/rosbag2_tests/CHANGELOG.rst
+++ b/rosbag2_tests/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog for package rosbag2_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_) (`#2206 <https://github.com/ros2/rosbag2/issues/2206>`_)
+* Use rclcpp typesupport helpers in rosbag2_cpp (`#2017 <https://github.com/ros2/rosbag2/issues/2017>`_) (`#2129 <https://github.com/ros2/rosbag2/issues/2129>`_)
+* Expose more of the player/recorder API through Python (`#2062 <https://github.com/ros2/rosbag2/issues/2062>`_) (`#2099 <https://github.com/ros2/rosbag2/issues/2099>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Bugfixes for deadlocks in Rosbag2 player when calling stop API (`#2057 <https://github.com/ros2/rosbag2/issues/2057>`_) (`#2059 <https://github.com/ros2/rosbag2/issues/2059>`_)
+* Address flakiness in tests where need to spin a node (`#2001 <https://github.com/ros2/rosbag2/issues/2001>`_) (`#2018 <https://github.com/ros2/rosbag2/issues/2018>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Implement actions recording and displaying information about recorded actions features (`#1939 <https://github.com/ros2/rosbag2/issues/1939>`_)

--- a/rosbag2_transport/CHANGELOG.rst
+++ b/rosbag2_transport/CHANGELOG.rst
@@ -2,6 +2,38 @@
 Changelog for package rosbag2_transport
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* Fix macOS build: Disable thread-safety annotations in locked_priority_queue.hpp (`#2245 <https://github.com/ros2/rosbag2/issues/2245>`_) (`#2247 <https://github.com/ros2/rosbag2/issues/2247>`_)
+* [kilted] Fix for C++ Recorder failure on stop() -> record() due to reusing the bag name (backport `#2224 <https://github.com/ros2/rosbag2/issues/2224>`_) (`#2244 <https://github.com/ros2/rosbag2/issues/2244>`_)
+* Enable RMW communication isolation in rosbag2_transport tests (`#2190 <https://github.com/ros2/rosbag2/issues/2190>`_) (`#2213 <https://github.com/ros2/rosbag2/issues/2213>`_)
+* Address flakiness in the recorder tests with small cache size (`#2203 <https://github.com/ros2/rosbag2/issues/2203>`_) (`#2206 <https://github.com/ros2/rosbag2/issues/2206>`_)
+* Reduce CPU overhead in the Rosbag2 recorder discovery (`#2201 <https://github.com/ros2/rosbag2/issues/2201>`_) (`#2204 <https://github.com/ros2/rosbag2/issues/2204>`_)
+* [kilted] Fix for data races in tests with MockSequentialWriter (backport `#2192 <https://github.com/ros2/rosbag2/issues/2192>`_) (`#2195 <https://github.com/ros2/rosbag2/issues/2195>`_)
+* Fix for possible data races in PlayerProgressBar class (`#2194 <https://github.com/ros2/rosbag2/issues/2194>`_) (`#2197 <https://github.com/ros2/rosbag2/issues/2197>`_)
+* Make the player respect the original messages' order with the same timestamp (`#2172 <https://github.com/ros2/rosbag2/issues/2172>`_) (`#2187 <https://github.com/ros2/rosbag2/issues/2187>`_)
+* [kilted] Follow-up on "Fix for multibag replay stagnation (`#2158 <https://github.com/ros2/rosbag2/issues/2158>`_)" (`#2182 <https://github.com/ros2/rosbag2/issues/2182>`_)
+* Bugfix: Player can't play with read_ahead_queue_size equal 1 (`#2174 <https://github.com/ros2/rosbag2/issues/2174>`_) (`#2179 <https://github.com/ros2/rosbag2/issues/2179>`_)
+* Fixes for multiple race conditions in player (`#2171 <https://github.com/ros2/rosbag2/issues/2171>`_) (`#2176 <https://github.com/ros2/rosbag2/issues/2176>`_)
+* Use rclcpp typesupport helpers in rosbag2_cpp (`#2017 <https://github.com/ros2/rosbag2/issues/2017>`_) (`#2129 <https://github.com/ros2/rosbag2/issues/2129>`_)
+* Fix for multibag replay stagnation (`#2158 <https://github.com/ros2/rosbag2/issues/2158>`_) (`#2169 <https://github.com/ros2/rosbag2/issues/2169>`_)
+* Bugfix for MCAPStorage::seek(time) advance in time is current (`#2157 <https://github.com/ros2/rosbag2/issues/2157>`_) (`#2159 <https://github.com/ros2/rosbag2/issues/2159>`_)
+* [kilted] Add RecorderEventNotifier class (backport `#2144 <https://github.com/ros2/rosbag2/issues/2144>`_) (`#2149 <https://github.com/ros2/rosbag2/issues/2149>`_)
+* Bugfix for deadlock in multibag replay (`#2143 <https://github.com/ros2/rosbag2/issues/2143>`_) (`#2147 <https://github.com/ros2/rosbag2/issues/2147>`_)
+* Add public API to get player's starting time and playback duration (`#2095 <https://github.com/ros2/rosbag2/issues/2095>`_) (`#2101 <https://github.com/ros2/rosbag2/issues/2101>`_)
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Bugfixes for deadlocks in Rosbag2 player when calling stop API (`#2057 <https://github.com/ros2/rosbag2/issues/2057>`_) (`#2059 <https://github.com/ros2/rosbag2/issues/2059>`_)
+* Skip flaky `can_record_again_after_stop` test (`#2031 <https://github.com/ros2/rosbag2/issues/2031>`_) (`#2032 <https://github.com/ros2/rosbag2/issues/2032>`_)
+* Bugfix: No output in cout if progress bar is disabled (`#2024 <https://github.com/ros2/rosbag2/issues/2024>`_) (`#2028 <https://github.com/ros2/rosbag2/issues/2028>`_)
+* Improvements in message publishing timings (`#2025 <https://github.com/ros2/rosbag2/issues/2025>`_) (`#2026 <https://github.com/ros2/rosbag2/issues/2026>`_)
+* Address flakiness in tests where need to spin a node (`#2001 <https://github.com/ros2/rosbag2/issues/2001>`_) (`#2018 <https://github.com/ros2/rosbag2/issues/2018>`_)
+* Avoid sending non-existent cancel requests (`#2005 <https://github.com/ros2/rosbag2/issues/2005>`_) (`#2010 <https://github.com/ros2/rosbag2/issues/2010>`_)
+* Fix a maybe-uninitialized warning in player_action_client.cpp (`#1969 <https://github.com/ros2/rosbag2/issues/1969>`_) (`#1989 <https://github.com/ros2/rosbag2/issues/1989>`_)
+* Upstream quality changes from Apex.AI part-2 (`#1924 <https://github.com/ros2/rosbag2/issues/1924>`_) (`#1986 <https://github.com/ros2/rosbag2/issues/1986>`_)
+* Bugfix: `ros2 bag convert` dropping messages with compression mode message (`#1975 <https://github.com/ros2/rosbag2/issues/1975>`_) (`#1984 <https://github.com/ros2/rosbag2/issues/1984>`_)
+* Use DDS queue depth for subscriptions as a maximum value across publishers (`#1960 <https://github.com/ros2/rosbag2/issues/1960>`_) (`#1979 <https://github.com/ros2/rosbag2/issues/1979>`_)
+* Contributors: Michael Orlov, mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 * Add actions replay feature (`#1955 <https://github.com/ros2/rosbag2/issues/1955>`_)

--- a/sqlite3_vendor/CHANGELOG.rst
+++ b/sqlite3_vendor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package sqlite3_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 

--- a/zstd_vendor/CHANGELOG.rst
+++ b/zstd_vendor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package zstd_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.32.1 (2025-12-23)
+-------------------
+* fix CMAKE deprecation (`#2067 <https://github.com/ros2/rosbag2/issues/2067>`_) (`#2068 <https://github.com/ros2/rosbag2/issues/2068>`_)
+* Contributors: mergify[bot]
+
 0.32.0 (2025-04-18)
 -------------------
 


### PR DESCRIPTION
Kilted 0.32.1 release

As soon as this PR is reviewed, I will squash commits, merge on the Kilted branch, fix the tag, and then do a bloom release for the Rosbag2 repo.