### PR TITLE
Add missing "RecordOptions" fields to the encode/decode functions

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -90,6 +90,10 @@ public:
   /// will be published. If set to 0, no statistics will be published. The value must be greater
   /// than or equal to 0 and less than or equal to 1000.
   float statistics_max_publishing_rate = 1.0f;
+
+  /// Note: Please don't forget to update the YAML serialization and deserialization logic in
+  /// `record_options.cpp` and the test case `test_yaml_serialization_deserialization`
+  /// in `test_record_options.cpp` when updating the fields in RecordOptions.
 };
 
 }  // namespace rosbag2_transport

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -57,6 +57,9 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
   node["include_hidden_topics"] = record_options.include_hidden_topics;
   node["include_unpublished_topics"] = record_options.include_unpublished_topics;
   node["disable_keyboard_controls"] = record_options.disable_keyboard_controls;
+  node["ignore_leaf_topics"] = record_options.ignore_leaf_topics;
+  node["start_paused"] = record_options.start_paused;
+  node["use_sim_time"] = record_options.use_sim_time;
   return node;
 }
 
@@ -124,6 +127,9 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<bool>(
     node, "disable_keyboard_controls",
     record_options.disable_keyboard_controls);
+  optional_assign<bool>(node, "ignore_leaf_topics", record_options.ignore_leaf_topics);
+  optional_assign<bool>(node, "start_paused", record_options.start_paused);
+  optional_assign<bool>(node, "use_sim_time", record_options.use_sim_time);
   return true;
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -47,18 +47,18 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
   node["is_discovery_disabled"] = is_discovery_disabled;
   node["topics"] = topics;
   node["topic_types"] = topic_types;
-  node["exclude_topic_types"] = exclude_topic_types;
   node["services"] = services;
   node["actions"] = actions;
+  node["exclude_topics"] = exclude_topics;
+  node["exclude_topic_types"] = exclude_topic_types;
+  node["exclude_services"] = exclude_service_events;
+  node["exclude_actions"] = exclude_actions;
   node["rmw_serialization_format"] = rmw_serialization_format;
   node["input_serialization_format"] = input_serialization_format;
   node["output_serialization_format"] = output_serialization_format;
   node["topic_polling_interval"] = topic_polling_interval;
   node["regex"] = regex;
   node["exclude_regex"] = exclude_regex;
-  node["exclude_topics"] = exclude_topics;
-  node["exclude_services"] = exclude_service_events;
-  node["exclude_actions"] = exclude_actions;
   node["node_prefix"] = node_prefix;
   node["compression_mode"] = compression_mode;
   node["compression_format"] = compression_format;
@@ -69,11 +69,11 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
     convert<std::unordered_map<std::string, rclcpp::QoS>>::encode(topic_qos_profile_overrides);
   node["include_hidden_topics"] = include_hidden_topics;
   node["include_unpublished_topics"] = include_unpublished_topics;
-  node["static_topics_uri"] = static_topics_uri;
-  node["disable_keyboard_controls"] = disable_keyboard_controls;
   node["ignore_leaf_topics"] = ignore_leaf_topics;
   node["start_paused"] = start_paused;
   node["use_sim_time"] = use_sim_time;
+  node["static_topics_uri"] = static_topics_uri;
+  node["disable_keyboard_controls"] = disable_keyboard_controls;
   node["statistics_max_publishing_rate"] = statistics_max_publishing_rate;
   return node;
 }
@@ -112,6 +112,10 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<std::vector<std::string>>(node, "topic_types", topic_types);
   optional_assign<std::vector<std::string>>(node, "services", services);
   optional_assign<std::vector<std::string>>(node, "actions", actions);
