### PR TITLE
Use QoS override settings for inner Rosbag2 publishing topics

### DIFF
--- a/rosbag2_storage/include/rosbag2_storage/qos.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/qos.hpp
@@ -53,13 +53,6 @@ public:
     return *this;
   }
 
-  static Rosbag2QoS EventQoS()
-  {
-    return Rosbag2QoS(rclcpp::QoS(3)
-             .reliable()
-             .durability_volatile());
-  }
-
   /// \brief Convert this QoS profile to a string representation.
   /// \return string representation of this QoS profile.
   [[nodiscard]] std::string to_string() const;

--- a/rosbag2_storage/include/rosbag2_storage/qos.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/qos.hpp
@@ -53,6 +53,13 @@ public:
     return *this;
   }
 
+  static Rosbag2QoS EventQoS()
+  {
+    return Rosbag2QoS(rclcpp::QoS(3)
+             .reliable()
+             .durability_volatile());
+  }
+
   /// \brief Convert this QoS profile to a string representation.
   /// \return string representation of this QoS profile.
   [[nodiscard]] std::string to_string() const;

--- a/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder_event_notifier.hpp
@@ -27,6 +27,7 @@
 #include "rosbag2_interfaces/msg/messages_lost_event.hpp"
 #include "rosbag2_interfaces/msg/write_split_event.hpp"
 #include "rosbag2_transport/rclcpp_publisher_wrapper.hpp"
+#include <rosbag2_transport/record_options.hpp>
 #include "rosbag2_transport/visibility_control.hpp"
 
 #ifdef _WIN32
@@ -58,12 +59,14 @@ public:
   /// \details This constructor initializes the event notifier with a node and optional publishers
   /// for split events and messages lost events.
   /// \param node Pointer to the rclcpp Node that will be used for publishing events.
+  /// \param record_options The record options used by the recorder.
   /// \param split_event_pub Optional publisher for WriteSplitEvent messages. If not provided, a
   /// new publisher will be created with the topic name "events/write_split".
   /// \param msgs_lost_event_pub Optional publisher for MessagesLostEvent messages. If not provided,
   /// a new publisher will be created with the topic name "events/rosbag2_messages_lost".
   explicit RecorderEventNotifier(
     rclcpp::Node * node,
+    const rosbag2_transport::RecordOptions & record_options = {},
     RclcppPublisherWrapper<WriteSplitEvent>::SharedPtr split_event_pub = nullptr,
     RclcppPublisherWrapper<MessagesLostEvent>::SharedPtr msgs_lost_event_pub = nullptr);
 
@@ -117,6 +120,14 @@ public:
 
   /// \brief Get the topic name used for publishing messages lost events.
   [[nodiscard]] std::string_view get_messages_lost_topic_name() const;
+
+  /// \brief Get the QoS profile used for write split event publisher.
+  /// \return The QoS profile used for publishing write split events.
+  [[nodiscard]] rclcpp::QoS get_write_split_qos() const;
+
+  /// \brief Get the QoS profile used for messages lost event publisher.
+  /// \return The QoS profile used for publishing messages lost events.
+  [[nodiscard]] rclcpp::QoS get_messages_lost_qos() const;
 
 private:
   std::unique_ptr<RecorderEventNotifierImpl> pimpl_;

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -1635,16 +1635,16 @@ void PlayerImpl::prepare_publishers()
 
   // Create a publisher and callback for when encountering a split in the input
   rosbag2_storage::Rosbag2QoS split_event_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
