### PR TITLE
Allow pause/resume service calls while not in recording

### DIFF
--- a/rosbag2_interfaces/srv/Resume.srv
+++ b/rosbag2_interfaces/srv/Resume.srv
@@ -4,8 +4,3 @@
 # request with player.
 builtin_interfaces/Time resume_time
 ---
-# Return code. Returns 1 when recording is not running or in case of error, otherwise 0.
-int32 return_code
-
-# Error string. Empty if no error occurred.
-string error_string

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -2077,17 +2077,10 @@ void PlayerImpl::create_control_services()
   srv_resume_ = owner_->create_service<rosbag2_interfaces::srv::Resume>(
     "~/resume",
     [this](
-      rosbag2_interfaces::srv::Resume::Request::ConstSharedPtr request,
-      rosbag2_interfaces::srv::Resume::Response::SharedPtr response)
+      rosbag2_interfaces::srv::Resume::Request::ConstSharedPtr /*request*/,
+      rosbag2_interfaces::srv::Resume::Response::SharedPtr /*response*/)
     {
-      if (!(request->resume_time.sec == 0 && request->resume_time.nanosec == 0)) {
-        response->return_code = 1;
-        response->error_string =
-        "'Resume' request with resume_time is not supported yet. Request ignored.";
-      } else {
-        owner_->resume();
-        response->return_code = 0;
-      }
+      owner_->resume();
     });
   srv_toggle_paused_ = owner_->create_service<rosbag2_interfaces::srv::TogglePaused>(
     "~/toggle_paused",

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -906,7 +906,7 @@ void RecorderImpl::create_control_services()
     [this](
       const std::shared_ptr<rmw_request_id_t>/* request_header */,
       const std::shared_ptr<rosbag2_interfaces::srv::Resume::Request> request,
-      const std::shared_ptr<rosbag2_interfaces::srv::Resume::Response> response)
+      const std::shared_ptr<rosbag2_interfaces::srv::Resume::Response>/* response */)
     {
       auto resume_time = optional_time_from_request(request->resume_time);
       if (should_execute_immediately(resume_time)) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -911,28 +911,14 @@ void RecorderImpl::create_control_services()
       auto resume_time = optional_time_from_request(request->resume_time);
       if (should_execute_immediately(resume_time)) {
         std::lock_guard<std::mutex> state_lock(start_stop_transition_mutex_);
-        if (!in_recording_.load()) {
-          RCLCPP_WARN(node->get_logger(),
-            "Received Resume request while not in recording. Ignoring request.");
-          set_service_error(response, "Called 'Resume' request while not recording. "
-                                      "Request ignored.");
-        } else {
-          this->resume();
-          set_service_success(response);
-        }
+        this->resume();
       } else {
         auto action_task = [this]() {
           std::lock_guard<std::mutex> state_lock(start_stop_transition_mutex_);
-          if (!in_recording_.load()) {
-            RCLCPP_WARN(node->get_logger(),
-              "Skipping scheduled Resume request while not recording.");
-            return;
-          }
           this->resume();
         };
-        action_task_runner_.schedule(resume_time.value(),
-                                     std::move(action_task),
-                                     "Resume recording");
+        action_task_runner_.schedule(
+          resume_time.value(), std::move(action_task), "Resume recording");
       }
     });
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -789,8 +789,6 @@ TEST_F(RecordSrvsTest, pause_resume)
   auto request = std::make_shared<Resume::Request>();
   auto response = std::make_shared<Resume::Response>();
   EXPECT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
-  EXPECT_EQ(0, response->return_code);
-  EXPECT_TRUE(response->error_string.empty());
   EXPECT_FALSE(recorder_->is_paused());
   is_paused_response = std::make_shared<IsPaused::Response>();
   EXPECT_TRUE(successful_service_request<IsPaused>(cli_is_paused_, is_paused_response));

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -147,7 +147,7 @@ public:
       });
 
     // Wait for the executor to start spinning in the newly spawned thread to avoid race conditions
