### PR TITLE
Remove unnecessary dependencies on yaml_cpp_vendor.

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/CMakeLists.txt
@@ -23,8 +23,6 @@ find_package(rosbag2_storage REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosbag2_performance_benchmarking_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(yaml_cpp_vendor REQUIRED)
-find_package(yaml-cpp REQUIRED)
 
 add_executable(writer_benchmark
   src/config_utils.cpp
@@ -49,7 +47,6 @@ target_link_libraries(writer_benchmark
   rosbag2_compression::rosbag2_compression
   rosbag2_cpp::rosbag2_cpp
   rosbag2_storage::rosbag2_storage
-  yaml-cpp::yaml-cpp
 )
 
 target_link_libraries(benchmark_publishers
@@ -57,7 +54,6 @@ target_link_libraries(benchmark_publishers
   rosbag2_storage::rosbag2_storage
   ${rosbag2_performance_benchmarking_msgs_TARGETS}
   ${sensor_msgs_TARGETS}
-  yaml-cpp::yaml-cpp
 )
 
 target_link_libraries(results_writer

--- a/rosbag2_performance/rosbag2_performance_benchmarking/package.xml
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/package.xml
@@ -25,7 +25,6 @@
   <depend>rmw</depend>
   <depend>rosbag2_performance_benchmarking_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -28,8 +28,6 @@ find_package(mcap_vendor REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
-find_package(yaml_cpp_vendor REQUIRED)
-find_package(yaml-cpp REQUIRED)
 
 ament_python_install_package(ros2bag_mcap_cli)
 
@@ -47,7 +45,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   pluginlib::pluginlib
   rcutils::rcutils
   rosbag2_storage::rosbag2_storage
-  yaml-cpp::yaml-cpp
 )
 
 set(MCAP_COMPILE_DEFS)
@@ -108,7 +105,6 @@ if(BUILD_TESTING)
     rosbag2_storage::rosbag2_storage
     rosbag2_test_common::rosbag2_test_common
     ${std_msgs_TARGETS}
-    yaml-cpp::yaml-cpp
   )
   target_compile_definitions(test_mcap_storage PRIVATE ${MCAP_COMPILE_DEFS})
 

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -17,7 +17,6 @@
   <depend>pluginlib</depend>
   <depend>rcutils</depend>
   <depend>rosbag2_storage</depend>
-  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -20,23 +20,7 @@
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
 #include "rosbag2_storage_mcap/visibility_control.hpp"
 
-#ifdef ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP
-  #include "rosbag2_storage/yaml.hpp"
-#else
-  // COMPATIBILITY(foxy, galactic) - this block is available in rosbag2_storage/yaml.hpp in H
-  #ifdef _WIN32
-    // This is necessary because of a bug in yaml-cpp's cmake
-    #define YAML_CPP_DLL
-    // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-    #pragma warning(push)
-    #pragma warning(disable : 4251)
-    #pragma warning(disable : 4275)
-  #endif
-  #include "yaml-cpp/yaml.h"
-  #ifdef _WIN32
-    #pragma warning(pop)
-  #endif
-#endif
+#include "rosbag2_storage/yaml.hpp"
 
 #include <mcap/mcap.hpp>
 

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -18,9 +18,8 @@
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
-#include "rosbag2_storage_mcap/visibility_control.hpp"
-
 #include "rosbag2_storage/yaml.hpp"
+#include "rosbag2_storage_mcap/visibility_control.hpp"
 
 #include <mcap/mcap.hpp>
 

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -40,8 +40,6 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_interfaces REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
-find_package(yaml_cpp_vendor REQUIRED)
-find_package(yaml-cpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/rosbag2_transport/bag_rewrite.cpp
@@ -76,7 +74,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   rcutils::rcutils
   rmw::rmw
   rosbag2_compression::rosbag2_compression
-  yaml-cpp::yaml-cpp
 )
 
 rclcpp_components_register_node(

--- a/rosbag2_transport/package.xml
+++ b/rosbag2_transport/package.xml
@@ -23,7 +23,6 @@
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_interfaces</depend>
   <depend>rosbag2_storage</depend>
-  <depend>yaml_cpp_vendor</depend>
   <depend>keyboard_handler</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>


### PR DESCRIPTION
## Description

While looking at other things, I noticed that yaml_cpp_vendor is unnecessarily included in a number of places in rosbag2. In particular:

* rosbag2_performance_benchmarking has a dependency on it, but never uses it directly.
* rosbag2_storage_mcap does use it directly, but only in a compatiblity-only capacity that is no longer needed.
* rosbag2_transport has a dependency on it, but never uses it directly.

Remove these uses of yaml_cpp_vendor

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

N/A