-  if (play_options_.topic_qos_profile_overrides.find(kDefaultReadSplitTopicName) !=
+  auto read_split_topic_name = rclcpp::expand_topic_or_service_name(
+    kDefaultReadSplitTopicName, owner_->get_name(), owner_->get_namespace(), false);
+  if (play_options_.topic_qos_profile_overrides.find(read_split_topic_name) !=
     play_options_.topic_qos_profile_overrides.end())
   {
-    const auto & override_qos =
-      play_options_.topic_qos_profile_overrides.at(kDefaultReadSplitTopicName);
+    const auto & override_qos = play_options_.topic_qos_profile_overrides.at(read_split_topic_name);
     split_event_qos = rosbag2_storage::Rosbag2QoS(override_qos);
     RCLCPP_DEBUG(owner_->get_logger(),
       "Using overridden QoS profile: \n%s\nfor '%s' topic.",
-      split_event_qos.to_string().c_str(),
-      kDefaultReadSplitTopicName);
+      split_event_qos.to_string().c_str(), read_split_topic_name.c_str());
   }
 
   split_event_pub_ = owner_->create_publisher<rosbag2_interfaces::msg::ReadSplitEvent>(

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -356,6 +356,7 @@ private:
 
   Player * owner_;
   rosbag2_transport::PlayOptions play_options_;
+  static constexpr const char * kDefaultReadSplitTopicName = "events/read_split";
   rcutils_time_point_value_t play_until_timestamp_ = -1;
   LockedPriorityQueue<rosbag2_storage::SerializedBagMessageSharedPtr> message_queue_;
   using BagMessageComparator =
@@ -1633,8 +1634,21 @@ void PlayerImpl::prepare_publishers()
   }
 
   // Create a publisher and callback for when encountering a split in the input
+  rosbag2_storage::Rosbag2QoS split_event_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
+  if (play_options_.topic_qos_profile_overrides.find(kDefaultReadSplitTopicName) !=
+    play_options_.topic_qos_profile_overrides.end())
+  {
+    const auto & override_qos =
+      play_options_.topic_qos_profile_overrides.at(kDefaultReadSplitTopicName);
+    split_event_qos = rosbag2_storage::Rosbag2QoS(override_qos);
+    RCLCPP_DEBUG(owner_->get_logger(),
+      "Using overridden QoS profile: \n%s\nfor '%s' topic.",
+      split_event_qos.to_string().c_str(),
+      kDefaultReadSplitTopicName);
+  }
+
   split_event_pub_ = owner_->create_publisher<rosbag2_interfaces::msg::ReadSplitEvent>(
-    "events/read_split", rosbag2_storage::Rosbag2QoS::EventQoS());
+    kDefaultReadSplitTopicName, split_event_qos);
   rosbag2_cpp::bag_events::ReaderEventCallbacks callbacks;
   callbacks.read_split_callback =
     [this](rosbag2_cpp::bag_events::BagSplitInfo & info) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -258,7 +258,7 @@ RecorderImpl::RecorderImpl(
   node(owner),
   paused_(record_options.start_paused),
   keyboard_handler_(std::move(keyboard_handler)),
-  event_notifier_(std::make_unique<RecorderEventNotifier>(node))
+  event_notifier_(std::make_unique<RecorderEventNotifier>(node, record_options))
 {
   event_notifier_->set_messages_lost_statistics_max_publishing_rate(
     record_options.statistics_max_publishing_rate);

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
 
@@ -23,10 +24,12 @@ namespace rosbag2_transport
 
 RecorderEventNotifier::RecorderEventNotifier(
   rclcpp::Node * node,
+  const rosbag2_transport::RecordOptions & record_options,
   RclcppPublisherWrapper<rosbag2_interfaces::msg::WriteSplitEvent>::SharedPtr split_event_pub,
   RclcppPublisherWrapper<rosbag2_interfaces::msg::MessagesLostEvent>::SharedPtr msgs_lost_event_pub)
 {
   pimpl_ = std::make_unique<RecorderEventNotifierImpl>(node,
+                                                       record_options,
                                                        std::move(split_event_pub),
                                                        std::move(msgs_lost_event_pub));
 }
@@ -100,6 +103,16 @@ std::string_view RecorderEventNotifier::get_write_split_topic_name() const
 std::string_view RecorderEventNotifier::get_messages_lost_topic_name() const
 {
   return pimpl_->get_messages_lost_topic_name();
+}
+
+rclcpp::QoS RecorderEventNotifier::get_write_split_qos() const
+{
+  return pimpl_->get_write_split_qos();
+}
+
+rclcpp::QoS RecorderEventNotifier::get_messages_lost_qos() const
+{
+  return pimpl_->get_messages_lost_qos();
 }
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -51,28 +51,60 @@ public:
 
   explicit RecorderEventNotifierImpl(
     rclcpp::Node * node,
+    const rosbag2_transport::RecordOptions & record_options,
     RclcppPublisherWrapper<WriteSplitEvent>::SharedPtr split_event_pub = nullptr,
     RclcppPublisherWrapper<MessagesLostEvent>::SharedPtr msgs_lost_event_pub = nullptr)
-  : node(node)
+  : node_(node)
   {
     if (!node) {
       throw std::invalid_argument("Node pointer cannot be null");
     }
 
+    rosbag2_storage::Rosbag2QoS split_event_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
+    rosbag2_storage::Rosbag2QoS msgs_lost_event_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
+
+    if (record_options.topic_qos_profile_overrides.find(kDefaultWriteSplitTopicName) !=
+      record_options.topic_qos_profile_overrides.end())
+    {
+      const auto & override_qos =
+        record_options.topic_qos_profile_overrides.at(kDefaultWriteSplitTopicName);
+      split_event_qos = rosbag2_storage::Rosbag2QoS(override_qos);
+      RCLCPP_DEBUG(node_->get_logger(),
+                   "Using overridden QoS profile: \n%s\nfor '%s' topic.",
+                   split_event_qos.to_string().c_str(),
+                   kDefaultWriteSplitTopicName);
+    }
+
+    if (record_options.topic_qos_profile_overrides.find(kDefaultMessagesLostTopicName) !=
+      record_options.topic_qos_profile_overrides.end())
+    {
+      const auto & override_qos =
+        record_options.topic_qos_profile_overrides.at(kDefaultMessagesLostTopicName);
+      msgs_lost_event_qos = rosbag2_storage::Rosbag2QoS(override_qos);
+      RCLCPP_DEBUG(node_->get_logger(),
+                   "Using overridden QoS profile: \n%s\nfor '%s' topic.",
+                   msgs_lost_event_qos.to_string().c_str(),
+                   kDefaultMessagesLostTopicName);
+    }
+
+    // Store QoS profiles for getter methods
+    split_event_qos_ = split_event_qos;
+    msgs_lost_event_qos_ = msgs_lost_event_qos;
+
     if (split_event_pub) {
       split_event_pub_ = std::move(split_event_pub);
     } else {
       split_event_pub_ = RclcppPublisherWrapper<WriteSplitEvent>::make_shared(
-        node->create_publisher<WriteSplitEvent>(kDefaultWriteSplitTopicName,
-                                                rosbag2_storage::Rosbag2QoS::EventQoS()));
+        node_->create_publisher<WriteSplitEvent>(kDefaultWriteSplitTopicName,
+                                                 split_event_qos));
     }
 
     if (msgs_lost_event_pub) {
       msgs_lost_event_pub_ = std::move(msgs_lost_event_pub);
     } else {
       msgs_lost_event_pub_ = RclcppPublisherWrapper<MessagesLostEvent>::make_shared(
-        node->create_publisher<MessagesLostEvent>(kDefaultMessagesLostTopicName,
-                                                  rosbag2_storage::Rosbag2QoS::EventQoS()));
+        node_->create_publisher<MessagesLostEvent>(kDefaultMessagesLostTopicName,
+                                                   msgs_lost_event_qos));
     }
 
     // Start the thread that will publish events
@@ -114,6 +146,16 @@ public:
     }
   }
 
