### PR TITLE
Humble: Added writer for std::shared_ptr<const rclcpp::SerializedMessage>

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -178,6 +178,24 @@ public:
     const rclcpp::Time & time);
 
   /**
+   * Write a serialized message to a bagfile.
+   * The topic will be created if it has not been created already.
+   *
+   * \warning after calling this function, the serialized data will no longer be managed by message.
+   *
+   * \param message rclcpp::SerializedMessage The serialized message to be written to the bagfile
+   * \param topic_name the string of the topic this messages belongs to
+   * \param type_name the string of the type associated with this message
+   * \param time The time stamp of the message
+   * \throws runtime_error if the Writer is not open.
+   */
+  void write(
+    std::shared_ptr<const rclcpp::SerializedMessage> message,
+    const std::string & topic_name,
+    const std::string & type_name,
+    const rclcpp::Time & time);
+
+  /**
    * Write a non-serialized message to a bagfile.
    * The topic will be created if it has not been created already.
    *

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -188,6 +188,29 @@ void Writer::write(
   return write(serialized_bag_message, topic_name, type_name, rmw_get_serialization_format());
 }
 
+void Writer::write(
+  std::shared_ptr<const rclcpp::SerializedMessage> message,
+  const std::string & topic_name,
+  const std::string & type_name,
+  const rclcpp::Time & time)
+{
+  auto serialized_bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  serialized_bag_message->topic_name = topic_name;
+  serialized_bag_message->time_stamp = time.nanoseconds();
+  // point to actual data and keep reference to original message to avoid premature releasing
+  serialized_bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
+    new rcutils_uint8_array_t(message->get_rcl_serialized_message()),
+    [message](rcutils_uint8_array_t * data) {
+      (void)message;
+      if (data != nullptr) {
+        data->buffer = nullptr;
+        delete data;
+      }
+    });
+
+  return write(serialized_bag_message, topic_name, type_name, rmw_get_serialization_format());
+}
+
 void Writer::add_event_callbacks(bag_events::WriterEventCallbacks & callbacks)
 {
   writer_impl_->add_event_callbacks(callbacks);


### PR DESCRIPTION
## Description

When following the documentation on humble for [Recording a Bag From Your Own Node](https://docs.ros.org/en/humble/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.html) I was unable to succesfully build the  bag_recorder_nodes. I already opened up an issue on the documentation page here [Advanced tutorial for recording a bag from your own node is incorrect on Humble](https://github.com/ros2/ros2_documentation/issues/6277). 

It seems you are unable to write to a bag using an instance of rosbag2_cpp if the underlying msg is of type `std::shared_ptr<const rclcpp::SerializedMessage>`. 

On older branches (iron, jazzy, etc.) there is an implementation for this method with type 'std::shared_ptr<const rclcpp::SerializedMessage>`.. For example on iron: 
```
void Writer::write(
  std::shared_ptr<const rclcpp::SerializedMessage> message,
  const std::string & topic_name,
  const std::string & type_name,
  const rclcpp::Time & time)
{
  auto serialized_bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
  serialized_bag_message->topic_name = topic_name;
  serialized_bag_message->time_stamp = time.nanoseconds();
  // point to actual data and keep reference to original message to avoid premature releasing
  serialized_bag_message->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
    new rcutils_uint8_array_t(message->get_rcl_serialized_message()),
    [message](rcutils_uint8_array_t * data) {
      (void)message;
      if (data != nullptr) {
        data->buffer = nullptr;
        delete data;
      }
    });

  return write(serialized_bag_message, topic_name, type_name, rmw_get_serialization_format());
}
```
I took the above code and added it to the writer.cpp source file (and update the header writer.hpp accordingly) on a local ros2 humble build. This fixed the issue I was having where I was unable to write to a ROS bag using the `std::shared_ptr<const rclcpp::SerializedMessage>` and I was successfully able to run the test nodes from [Recording a Bag From Your Own Node](https://docs.ros.org/en/humble/Tutorials/Advanced/Recording-A-Bag-From-Your-Own-Node-CPP.html)

Fixes  

### Is this user-facing behavior change?

Users can now pass an `std::shared_ptr<const rclcpp::SerializedMessage>` argument while calling write to an instance of the `rosbag2_cpp::Writer` class. 


### Did you use Generative AI?

No AI was used. 


### Additional Information

Tested on Ubuntu 24.04.5 LTS AMD64. Passed all colcon-test results.
