### PR TITLE
Enable message cache by default (100 MiB)

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_storage.cpp
+++ b/rosbag2_py/src/rosbag2_py/_storage.cpp
@@ -84,7 +84,7 @@ PYBIND11_MODULE(_storage, m) {
     pybind11::arg("storage_id") = "",
     pybind11::arg("max_bagfile_size") = 0,
     pybind11::arg("max_bagfile_duration") = 0,
-    pybind11::arg("max_cache_size") = 0,
+    pybind11::arg("max_cache_size") = 100 * 1024 * 1024,
     pybind11::arg("storage_preset_profile") = "",
     pybind11::arg("storage_config_uri") = "",
     pybind11::arg("snapshot_mode") = false)

--- a/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_options.hpp
@@ -38,10 +38,12 @@ public:
   // A value of 0 indicates that bagfile splitting will not be used.
   uint64_t max_bagfile_duration = 0;
 
-  // The cache size indiciates how many messages can maximally be hold in cache
-  // before these being written to disk.
+  // The cache size indicates how many bytes of messages to hold in each buffer
+  // of cache before writing to disk. Uses double buffering, so peak memory
+  // usage can be up to twice this value.
   // A value of 0 disables caching and every write happens directly to disk.
-  uint64_t max_cache_size = 0;
+  // Defaults to 100 MiB, matching the ros2 bag record CLI default.
+  uint64_t max_cache_size = 100u * 1024u * 1024u;
 
   // Preset storage configuration. Preset settings can be overriden with
   // corresponding settings specified through storage_config_uri file


### PR DESCRIPTION
## Summary
- Set the C++ `StorageOptions::max_cache_size` default to 100 MiB (was 0 / disabled)
- Update the pybind11 constructor default to match
- The `ros2 bag record` CLI already defaults `--max-cache-size` to 100 MiB, but the C++ struct defaulted to 0, so programmatic users got synchronous per-message writes unless they explicitly enabled caching

## Motivation
Without caching enabled, every incoming message triggers a synchronous storage write inside the RCL executor thread. This causes:
- Per-message transaction overhead (no batching)
- The global `writer_mutex_` blocks the executor on every write
- High-frequency topics stall callbacks for all other topics

Enabling the double-buffer cache by default moves storage I/O to a background consumer thread and batches writes into single transactions, which can reduce write overhead by 10-100x.

## Test plan
- [x] Existing tests that explicitly set `max_cache_size` are unaffected
- [ ] Tests that rely on the default being 0 without explicitly setting it will now exercise the cache path — these should be updated to explicitly set `max_cache_size = 0` if they need direct writes
- [ ] Verify recording performance with default settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)