### PR TITLE
Update mcap vendor to version 1.4.2

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -34,8 +34,8 @@ endif()
 macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
-    URL https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.4.0.tar.gz
-    URL_HASH SHA1=354d894efb6a0c3968885c0e6d43224ff61fa762 # v1.4.0
+    URL https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.4.2.tar.gz
+    URL_HASH SHA1=d32cf3c807a52da302d31d2739b7762032e2f8ee # v1.4.2
   )
   fetchcontent_makeavailable(mcap)
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Changelog:
PR 1291 added an optimization, which caused the behavior reported in issue 1355. The intention of that change was to close a non-empty chunk before writing a message that would overflow the chunk size. It checks whether the chunk is non-empty _after_ writing `Channel` & `Schema` records to the chunk. Therefore, it's possible to write a chunk that contains no messages.

The writer has a small bug in the metadata that it writes into the chunk index record. The `currentChunkStart_` register is initialized as `MaxTime`, and only updated when a message is added to the chunk. But when writing a message-less chunk, we need to write the message start time as 0.

The indexed message reader has a small bug in the way it detects the presence of a message index. It only looks for a message index on the first chunk index record, instead of scanning all chunk index records. This is why the test case provided in 1355 fails: the first chunk contains only `Channel` & `Schema` records without messages, and therefore the first chunk index has no message index.

Remove dead members in McapReader
cpp: Fix for undefined behavior in mcap::ParseByteArray(..)


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