+  optional_assign<std::vector<std::string>>(node, "exclude_topics", exclude_topics);
+  optional_assign<std::vector<std::string>>(node, "exclude_topic_types", exclude_topic_types);
+  optional_assign<std::vector<std::string>>(node, "exclude_services", exclude_service_events);
+  optional_assign<std::vector<std::string>>(node, "exclude_actions", exclude_actions);
   optional_assign<std::string>(
     node, "rmw_serialization_format", rmw_serialization_format);
   optional_assign<std::string>(
@@ -126,10 +130,6 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   // Map exclude to the "exclude_regex" for backward compatability.
   optional_assign<std::string>(node, "exclude", exclude_regex);
   optional_assign<std::string>(node, "exclude_regex", exclude_regex);
-  optional_assign<std::vector<std::string>>(node, "exclude_topics", exclude_topics);
-  optional_assign<std::vector<std::string>>(node, "exclude_topic_types", exclude_topic_types);
-  optional_assign<std::vector<std::string>>(node, "exclude_services", exclude_service_events);
-  optional_assign<std::vector<std::string>>(node, "exclude_actions", exclude_actions);
   optional_assign<std::string>(node, "node_prefix", node_prefix);
   optional_assign<std::string>(node, "compression_mode", compression_mode);
   optional_assign<std::string>(node, "compression_format", compression_format);
@@ -146,11 +146,11 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
 
   optional_assign<bool>(node, "include_hidden_topics", include_hidden_topics);
   optional_assign<bool>(node, "include_unpublished_topics", include_unpublished_topics);
-  optional_assign<std::string>(node, "static_topics_uri", static_topics_uri);
-  optional_assign<bool>(node, "disable_keyboard_controls", disable_keyboard_controls);
   optional_assign<bool>(node, "ignore_leaf_topics", ignore_leaf_topics);
   optional_assign<bool>(node, "start_paused", start_paused);
   optional_assign<bool>(node, "use_sim_time", use_sim_time);
+  optional_assign<std::string>(node, "static_topics_uri", static_topics_uri);
+  optional_assign<bool>(node, "disable_keyboard_controls", disable_keyboard_controls);
   optional_assign<float>(node, "statistics_max_publishing_rate", statistics_max_publishing_rate);
   return true;
 }

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -26,110 +26,132 @@ namespace YAML
 Node convert<rosbag2_transport::RecordOptions>::encode(
   const rosbag2_transport::RecordOptions & record_options)
 {
+  // Structured binding check - this line will fail to compile if fields are added/removed to
+  // RecordOptions without updating this function.
+  // Note: Please don't forget to update the test case `test_yaml_serialization_deserialization`
+  // in `test_record_options.cpp` when updating the fields in RecordOptions.
+  auto & [all_topics, all_services, all_actions, is_discovery_disabled,
+    topics, topic_types, services, actions,
+    exclude_topics, exclude_topic_types, exclude_service_events, exclude_actions,
+    rmw_serialization_format, input_serialization_format, output_serialization_format,
+    topic_polling_interval, regex, exclude_regex, node_prefix,
+    compression_mode, compression_format, compression_queue_size, compression_threads,
+    compression_threads_priority, topic_qos_profile_overrides,
+    include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
+    start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
+    statistics_max_publishing_rate] = record_options;
   Node node;
-  node["all_topics"] = record_options.all_topics;
-  node["all_services"] = record_options.all_services;
-  node["all_actions"] = record_options.all_actions;
-  node["is_discovery_disabled"] = record_options.is_discovery_disabled;
-  node["topics"] = record_options.topics;
-  node["topic_types"] = record_options.topic_types;
-  node["exclude_topic_types"] = record_options.exclude_topic_types;
-  node["services"] = record_options.services;
-  node["actions"] = record_options.actions;
-  node["rmw_serialization_format"] = record_options.rmw_serialization_format;
-  node["input_serialization_format"] = record_options.input_serialization_format;
-  node["output_serialization_format"] = record_options.output_serialization_format;
-  node["topic_polling_interval"] = record_options.topic_polling_interval;
-  node["regex"] = record_options.regex;
-  node["exclude_regex"] = record_options.exclude_regex;
-  node["exclude_topics"] = record_options.exclude_topics;
-  node["exclude_services"] = record_options.exclude_service_events;
-  node["exclude_actions"] = record_options.exclude_actions;
-  node["node_prefix"] = record_options.node_prefix;
-  node["compression_mode"] = record_options.compression_mode;
-  node["compression_format"] = record_options.compression_format;
-  node["compression_queue_size"] = record_options.compression_queue_size;
-  node["compression_threads"] = record_options.compression_threads;
-  node["compression_threads_priority"] = record_options.compression_threads_priority;
+  node["all_topics"] = all_topics;
+  node["all_services"] = all_services;
+  node["all_actions"] = all_actions;
+  node["is_discovery_disabled"] = is_discovery_disabled;
+  node["topics"] = topics;
+  node["topic_types"] = topic_types;
+  node["exclude_topic_types"] = exclude_topic_types;
+  node["services"] = services;
+  node["actions"] = actions;
+  node["rmw_serialization_format"] = rmw_serialization_format;
+  node["input_serialization_format"] = input_serialization_format;
+  node["output_serialization_format"] = output_serialization_format;
+  node["topic_polling_interval"] = topic_polling_interval;
+  node["regex"] = regex;
+  node["exclude_regex"] = exclude_regex;
+  node["exclude_topics"] = exclude_topics;
+  node["exclude_services"] = exclude_service_events;
+  node["exclude_actions"] = exclude_actions;
+  node["node_prefix"] = node_prefix;
+  node["compression_mode"] = compression_mode;
+  node["compression_format"] = compression_format;
+  node["compression_queue_size"] = compression_queue_size;
+  node["compression_threads"] = compression_threads;
+  node["compression_threads_priority"] = compression_threads_priority;
   node["topic_qos_profile_overrides"] =
-    convert<std::unordered_map<std::string, rclcpp::QoS>>::encode(
-    record_options.topic_qos_profile_overrides);
-  node["include_hidden_topics"] = record_options.include_hidden_topics;
-  node["include_unpublished_topics"] = record_options.include_unpublished_topics;
-  node["disable_keyboard_controls"] = record_options.disable_keyboard_controls;
-  node["ignore_leaf_topics"] = record_options.ignore_leaf_topics;
-  node["start_paused"] = record_options.start_paused;
-  node["use_sim_time"] = record_options.use_sim_time;
+    convert<std::unordered_map<std::string, rclcpp::QoS>>::encode(topic_qos_profile_overrides);
+  node["include_hidden_topics"] = include_hidden_topics;
+  node["include_unpublished_topics"] = include_unpublished_topics;
+  node["static_topics_uri"] = static_topics_uri;
+  node["disable_keyboard_controls"] = disable_keyboard_controls;
+  node["ignore_leaf_topics"] = ignore_leaf_topics;
+  node["start_paused"] = start_paused;
+  node["use_sim_time"] = use_sim_time;
+  node["statistics_max_publishing_rate"] = statistics_max_publishing_rate;
   return node;
 }
 
 bool convert<rosbag2_transport::RecordOptions>::decode(
   const Node & node, rosbag2_transport::RecordOptions & record_options, int version)
 {
-  optional_assign<bool>(node, "all_topics", record_options.all_topics);
-  optional_assign<bool>(node, "all_services", record_options.all_services);
-  optional_assign<bool>(node, "all_actions", record_options.all_actions);
+  // Structured binding check - this line will fail to compile if fields are added/removed to
+  // RecordOptions without updating this function.
+  // Note: Please don't forget to update the test case `test_yaml_serialization_deserialization`
+  // in `test_record_options.cpp` when updating the fields in RecordOptions.
+  auto & [all_topics, all_services, all_actions, is_discovery_disabled,
+    topics, topic_types, services, actions,
+    exclude_topics, exclude_topic_types, exclude_service_events, exclude_actions,
+    rmw_serialization_format, input_serialization_format, output_serialization_format,
+    topic_polling_interval, regex, exclude_regex, node_prefix,
+    compression_mode, compression_format, compression_queue_size, compression_threads,
+    compression_threads_priority, topic_qos_profile_overrides,
+    include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
+    start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
+    statistics_max_publishing_rate] = record_options;
+
+  optional_assign<bool>(node, "all_topics", all_topics);
+  optional_assign<bool>(node, "all_services", all_services);
+  optional_assign<bool>(node, "all_actions", all_actions);
   bool record_options_all{false};  // Parse `all` for backward compatability and convenient usage
   optional_assign<bool>(node, "all", record_options_all);
   if (record_options_all) {
-    record_options.all_topics = true;
-    record_options.all_services = true;
-    record_options.all_actions = true;
+    all_topics = true;
+    all_services = true;
+    all_actions = true;
   }
 
-  optional_assign<bool>(node, "is_discovery_disabled", record_options.is_discovery_disabled);
-  optional_assign<std::vector<std::string>>(node, "topics", record_options.topics);
-  optional_assign<std::vector<std::string>>(node, "topic_types", record_options.topic_types);
-  optional_assign<std::vector<std::string>>(node, "services", record_options.services);
-  optional_assign<std::vector<std::string>>(node, "actions", record_options.actions);
+  optional_assign<bool>(node, "is_discovery_disabled", is_discovery_disabled);
+  optional_assign<std::vector<std::string>>(node, "topics", topics);
+  optional_assign<std::vector<std::string>>(node, "topic_types", topic_types);
+  optional_assign<std::vector<std::string>>(node, "services", services);
+  optional_assign<std::vector<std::string>>(node, "actions", actions);
   optional_assign<std::string>(
-    node, "rmw_serialization_format", record_options.rmw_serialization_format);
+    node, "rmw_serialization_format", rmw_serialization_format);
   optional_assign<std::string>(
-    node, "input_serialization_format", record_options.input_serialization_format);
+    node, "input_serialization_format", input_serialization_format);
   optional_assign<std::string>(
-    node, "output_serialization_format", record_options.output_serialization_format);
+    node, "output_serialization_format", output_serialization_format);
 
   optional_assign<std::chrono::milliseconds>(
-    node, "topic_polling_interval", record_options.topic_polling_interval);
+    node, "topic_polling_interval", topic_polling_interval);
 
