### PR TITLE
Address a possible deadlock in seek(timestamp)

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -896,22 +896,20 @@ size_t PlayerImpl::burst(const size_t num_messages)
 
 void PlayerImpl::seek(rcutils_time_point_value_t time_point)
 {
-  {
-    rcpputils::unique_lock<std::mutex> is_in_playback_lk(is_in_playback_mutex_);
-    if (!is_in_playback_) {
-      RCLCPP_WARN(owner_->get_logger(), "Called seek, but player is not playing.");
-      return;
-    }
+  rcpputils::unique_lock<std::mutex> is_in_playback_lk(is_in_playback_mutex_);
+  if (!is_in_playback_) {
+    RCLCPP_WARN(owner_->get_logger(), "Called seek, but player is not playing.");
+    return;
   }
+
+  // Wait for player to be ready for playback messages from queue i.e. wait for Player:play() to
+  // be called if not yet and queue to be filled with messages.
+  std::unique_lock<std::mutex> lk(ready_to_play_from_queue_mutex_);
+  ready_to_play_from_queue_cv_.wait(lk, [this] {return is_ready_to_play_from_queue_;});
+
   // Temporary stop playback in play_messages_from_queue() and block play_next()
   std::lock_guard<std::mutex> main_play_loop_lk(main_play_loop_mutex_);
   skip_message_in_main_play_loop_ = true;
-  // Wait for player to be ready for playback messages from queue i.e. wait for Player:play() to
-  // be called if not yet and queue to be filled with messages.
-  {
-    std::unique_lock<std::mutex> lk(ready_to_play_from_queue_mutex_);
-    ready_to_play_from_queue_cv_.wait(lk, [this] {return is_ready_to_play_from_queue_;});
-  }
   cancel_wait_for_next_message_ = true;
   // if given seek value is earlier than the beginning of the bag, then clamp
   // it to the beginning of the bag


### PR DESCRIPTION
## Description
This PR addresses a possible deadlock when `play_options_.loop = true` and  `seek(timestamp)` was called at the moment when we finished the one  `play_messages_from_queue()`, but hadn't started the other one.

Essentially, it was a deadlock on the waiting for the `main_play_loop_mutex_` to be locked in `play() 
https://github.com/ros2/rosbag2/blob/52bf18cfd32a123456b3ca1df54844762f4e61ca/rosbag2_transport/src/rosbag2_transport/player.cpp#L631-L637

 while the same mutex had already been held in the `seek()` and we were waiting on a `ready_to_play_from_queue_cv_`
https://github.com/ros2/rosbag2/blob/52bf18cfd32a123456b3ca1df54844762f4e61ca/rosbag2_transport/src/rosbag2_transport/player.cpp#L906-L914

But the `ready_to_play_from_queue_cv_` is set to true further in the `play()` function when calling for the play_messages_from_queue(); but after going through the section with the same `main_play_loop_mutex_` lock.
https://github.com/ros2/rosbag2/blob/52bf18cfd32a123456b3ca1df54844762f4e61ca/rosbag2_transport/src/rosbag2_transport/player.cpp#L633-L661

To eliminate this deadlock, locking the `main_play_loop_mutex_` in the `seek(timestamp)` was moved after waiting on the `ready_to_play_from_queue_cv_`.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Relates #2343

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported.
