### PR TITLE
Remove deprecated CLI arguments and options from ros2bag.

### DIFF
--- a/ros2bag/ros2bag/api/__init__.py
+++ b/ros2bag/ros2bag/api/__init__.py
@@ -184,18 +184,12 @@ def add_standard_multi_reader_args(parser: ArgumentParser) -> None:
     """
     # Let user provide an input bag path using an optional positional arg, but require them to use
     # --input to provide an input bag with a specific storage ID
-    reader_choices = rosbag2_py.get_registered_readers()
     parser.add_argument(
         'bag_path',
         nargs='?',
         type=check_path_exists,
         help='Bag to open. '
              'Use --input instead to provide an input bag with a specific storage ID.')
-    parser.add_argument(
-        '-s', '--storage', default='', choices=reader_choices,
-        help='Storage implementation of bag. '
-             'By default attempts to detect automatically - use this argument to override.'
-             ' (deprecated: use --input to provide an input bag with a specific storage ID)')
     add_multi_bag_input_arg(parser, required=False)
 
 

--- a/ros2bag/ros2bag/verb/play.py
+++ b/ros2bag/ros2bag/verb/play.py
@@ -262,12 +262,9 @@ class PlayVerb(VerbExtension):
         if args.bag_path:
             storage_options.append(StorageOptions(
                 uri=args.bag_path,
-                storage_id=args.storage,
+                storage_id='',
                 storage_config_uri=storage_config_file,
             ))
-            if args.storage:
-                print(print_warn('--storage option is deprecated, use -i,--input to '
-                                 'provide an input bag with a specific storage ID'))
         try:
             storage_options.extend(
                 input_bag_arg_to_storage_options(args.input or [], storage_config_file))

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -63,11 +63,7 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
         help="Storage identifier to be used, defaults to '%(default)s'.")
 
     # Topic filter arguments
-    topics_args_group = parser.add_mutually_exclusive_group()
-    topics_args_group.add_argument(
-        'topics_positional', type=str, default=[], metavar='[Topic ...]', nargs='*',
-        help='Space-delimited list of topics to record. (deprecated)')
-    topics_args_group.add_argument(
+    parser.add_argument(
         '--topics', type=str, default=[], metavar='Topic', nargs='+',
         help='Space-delimited list of topics to record.')
     parser.add_argument(
@@ -267,11 +263,6 @@ def check_necessary_argument(args):
 
 
 def validate_parsed_arguments(args, uri) -> str:
-    if args.topics_positional:
-        print(print_warn('Positional "topics" argument deprecated. '
-                         'Please use optional "--topics" argument instead.'), flush=True)
-        args.topics = args.topics_positional
-
     if not check_necessary_argument(args):
         return print_error('Need to specify at least one option out of --all, --all-topics, '
                            '--all-services, --services, --topics, --topic-types,'

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -33,16 +33,6 @@ def test_arguments_parser():
     return parser
 
 
-def test_recorder_positional_topics_list_argument(test_arguments_parser):
-    """Test recorder positional topics list argument parser."""
-    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
-    args = test_arguments_parser.parse_args(
-        ['topic1', 'topic2', '--output', output_path.as_posix()]
-    )
-    assert ['topic1', 'topic2'] == args.topics_positional
-    assert output_path.as_posix() == args.output
-
-
 def test_recorder_optional_topics_list_argument(test_arguments_parser):
     """Test recorder optional --topics list argument parser."""
     output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
@@ -73,25 +63,25 @@ def test_recorder_actions_list_argument(test_arguments_parser):
     assert output_path.as_posix() == args.output
 
 
-def test_recorder_services_and_positional_topics_list_arguments(test_arguments_parser):
-    """Test recorder --services list and positional topics list arguments parser."""
+def test_recorder_services_and_topics_list_arguments(test_arguments_parser):
+    """Test recorder --services list and --topics list arguments parser."""
     output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
     args = test_arguments_parser.parse_args(
         ['--output', output_path.as_posix(),
-         '--services', 'service1', 'service2', '--', 'topic1', 'topic2'])
+         '--services', 'service1', 'service2', '--topics', 'topic1', 'topic2'])
     assert ['service1', 'service2'] == args.services
-    assert ['topic1', 'topic2'] == args.topics_positional
+    assert ['topic1', 'topic2'] == args.topics
     assert output_path.as_posix() == args.output
 
 
-def test_recorder_actions_and_positional_topics_list_arguments(test_arguments_parser):
-    """Test recorder --actions list and positional topics list arguments parser."""
+def test_recorder_actions_and_topics_list_arguments(test_arguments_parser):
+    """Test recorder --actions list and --topics list arguments parser."""
     output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
     args = test_arguments_parser.parse_args(
         ['--output', output_path.as_posix(),
-         '--actions', 'action1', 'action2', '--', 'topic1', 'topic2'])
+         '--actions', 'action1', 'action2', '--topics', 'topic1', 'topic2'])
     assert ['action1', 'action2'] == args.actions
-    assert ['topic1', 'topic2'] == args.topics_positional
+    assert ['topic1', 'topic2'] == args.topics
     assert output_path.as_posix() == args.output
 
 


### PR DESCRIPTION
## Description

minor cosmetic changes to remove deprecated arguments and options. (those have been deprecated in kilted already, so that we can remove them.)
Removed:
- Positional space delimited topics list in the `ros2 bag record` CLI. Need to use `--topics` argument explicitly.
- `-s`, `--storage` CLI argumnet from the `ros2 bag play` CLI. Need to use `--input /path/to/bag1 --input /path/to/bag2 storage_id` arguments instead.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

Yes, this is enforcement not to use deprecated arguments and options anymore.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No,

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
