### PR TITLE
Add on start recording callback for Recorder

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -22,6 +22,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <functional>
 
 #include "keyboard_handler/keyboard_handler.hpp"
 
@@ -272,6 +273,14 @@ public:
   /// Return the current discovery state.
   ROSBAG2_TRANSPORT_PUBLIC
   bool is_discovery_running() const;
+
+  /// \brief Type alias for the callback to be invoked when recording is started.
+  using OnStartRecordingCallback = std::function<void()>;
+
+  /// \brief Set the callback to be invoked when recording is started.
+  /// \param callback The callback to be invoked when recording is started.
+  ROSBAG2_TRANSPORT_PUBLIC
+  void set_on_start_recording_callback(OnStartRecordingCallback callback) const;
 
   inline constexpr static const auto kPauseResumeToggleKey = KeyboardHandler::KeyCode::SPACE;
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -202,6 +202,7 @@ public:
   std::unordered_map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> subscriptions_;
 
   std::vector<std::pair<std::string, std::string>> static_topics_{};  // topic_name, topic_type
+  Recorder::OnStartRecordingCallback on_start_recording_callback_{};
 
 private:
   using SplitBagFileResponse = rosbag2_interfaces::srv::SplitBagfile::Response;
@@ -683,6 +684,10 @@ bool RecorderImpl::record(const std::string & uri)
     RCLCPP_INFO(node->get_logger(), "Recording...");
   }
   in_recording_ = true;
+
+  if (on_start_recording_callback_) {
+    on_start_recording_callback_();
+  }
   return true;
 }
 
@@ -1845,6 +1850,11 @@ bool
 Recorder::is_discovery_running() const
 {
   return pimpl_->is_discovery_running();
+}
+
+void Recorder::set_on_start_recording_callback(OnStartRecordingCallback callback) const
+{
+  pimpl_->on_start_recording_callback_ = std::move(callback);
 }
 
 void Recorder::read_static_topics() noexcept

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <atomic>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -251,6 +252,31 @@ TEST_F(RecordIntegrationTestFixture, can_record_again_after_stop)
     const uint64_t expected_u64_value = i % num_messages_to_publish;
     EXPECT_THAT(basic_type_messages[i]->uint64_value, Eq(expected_u64_value));
   }
+}
+
+TEST_F(RecordIntegrationTestFixture,
+  recording_started_callback_is_called_each_time_recording_starts)
+{
+  rosbag2_transport::RecordOptions record_options{};
+  record_options.is_discovery_disabled = true;
+  record_options.disable_keyboard_controls = true;
+
+  std::atomic_size_t recording_started_callback_count{0};
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_),
+    storage_options_,
+    record_options);
+  recorder->set_on_start_recording_callback(
+    [&recording_started_callback_count]() {++recording_started_callback_count;});
+
+  EXPECT_EQ(recording_started_callback_count.load(), 0U);
+
+  recorder->record();
+  EXPECT_EQ(recording_started_callback_count.load(), 1U);
+
+  recorder->stop();
+  recorder->record();
+  EXPECT_EQ(recording_started_callback_count.load(), 2U);
 }
 
 TEST_F(RecordIntegrationTestFixture, qos_is_stored_in_metadata)


### PR DESCRIPTION
## Description
This PR adds a new public API `set_on_start_recording_callback()` to the `rosbag2_transport::Recorder` class, which sets the callback to be invoked when recording is started.

Motivation: 
  We need to know on a C++ layer when `rosbag2_transport::Recorder` starts recording is triggered via a service call or possibly by other means (from another thread).

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes # N/A

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported.
<!--
If applicable, provide any additional context or details about the changes.
-->
