### PR TITLE
rosbag2_cpp: Add support for reindexing compressed bags

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -52,6 +52,7 @@ find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
+find_package(rosbag2_compression REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/cache/cache_consumer.cpp
@@ -89,6 +90,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE
   ament_index_cpp::ament_index_cpp
+  rosbag2_compression::rosbag2_compression
   rosidl_typesupport_cpp::rosidl_typesupport_cpp
 )
 

--- a/rosbag2_cpp/include/rosbag2_cpp/reindexer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reindexer.hpp
@@ -35,6 +35,12 @@
 #include "rosbag2_cpp/serialization_format_converter_factory_interface.hpp"
 #include "rosbag2_cpp/visibility_control.hpp"
 
+// Forward declaration due to  circular dependency
+namespace rosbag2_compression
+{
+class CompressionFactory;
+}
+
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/storage_factory.hpp"
 #include "rosbag2_storage/storage_factory_interface.hpp"
@@ -72,9 +78,10 @@ public:
     std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory =
     std::make_unique<rosbag2_storage::StorageFactory>(),
     std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io =
-    std::make_unique<rosbag2_storage::MetadataIo>());
+    std::make_unique<rosbag2_storage::MetadataIo>(),
+    std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory = nullptr);
 
-  virtual ~Reindexer() = default;
+  virtual ~Reindexer();
 
   /// Use the supplied storage options to reindex a bag defined by the storage options URI.
   /*
@@ -92,6 +99,7 @@ private:
   std::string regex_bag_pattern_;
   std::filesystem::path base_folder_;   // The folder that the bag files are in
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_{};
+  std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory_{};
   void get_bag_files(
     const std::filesystem::path & base_folder,
     std::vector<std::filesystem::path> & output);

--- a/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/reindexer.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "rcpputils/asserts.hpp"
+#include "rosbag2_compression/compression_factory.hpp"
 
 #include "rosbag2_cpp/logging.hpp"
 #include "rosbag2_cpp/reader.hpp"
@@ -45,12 +46,16 @@ namespace rosbag2_cpp
 {
 Reindexer::Reindexer(
   std::unique_ptr<rosbag2_storage::StorageFactoryInterface> storage_factory,
-  std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io)
+  std::unique_ptr<rosbag2_storage::MetadataIo> metadata_io,
+  std::unique_ptr<rosbag2_compression::CompressionFactory> compression_factory)
 : storage_factory_(std::move(storage_factory)),
-  metadata_io_(std::move(metadata_io))
+  metadata_io_(std::move(metadata_io)),
+  compression_factory_(std::move(compression_factory))
 {
-  regex_bag_pattern_ = R"(.+_(\d+)\.([a-zA-Z0-9])+)";
+  regex_bag_pattern_ = R"(.+_(\d+)\.([a-zA-Z0-9]+)(?:\.([a-zA-Z0-9]+))?)";
 }
+
+Reindexer::~Reindexer() = default;
 
 /// Determine which path should be placed first in a vector ordered by file number.
 /**
@@ -176,9 +181,29 @@ void Reindexer::aggregate_metadata(
 
     metadata_.bag_size += fs::file_size(f_);
 
+    // Check for compressed file source
+    auto file_string = f_.generic_string();
+    std::string uri_to_read = file_string;
+    std::string original_filename = f_.filename().string();
+    
+    if (file_string.size() > 5 && file_string.substr(file_string.size() - 5) == ".zstd") {
+      if (!compression_factory_) {
+        compression_factory_ = std::make_unique<rosbag2_compression::CompressionFactory>();
+      }
+      
+      // Decompress to /tmp
+      auto decompressor = compression_factory_->create_decompressor("zstd");
+      uri_to_read = decompressor->decompress_uri(file_string);
+      
+      if (metadata_.compression_format.empty()) {
+        metadata_.compression_format = "zstd";
+        metadata_.compression_mode = "FILE";
+      }
+    }
+
     // Set up reader
     rosbag2_storage::StorageOptions temp_so = storage_options;
-    temp_so.uri = f_.string();
+    temp_so.uri = uri_to_read;
 
     // We aren't actually interested in reading messages, so use a blank converter option
     rosbag2_cpp::ConverterOptions blank_converter_options {};
@@ -225,6 +250,13 @@ void Reindexer::aggregate_metadata(
         }
       }
     }
+
+    rosbag2_storage::FileInformation file_info;
+    file_info.path = original_filename;
+    file_info.starting_time = temp_metadata.starting_time;
+    file_info.duration = temp_metadata.duration;
+    file_info.message_count = temp_metadata.message_count;
+    metadata_.files.push_back(file_info);
 
     bag_reader->close();
   }

--- a/rosbag2_py/CMakeLists.txt
+++ b/rosbag2_py/CMakeLists.txt
@@ -115,6 +115,7 @@ pybind11_add_module(_reindexer
   src/rosbag2_py/_reindexer.cpp
 )
 target_link_libraries(_reindexer PUBLIC
+  rosbag2_compression::rosbag2_compression
   rosbag2_cpp::rosbag2_cpp
   rosbag2_storage::rosbag2_storage
 )

--- a/rosbag2_py/src/rosbag2_py/_reindexer.cpp
+++ b/rosbag2_py/src/rosbag2_py/_reindexer.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "rosbag2_cpp/reindexer.hpp"
+#include "rosbag2_compression/compression_factory.hpp"
 #include "rosbag2_storage/storage_options.hpp"
 
 #include "./pybind11.hpp"


### PR DESCRIPTION
The reindexer used to fail for compressed files(.zstd) This fixes it by decompressing the files to /tmp before reindexing

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

- **rosbag2_cpp/reindexer.cpp**: 
- extended regular expression to detect the compression extention.
- Added function to call decompression api to decompress files to /tmp
- Reindex and update the related files and files path with compressed files path

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #990

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

user can now reindex compressed files using rosbag

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