-    if (!wait_until_condition([this]() {return exec_->is_spinning();}, std::chrono::seconds(5))) {
+    if (!wait_until_condition([this]() {return exec_->is_spinning();}, std::chrono::seconds(10))) {
       std::cerr << "Failed to start spinning nodes: '" <<
         recorder_->get_name() << ", " << client_node_->get_name() << "'" << std::endl;
       throw std::runtime_error("Failed to start spinning nodes");
@@ -162,7 +162,7 @@ public:
       ASSERT_TRUE(
         rosbag2_test_common::wait_until_condition(
           [this]() {return recorder_->get_clock()->started();},
-          std::chrono::seconds(5)));
+          std::chrono::seconds(10)));
       EXPECT_EQ(recorder_->get_clock()->get_clock_type(), RCL_ROS_TIME);
       ASSERT_TRUE(recorder_->get_clock()->ros_time_is_active());
     }
@@ -323,7 +323,7 @@ TEST_F(RecordSrvsSnapshotTest, trigger_snapshot)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&mock_writer]() {return mock_writer.get_snapshot_buffer_size() > 0;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Failed to capture message in time";
 
   EXPECT_THAT(mock_writer.get_number_of_recorded_messages(), Eq(0u));
@@ -378,7 +378,7 @@ TEST_F(RecordSrvsTest, split_bagfile_with_default_parameters)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 0;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Failed to capture message in time";
 
   ASSERT_FALSE(split_called.load());
@@ -404,7 +404,7 @@ TEST_F(RecordSrvsSimTimeTest, split_bagfile_by_receive_time_scheduled)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&tracked_pub]() {return tracked_pub->get_subscription_count() > 0;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   );
 
   auto & writer = recorder_->get_writer_handle();
@@ -436,14 +436,14 @@ TEST_F(RecordSrvsSimTimeTest, split_bagfile_by_receive_time_scheduled)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [this]() {return recorder_->now() >= current_sim_time_;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Recorder node failed to advance to the current sim time";
 
   tracked_pub->publish(*string_message);
 
   const bool split_happened = rosbag2_test_common::wait_until_condition(
     [&split_called]() {return split_called.load();},
-    std::chrono::seconds(5));
+    std::chrono::seconds(10));
   ASSERT_TRUE(split_happened) << "Timed out waiting for receive-time split to occur.";
 }
 
@@ -456,7 +456,7 @@ TEST_F(RecordSrvsSimTimeTest, split_bagfile_by_receive_time_immediate_due)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&tracked_pub]() {return tracked_pub->get_subscription_count() > 0;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   );
 
   auto & writer = recorder_->get_writer_handle();
@@ -472,7 +472,7 @@ TEST_F(RecordSrvsSimTimeTest, split_bagfile_by_receive_time_immediate_due)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [this]() {return recorder_->now() >= current_sim_time_;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Recorder node failed to advance to the current sim time";
 
   // Publish a message to establish a receive timestamp baseline
@@ -481,7 +481,7 @@ TEST_F(RecordSrvsSimTimeTest, split_bagfile_by_receive_time_immediate_due)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 0;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Failed to capture message in time";
 
   // Request a receive-time split using a split time in the past
@@ -533,7 +533,7 @@ TEST_F(RecordSrvsTest, split_bagfile_by_publish_time_immediate_due)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 1;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Failed to capture message in time";
 
   const auto first_publish_timestamp = mock_writer.get_messages().front()->send_timestamp;
@@ -575,7 +575,7 @@ TEST_F(RecordSrvsTest, split_bagfile_by_publish_time_scheduled)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&tracked_pub]() {return tracked_pub->get_subscription_count() > 0;},
-      std::chrono::seconds(5)
+      std::chrono::seconds(10)
     )
   );
   // Publish a message to establish a publish timestamp baseline
@@ -595,7 +595,7 @@ TEST_F(RecordSrvsTest, split_bagfile_by_publish_time_scheduled)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 0;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Failed to capture message in time";
 
   const auto last_publish_timestamp = mock_writer.get_messages().back()->send_timestamp;
