### PR TITLE
Fix for the flaky "can_record_again_after_stop" test

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -361,7 +361,12 @@ void RecorderImpl::stop()
   }
 
   stop_discovery();
-  pause();
+  // Explicitly disable all subscription's callbacks to avoid UB and receiving new messages on
+  // deleted subscriptions. Note: The callbacks propagated to the executor and may still be in the
+  // executor's queue, but they will no longer be called after this point.
+  for (auto & [_, subscription] : subscriptions_) {
+    subscription->disable_callbacks();
+  }
   subscriptions_.clear();
   writer_->close();  // Call writer->close() to finalize current bag file and write metadata
 
@@ -419,7 +424,7 @@ void RecorderImpl::record(const std::string & uri)
       "No output serialization format specified, using rmw serialization format. '%s'.",
       record_options_.output_serialization_format.c_str());
   }
-  subscriptions_.clear();
+
   event_notifier_->reset_total_num_messages_lost_in_transport();
   event_notifier_->reset_total_num_messages_lost_in_recorder();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -164,8 +164,6 @@ TEST_F(TemporaryDirectoryFixture, can_record_again_after_stop_with_real_storage)
 
 TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
 {
-  GTEST_SKIP() << "Skipping test `can_record_again_after_stop` in rosbag2_transport, until "
-                  "https://github.com/ros2/rosbag2/issues/1914 will be resolved.";
   auto basic_type_message = get_messages_basic_types()[0];
   basic_type_message->uint64_value = 5;
   basic_type_message->int64_value = -1;


### PR DESCRIPTION
## Description

This PR addresses undefined behaviour and possible call for the callbacks of the already deleted subscriptions after calling `Recorder::Stop()` API.

Note: The subscription's callbacks propagated to the executor and may still be in the executor's queue, but they will no longer be called after disabling callbacks.

- This PR depends on the non-backportable https://github.com/ros2/rclcpp/pull/2985

- Fixes #https://github.com/ros2/rosbag2/issues/1914

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.

### Additional Information
- This PR is not backportable because it depends on the non-backportable https://github.com/ros2/rclcpp/pull/2985