+  [[nodiscard]] rclcpp::QoS get_write_split_qos() const
+  {
+    return split_event_qos_;
+  }
+
+  [[nodiscard]] rclcpp::QoS get_messages_lost_qos() const
+  {
+    return msgs_lost_event_qos_;
+  }
+
   /// \brief Set the maximum publishing rate for messages lost statistics.
   void set_messages_lost_statistics_max_publishing_rate(float update_rate_hz)
   {
@@ -121,7 +163,7 @@ public:
       std::unique_lock<std::mutex> pub_thread_lock(event_publisher_thread_mutex_);
       if (update_rate_hz == 0.0f) {
         disable_publishing_msgs_lost_statistics_ = true;
-        RCLCPP_DEBUG(node->get_logger(), "Messages lost statistics publishing is disabled");
+        RCLCPP_DEBUG(node_->get_logger(), "Messages lost statistics publishing is disabled");
       } else if (update_rate_hz > 0.0f) {
         if (update_rate_hz >= 1000.0f) {
           throw std::invalid_argument("Update rate must be less than 1000 Hz");
@@ -129,7 +171,7 @@ public:
         disable_publishing_msgs_lost_statistics_ = false;
         msgs_lost_stats_max_publishing_period_ =
           std::chrono::milliseconds(static_cast<int>(1000 / update_rate_hz));
-        RCLCPP_DEBUG(node->get_logger(),
+        RCLCPP_DEBUG(node_->get_logger(),
                      "Messages lost statistics publishing update rate set to %ld ms",
                      msgs_lost_stats_max_publishing_period_.count());
       } else {
@@ -162,7 +204,7 @@ public:
           log_text += "\n\t" + info.topic_name + ": " + std::to_string(info.num_messages_lost);
         }
       }
-      RCLCPP_DEBUG(node->get_logger(), "%s", log_text.c_str());
+      RCLCPP_DEBUG(node_->get_logger(), "%s", log_text.c_str());
     }
   }
 
