### PR TITLE
Surpressing multi-threaded process warning from rosbag2 flake8.

### DIFF
--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -27,6 +27,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>rosbag2_storage_default_plugins</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
 

--- a/ros2bag/pytest.ini
+++ b/ros2bag/pytest.ini
@@ -1,4 +1,14 @@
 [pytest]
 junit_family=xunit2
-# flake8 in Ubuntu 22.04 prints this warning; we ignore it for now
-filterwarnings=ignore:SelectableGroups:DeprecationWarning
+# Set a maximum timeout of 900 seconds (15 minutes) for each test to prevent hanging tests
+timeout=900
+# Use thread-based timeout method instead of signal-based to avoid conflicts with multi-threaded tests
+timeout_method=thread
+# Filter out warnings that are expected and don't indicate actual issues
+filterwarnings=
+    # flake8 in Ubuntu 22.04 prints this warning; we ignore it for now
+    ignore:SelectableGroups:DeprecationWarning
+    # Suppress fork() warnings from multi-threaded processes (e.g., during flake8 tests)
+    # These warnings occur because pytest is multi-threaded and fork() can cause deadlocks,
+    # but they don't affect test functionality
+    ignore:.*use of fork\(\) may lead to deadlocks in the child.*

--- a/ros2bag/pytest.ini
+++ b/ros2bag/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 junit_family=xunit2
-# Set a maximum timeout of 900 seconds (15 minutes) for each test to prevent hanging tests
-timeout=900
+# Set a maximum timeout of 120 seconds (2 minutes) for each test to prevent hanging tests
+timeout=120
 # Use thread-based timeout method instead of signal-based to avoid conflicts with multi-threaded tests
 timeout_method=thread
 # Filter out warnings that are expected and don't indicate actual issues


### PR DESCRIPTION
## Description

- before

```console
root@tomoyafujita-B760M-Pro-RS-D4:~/ros2_ws/colcon_ws# colcon test --event-handlers console_direct+ --packages-select ros2bag
Starting >>> ros2bag
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
cachedir: /root/ros2_ws/colcon_ws/build/ros2bag/.pytest_cache
rootdir: /root/ros2_ws/colcon_ws/src/ros2/rosbag2/ros2bag
configfile: pytest.ini
plugins: launch-testing-ros-0.29.5, launch-testing-3.9.6, ament-mypy-0.20.3, ament-xmllint-0.20.3, ament-copyright-0.20.3, ament-pep257-0.20.3, ament-flake8-0.20.3, ament-lint-0.20.3, anyio-4.11.0, None-None, timeout-2.2.0, cov-4.1.0, rerunfailures-12.0, mock-3.12.0, colcon-core-0.20.1
collecting ...
collected 41 items

test/test_api.py .......                                                 [ 17%]
test/test_burst.py .                                                     [ 19%]
test/test_cli_extension.py .                                             [ 21%]
test/test_copyright.py .                                                 [ 24%]
test/test_flake8.py .                                                    [ 26%]
test/test_info.py .                                                      [ 29%]
test/test_pep257.py .                                                    [ 31%]
test/test_play_qos_profiles.py .                                         [ 34%]
test/test_record.py .                                                    [ 36%]
test/test_record_qos_profiles.py .                                       [ 39%]
test/test_record_with_compression_thread_priority.py .                   [ 41%]
test/test_recorder_args_parser.py .......................                [ 97%]
test/test_xmllint.py .                                                   [100%]

=============================== warnings summary ===============================
test/test_flake8.py: 28 warnings
  Warning: This process (pid=34066) is multi-threaded, use of fork() may lead to deadlocks in the child.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----- generated xml file: /root/ros2_ws/colcon_ws/build/ros2bag/pytest.xml -----
======================= 41 passed, 28 warnings in 10.10s =======================
--- stderr: ros2bag

=============================== warnings summary ===============================
test/test_flake8.py: 28 warnings
  Warning: This process (pid=34066) is multi-threaded, use of fork() may lead to deadlocks in the child.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---
Finished <<< ros2bag [10.7s]

Summary: 1 package finished [11.5s]
  1 package had stderr output: ros2bag
```

- after

```console
root@tomoyafujita-B760M-Pro-RS-D4:~/ros2_ws/colcon_ws# colcon test --event-handlers console_direct+ --packages-select ros2bag
Starting >>> ros2bag
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
cachedir: /root/ros2_ws/colcon_ws/build/ros2bag/.pytest_cache
rootdir: /root/ros2_ws/colcon_ws/src/ros2/rosbag2/ros2bag
configfile: pytest.ini
plugins: launch-testing-ros-0.29.5, launch-testing-3.9.6, ament-mypy-0.20.3, ament-xmllint-0.20.3, ament-copyright-0.20.3, ament-pep257-0.20.3, ament-flake8-0.20.3, ament-lint-0.20.3, anyio-4.11.0, None-None, timeout-2.2.0, cov-4.1.0, rerunfailures-12.0, mock-3.12.0, colcon-core-0.20.1
timeout: 900.0s
timeout method: thread
timeout func_only: False
collecting ...
collected 41 items

test/test_api.py .......                                                 [ 17%]
test/test_burst.py .                                                     [ 19%]
test/test_cli_extension.py .                                             [ 21%]
test/test_copyright.py .                                                 [ 24%]
test/test_flake8.py .                                                    [ 26%]
test/test_info.py .                                                      [ 29%]
test/test_pep257.py .                                                    [ 31%]
test/test_play_qos_profiles.py .                                         [ 34%]
test/test_record.py .                                                    [ 36%]
test/test_record_qos_profiles.py .                                       [ 39%]
test/test_record_with_compression_thread_priority.py .                   [ 41%]
test/test_recorder_args_parser.py .......................                [ 97%]
test/test_xmllint.py .                                                   [100%]

----- generated xml file: /root/ros2_ws/colcon_ws/build/ros2bag/pytest.xml -----
============================== 41 passed in 9.56s ==============================
Finished <<< ros2bag [10.2s]

Summary: 1 package finished [11.0s]
```

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

https://github.com/ros2/sros2/blob/rolling/sros2/pytest.ini, we have done the same thing to sros2.