-  optional_assign<std::string>(node, "regex", record_options.regex);
+  optional_assign<std::string>(node, "regex", regex);
   // Map exclude to the "exclude_regex" for backward compatability.
-  optional_assign<std::string>(node, "exclude", record_options.exclude_regex);
-  optional_assign<std::string>(node, "exclude_regex", record_options.exclude_regex);
-  optional_assign<std::vector<std::string>>(node, "exclude_topics", record_options.exclude_topics);
-  optional_assign<std::vector<std::string>>(
-    node, "exclude_topic_types",
-    record_options.exclude_topic_types);
-  optional_assign<std::vector<std::string>>(
-    node, "exclude_services", record_options.exclude_service_events);
-  optional_assign<std::vector<std::string>>(
-    node, "exclude_actions", record_options.exclude_actions);
-  optional_assign<std::string>(node, "node_prefix", record_options.node_prefix);
-  optional_assign<std::string>(node, "compression_mode", record_options.compression_mode);
-  optional_assign<std::string>(node, "compression_format", record_options.compression_format);
-  optional_assign<uint64_t>(node, "compression_queue_size", record_options.compression_queue_size);
-  optional_assign<uint64_t>(node, "compression_threads", record_options.compression_threads);
-  optional_assign<int32_t>(
-    node, "compression_threads_priority",
-    record_options.compression_threads_priority);
+  optional_assign<std::string>(node, "exclude", exclude_regex);
+  optional_assign<std::string>(node, "exclude_regex", exclude_regex);
+  optional_assign<std::vector<std::string>>(node, "exclude_topics", exclude_topics);
+  optional_assign<std::vector<std::string>>(node, "exclude_topic_types", exclude_topic_types);
+  optional_assign<std::vector<std::string>>(node, "exclude_services", exclude_service_events);
+  optional_assign<std::vector<std::string>>(node, "exclude_actions", exclude_actions);
+  optional_assign<std::string>(node, "node_prefix", node_prefix);
+  optional_assign<std::string>(node, "compression_mode", compression_mode);
+  optional_assign<std::string>(node, "compression_format", compression_format);
+  optional_assign<uint64_t>(node, "compression_queue_size", compression_queue_size);
+  optional_assign<uint64_t>(node, "compression_threads", compression_threads);
+  optional_assign<int32_t>(node, "compression_threads_priority", compression_threads_priority);
 
   std::unordered_map<std::string, rclcpp::QoS> qos_overrides;
   if (node["topic_qos_profile_overrides"]) {
     qos_overrides = YAML::decode_for_version<std::unordered_map<std::string, rclcpp::QoS>>(
       node["topic_qos_profile_overrides"], version);
   }