@@ -172,7 +214,7 @@ public:
   {
     total_num_messages_lost_in_transport_.fetch_add(qos_msgs_lost_info.total_count_change);
     RCLCPP_DEBUG(
-      node->get_logger(),
+      node_->get_logger(),
       "Messages lost on transport layer for topic '%s'. Total lost: %lu",
       topic_name.c_str(), qos_msgs_lost_info.total_count);
 
@@ -205,7 +247,7 @@ public:
 
   void event_publisher_thread_main()
   {
-    RCLCPP_INFO(node->get_logger(), "Event publisher thread: Started");
+    RCLCPP_INFO(node_->get_logger(), "Event publisher thread: Started");
     while (!event_publisher_thread_should_exit_.load()) {
       std::unique_lock<std::mutex> pub_thread_lock(event_publisher_thread_mutex_);
       if (disable_publishing_msgs_lost_statistics_) {
@@ -233,14 +275,14 @@ public:
           auto message = rosbag2_interfaces::msg::WriteSplitEvent();
           message.closed_file = bag_split_info.closed_file;
           message.opened_file = bag_split_info.opened_file;
-          message.node_name = node->get_fully_qualified_name();
+          message.node_name = node_->get_fully_qualified_name();
           split_event_pub_->publish(message);
         } catch (const std::exception & e) {
-          RCLCPP_ERROR_STREAM(node->get_logger(),
+          RCLCPP_ERROR_STREAM(node_->get_logger(),
             "Failed to publish message on '" << get_write_split_topic_name() <<
             "' topic. \nError: " << e.what());
         } catch (...) {
-          RCLCPP_ERROR_STREAM(node->get_logger(),
+          RCLCPP_ERROR_STREAM(node_->get_logger(),
             "Failed to publish message on '" << get_write_split_topic_name() << "' topic.");
         }
         bag_split_info_queue_.pop();
@@ -251,7 +293,7 @@ public:
         if (!per_topic_messages_lost_statistics_.empty()) {
           try {
             auto message = rosbag2_interfaces::msg::MessagesLostEvent();
-            message.node_name = node->get_fully_qualified_name();
+            message.node_name = node_->get_fully_qualified_name();
             for (const auto &[topic, lost_stats] : per_topic_messages_lost_statistics_) {
               const auto &[transport_lost, recorder_lost] = lost_stats;
               message.messages_lost_statistics.emplace_back();
@@ -264,23 +306,25 @@ public:
             statistics_lock.unlock();
             msgs_lost_event_pub_->publish(message);
           } catch (const std::exception & e) {
-            RCLCPP_ERROR_STREAM(node->get_logger(),
+            RCLCPP_ERROR_STREAM(node_->get_logger(),
               "Failed to publish message on '" << get_messages_lost_topic_name() <<
               "' topic. \nError: " << e.what());
           } catch (...) {
-            RCLCPP_ERROR_STREAM(node->get_logger(),
+            RCLCPP_ERROR_STREAM(node_->get_logger(),
               "Failed to publish message on '" << get_messages_lost_topic_name() << "' topic.");
           }
         }
       }
     }
-    RCLCPP_INFO(node->get_logger(), "Event publisher thread: Exited");
+    RCLCPP_INFO(node_->get_logger(), "Event publisher thread: Exited");
   }
 
 private:
-  rclcpp::Node * node;
+  rclcpp::Node * node_;
   RclcppPublisherWrapper<WriteSplitEvent>::SharedPtr split_event_pub_;
   RclcppPublisherWrapper<MessagesLostEvent>::SharedPtr msgs_lost_event_pub_;
+  rclcpp::QoS split_event_qos_{1};
+  rclcpp::QoS msgs_lost_event_qos_{1};
   std::atomic<bool> event_publisher_thread_should_exit_ = false;
   std::queue<rosbag2_cpp::bag_events::BagSplitInfo> bag_split_info_queue_;
   std::mutex event_publisher_thread_mutex_;

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -63,28 +63,36 @@ public:
     rosbag2_storage::Rosbag2QoS split_event_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
     rosbag2_storage::Rosbag2QoS msgs_lost_event_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
 
-    if (record_options.topic_qos_profile_overrides.find(kDefaultWriteSplitTopicName) !=
+    // Need to expand the default relative topic name to check for QoS overrides
+    auto write_split_topic_name = rclcpp::expand_topic_or_service_name(
+      kDefaultWriteSplitTopicName, node->get_name(), node->get_namespace(), false);
+
+    if (record_options.topic_qos_profile_overrides.find(write_split_topic_name) !=
       record_options.topic_qos_profile_overrides.end())
     {
       const auto & override_qos =
-        record_options.topic_qos_profile_overrides.at(kDefaultWriteSplitTopicName);
+        record_options.topic_qos_profile_overrides.at(write_split_topic_name);
       split_event_qos = rosbag2_storage::Rosbag2QoS(override_qos);
       RCLCPP_DEBUG(node_->get_logger(),
                    "Using overridden QoS profile: \n%s\nfor '%s' topic.",
                    split_event_qos.to_string().c_str(),
-                   kDefaultWriteSplitTopicName);
+                   write_split_topic_name.c_str());
     }
 
-    if (record_options.topic_qos_profile_overrides.find(kDefaultMessagesLostTopicName) !=
+    // Need to expand the default relative topic name to check for QoS overrides
+    auto messages_lost_topic_name = rclcpp::expand_topic_or_service_name(
+      kDefaultMessagesLostTopicName, node->get_name(), node->get_namespace(), false);
+
+    if (record_options.topic_qos_profile_overrides.find(messages_lost_topic_name) !=
       record_options.topic_qos_profile_overrides.end())
     {
       const auto & override_qos =
-        record_options.topic_qos_profile_overrides.at(kDefaultMessagesLostTopicName);
+        record_options.topic_qos_profile_overrides.at(messages_lost_topic_name);
       msgs_lost_event_qos = rosbag2_storage::Rosbag2QoS(override_qos);
       RCLCPP_DEBUG(node_->get_logger(),
                    "Using overridden QoS profile: \n%s\nfor '%s' topic.",
                    msgs_lost_event_qos.to_string().c_str(),
-                   kDefaultMessagesLostTopicName);
+                   messages_lost_topic_name.c_str());
     }
 
     // Store QoS profiles for getter methods

--- a/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder_event_notifier_impl.hpp
@@ -31,6 +31,7 @@
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/publisher.hpp"
+#include "rclcpp/qos.hpp"
 
 #include "rosbag2_interfaces/msg/messages_lost_event.hpp"
 #include "rosbag2_interfaces/msg/write_split_event.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -626,8 +626,12 @@ TEST_F(TestRecorderEventNotifier, applies_qos_override_for_write_split_topic)
   // Set custom QoS for write_split topic
   rclcpp::QoS custom_qos(10);
   custom_qos.reliable().transient_local();
-  record_options.topic_qos_profile_overrides.insert(
-    {RecorderEventNotifier::get_default_write_split_topic_name(), custom_qos});
+  // Need to expand the default relative topic name to check for QoS overrides
+  auto write_split_topic_name = rclcpp::expand_topic_or_service_name(
+    RecorderEventNotifier::get_default_write_split_topic_name(),
+    node_->get_name(), node_->get_namespace(), false);
+
+  record_options.topic_qos_profile_overrides.insert({write_split_topic_name, custom_qos});
 
   auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
 
@@ -651,8 +655,12 @@ TEST_F(TestRecorderEventNotifier, applies_qos_override_for_messages_lost_topic)
   // Set custom QoS for messages_lost topic
   rclcpp::QoS custom_qos(20);
   custom_qos.best_effort().durability_volatile();
-  record_options.topic_qos_profile_overrides.insert(
-    {RecorderEventNotifier::get_default_messages_lost_topic_name(), custom_qos});
+  // Need to expand the default relative topic name to check for QoS overrides
+  auto messages_lost_topic_name = rclcpp::expand_topic_or_service_name(
+    RecorderEventNotifier::get_default_messages_lost_topic_name(),
+    node_->get_name(), node_->get_namespace(), false);
+
+  record_options.topic_qos_profile_overrides.insert({messages_lost_topic_name, custom_qos});
 
   auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
 
@@ -680,10 +688,16 @@ TEST_F(TestRecorderEventNotifier, applies_qos_overrides_for_both_event_topics)
   rclcpp::QoS custom_lost_qos(25);
   custom_lost_qos.best_effort().durability_volatile();
 
-  record_options.topic_qos_profile_overrides.insert(
-    {RecorderEventNotifier::get_default_write_split_topic_name(), custom_split_qos});
-  record_options.topic_qos_profile_overrides.insert(
-    {RecorderEventNotifier::get_default_messages_lost_topic_name(), custom_lost_qos});
+  // Need to expand the default relative topic names
+  auto write_split_topic_name = rclcpp::expand_topic_or_service_name(
+    RecorderEventNotifier::get_default_write_split_topic_name(),
+    node_->get_name(), node_->get_namespace(), false);
+  auto messages_lost_topic_name = rclcpp::expand_topic_or_service_name(
+    RecorderEventNotifier::get_default_messages_lost_topic_name(),
+    node_->get_name(), node_->get_namespace(), false);
+
+  record_options.topic_qos_profile_overrides.insert({write_split_topic_name, custom_split_qos});
+  record_options.topic_qos_profile_overrides.insert({messages_lost_topic_name, custom_lost_qos});
 
   auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
 
@@ -704,8 +718,13 @@ TEST_F(TestRecorderEventNotifier, qos_override_preserves_functionality_for_event
 {
   rosbag2_transport::RecordOptions record_options;
   const size_t expected_number_of_messages = 1;
-  const std::string split_topic_name = RecorderEventNotifier::get_default_write_split_topic_name();
-  const std::string lost_topic_name = RecorderEventNotifier::get_default_messages_lost_topic_name();
+  // Need to expand the default relative topic names
+  auto split_topic_name = rclcpp::expand_topic_or_service_name(
+    RecorderEventNotifier::get_default_write_split_topic_name(),
+    node_->get_name(), node_->get_namespace(), false);
+  auto lost_topic_name = rclcpp::expand_topic_or_service_name(
+    RecorderEventNotifier::get_default_messages_lost_topic_name(),
+    node_->get_name(), node_->get_namespace(), false);
 
   // Set custom QoS for write_split topic
   rclcpp::QoS custom_qos(5);

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "rclcpp/qos.hpp"
 #include "rosbag2_interfaces/msg/messages_lost_event.hpp"
 #include "rosbag2_interfaces/msg/messages_lost_event_topic_stat.hpp"
 #include "rosbag2_interfaces/msg/write_split_event.hpp"

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -396,8 +396,10 @@ TEST_F(TestRecorderEventNotifier, event_notifier_respects_max_publishing_rate) {
   ));
 
   // Pass the shared_ptr mocks directly to the notifier
-  notifier_ =
-    std::make_unique<RecorderEventNotifier>(node_.get(), write_split_pub_mock, msgs_lost_pub_mock);
+  notifier_ = std::make_unique<RecorderEventNotifier>(node_.get(),
+                                                      rosbag2_transport::RecordOptions{},
+                                                      write_split_pub_mock,
+                                                      msgs_lost_pub_mock);
 
   notifier_->set_messages_lost_statistics_max_publishing_rate(2.0f);  // 2 Hz
 
@@ -591,4 +593,169 @@ TEST_F(TestRecorderEventNotifier, thread_safety_with_concurrent_access)
   // Verify that the total counts are consistent
   EXPECT_EQ(notifier_->get_total_num_messages_lost_in_transport(), expected_transport_lost);
   EXPECT_EQ(notifier_->get_total_num_messages_lost_in_recorder(), expected_recorder_lost);
+}
+
+TEST_F(TestRecorderEventNotifier, uses_default_qos_when_no_overrides_specified)
+{
+  // Create notifier without QoS overrides
+  rosbag2_transport::RecordOptions record_options;
+  auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
+
+  // Get the QoS profiles used by the notifier
+  auto write_split_qos = notifier->get_write_split_qos();
+  auto msgs_lost_qos = notifier->get_messages_lost_qos();
+
+  // Default EventQoS is: depth=3, reliable, volatile
+  auto default_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
+
+  EXPECT_EQ(write_split_qos.history(), default_qos.history());
+  EXPECT_EQ(write_split_qos.depth(), default_qos.depth());
+  EXPECT_EQ(write_split_qos.reliability(), default_qos.reliability());
+  EXPECT_EQ(write_split_qos.durability(), default_qos.durability());
+
+  EXPECT_EQ(msgs_lost_qos.history(), default_qos.history());
+  EXPECT_EQ(msgs_lost_qos.depth(), default_qos.depth());
+  EXPECT_EQ(msgs_lost_qos.reliability(), default_qos.reliability());
+  EXPECT_EQ(msgs_lost_qos.durability(), default_qos.durability());
+}
+
+TEST_F(TestRecorderEventNotifier, applies_qos_override_for_write_split_topic)
+{
+  rosbag2_transport::RecordOptions record_options;
+
+  // Set custom QoS for write_split topic
+  rclcpp::QoS custom_qos(10);
+  custom_qos.reliable().transient_local();
+  record_options.topic_qos_profile_overrides.insert(
+    {RecorderEventNotifier::get_default_write_split_topic_name(), custom_qos});
+
+  auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
+
+  // Verify the QoS was applied
+  auto actual_qos = notifier->get_write_split_qos();
+
+  EXPECT_EQ(actual_qos.depth(), custom_qos.depth());
+  EXPECT_EQ(actual_qos.reliability(), custom_qos.reliability());
+  EXPECT_EQ(actual_qos.durability(), custom_qos.durability());
+
+  // Verify messages_lost QoS remains default
+  auto msgs_lost_qos = notifier->get_messages_lost_qos();
+  auto default_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
+  EXPECT_EQ(msgs_lost_qos.depth(), default_qos.depth());
+}
+
+TEST_F(TestRecorderEventNotifier, applies_qos_override_for_messages_lost_topic)
+{
+  rosbag2_transport::RecordOptions record_options;
+
+  // Set custom QoS for messages_lost topic
+  rclcpp::QoS custom_qos(20);
+  custom_qos.best_effort().durability_volatile();
+  record_options.topic_qos_profile_overrides.insert(
+    {RecorderEventNotifier::get_default_messages_lost_topic_name(), custom_qos});
+
+  auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
+
+  // Verify the QoS was applied
+  auto actual_qos = notifier->get_messages_lost_qos();
+
+  EXPECT_EQ(actual_qos.depth(), custom_qos.depth());
+  EXPECT_EQ(actual_qos.reliability(), custom_qos.reliability());
+  EXPECT_EQ(actual_qos.durability(), custom_qos.durability());
+
+  // Verify write_split QoS remains default
+  auto write_split_qos = notifier->get_write_split_qos();
+  auto default_qos = rosbag2_storage::Rosbag2QoS::EventQoS();
+  EXPECT_EQ(write_split_qos.depth(), default_qos.depth());
+}
+
+TEST_F(TestRecorderEventNotifier, applies_qos_overrides_for_both_event_topics)
+{
+  rosbag2_transport::RecordOptions record_options;
+
+  // Set custom QoS for both event topics
+  rclcpp::QoS custom_split_qos(15);
+  custom_split_qos.reliable().transient_local();
+
+  rclcpp::QoS custom_lost_qos(25);
+  custom_lost_qos.best_effort().durability_volatile();
+
+  record_options.topic_qos_profile_overrides.insert(
+    {RecorderEventNotifier::get_default_write_split_topic_name(), custom_split_qos});
+  record_options.topic_qos_profile_overrides.insert(
+    {RecorderEventNotifier::get_default_messages_lost_topic_name(), custom_lost_qos});
+
+  auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
+
+  // Verify write_split QoS
+  auto actual_split_qos = notifier->get_write_split_qos();
+  EXPECT_EQ(actual_split_qos.depth(), custom_split_qos.depth());
+  EXPECT_EQ(actual_split_qos.reliability(), custom_split_qos.reliability());
+  EXPECT_EQ(actual_split_qos.durability(), custom_split_qos.durability());
+
+  // Verify messages_lost QoS
+  auto actual_lost_qos = notifier->get_messages_lost_qos();
+  EXPECT_EQ(actual_lost_qos.depth(), custom_lost_qos.depth());
+  EXPECT_EQ(actual_lost_qos.reliability(), custom_lost_qos.reliability());
+  EXPECT_EQ(actual_lost_qos.durability(), custom_lost_qos.durability());
+}
+
+TEST_F(TestRecorderEventNotifier, qos_override_preserves_functionality_for_events)
+{
+  rosbag2_transport::RecordOptions record_options;
+  const size_t expected_number_of_messages = 1;
+  const std::string split_topic_name = RecorderEventNotifier::get_default_write_split_topic_name();
+  const std::string lost_topic_name = RecorderEventNotifier::get_default_messages_lost_topic_name();
+
+  // Set custom QoS for write_split topic
+  rclcpp::QoS custom_qos(5);
+  custom_qos.reliable().transient_local();
+
+  record_options.topic_qos_profile_overrides.insert({split_topic_name, custom_qos});
+  record_options.topic_qos_profile_overrides.insert({lost_topic_name, custom_qos});
+
+  auto notifier = std::make_unique<RecorderEventNotifier>(node_.get(), record_options);
+  notifier->set_messages_lost_statistics_max_publishing_rate(30.0f);
+
+  auto sub = std::make_unique<SubscriptionManager>();
+  sub->add_subscription<WriteSplitEvent>(split_topic_name, expected_number_of_messages, custom_qos);
+
+  ASSERT_TRUE(sub->spin_and_wait_for_matched({split_topic_name}, std::chrono::seconds(30), 1));
+  auto await_received_messages = sub->spin_subscriptions(std::chrono::seconds(30));
+
+  // Trigger event
+  rosbag2_cpp::bag_events::BagSplitInfo bag_split_info;
+  bag_split_info.closed_file = "test_closed.bag";
+  bag_split_info.opened_file = "test_opened.bag";
+  notifier->on_bag_split_in_recorder(bag_split_info);
+
+  await_received_messages.get();
+  auto write_split_msgs_received = sub->get_received_messages<WriteSplitEvent>(split_topic_name);
+
+  // Verify event was received correctly even with custom QoS
+  ASSERT_THAT(write_split_msgs_received, SizeIs(expected_number_of_messages));
+  EXPECT_THAT(write_split_msgs_received[0]->node_name, Eq(node_->get_fully_qualified_name()));
+  EXPECT_THAT(write_split_msgs_received[0]->closed_file, Eq(bag_split_info.closed_file));
+  EXPECT_THAT(write_split_msgs_received[0]->opened_file, Eq(bag_split_info.opened_file));
+
+  // Verify messages_lost event with custom QoS
+  sub->add_subscription<MessagesLostEvent>(lost_topic_name,
+                                           expected_number_of_messages,
+                                           custom_qos);
+
+  ASSERT_TRUE(sub->spin_and_wait_for_matched({lost_topic_name}, std::chrono::seconds(30), 1));
+  await_received_messages = sub->spin_subscriptions(std::chrono::seconds(30));
+
+  // Trigger event
+  rclcpp::QOSMessageLostInfo msgs_lost_info;
+  msgs_lost_info.total_count = 10;
+  msgs_lost_info.total_count_change = 5;
+  notifier->on_messages_lost_in_transport("test_topic", msgs_lost_info);
+
+  await_received_messages.get();
+  auto lost_msgs_received = sub->get_received_messages<MessagesLostEvent>(lost_topic_name);
+
+  // Verify event was received correctly even with custom QoS
+  ASSERT_THAT(lost_msgs_received, SizeIs(expected_number_of_messages));
+  EXPECT_THAT(lost_msgs_received[0]->node_name, Eq(node_->get_fully_qualified_name()));
 }


### PR DESCRIPTION
## Description

This PR will add the ability to override the Rosbag2's inner publishing topics, such as `write{read}_split_event` and `messages_lost_event` with `bag record --qos-profile-overrides-path` CLI option.

- Fixes # https://github.com/ros2/rosbag2/issues/2285

### Is this user-facing behavior change?
Yes. The user will have the ability to override the Rosbag2's inner publishing topics, such as `write{read}_split_event` and `messages_lost_event` with `bag record --qos-profile-overrides-path` CLI option.

### Did you use Generative AI?
Yes. I am using GitHub Copilot, GPT-5 in my workflow. Mostly to help with test creation and Doxygen comments.

### Additional Information
This PR has an API breaking changes in the `RecorderEventNotifier` class. However, if we will merge it before the next Rosbag2 release on Jazzy and Kilted. We will not break API because the `RecorderEventNotifier` class itself was introduced recently after the latest current release.  
cc: @ahcorde 