### PR TITLE
Fix Kilted CI to use the right ROS distro

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
@@ -18,7 +18,7 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.1.4
       with:
         linter: ${{ matrix.linter }}
-        distribution: rolling
+        distribution: kilted
         package-name: |
             ros2bag
             rosbag2
@@ -38,7 +38,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +49,7 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.1.4
       with:
         linter: ${{ matrix.linter }}
-        distribution: rolling
+        distribution: kilted
         package-name: |
             rosbag2_compression
             rosbag2_compression_zstd
@@ -66,7 +66,7 @@ jobs:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
@@ -81,14 +81,14 @@ jobs:
       with:
         linter: ${{ matrix.linter }}
         arguments: ${{ matrix.arguments }}
-        distribution: rolling
+        distribution: kilted
         package-name: rosbag2_storage_mcap
 
   ament_lint_python: # Linters applicable to Python packages
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-kilted-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
@@ -98,7 +98,7 @@ jobs:
     - uses: ros-tooling/action-ros-lint@0.1.4
       with:
         linter: ${{ matrix.linter }}
-        distribution: rolling
+        distribution: kilted
         package-name: |
             ros2bag
             rosbag2_py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - name: Build and run tests
       id: action-ros-ci
-      uses: ros-tooling/action-ros-ci@v0.3
+      uses: ros-tooling/action-ros-ci@v0.4
       with:
         target-ros2-distro: kilted
         vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/kilted/ros2.repos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - rolling
+      - kilted
   schedule:
     # Run every hour. This helps detect flakiness,
     # and broken external dependencies.
@@ -19,8 +19,8 @@ jobs:
       id: action-ros-ci
       uses: ros-tooling/action-ros-ci@v0.3
       with:
-        target-ros2-distro: rolling
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+        target-ros2-distro: kilted
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/kilted/ros2.repos
         colcon-defaults: |
           {
             "build": {
@@ -82,7 +82,7 @@ jobs:
       run: |
         rosbag2_path=$(colcon list -p --packages-select rosbag2)/..
         rosbag2_packages=$(colcon list -n --base-paths ${rosbag2_path})
-        source /opt/ros/rolling/setup.sh && colcon test --mixin linters-skip --packages-select ${rosbag2_packages} --packages-skip rosbag2_performance_benchmarking --event-handlers console_cohesion+ --return-code-on-test-failure --ctest-args "-L xfail" --pytest-args "-m xfail"
+        source /opt/ros/kilted/setup.sh && colcon test --mixin linters-skip --packages-select ${rosbag2_packages} --packages-skip rosbag2_performance_benchmarking --event-handlers console_cohesion+ --return-code-on-test-failure --ctest-args "-L xfail" --pytest-args "-m xfail"
       working-directory: ${{ steps.action-ros-ci.outputs.ros-workspace-directory-name }}
       shell: bash
     - name: Is regeneration of Python stubs required?

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ If you want Rosbag2 to replay recorded action messages in the role of an action 
 ```
 $ ros2 bag play --send-actions-as-client <bag>
 ```
-Rosbag2 will send recorded goal request, cancel request and result request to action server.  
-For more information, please refer to https://github.com/ros2/rosbag2/blob/rolling/docs/design/rosbag2_record_replay_action.md.
+Rosbag2 will send recorded goal request, cancel request and result request to action server.
+For more information, please refer to https://github.com/ros2/rosbag2/blob/kilted/docs/design/rosbag2_record_replay_action.md.
 
 #### Controlling playback via services
 
@@ -454,15 +454,15 @@ Play and record are fundamental tasks of Rosbag2. However, playing or recording 
 
 ROS 2 C++ nodes can benefit from intra-process communication to partially or completely bypass network transport of messages between two nodes.
 
-Multiple _components_ can be _composed_, either [statically](https://docs.ros.org/en/rolling/Tutorials/Intermediate/Composition.html#compile-time-composition-with-hardcoded-nodes) or [dynamically](https://docs.ros.org/en/rolling/Tutorials/Intermediate/Composition.html#run-time-composition-using-ros-services-with-a-publisher-and-subscriber): all the composed component will share the same address space because they will be loaded in a single process.
+Multiple _components_ can be _composed_, either [statically](https://docs.ros.org/en/kilted/Tutorials/Intermediate/Composition.html#compile-time-composition-with-hardcoded-nodes) or [dynamically](https://docs.ros.org/en/kilted/Tutorials/Intermediate/Composition.html#run-time-composition-using-ros-services-with-a-publisher-and-subscriber): all the composed component will share the same address space because they will be loaded in a single process.
 
-A prerequirement is for each C++ node to be [_composable_](https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Composition.html?highlight=composition) and to follow the [guidelines](https://docs.ros.org/en/rolling/Tutorials/Demos/Intra-Process-Communication.html?highlight=intra) for efficient publishing & subscription.
+A prerequirement is for each C++ node to be [_composable_](https://docs.ros.org/en/kilted/Concepts/Intermediate/About-Composition.html?highlight=composition) and to follow the [guidelines](https://docs.ros.org/en/kilted/Tutorials/Demos/Intra-Process-Communication.html?highlight=intra) for efficient publishing & subscription.
 
 With the above requirements met, the user can:
 - compose multiple nodes together
 - explicitly enable intra-process communication
 
-Whenever a publisher and a subscriber on the same topic belong to the same _composed_ process, and intra-process is enabled for both, `rclcpp` completely bypasses RMW layer and below transport layer (i.e. DDS). Instead, messages are shared via process memory and *potentially* never copied. Some exception hold, so please have a look to the [IPC guidelines](https://docs.ros.org/en/rolling/Tutorials/Demos/Intra-Process-Communication.html?highlight=intra).
+Whenever a publisher and a subscriber on the same topic belong to the same _composed_ process, and intra-process is enabled for both, `rclcpp` completely bypasses RMW layer and below transport layer (i.e. DDS). Instead, messages are shared via process memory and *potentially* never copied. Some exception hold, so please have a look to the [IPC guidelines](https://docs.ros.org/en/kilted/Tutorials/Demos/Intra-Process-Communication.html?highlight=intra).
 
 Here is an example of Python launchfile composition. Notice that composable container components do not expect YAML files to be directly passed to them: parameters have to be "dumped" out from the YAML file (if you have one). A suggestion of possible implementation is offered as a starting point.
 
@@ -579,8 +579,8 @@ This also allows to record data in a native format to optimize for speed, but to
 
 By default, Rosbag2 can convert from and to CDR as it's the default serialization format for ROS 2.
 
-[qos-override-tutorial]: https://docs.ros.org/en/rolling/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.html
-[about-qos-settings]: https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html
+[qos-override-tutorial]: https://docs.ros.org/en/kilted/Guides/Overriding-QoS-Policies-For-Recording-And-Playback.html
+[about-qos-settings]: https://docs.ros.org/en/kilted/Concepts/About-Quality-of-Service-Settings.html
 
 ## Tips and Tricks
 

--- a/docs/message_definition_encoding.md
+++ b/docs/message_definition_encoding.md
@@ -17,8 +17,8 @@ This set of definitions with all field types recursively included can be called 
 ## `ros2msg` encoding
 
 This encoding consists of definitions in
-[.msg](https://docs.ros.org/en/rolling/Concepts/Basic/About-Interfaces.html#messages) and
-[.srv](https://docs.ros.org/en/rolling/Concepts/Basic/About-Interfaces.html#services) format,
+[.msg](https://docs.ros.org/en/kilted/Concepts/Basic/About-Interfaces.html#messages) and
+[.srv](https://docs.ros.org/en/kilted/Concepts/Basic/About-Interfaces.html#services) format,
 concatenated together in human-readable form with
 a delimiter.
 


### PR DESCRIPTION
## Description

I noticed here https://github.com/ros2/rosbag2/pull/2294 that `kilted` CI is using `rolling`

I also updated some other links to documentation