-  record_options.topic_qos_profile_overrides = qos_overrides;
+  topic_qos_profile_overrides = qos_overrides;
 
-  optional_assign<bool>(node, "include_hidden_topics", record_options.include_hidden_topics);
-  optional_assign<bool>(
-    node, "include_unpublished_topics",
-    record_options.include_unpublished_topics);
-  optional_assign<bool>(
-    node, "disable_keyboard_controls",
-    record_options.disable_keyboard_controls);
-  optional_assign<bool>(node, "ignore_leaf_topics", record_options.ignore_leaf_topics);
-  optional_assign<bool>(node, "start_paused", record_options.start_paused);
-  optional_assign<bool>(node, "use_sim_time", record_options.use_sim_time);
+  optional_assign<bool>(node, "include_hidden_topics", include_hidden_topics);
+  optional_assign<bool>(node, "include_unpublished_topics", include_unpublished_topics);
+  optional_assign<std::string>(node, "static_topics_uri", static_topics_uri);
+  optional_assign<bool>(node, "disable_keyboard_controls", disable_keyboard_controls);
+  optional_assign<bool>(node, "ignore_leaf_topics", ignore_leaf_topics);
+  optional_assign<bool>(node, "start_paused", start_paused);
+  optional_assign<bool>(node, "use_sim_time", use_sim_time);
+  optional_assign<float>(node, "statistics_max_publishing_rate", statistics_max_publishing_rate);
   return true;
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -19,17 +19,20 @@
 
 using namespace ::testing;  // NOLINT
 
