### PR TITLE
Fix YAML decode/encode for ignore_leaf_topics, start_paused and use_sim_time in RecordOptions

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -60,6 +60,9 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
   node["topic_qos_profile_overrides"] = qos_overrides;
   node["include_hidden_topics"] = record_options.include_hidden_topics;
   node["include_unpublished_topics"] = record_options.include_unpublished_topics;
+  node["ignore_leaf_topics"] = record_options.ignore_leaf_topics;
+  node["start_paused"] = record_options.start_paused;
+  node["use_sim_time"] = record_options.use_sim_time;
   return node;
 }
 
@@ -91,6 +94,9 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<bool>(
     node, "include_unpublished_topics",
     record_options.include_unpublished_topics);
+  optional_assign<bool>(node, "ignore_leaf_topics", record_options.ignore_leaf_topics);
+  optional_assign<bool>(node, "start_paused", record_options.start_paused);
+  optional_assign<bool>(node, "use_sim_time", record_options.use_sim_time);
   return true;
 }
 


### PR DESCRIPTION
## Description

This PR adds missing YAML encode/decode support for the following rosbag2_transport::RecordOptions fields:

- ignore_leaf_topics
- start_paused
- use_sim_time

These fields are defined in RecordOptions but were not handled in the YAML::convert<RecordOptions> specialization. As a result, when using YAML-based configuration, these options were silently ignored and always retained their default values.

This change updates both:

- encode() to properly serialize these fields.
- decode() to correctly parse them from YAML.

The behavior remains unchanged unless these parameters are explivitly provided in a YAML configuration file.

### Is this user-facing behavior change?

Yes, but only in the case where these parameters are provided in YAML configuration.

Previously, the following YAML fields had no effect:

- ignore_leaf_topics
- start_paused
- use_sim_time

After this change, these parameters are correctly applied when specified in YAML profiles.

There is no change for users who do not use these fields in YAML.

### Did you use Generative AI?

No.