### PR TITLE
Static topic list for recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ static_topics_and_types_list:
 ```
 
 For topics from the static topics list, subscriptions will be created even if they are not
-discoverable via ROS graph. 
+discoverable via the ROS graph and even if publishers do not yet exist on those topics.
 
 If not further specified, `ros2 bag record` will create a new folder named to the current time stamp and stores all data within this folder.
 A user defined name can be given with `-o, --output`.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To record a set of predefined topics, one can specify them on the command line e
 $ ros2 bag record <topic1> <topic2> … <topicN>
 ```
 
-Press ++ctrl+c++ to stop the recording.
+Press `Ctrl+C` to stop the recording.
 
 The specified topics don't necessarily have to be present at the start time.
 The discovery function will automatically recognize if one of the specified topics appears.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,23 @@ To record a set of predefined topics, one can specify them on the command line e
 $ ros2 bag record <topic1> <topic2> … <topicN>
 ```
 
-The specified topics don't necessarily have to be present at start time.
-The discovery function will automatically recognize if one of the specified topics appeared.
-In the same fashion, this auto discovery can be disabled with `--no-discovery`.
+Press ++ctrl+c++ to stop the recording.
+
+The specified topics don't necessarily have to be present at the start time.
+The discovery function will automatically recognize if one of the specified topics appears.
+In the same fashion, this auto-discovery can be disabled with `--no-discovery`.\
+The topics can also be specified via a static topic list with the `--static-topics-path` option.
+Recorder will expect yaml file in the following format:
+
+```yaml
+static_topics_and_types_list:
+ - [/topic_name1, topic_type1]
+ - [/topic_name2, topic_type2]
+ - [/topic_name3, topic_type3]
+```
+
+For topics from the static topics list, subscriptions will be created even if they are not
+discoverable via ROS graph. 
 
 If not further specified, `ros2 bag record` will create a new folder named to the current time stamp and stores all data within this folder.
 A user defined name can be given with `-o, --output`.

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -71,6 +71,14 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
         '--topics', type=str, default=[], metavar='Topic', nargs='+',
         help='Space-delimited list of topics to record.')
     parser.add_argument(
+        '--static-topics-path', type=FileType('r'),
+        help='Path to a YAML file with statically defining topic names and types.'
+             'Recorder will expect a YAML file in the following format:\n'
+             'static_topics_and_types_list:\n'
+             ' - [/topic_name1, topic_type1]\n'
+             ' - [/topic_name2, topic_type2]\n'
+             ' - [/topic_name3, topic_type3]')
+    parser.add_argument(
         '--services', type=str, metavar='ServiceName', nargs='+',
         help='Space-delimited list of services to record.')
     parser.add_argument(
@@ -247,12 +255,13 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
 
 def check_necessary_argument(args):
     # At least one options out of --all, --all-topics, --all-services, --all-actions, --services,
-    # --actions --topics, --topic-types or --regex must be used
+    # --actions --topics, --topic-types, --static-topics-path or --regex must be used
     if not (args.all or args.all_topics or args.all_services or args.all_actions or
             (args.services and len(args.services) > 0) or
             (args.actions and len(args.actions) > 0) or
             (args.topics and len(args.topics) > 0) or
-            (args.topic_types and len(args.topic_types) > 0) or args.regex):
+            (args.topic_types and len(args.topic_types) > 0) or args.regex or
+            args.static_topics_path):
         return False
     return True
 
@@ -265,7 +274,8 @@ def validate_parsed_arguments(args, uri) -> str:
 
     if not check_necessary_argument(args):
         return print_error('Need to specify at least one option out of --all, --all-topics, '
-                           '--all-services, --services, --topics, --topic-types or --regex')
+                           '--all-services, --services, --topics, --topic-types,'
+                           '--static-topics-path or --regex')
 
     if args.exclude_regex and not \
             (args.all or args.all_topics or args.topic_types or args.all_services or
@@ -381,6 +391,10 @@ class RecordVerb(VerbExtension):
             key_value_pairs = [pair.split('=') for pair in args.custom_data]
             custom_data = {pair[0]: pair[1] for pair in key_value_pairs}
 
+        static_topics_uri = ''
+        if args.static_topics_path:
+            static_topics_uri = args.static_topics_path.name
+
         storage_config_file = ''
         if args.storage_config_file:
             storage_config_file = args.storage_config_file.name
@@ -398,6 +412,7 @@ class RecordVerb(VerbExtension):
             custom_data=custom_data
         )
         record_options = RecordOptions()
+        record_options.static_topics_uri = static_topics_uri
         record_options.all_topics = args.all_topics or args.all
         record_options.all_services = args.all_services or args.all
         record_options.all_actions = args.all_actions or args.all

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -72,7 +72,7 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
         help='Space-delimited list of topics to record.')
     parser.add_argument(
         '--static-topics-path', type=FileType('r'),
-        help='Path to a YAML file with statically defining topic names and types.'
+        help='Path to a YAML file with statically defined topic names and types.'
              'Recorder will expect a YAML file in the following format:\n'
              'static_topics_and_types_list:\n'
              ' - [/topic_name1, topic_type1]\n'

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -124,6 +124,7 @@ class RecordOptions:
     rmw_serialization_format: str
     services: List[str]
     start_paused: bool
+    static_topics_uri: str
     statistics_max_publishing_rate: float
     topic_polling_interval: datetime.timedelta
     topic_qos_profile_overrides: dict

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -929,6 +929,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("all_topics", &RecordOptions::all_topics)
   .def_readwrite("is_discovery_disabled", &RecordOptions::is_discovery_disabled)
   .def_readwrite("topics", &RecordOptions::topics)
+  .def_readwrite("static_topics_uri", &RecordOptions::static_topics_uri)
   .def_readwrite("topic_types", &RecordOptions::topic_types)
   .def_readwrite("exclude_topic_types", &RecordOptions::exclude_topic_types)
   .def_readwrite("rmw_serialization_format", &RecordOptions::rmw_serialization_format)

--- a/rosbag2_tests/resources/static_topics_list.yaml
+++ b/rosbag2_tests/resources/static_topics_list.yaml
@@ -1,0 +1,3 @@
+static_topics_and_types_list:
+  - [/test_topic1, test_msgs/msg/Strings]
+  - [/test_topic2, test_msgs/msg/Strings]

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -169,6 +169,57 @@ TEST_P(RecordFixture, record_end_to_end_test) {
   EXPECT_THAT(unrecorded_topic_messages, IsEmpty());
 }
 
+TEST_P(RecordFixture, record_end_to_end_test_with_static_topics_only) {
+  namespace fs = std::filesystem;
+  auto message = get_messages_strings()[0];
+  message->string_value = "test";
+  const size_t expected_test_messages = 3;
+  rclcpp::QoS qos = rclcpp::SystemDefaultsQoS().keep_last(expected_test_messages).reliable();
+  auto unrecorded_message = get_messages_strings()[0];
+  unrecorded_message->string_value = "unrecorded_content";
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher("/test_topic1", message, expected_test_messages, qos);
+  pub_manager.setup_publisher("/unrecorded_topic", unrecorded_message, expected_test_messages, qos);
+
+  // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
+  auto const static_topics_uri =
+    fs::absolute(fs::path(_SRC_RESOURCES_DIR_PATH) / "static_topics_list.yaml").generic_string();
+
+  auto process_handle = start_execution(
+    get_base_record_command() + " --static-topics-path " + static_topics_uri);
+  auto cleanup_process_handle = rcpputils::make_scope_exit(
+    [process_handle]() {
+      stop_execution(process_handle);
+    });
+
+  ASSERT_TRUE(pub_manager.wait_for_matched("/test_topic1")) << "Expected find rosbag subscription";
+
+  wait_for_storage_file();
+
+  pub_manager.run_publishers();
+
+  stop_execution(process_handle);
+  cleanup_process_handle.cancel();
+
+  finalize_metadata_kludge();
+  wait_for_metadata();
+  auto test_topic_messages = get_messages_for_topic<test_msgs::msg::Strings>("/test_topic1");
+  EXPECT_THAT(test_topic_messages, SizeIs(expected_test_messages));
+
+  for (const auto & received_message : test_topic_messages) {
+    EXPECT_EQ(received_message->string_value, "test");
+  }
+
+  EXPECT_THAT(
+    get_serialization_format_for_topic("/test_topic1"),
+    Eq(rmw_get_serialization_format()));
+
+  auto unrecorded_topic_messages =
+    get_messages_for_topic<test_msgs::msg::Strings>("/unrecorded_topic");
+  EXPECT_THAT(unrecorded_topic_messages, IsEmpty());
+}
+
 TEST_P(RecordFixture, record_end_to_end_test_start_paused) {
   auto message = get_messages_strings()[0];
   message->string_value = "test";

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -187,7 +187,11 @@ TEST_P(RecordFixture, record_end_to_end_test_with_static_topics_only) {
     fs::absolute(fs::path(_SRC_RESOURCES_DIR_PATH) / "static_topics_list.yaml").generic_string();
 
   auto process_handle = start_execution(
-    get_base_record_command() + " --static-topics-path " + static_topics_uri);
+    // Note: Use --include-unpublished-topics to record static topics even if there are no
+    // publishers in the node graph at time of recording. This is needed to avoid race conditions
+    // since node graph need to spin for some time to discover all publishers.
+    get_base_record_command() + " --include-unpublished-topics" +
+      " --static-topics-path " + static_topics_uri);
   auto cleanup_process_handle = rcpputils::make_scope_exit(
     [process_handle]() {
       stop_execution(process_handle);

--- a/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
+++ b/rosbag2_tests/test/rosbag2_tests/test_rosbag2_record_end_to_end.cpp
@@ -187,11 +187,7 @@ TEST_P(RecordFixture, record_end_to_end_test_with_static_topics_only) {
     fs::absolute(fs::path(_SRC_RESOURCES_DIR_PATH) / "static_topics_list.yaml").generic_string();
 
   auto process_handle = start_execution(
-    // Note: Use --include-unpublished-topics to record static topics even if there are no
-    // publishers in the node graph at time of recording. This is needed to avoid race conditions
-    // since node graph need to spin for some time to discover all publishers.
-    get_base_record_command() + " --include-unpublished-topics" +
-      " --static-topics-path " + static_topics_uri);
+    get_base_record_command() + " --static-topics-path " + static_topics_uri);
   auto cleanup_process_handle = rcpputils::make_scope_exit(
     [process_handle]() {
       stop_execution(process_handle);

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -598,6 +598,16 @@ if(BUILD_TESTING)
     rosbag2_test_common::rosbag2_test_common
     rcutils::rcutils
   )
+
+  ament_add_gmock(test_record_static_topics
+    test/rosbag2_transport/test_record_static_topics.cpp)
+  target_link_libraries(test_record_static_topics
+    ${PROJECT_NAME}
+    ${test_msgs_TARGTES}
+    rosbag2_test_common::rosbag2_test_common
+    test_msgs::test_msgs_includes
+  )
+
 endif()
 
 ament_package()

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -603,7 +603,7 @@ if(BUILD_TESTING)
     test/rosbag2_transport/test_record_static_topics.cpp)
   target_link_libraries(test_record_static_topics
     ${PROJECT_NAME}
-    ${test_msgs_TARGTES}
+    ${test_msgs_TARGETS}
     rosbag2_test_common::rosbag2_test_common
     test_msgs::test_msgs_includes
   )

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -81,6 +81,8 @@ public:
   bool start_paused = false;
   /// \brief Use simulated time (if true).
   bool use_sim_time = false;
+  /// \brief URI of where to read static topics from.
+  std::string static_topics_uri = "";
   /// \brief Disable keyboard controls if true. This parameter is only used during construction of
   /// the Recorder class to decide whether to initialize KeyboardHandler class or not.
   bool disable_keyboard_controls = false;

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -270,6 +270,12 @@ public:
 
 protected:
   ROSBAG2_TRANSPORT_PUBLIC
+  void read_static_topics() noexcept;
+
+  ROSBAG2_TRANSPORT_PUBLIC
+  const std::vector<std::pair<std::string, std::string>> & get_static_topics() noexcept;
+
+  ROSBAG2_TRANSPORT_PUBLIC
   std::unordered_map<std::string, std::string> get_requested_or_available_topics();
 
   ROSBAG2_TRANSPORT_PUBLIC

--- a/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
@@ -19,8 +19,8 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "rosbag2_transport/record_options.hpp"
 #include "rosbag2_transport/visibility_control.hpp"

--- a/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/topic_filter.hpp
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <utility>
 
 #include "rosbag2_transport/record_options.hpp"
 #include "rosbag2_transport/visibility_control.hpp"
@@ -46,10 +47,12 @@ public:
   /// be disabled.
   /// @param allow_unknown_types Allow unknown types, i.e. types for which type support cannot be
   /// loaded.
+  /// @param static_topic_names_and_types List of static topics and their types to always include.
   explicit TopicFilter(
     RecordOptions record_options,
     rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph = nullptr,
-    bool allow_unknown_types = false);
+    bool allow_unknown_types = false,
+    const std::vector<std::pair<std::string, std::string>> & static_topic_names_and_types = {});
   virtual ~TopicFilter();
 
   /// \brief Filter topics based on the options provided in the constructor
@@ -69,10 +72,10 @@ public:
   /// - exclude services list
   /// - unpublished topics
   /// - leaf topics
-  /// @param topic_names_and_types The map of topic names and their associated types to filter
+  /// @param all_topic_names_and_types The map of topic names and their associated types to filter
   /// @return The filtered map of topic names and their associated types
   std::unordered_map<std::string, std::string> filter_topics(
-    const std::map<std::string, std::vector<std::string>> & topic_names_and_types);
+    const std::map<std::string, std::vector<std::string>> & all_topic_names_and_types);
 
 protected:
   /// \brief Check if the topic is selected by include/exclude lists or regexes
@@ -135,6 +138,9 @@ private:
   /// The action name in record_options.exclude_action will be converted into the action interface
   /// name and saved in this set
   std::unordered_set<std::string> exclude_action_interface_names_;
+
+  /// List of static topics and services to always include
+  std::vector<std::string> static_topics_and_services_;
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -847,6 +847,7 @@ RecorderImpl::get_requested_or_available_topics()
   if (record_options_.all_topics || !record_options_.topics.empty() ||
     !record_options_.topic_types.empty() ||
     record_options_.all_services || !record_options_.services.empty() ||
+    record_options_.all_actions || !record_options_.actions.empty() ||
     !record_options_.regex.empty())
   {
     all_topics_and_types = node->get_topic_names_and_types();

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -488,6 +488,7 @@ void RecorderImpl::record(const std::string & uri)
   if (!static_topics_.empty() &&
     !(record_options_.all_topics || !record_options_.topics.empty() ||
     record_options_.all_services || !record_options_.services.empty() ||
+    record_options_.all_actions || !record_options_.actions.empty() ||
     !record_options_.regex.empty()))
   {
     record_options_.is_discovery_disabled = true;
@@ -1195,27 +1196,38 @@ void RecorderImpl::read_static_topics() noexcept
       RCLCPP_INFO_STREAM(node->get_logger(),
         "Reading static topics from " << record_options_.static_topics_uri);
       YAML::Node yaml_file = YAML::LoadFile(record_options_.static_topics_uri);
-      auto bag_nodes = yaml_file["static_topics_and_types_list"];
-      if (!bag_nodes) {
+      auto list_nodes = yaml_file["static_topics_and_types_list"];
+      if (!list_nodes) {
         throw std::runtime_error(
                 "Static topics YAML file must have top-level key 'static_topics_and_types_list'");
       }
-      if (!bag_nodes.IsSequence()) {
+      if (!list_nodes.IsSequence()) {
         throw std::runtime_error(
                 "Top-level key 'static_topics_and_types_list' must contain a list of "
                 "'topic_name, topic_type' pairs");
       }
-      for (const auto & bag_node : bag_nodes) {
+      for (const auto & bag_node : list_nodes) {
         const auto topic_name = bag_node[0].as<std::string>();
         const auto topic_type = bag_node[1].as<std::string>();
         if (topic_type.empty()) {
           RCLCPP_ERROR_STREAM(node->get_logger(),
-            "Static topic " << topic_name.c_str() << " has no corresponding type");
+            "Static topic " << topic_name << " has no corresponding type");
         }
         static_topics_.emplace_back(topic_name, topic_type);
       }
     } catch (std::exception & e) {
       RCLCPP_ERROR_STREAM(node->get_logger(), "Failed to read static topics list: " << e.what());
+      // Print current static topics read so far
+      RCLCPP_INFO_STREAM(node->get_logger(),
+                         "Read " << static_topics_.size() << " static topics before failure");
+      for (const auto & [topic_name, topic_type] : static_topics_) {
+        RCLCPP_INFO_STREAM(node->get_logger(),
+                           " \ttopic: " << topic_name << " \t\t type: " << topic_type);
+      }
+      // Clear any partially read topics
+      static_topics_.clear();
+      RCLCPP_INFO_STREAM(node->get_logger(), "Cleared static topics list due to read failure.");
+      return;
     }
     RCLCPP_INFO_STREAM(node->get_logger(), "Read " << static_topics_.size() << " static topics");
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <chrono>
 #include <future>
+#include <map>
 #include <memory>
 #include <regex>
 #include <stdexcept>
@@ -187,12 +188,16 @@ public:
 
   std::unordered_map<std::string, std::string> get_requested_or_available_topics();
 
+  void read_static_topics() noexcept;
+
   /// Public members for access by wrapper
   std::unordered_set<std::string> topics_warned_about_incompatibility_;
   std::shared_ptr<rosbag2_cpp::Writer> writer_;
   rosbag2_storage::StorageOptions storage_options_;
   rosbag2_transport::RecordOptions record_options_;
   std::unordered_map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> subscriptions_;
+
+  std::vector<std::pair<std::string, std::string>> static_topics_{};  // topic_name, topic_type
 
 private:
   void create_control_services();
@@ -313,6 +318,13 @@ RecorderImpl::RecorderImpl(
       "Press " << key_str << " for pausing/resuming");
   }
 
+  read_static_topics();
+  for (auto & [topic_name, _] : static_topics_) {
+    topic_name = rclcpp::expand_topic_or_service_name(
+      topic_name, node->get_name(),
+      node->get_namespace(), false);
+  }
+
   for (auto & topic : record_options_.topics) {
     topic = rclcpp::expand_topic_or_service_name(
       topic, node->get_name(),
@@ -337,7 +349,8 @@ RecorderImpl::RecorderImpl(
       node->get_namespace(), false);
   }
 
-  topic_filter_ = std::make_unique<TopicFilter>(record_options_, node->get_node_graph_interface());
+  topic_filter_ = std::make_unique<TopicFilter>(record_options, node->get_node_graph_interface(),
+      false, static_topics_);
 
   create_control_services();
 }
@@ -470,6 +483,16 @@ void RecorderImpl::record(const std::string & uri)
   if (!record_options_.use_sim_time) {
     subscribe_topics(get_requested_or_available_topics());
   }
+
+  // Disable discovery if only static topics defined
+  if (!static_topics_.empty() &&
+    !(record_options_.all_topics || !record_options_.topics.empty() ||
+    record_options_.all_services || !record_options_.services.empty() ||
+    !record_options_.regex.empty()))
+  {
+    record_options_.is_discovery_disabled = true;
+  }
+
   if (!record_options_.is_discovery_disabled) {
     start_discovery();
     RCLCPP_INFO(node->get_logger(), "Listening for topics...");
@@ -819,7 +842,21 @@ void RecorderImpl::topics_discovery() noexcept
 std::unordered_map<std::string, std::string>
 RecorderImpl::get_requested_or_available_topics()
 {
-  auto all_topics_and_types = node->get_topic_names_and_types();
+  std::map<std::string, std::vector<std::string>> all_topics_and_types;
+  // Take topic names and types from graph only if inclusive filters among static topics defined
+  if (record_options_.all_topics || !record_options_.topics.empty() ||
+    !record_options_.topic_types.empty() ||
+    record_options_.all_services || !record_options_.services.empty() ||
+    !record_options_.regex.empty())
+  {
+    all_topics_and_types = node->get_topic_names_and_types();
+  }
+
+  for (const auto & [static_topic_name, static_topic_type] : static_topics_) {
+    if (all_topics_and_types.find(static_topic_name) == all_topics_and_types.cend()) {
+      all_topics_and_types[static_topic_name] = {static_topic_type};
+    }
+  }
   return topic_filter_->filter_topics(all_topics_and_types);
 }
 
@@ -1150,6 +1187,39 @@ void RecorderImpl::warn_if_new_qos_for_subscribed_topic(const std::string & topi
   }
 }
 
+void RecorderImpl::read_static_topics() noexcept
+{
+  if (!record_options_.static_topics_uri.empty()) {
+    try {
+      RCLCPP_INFO_STREAM(node->get_logger(),
+        "Reading static topics from " << record_options_.static_topics_uri);
+      YAML::Node yaml_file = YAML::LoadFile(record_options_.static_topics_uri);
+      auto bag_nodes = yaml_file["static_topics_and_types_list"];
+      if (!bag_nodes) {
+        throw std::runtime_error(
+                "Static topics YAML file must have top-level key 'static_topics_and_types_list'");
+      }
+      if (!bag_nodes.IsSequence()) {
+        throw std::runtime_error(
+                "Top-level key 'static_topics_and_types_list' must contain a list of "
+                "'topic_name, topic_type' pairs");
+      }
+      for (const auto & bag_node : bag_nodes) {
+        const auto topic_name = bag_node[0].as<std::string>();
+        const auto topic_type = bag_node[1].as<std::string>();
+        if (topic_type.empty()) {
+          RCLCPP_ERROR_STREAM(node->get_logger(),
+            "Static topic " << topic_name.c_str() << " has no corresponding type");
+        }
+        static_topics_.emplace_back(topic_name, topic_type);
+      }
+    } catch (std::exception & e) {
+      RCLCPP_ERROR_STREAM(node->get_logger(), "Failed to read static topics list: " << e.what());
+    }
+    RCLCPP_INFO_STREAM(node->get_logger(), "Read " << static_topics_.size() << " static topics");
+  }
+}
+
 ///////////////////////////////
 // Recorder public interface
 
@@ -1323,6 +1393,16 @@ bool
 Recorder::is_discovery_running() const
 {
   return pimpl_->is_discovery_running();
+}
+
+void Recorder::read_static_topics() noexcept
+{
+  return pimpl_->read_static_topics();
+}
+
+const std::vector<std::pair<std::string, std::string>> & Recorder::get_static_topics() noexcept
+{
+  return pimpl_->static_topics_;
 }
 
 std::unordered_map<std::string, std::string>

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -106,10 +106,11 @@ namespace rosbag2_transport
 TopicFilter::TopicFilter(
   RecordOptions record_options,
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
-  bool allow_unknown_types)
+  bool allow_unknown_types,
+  const std::vector<std::pair<std::string, std::string>> & static_topic_names_and_types)
 : record_options_(std::move(record_options)),
   allow_unknown_types_(allow_unknown_types),
-  node_graph_(node_graph)
+  node_graph_(std::move(node_graph))
 {
   if (record_options_.actions.size() > 0) {
     for ( auto & action_name : record_options_.actions ) {
@@ -128,21 +129,27 @@ TopicFilter::TopicFilter(
         action_interface_names.begin(), action_interface_names.end());
     }
   }
+
+  static_topics_and_services_.reserve(static_topic_names_and_types.size());
+  for (const auto & [static_topic_name, _] : static_topic_names_and_types) {
+    static_topics_and_services_.push_back(static_topic_name);
+  }
 }
 
 TopicFilter::~TopicFilter() = default;
 
 std::unordered_map<std::string, std::string> TopicFilter::filter_topics(
-  const std::map<std::string, std::vector<std::string>> & topic_names_and_types)
+  const std::map<std::string, std::vector<std::string>> & all_topic_names_and_types)
 {
   std::unordered_map<std::string, std::string> filtered_topics;
-  for (const auto & [topic_name, topic_types] : topic_names_and_types) {
+  for (const auto & [topic_name, topic_types] : all_topic_names_and_types) {
     if (take_topic(topic_name, topic_types)) {
       filtered_topics.insert(std::make_pair(topic_name, topic_types[0]));
     }
   }
   return filtered_topics;
 }
+
 
 bool TopicFilter::topic_selected_by_lists_or_regex(
   const std::string & topic_name,
@@ -158,6 +165,7 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
     // Regular topic
     if (!record_options_.all_topics &&
       record_options_.topics.empty() &&
+      static_topics_and_services_.empty() &&
       record_options_.topic_types.empty() &&
       record_options_.regex.empty() &&
       !record_options_.include_hidden_topics)
@@ -170,6 +178,7 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
     if (!record_options_.all_topics) {
       // Not in include topic list. Note: all_topics shall override include topic lists
       if (!topic_in_list(topic_name, record_options_.topics) &&
+        !topic_in_list(topic_name, static_topics_and_services_) &&
         !topic_type_in_list(topic_type, record_options_.topic_types))
       {
         // Not match include regex
@@ -209,6 +218,7 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
     // Service event topic
     if (!record_options_.all_services &&
       record_options_.services.empty() &&
+      static_topics_and_services_.empty() &&
       record_options_.regex.empty())
     {
       // Note: This check is needed to avoid extra checks and service name conversion in case
@@ -221,7 +231,9 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
 
     if (!record_options_.all_services) {
       // Not in include service list
-      if (!topic_in_list(topic_name, record_options_.services)) {
+      if (!topic_in_list(topic_name, record_options_.services) &&
+        !topic_in_list(topic_name, static_topics_and_services_))
+      {
         // Not match include regex
         if (!record_options_.regex.empty()) {
           std::regex include_regex(record_options_.regex);

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -150,7 +150,6 @@ std::unordered_map<std::string, std::string> TopicFilter::filter_topics(
   return filtered_topics;
 }
 
-
 bool TopicFilter::topic_selected_by_lists_or_regex(
   const std::string & topic_name,
   const std::string & topic_type)
@@ -337,7 +336,8 @@ bool TopicFilter::take_topic(
     return false;
   }
 
-  if (!record_options_.include_unpublished_topics && node_graph_ &&
+  if (!topic_in_list(topic_name, static_topics_and_services_) &&
+    !record_options_.include_unpublished_topics && node_graph_ &&
     topic_is_unpublished(topic_name, *node_graph_))
   {
     return false;

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -261,6 +261,7 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
 
     // Check if topics for action need to be recorded
     if (!record_options_.all_actions &&
+      static_topics_and_services_.empty() &&
       record_options_.actions.empty() &&
       record_options_.regex.empty())
     {
@@ -270,7 +271,9 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
     // Convert topic name to action name
     auto action_name = rosbag2_cpp::action_interface_name_to_action_name(topic_name);
 
-    if (!record_options_.all_actions) {
+    if (!record_options_.all_actions &&
+      !topic_in_list(topic_name, static_topics_and_services_))
+    {
       // Not in include action interface list
       if (include_action_interface_names_.find(topic_name) ==
         include_action_interface_names_.end())

--- a/rosbag2_transport/test/resources/static_topics_list.yaml
+++ b/rosbag2_transport/test/resources/static_topics_list.yaml
@@ -1,0 +1,4 @@
+static_topics_and_types_list:
+  - [/topic_name1, test_msgs/msg/Strings]
+  - [/topic_name2, test_msgs/msg/Strings]
+  - [/topic_name3, test_msgs/msg/Strings]

--- a/rosbag2_transport/test/rosbag2_transport/mock_recorder.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_recorder.hpp
@@ -72,6 +72,7 @@ public:
     return available_for_recording;
   }
 
+  using rosbag2_transport::Recorder::get_static_topics;
   using rosbag2_transport::Recorder::get_storage_options;
   using rosbag2_transport::Recorder::get_record_options;
 };

--- a/rosbag2_transport/test/rosbag2_transport/test_record_static_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_static_topics.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024, Apex.AI
+// Copyright 2025, Apex.AI
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rosbag2_transport/test/rosbag2_transport/test_record_static_topics.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_static_topics.cpp
@@ -1,0 +1,77 @@
+// Copyright 2024, Apex.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <filesystem>
+#include <memory>
+#include <utility>
+
+#include "record_integration_fixture.hpp"
+#include "mock_recorder.hpp"
+#include "rosbag2_test_common/publication_manager.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+using namespace ::testing;  // NOLINT
+namespace fs = std::filesystem;
+
+TEST_F(RecordIntegrationTestFixture, recorder_can_read_static_topics_list)
+{
+  rosbag2_transport::RecordOptions record_options = rosbag2_transport::RecordOptions{
+    true, true, true, true, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+
+  // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
+  record_options.static_topics_uri =
+    fs::absolute(fs::path(_SRC_RESOURCES_DIR_PATH) / "static_topics_list.yaml").generic_string();
+  auto recorder = std::make_shared<MockRecorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  auto static_topics = recorder->get_static_topics();
+
+  ASSERT_EQ(static_topics.size(), 3U);
+
+  EXPECT_EQ(static_topics[0].first, "/topic_name1");
+  EXPECT_EQ(static_topics[0].second, "test_msgs/msg/Strings");
+
+  EXPECT_EQ(static_topics[2].first, "/topic_name3");
+  EXPECT_EQ(static_topics[2].second, "test_msgs/msg/Strings");
+}
+
+TEST_F(RecordIntegrationTestFixture, exclude_applies_above_static_topics_list)
+{
+  auto string_message = get_messages_strings()[0];
+  string_message->string_value = "Hello World";
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher("/topic_name1", string_message, 5);
+  rosbag2_transport::RecordOptions record_options = rosbag2_transport::RecordOptions{
+    false, false, false, true, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 100ms};
+  record_options.include_unpublished_topics = true;
+  record_options.exclude_regex = ".*_name2.*";
+
+  // _SRC_RESOURCES_DIR_PATH defined in CMakeLists.txt
+  record_options.static_topics_uri =
+    fs::absolute(fs::path(_SRC_RESOURCES_DIR_PATH) / "static_topics_list.yaml").generic_string();
+  auto recorder = std::make_shared<MockRecorder>(
+    std::move(writer_), storage_options_, record_options);
+
+  recorder->record();
+  // Wait until the recorder will subscribe to the publisher's topic to make sure that
+  // recorder::record(..) in another thread got to the topics filter call
+  ASSERT_TRUE(pub_manager.wait_for_matched("/topic_name1"));
+  recorder->stop();
+
+  EXPECT_TRUE(recorder->topic_available_for_recording("/topic_name1"));
+  EXPECT_FALSE(recorder->topic_available_for_recording("/topic_name2"));
+  EXPECT_TRUE(recorder->topic_available_for_recording("/topic_name3"));
+}

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -872,3 +872,143 @@ TEST_F(TestTopicFilter, take_topic_uses_cache) {
   find_in_selected_topics_cache_it->second = false;
   EXPECT_FALSE(filter.take_topic(topic_name, {topic_type}));
 }
+
+// Minimal stub for NodeGraphInterface to simulate unpublished topics
+class UnpublishedNodeGraphStub : public rclcpp::node_interfaces::NodeGraphInterface
+{
+public:
+  // Return empty publishers for any topic to mark it unpublished
+  std::vector<rclcpp::TopicEndpointInfo> get_publishers_info_by_topic(
+    const std::string & /*topic_name*/,
+    bool /*no_mangle*/ = false) const override
+  {
+    return {};
+  }
+
+  // Return empty subscriptions; not relevant for this test
+  std::vector<rclcpp::TopicEndpointInfo> get_subscriptions_info_by_topic(
+    const std::string & /*topic_name*/,
+    bool /*no_mangle*/ = false) const override
+  {
+    return {};
+  }
+
+  // Topics/services names and types
+  std::map<std::string, std::vector<std::string>> get_topic_names_and_types(
+    bool /*no_demangle*/ = false) const override
+  {
+    return {};
+  }
+
+  std::map<std::string, std::vector<std::string>> get_service_names_and_types() const override
+  {
+    return {};
+  }
+
+  std::map<std::string, std::vector<std::string>> get_service_names_and_types_by_node(
+    const std::string & /*node_name*/,
+    const std::string & /*namespace_*/) const override
+  {
+    return {};
+  }
+
+  std::map<std::string, std::vector<std::string>> get_client_names_and_types_by_node(
+    const std::string & /*node_name*/,
+    const std::string & /*namespace_*/) const override
+  {
+    return {};
+  }
+
+  std::map<std::string, std::vector<std::string>> get_publisher_names_and_types_by_node(
+    const std::string & /*node_name*/,
+    const std::string & /*namespace_*/,
+    bool /*no_demangle*/ = false) const override
+  {
+    return {};
+  }
+
+  std::map<std::string, std::vector<std::string>> get_subscriber_names_and_types_by_node(
+    const std::string & /*node_name*/,
+    const std::string & /*namespace_*/,
+    bool /*no_demangle*/ = false) const override
+  {
+    return {};
+  }
+
+  // Node names related APIs
+  std::vector<std::string> get_node_names() const override {return {};}
+
+  std::vector<std::tuple<std::string, std::string, std::string>>
+  get_node_names_with_enclaves() const override {return {};}
+
+  std::vector<std::pair<std::string, std::string>>
+  get_node_names_and_namespaces() const override {return {};}
+
+  // Counts
+  size_t count_publishers(const std::string & /*topic_name*/) const override {return 0;}
+  size_t count_subscribers(const std::string & /*topic_name*/) const override {return 0;}
+  size_t count_clients(const std::string & /*service_name*/) const override {return 0;}
+  size_t count_services(const std::string & /*service_name*/) const override {return 0;}
+
+  // Graph condition/event APIs
+  const rcl_guard_condition_t * get_graph_guard_condition() const override {return nullptr;}
+  void notify_graph_change() override {}
+  void notify_shutdown() override {}
+  rclcpp::Event::SharedPtr get_graph_event() override {return nullptr;}
+  void wait_for_graph_change(
+    rclcpp::Event::SharedPtr /*event*/,
+    std::chrono::nanoseconds /*timeout*/) override {}
+  size_t count_graph_users() const override {return 0;}
+
+  // Parameter/service endpoint info APIs
+  std::vector<rclcpp::ServiceEndpointInfo> get_clients_info_by_service(
+    const std::string & /*service_name*/, bool /*no_mangle*/ = false) const override
+  {
+    return {};
+  }
+
+  std::vector<rclcpp::ServiceEndpointInfo> get_servers_info_by_service(
+    const std::string & /*service_name*/, bool /*no_mangle*/ = false) const override
+  {
+    return {};
+  }
+};
+
+TEST_F(TestTopicFilter, static_topics_are_not_filtered_by_unpublished_option)
+{
+  // Prepare topics: one static and one regular
+  std::map<std::string, std::vector<std::string>> topics_and_types {
+    {"/static_topic1", {"test_msgs/BasicTypes"}},
+    {"/static_topic2", {"test_msgs/BasicTypes"}},
+    {"/regular_topic1", {"test_msgs/BasicTypes"}},
+    {"/regular_topic2", {"test_msgs/BasicTypes"}},
+  };
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.topics = {"/static_topic", "/regular_topic"};
+  record_options.include_unpublished_topics = false;  // filter unpublished topics
+
+  // Provide static topic list; "/static_topic" should bypass unpublished filtering
+  std::vector<std::pair<std::string, std::string>> static_topics_and_types = {
+    {"/static_topic1", "test_msgs/BasicTypes"},
+    {"/static_topic2", "test_msgs/BasicTypes"},
+  };
+
+  auto node_graph = std::make_shared<UnpublishedNodeGraphStub>();
+
+  rosbag2_transport::TopicFilter filter{
+    record_options,
+    node_graph,
+    true,    // allow unknown types to avoid type filtering noise
+    static_topics_and_types
+  };
+
+  auto filtered_topics = filter.filter_topics(topics_and_types);
+
+  // Expect static topic remains, regular unpublished topics are filtered out
+  ASSERT_EQ(2u, filtered_topics.size());
+  EXPECT_TRUE(filtered_topics.find("/static_topic1") != filtered_topics.end());
+  EXPECT_TRUE(filtered_topics.find("/static_topic2") != filtered_topics.end());
+  EXPECT_FALSE(filtered_topics.find("/regular_topic1") != filtered_topics.end());
+  EXPECT_FALSE(filtered_topics.find("/regular_topic2") != filtered_topics.end());
+}


### PR DESCRIPTION
## Description

This PR introduces a new CLI option "--static-topics-list", with an argument as a path to the yaml config file with a list of pairs "topic_name - topic_type".
The '--static-topics-path' CLI option will expect yaml file in the following format:
```
static_topics_and_types_list:
  - [topic1_name, topic1_type]
  - [topic2_name, topic2_type]
  - [topic3_name, topic3_type]
```
The static topic list can be used to create subscriptions to the topics at the start of the recording, even if the topics are not available/discoverable via the ROS graph and even if publishers do not yet exist on those topics.

- Fixes #https://github.com/ros2/rosbag2/issues/2318

### Is this user-facing behavior change?
Yes, a new "--static-topics-list" CLI option will be added to the `ros2 bag record` command.

### Did you use Generative AI?
Yes. The GitHub Copilot, GPT-5 was used to help with writing some tests and doxygen comments.

### Additional Information
This PR is not backportable since it introduces API/ABI-breaking changes.