-TEST(record_options, test_yaml_serialization)
+
+TEST(record_options, test_yaml_serialization_deserialization)
 {
-  rosbag2_transport::RecordOptions original;
+ rosbag2_transport::RecordOptions original;
   original.all_topics = true;
   original.all_services = true;
   original.all_actions = true;
   original.is_discovery_disabled = true;
   original.topics = {"topic", "other_topic"};
+  original.topic_types = {"type_a", "type_b"};
   original.services = {"service", "other_service"};
   original.actions = {"action", "other_action"};
   original.exclude_topics = {"exclude_topic1", "exclude_topic2"};
+  original.exclude_topic_types = {"exclude_type1", "exclude_type2"};
   original.exclude_service_events = {"exclude_service1", "exclude_service2"};
   original.exclude_actions = {"exclude_action1", "exclude_action2"};
   original.rmw_serialization_format = "cdr";
@@ -43,11 +46,18 @@ TEST(record_options, test_yaml_serialization)
   original.compression_format = "h264";
   original.compression_queue_size = 2;
   original.compression_threads = 123;
+  original.compression_threads_priority = -10;
   original.topic_qos_profile_overrides.emplace("topic", rclcpp::QoS(10).transient_local());
   original.include_hidden_topics = true;
   original.include_unpublished_topics = true;
+  original.ignore_leaf_topics = true;
+  original.start_paused = true;
+  original.use_sim_time = true;
+  original.static_topics_uri = "/static/topics.yaml";
+  original.disable_keyboard_controls = true;
+  original.statistics_max_publishing_rate = 5.0f;
 
-  auto node = YAML::convert<rosbag2_transport::RecordOptions>().encode(original);
+  auto node = YAML::convert<rosbag2_transport::RecordOptions>::encode(original);
 
   std::stringstream serializer;
   serializer << node;
@@ -60,15 +70,36 @@ TEST(record_options, test_yaml_serialization)
   CHECK(all_actions);
   CHECK(is_discovery_disabled);
   CHECK(topics);
+  CHECK(topic_types);
   CHECK(services);
   CHECK(actions);
   CHECK(exclude_topics);
+  CHECK(exclude_topic_types);
   CHECK(exclude_service_events);
   CHECK(exclude_actions);
   CHECK(rmw_serialization_format);
   CHECK(input_serialization_format);
   CHECK(output_serialization_format);
+  CHECK(topic_polling_interval);
+  CHECK(regex);
+  CHECK(exclude_regex);
+  CHECK(node_prefix);
+  CHECK(compression_mode);
+  CHECK(compression_format);
+  CHECK(compression_queue_size);
+  CHECK(compression_threads);
+  CHECK(compression_threads_priority);
+  CHECK(include_hidden_topics);
+  CHECK(include_unpublished_topics);
+  CHECK(ignore_leaf_topics);
+  CHECK(start_paused);
+  CHECK(use_sim_time);
+  CHECK(static_topics_uri);
+  CHECK(disable_keyboard_controls);
   #undef CHECK
+  ASSERT_FLOAT_EQ(original.statistics_max_publishing_rate,
+    reconstructed.statistics_max_publishing_rate);
+  ASSERT_EQ(original.topic_qos_profile_overrides, reconstructed.topic_qos_profile_overrides);
 }
 
 TEST(record_options, test_yaml_decode_for_all_and_exclude)

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -89,6 +89,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   CHECK(compression_queue_size);
   CHECK(compression_threads);
   CHECK(compression_threads_priority);
