### PR TITLE
Add error return code to the "~/stop" service request

### DIFF
--- a/rosbag2_interfaces/srv/Stop.srv
+++ b/rosbag2_interfaces/srv/Stop.srv
@@ -1,1 +1,5 @@
 ---
+# Return code. Returns 1 when recording or playback is already stopped or in case of error, otherwise 0.
+int32 return_code
+# Error string. Empty if no error occurred.
+string error_string

--- a/rosbag2_interfaces/srv/Stop.srv
+++ b/rosbag2_interfaces/srv/Stop.srv
@@ -1,5 +1,6 @@
 ---
 # Return code. Returns 1 when recording or playback is already stopped or in case of error, otherwise 0.
 int32 return_code
+
 # Error string. Empty if no error occurred.
 string error_string

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -354,6 +354,26 @@ private:
   void publish_clock_update();
   void publish_clock_update(const rclcpp::Time & time);
 
+  /// \brief Helper wrapper function to set a service response as success.
+  template<typename ResponseT>
+  void set_service_success(
+    ResponseT & response,
+    int32_t return_code = kServiceReturnCodeSuccess) const
+  {
+    response->return_code = return_code;
+    response->error_string.clear();
+  }
+
+  /// \brief Helper wrapper function to set a service response as error.
+  template<typename ResponseT>
+  void set_service_error(
+    ResponseT & response, const std::string & error_string,
+    int32_t error_code = kServiceReturnCodeError) const
+  {
+    response->return_code = error_code;
+    response->error_string = error_string;
+  }
+
   Player * owner_;
   rosbag2_transport::PlayOptions play_options_;
   static constexpr const char * kDefaultReadSplitTopicName = "events/read_split";
@@ -407,6 +427,9 @@ private:
   std::shared_ptr<PlayerServiceClientManager> player_service_client_manager_;
 
   std::unique_ptr<PlayerProgressBar> progress_bar_;
+
+  static constexpr int32_t kServiceReturnCodeSuccess = 0;
+  static constexpr int32_t kServiceReturnCodeError = 1;
 
   static BagMessageComparator get_bag_message_comparator(const MessageOrder & order);
 
@@ -2134,10 +2157,22 @@ void PlayerImpl::create_control_services()
   srv_stop_ = owner_->create_service<rosbag2_interfaces::srv::Stop>(
     "~/stop",
     [this](
-      rosbag2_interfaces::srv::Stop::Request::ConstSharedPtr,
-      rosbag2_interfaces::srv::Stop::Response::SharedPtr)
+      rosbag2_interfaces::srv::Stop::Request::ConstSharedPtr/* request */,
+      rosbag2_interfaces::srv::Stop::Response::SharedPtr response)
     {
-      owner_->stop();
+      if (!is_in_playback_) {
+        RCLCPP_WARN(owner_->get_logger(),
+           "Received Stop request while not in playback. Ignoring request.");
+        set_service_error(response, "Player is already stopped.");
+      } else {
+        try {
+          owner_->stop();
+          set_service_success(response);
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(owner_->get_logger(), "Error during Stop request: %s", e.what());
+          set_service_error(response, e.what());
+        }
+      }
     });
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -619,16 +619,19 @@ void RecorderImpl::create_control_services()
     [this](
       const std::shared_ptr<rmw_request_id_t>/* request_header */,
       const std::shared_ptr<rosbag2_interfaces::srv::Stop::Request>/* request */,
-      const std::shared_ptr<rosbag2_interfaces::srv::Stop::Response>/* response */)
+      const std::shared_ptr<rosbag2_interfaces::srv::Stop::Response> response)
     {
       if (!in_recording_) {
         RCLCPP_WARN(node->get_logger(),
           "Received Stop request while not in recording. Ignoring request.");
+        set_service_error(response, "Recorder is already stopped.");
       } else {
         try {
           this->stop();
+          set_service_success(response);
         } catch (const std::exception & e) {
           RCLCPP_ERROR(node->get_logger(), "Error during Stop request: %s", e.what());
+          set_service_error(response, e.what());
         }
       }
     }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -427,7 +427,8 @@ TEST_F(PlaySrvsTest, stop_in_pause) {
   ASSERT_TRUE(player_->is_paused());
   // Make sure that player reached out main play loop
   player_->wait_for_playback_to_start();
-  service_call_stop();
+  Stop::Response::SharedPtr stop_response = service_call_stop();
+  ASSERT_EQ(stop_response->return_code, 0);
   // playback shall successfully finish after "Stop" without rclcpp::shutdown()
   player_->wait_for_playback_to_finish();
   expect_messages(false);
@@ -462,7 +463,11 @@ TEST_F(PlaySrvsTest, stop_in_active_play) {
   // if we happened to call stop() after the next message started being processed in the callback
   lk.unlock();
   // Now call stop() while player is in active playback mode
-  service_call_stop();
+  Stop::Response::SharedPtr stop_response = service_call_stop();
+  ASSERT_EQ(stop_response->return_code, 0);
   // playback shall successfully finish after "Stop" without rclcpp::shutdown()
   player_->wait_for_playback_to_finish(10s);
+  // The second stop() call after playback has already stopped shall return return_code = 1
+  stop_response = service_call_stop();
+  ASSERT_EQ(stop_response->return_code, 1);
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <type_traits>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -41,6 +42,15 @@
 #include "record_integration_fixture.hpp"
 
 using namespace ::testing;  // NOLINT
+
+
+template<class T, class = void>
+struct type_has_return_code : std::false_type {};
+
+template<class T>
+struct type_has_return_code<T, std::void_t<decltype(std::declval<T &>().return_code)>>
+  : std::true_type
+{};
 
 class RecordSrvsTest : public RecordIntegrationTestFixture
 {
@@ -163,6 +173,16 @@ public:
     if (!response) {
       return ::testing::AssertionFailure() << "Service call returned unsuccessful response";
     }
+
+    if constexpr (type_has_return_code<typename Srv::Response>::value) {
+      if (response->return_code) {  // success is indicated by return_code == 0 or non-empty
+        return ::testing::AssertionFailure() << "Service call return_code = " <<
+               response->return_code;
+      } else {
+        return ::testing::AssertionSuccess();
+      }
+    }
+    // No further checks possible for services with empty response
     return ::testing::AssertionSuccess();
   }
 
@@ -372,6 +392,7 @@ TEST_F(RecordSrvsTest, record_stop)
 
   EXPECT_TRUE(successful_service_request<Stop>(cli_stop_));
   EXPECT_TRUE(mock_writer.closed_was_called());
+  EXPECT_FALSE(successful_service_request<Stop>(cli_stop_));  // second stop should fail
 
   auto record_response = std::make_shared<Record::Response>();
   EXPECT_TRUE(successful_service_request<Record>(cli_record_, record_response));


### PR DESCRIPTION
## Description

Add error return code to the "~/stop" service request
Rationale: For consistency with Start/Record service calls.
- This is a follow-up PR on https://github.com/ros2/rosbag2/pull/2248#discussion_r2671139540

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Relates https://github.com/ros2/rosbag2/issues/1548
- Relates https://github.com/ros2/rosbag2/issues/1634

### Is this user-facing behavior change?
Yes. From now on, the "~/stop" service request will return 
```
# Return code. Returns 1 when recording or playback is already stopped or in case of error, otherwise 0.
int32 return_code
# Error string. Empty if no error occurred.
string error_string
```

### Did you use Generative AI?
No.

### Additional Information
This PR is not backportable since it changes the interface for "~/stop" service request