@@ -614,7 +614,7 @@ TEST_F(RecordSrvsTest, split_bagfile_by_publish_time_scheduled)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [split_time, &system_clock]() {return system_clock.now() >= split_time;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "System clock did not reach split time in time";
 
   // Now send a message to trigger the split
@@ -623,7 +623,7 @@ TEST_F(RecordSrvsTest, split_bagfile_by_publish_time_scheduled)
 
   const bool split_happened = rosbag2_test_common::wait_until_condition(
     [&split_called]() {return split_called.load();},
-    std::chrono::seconds(5));
+    std::chrono::seconds(10));
   ASSERT_TRUE(split_happened) << "Timed out waiting for split to occur.";
 }
 
@@ -650,11 +650,11 @@ TEST_F(RecordSrvsPublishMultipleTopicsTest, split_bagfile_topic_filter_triggers_
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&tracked_pub]() {return tracked_pub->get_subscription_count() > 0;},
-      std::chrono::seconds(5)));
+      std::chrono::seconds(10)));
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&other_pub]() {return other_pub->get_subscription_count() > 0;},
-      std::chrono::seconds(5)));
+      std::chrono::seconds(10)));
 
   const auto initial_tracked_count = mock_writer.get_messages_per_topic(test_topic_);
 
@@ -668,7 +668,7 @@ TEST_F(RecordSrvsPublishMultipleTopicsTest, split_bagfile_topic_filter_triggers_
         return  mock_writer.get_messages_per_topic(test_topic_) > initial_tracked_count &&
                mock_writer.get_messages_per_topic(kSplitOtherTopic) > 0;
       },
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Failed to capture messages in time";
 
   auto split_time = current_sim_time_ + rclcpp::Duration(std::chrono::milliseconds(200));
@@ -690,7 +690,7 @@ TEST_F(RecordSrvsPublishMultipleTopicsTest, split_bagfile_topic_filter_triggers_
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [this]() {return recorder_->now() >= current_sim_time_;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Recorder node failed to advance to the current sim time";
 
   // Publish on other topic first, should not trigger split
@@ -706,7 +706,7 @@ TEST_F(RecordSrvsPublishMultipleTopicsTest, split_bagfile_topic_filter_triggers_
 
   const bool split_happened = rosbag2_test_common::wait_until_condition(
     [&split_called]() {return split_called.load();},
-  std::chrono::seconds(5));
+  std::chrono::seconds(10));
   ASSERT_TRUE(split_happened) << "Timed out waiting for split to occur.";
 }
 
@@ -740,13 +740,13 @@ TEST_F(RecordSrvsSimTimeTest, split_bagfile_by_node_time_respects_future_timesta
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [this]() {return recorder_->now() >= current_sim_time_;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Recorder node failed to advance to the current sim time";
 
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&callback_called]() {return callback_called.load();},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Timed out waiting for scheduled split to occur.";
 }
 
@@ -815,13 +815,13 @@ TEST_F(RecordSrvsSimTimeTest, resume_can_be_scheduled_in_future)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [this]() {return recorder_->now() >= current_sim_time_;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Recorder node failed to advance to the current sim time";
 
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [this]() {return !recorder_->is_paused();},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Timed out waiting for scheduled resume.";
 }
 
@@ -934,13 +934,13 @@ TEST_F(RecordSrvsSimTimeTest, record_can_be_scheduled_in_future)
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [this]() {return recorder_->now() >= current_sim_time_;},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Recorder node failed to advance to the current sim time";
 
   // Writer should now be re-opened
   ASSERT_TRUE(
     rosbag2_test_common::wait_until_condition(
       [&mock_writer]() {return !mock_writer.closed_was_called();},
-      std::chrono::seconds(5))
+      std::chrono::seconds(10))
   ) << "Timed out waiting for scheduled record start.";
 }


### PR DESCRIPTION
## Description

- This PR is a follow-up on the #2248. It will allow toggling pause/resume while not in the active recording state, which is to be on par with direct pause/resume API calls. Since we have already supported this functionality for the direct API calls. 
- Also, removed `return_code` and `error_string` from Resume.srv since the call is pretty simple and there no opportunity for failure.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Relates #2248

### Is this user-facing behavior change?
Yes. From the user's perspective, it may be handy to be able to preset the Recorder to pause/resume while it is not in an active recording state, i.e., stopped or not yet started recording.

### Did you use Generative AI?
Yes. GitHub Copilot, GPT-5.0, mostly to help with Doxygen comments and tests.

### Additional Information
N/A