+  CHECK(topic_qos_profile_overrides);
   CHECK(include_hidden_topics);
   CHECK(include_unpublished_topics);
   CHECK(ignore_leaf_topics);
@@ -98,8 +99,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   CHECK(disable_keyboard_controls);
   #undef CHECK
   ASSERT_FLOAT_EQ(original.statistics_max_publishing_rate,
-    reconstructed.statistics_max_publishing_rate);
-  ASSERT_EQ(original.topic_qos_profile_overrides, reconstructed.topic_qos_profile_overrides);
+                  reconstructed.statistics_max_publishing_rate);
 }
 
 TEST(record_options, test_yaml_decode_for_all_and_exclude)


### PR DESCRIPTION
> This PR retargets and supersedes the previous Humble PR as requested by maintainers.
> Original PR (Humble): #2331 

## Description

This PR adds missing YAML encode/decode support for the following rosbag2_transport::RecordOptions fields:

- ignore_leaf_topics
- start_paused
- use_sim_time

These fields are defined in RecordOptions but were not handled in the YAML::convert specialization. As a result, when using YAML-based configuration, these options were silently ignored and always retained their default values.

This change updates both:

- encode() to properly serialize these fields.
- decode() to correctly parse them from YAML.

The behavior remains unchanged unless these parameters are explivitly provided in a YAML configuration file.

### Is this user-facing behavior change?

Yes, but only in the case where these parameters are provided in YAML configuration.

Previously, the following YAML fields had no effect:

- ignore_leaf_topics
- start_paused
- use_sim_time

After this change, these parameters are correctly applied when specified in YAML profiles.

There is no change for users who do not use these fields in YAML.

### Did you use Generative AI?

No.
