### PR TITLE
Workaround for flaky "record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size" test

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -475,6 +475,8 @@ bool SequentialWriter::should_split_bagfile(
   if (storage_options_.max_bagfile_size !=
     rosbag2_storage::storage_interfaces::MAX_BAGFILE_SIZE_NO_SPLIT)
   {
+    // TODO(morlov): consider cached messages size in splitting decision. Right now we only consider
+    //  the size of already written messages in storage. Add message_cache_->get_current_size() API.
     should_split = (storage_->get_bagfile_size() >= storage_options_.max_bagfile_size);
   }
 

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -285,12 +285,15 @@ TEST_P(RecordFixture, record_end_to_end_with_splitting_bagsize_split_is_at_least
   constexpr const int message_size = 512 * 1024;  // 512KB
   const auto message = create_string_message(message_str, message_size);
   constexpr const int message_count = bagfile_split_size * expected_splits / message_size;
+  rclcpp::QoS qos = rclcpp::SystemDefaultsQoS().keep_last(message_count).reliable();
 
   rosbag2_test_common::PublicationManager pub_manager;
-  pub_manager.setup_publisher(topic_name, message, message_count);
+  pub_manager.setup_publisher(topic_name, message, message_count, qos);
 
   std::stringstream command;
-  command << get_base_record_command() <<
+  // TODO(morlov): remove " --max-cache-size 0" when split by size will take in to account
+  //  cached messages
+  command << get_base_record_command() << " --max-cache-size 0" <<
     " --max-bag-size " << bagfile_split_size <<
     " --topics " << topic_name;
   auto process_handle = start_execution(command.str());


### PR DESCRIPTION
## Description

This PR addresses flakiness in the `RecordFixture::record_end_to_end_with_splitting_bagsize_split_is_at_least_specified_size` test by the following changes:
1. Use QoS settings for the publisher manager explicitly as `rclcpp::QoS qos = rclcpp::SystemDefaultsQoS().keep_last(message_count). reliable();`
2. Temporarily add `--max-cache-size 0` to the CLI "command" string. To run a test with the disabled writer's cache.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Relates #https://github.com/ros2/rosbag2/issues/2310

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No

### Additional Information
Can be backported.