### PR TITLE
Add support for time based Resume service

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,29 @@ The Rosbag2 recorder provides the following services for remote control, which c
   * Pauses recording. All messages that have already arrived will be written, but all messages that
     arrive after pausing will be discarded. Has no effect if already paused. Takes no arguments.
 * `~/resume [rosbag2_interfaces/srv/Resume]`
-  * Resume recording if paused. Has no effect if not paused. Takes no arguments.
+  * Resume recording immediately or schedule resume based on a requested time and mode.
+  * The `publish_time` and `receive_time` resume modes are supported only by the recorder.
+  * Resume modes:
+    - **Node time**: uses the recorder node clock; resumes immediately if `resume_time` is unset
+      or in the past, or is scheduled in the future via the task runner.
+    - **Publish time**: pending resume evaluated against the message source/publication timestamp.
+    - **Receive time**: pending resume evaluated against the recorder receive timestamp.
+  * Topic tracking:
+    - `tracking_topic_name` optionally scopes publish/receive-time evaluation to a single topic.
+      If empty, the evaluation considers all recorded topics.
+  * Pending resume policy:
+    - If a pending timestamp-based resume exists and a new resume request arrives, the newer
+      request overrides the existing pending one.
+    - A timestamp-based resume is performed when a message with a timestamp >= requested
+      `resume_time` is processed on the tracked scope.
+  * Request fields:
+    - `resume_time`: target time; unset or past times cause immediate resume.
+    - `resume_mode`: one of `node_time`, `publish_time`, `receive_time`.
+    - `tracking_topic_name`: optional topic for timestamp-based evaluation.
+  * Response fields:
+    - `return_code`: `success`, `invalid_resume_mode`, `invalid_tracking_topic`, or
+      `resume_failed`.
+    - `error_string`: empty on success, otherwise describes the failure.
 * `~/split_bagfile [rosbag2_interfaces/srv/SplitBagfile]`
   * Triggers a split to a new file, either immediately or scheduled based on mode and time.
   * Split modes:
@@ -355,6 +377,19 @@ The Rosbag2 player provides the following services for remote control, which can
   * Play a single next message from the bag. Only works while paused.
 * `~/resume [rosbag2_interfaces/srv/Resume]`
   * Resume playback if paused.
+  * The newer `publish_time` and `receive_time` resume modes are recorder-only.
+  * Player only supports `resume_mode = node_time`.
+  * `resume_time` is not supported by player and must be zero for player resume requests.
+  * `tracking_topic_name` is not supported by player and must be empty.
+  * If `resume_mode` is `publish_time` or `receive_time`, player rejects the request with
+    `return_code = invalid_resume_mode` and a descriptive `error_string`.
+  * If `resume_mode` has any other invalid value, player also returns
+    `return_code = invalid_resume_mode`.
+  * If `tracking_topic_name` is set, player rejects the request with
+    `return_code = invalid_tracking_topic` and a descriptive `error_string`.
+  * Response fields:
+    - `return_code`: `success`, `invalid_resume_mode`, or `invalid_tracking_topic`.
+    - `error_string`: empty on success, otherwise describes the failure.
 * `~/seek [rosbag2_interfaces/srv/Seek]`
   * Change the play head to the specified timestamp. Can be forward or backward in time, the next played message is the next immediately after the seeked timestamp.
 * `~/set_rate [rosbag2_interfaces/srv/SetRate]`

--- a/rosbag2_interfaces/srv/Resume.srv
+++ b/rosbag2_interfaces/srv/Resume.srv
@@ -1,6 +1,28 @@
-# Timestamp in the future when to resume recording.
-# If empty or time in the past, resumes recording immediately.
-# Note: The resume_time is not supported by player and shall be set to zero when using Resume
-# request with player.
+# Resume mode to interpret resume_time:
+# 0 = node_time, 1 = publish_time, 2 = receive_time.
+int32 RESUME_MODE_NODE_TIME=0
+int32 RESUME_MODE_PUBLISH_TIME=1
+int32 RESUME_MODE_RECEIVE_TIME=2
+
+# Timestamp in the future when to resume recording/playback.
+# If empty or time in the past, resumes recording/playback immediately.
 builtin_interfaces/Time resume_time
+
+# Resume mode to use for the resume_time request.
+int32 resume_mode
+
+# Topic name to use for timestamp-based resume evaluation.
+# If empty, evaluate using messages from all topics.
+string tracking_topic_name
 ---
+# Return codes for Resume response.
+int32 RETURN_CODE_SUCCESS=0
+int32 RETURN_CODE_INVALID_RESUME_MODE=1
+int32 RETURN_CODE_INVALID_TRACKING_TOPIC=2
+int32 RETURN_CODE_RESUME_FAILED=3
+
+# Return code. Use RETURN_CODE_SUCCESS on success; otherwise use one of the error codes.
+int32 return_code
+
+# Error string. Empty if no error occurred.
+string error_string

--- a/rosbag2_interfaces/srv/Resume.srv
+++ b/rosbag2_interfaces/srv/Resume.srv
@@ -6,6 +6,8 @@ int32 RESUME_MODE_RECEIVE_TIME=2
 
 # Timestamp in the future when to resume recording/playback.
 # If empty or time in the past, resumes recording/playback immediately.
+# Note: The resume_time is not supported by player and shall be set to zero when using Resume with
+# player.
 builtin_interfaces/Time resume_time
 
 # Resume mode to use for the resume_time request.

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -2077,9 +2077,31 @@ void PlayerImpl::create_control_services()
   srv_resume_ = owner_->create_service<rosbag2_interfaces::srv::Resume>(
     "~/resume",
     [this](
-      rosbag2_interfaces::srv::Resume::Request::ConstSharedPtr /*request*/,
-      rosbag2_interfaces::srv::Resume::Response::SharedPtr /*response*/)
+      rosbag2_interfaces::srv::Resume::Request::ConstSharedPtr request,
+      rosbag2_interfaces::srv::Resume::Response::SharedPtr response)
     {
+      using ResumeRequest = rosbag2_interfaces::srv::Resume::Request;
+      using ResumeResponse = rosbag2_interfaces::srv::Resume::Response;
+
+      switch (request->resume_mode) {
+        case ResumeRequest::RESUME_MODE_NODE_TIME:
+          break;
+        case ResumeRequest::RESUME_MODE_PUBLISH_TIME:
+        case ResumeRequest::RESUME_MODE_RECEIVE_TIME:
+          response->return_code = ResumeResponse::RETURN_CODE_INVALID_RESUME_MODE;
+          response->error_string =
+          "Resume modes publish_time and receive_time are not supported by player.";
+          return;
+        default:
+          response->return_code = ResumeResponse::RETURN_CODE_INVALID_RESUME_MODE;
+          response->error_string = "Invalid resume_mode for Resume request.";
+          return;
+      }
+      if (!request->tracking_topic_name.empty()) {
+        response->return_code = ResumeResponse::RETURN_CODE_INVALID_TRACKING_TOPIC;
+        response->error_string = "tracking_topic_name is not supported by player Resume service.";
+        return;
+      }
       owner_->resume();
     });
   srv_toggle_paused_ = owner_->create_service<rosbag2_interfaces::srv::TogglePaused>(

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -630,7 +630,7 @@ void RecorderImpl::stop()
     std::lock_guard<std::mutex> lock(pending_resume_request_mutex_);
     pending_resume_request_.reset();
   }
-  
+
   last_seen_timestamps_.reset();  // Clear last seen timestamps
 
   in_recording_ = false;

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -204,6 +204,10 @@ public:
   std::vector<std::pair<std::string, std::string>> static_topics_{};  // topic_name, topic_type
 
 private:
+  using ResumeRequest = rosbag2_interfaces::srv::Resume::Request;
+  using ResumeResponse = rosbag2_interfaces::srv::Resume::Response;
+  using ResumeCallbackResponse = ResumeResponse::SharedPtr;
+
   using SplitBagFileResponse = rosbag2_interfaces::srv::SplitBagfile::Response;
   using SplitBagFileRequest = rosbag2_interfaces::srv::SplitBagfile::Request;
   using SplitBagFileCallbackResponse = SplitBagFileResponse::SharedPtr;
@@ -213,6 +217,13 @@ private:
     NodeTime = SplitBagFileRequest::SPLIT_MODE_NODE_TIME,
     PublishTime = SplitBagFileRequest::SPLIT_MODE_PUBLISH_TIME,
     ReceiveTime = SplitBagFileRequest::SPLIT_MODE_RECEIVE_TIME,
+  };
+
+  enum class ResumeMode : int32_t
+  {
+    NodeTime = ResumeRequest::RESUME_MODE_NODE_TIME,
+    PublishTime = ResumeRequest::RESUME_MODE_PUBLISH_TIME,
+    ReceiveTime = ResumeRequest::RESUME_MODE_RECEIVE_TIME,
   };
 
   /// \brief Return codes for split bag file operation.
@@ -225,12 +236,29 @@ private:
     SplitFailed = SplitBagFileResponse::RETURN_CODE_SPLIT_FAILED
   };
 
+  /// \brief Return codes for resume operation.
+  enum class ResumeReturnCode : int32_t
+  {
+    Success = ResumeResponse::RETURN_CODE_SUCCESS,
+    InvalidResumeMode = ResumeResponse::RETURN_CODE_INVALID_RESUME_MODE,
+    InvalidTrackingTopic = ResumeResponse::RETURN_CODE_INVALID_TRACKING_TOPIC,
+    ResumeFailed = ResumeResponse::RETURN_CODE_RESUME_FAILED
+  };
+
   /// \brief Pending bag split state for timestamp-based split requests.
   struct PendingBagSplitState
   {
     std::string tracking_topic_name{};
     int64_t time_ns = kNoPendingPublishSplit;
     SplitMode mode = SplitMode::NodeTime;
+  };
+
+  /// \brief Pending resume state for timestamp-based resume requests.
+  struct PendingResumeState
+  {
+    std::string tracking_topic_name{};
+    int64_t time_ns = kNoPendingResumeRequest;
+    ResumeMode mode = ResumeMode::NodeTime;
   };
 
   /// \brief Class to track last seen publish and receive timestamps for topics.
@@ -300,10 +328,20 @@ private:
   /// \return An optional SplitMode enum. If the integer is invalid, returns std::nullopt.
   static std::optional<SplitMode> get_split_mode(int32_t split_mode);
 
+  /// \brief Convert an integer resume mode to the corresponding ResumeMode enum.
+  /// \param resume_mode The integer resume mode from the service request.
+  /// \return An optional ResumeMode enum. If the integer is invalid, returns std::nullopt.
+  static std::optional<ResumeMode> get_resume_mode(int32_t resume_mode);
+
   /// \brief Convert a SplitMode enum to a human-readable string.
   /// \param split_mode The SplitMode enum.
   /// \return A string representation of the SplitMode.
   static const char * to_string(SplitMode split_mode);
+
+  /// \brief Convert a ResumeMode enum to a human-readable string.
+  /// \param resume_mode The ResumeMode enum.
+  /// \return A string representation of the ResumeMode.
+  static const char * to_string(ResumeMode resume_mode);
 
   /// \brief Convert enum class to its underlying type.
   template<typename E>
@@ -377,6 +415,29 @@ private:
   bool should_execute_immediately(const std::optional<rclcpp::Time> & target_time) const;
 
   // *INDENT-OFF*
+  /// \brief Handle a pending resume request based on publish/receive timestamps.
+  void handle_pending_resume_request(const std::string & topic_name,
+                                     const rcutils_time_point_value_t & publish_time,
+                                     const rcutils_time_point_value_t & receive_time) noexcept;
+
+  /// \brief Handle a timer-based resume request.
+  /// \param resume_time The time at which to resume recording. If std::nullopt, resume
+  /// immediately.
+  /// \param response The service response to populate.
+  void handle_timer_resume_request(std::optional<rclcpp::Time> resume_time,
+                                   ResumeCallbackResponse & response);
+
+  /// \brief Handle a timestamp-based resume request.
+  /// \param resume_time The time at which to resume recording. If std::nullopt, resume
+  /// immediately.
+  /// \param resume_mode The mode to use for the resume (publish time, receive time).
+  /// \param topic_name The topic to track for the resume. If empty, track all topics.
+  /// \param response The service response to populate.
+  void handle_timestamp_resume_request(const std::optional<rclcpp::Time> & resume_time,
+                                       ResumeMode resume_mode,
+                                       const std::string & topic_name,
+                                       ResumeCallbackResponse & response);
+
   /// \brief Handle a pending bag split request based on publish/receive timestamps.
   void handle_pending_bag_split_request(const std::string & topic_name,
                                         const rcutils_time_point_value_t & publish_time,
@@ -431,12 +492,19 @@ private:
   std::unique_ptr<RecorderEventNotifier> event_notifier_;
   DelayedActionTaskRunner action_task_runner_;
   static constexpr int64_t kNoPendingPublishSplit = -1;
+  static constexpr int64_t kNoPendingResumeRequest = -1;
 
   /// \brief Mutex to protect access to the pending bag split request.
   std::mutex pending_bag_split_request_mutex_;
 
   /// \brief Pending bag split request.
   std::unique_ptr<PendingBagSplitState> pending_bag_split_request_;
+
+  /// \brief Mutex to protect access to the pending resume request.
+  std::mutex pending_resume_request_mutex_;
+
+  /// \brief Pending resume request.
+  std::unique_ptr<PendingResumeState> pending_resume_request_;
 
   /// \brief Keeps last seen publish and receive timestamps for each topic.
   /// Used for handling pending split requests based on message timestamps.
@@ -446,6 +514,9 @@ private:
   // Ensure service return code mapping stays consistent with `SplitBagFileReturnCode`
   static_assert(static_cast<int32_t>(SplitBagFileReturnCode::Success) == kServiceReturnCodeSuccess,
                 "SplitBagFileReturnCode::Success expected to be equal kServiceReturnCodeSuccess");
+  // Ensure service return code mapping stays consistent with `ResumeReturnCode`
+  static_assert(static_cast<int32_t>(ResumeReturnCode::Success) == kServiceReturnCodeSuccess,
+                "ResumeReturnCode::Success expected to be equal kServiceReturnCodeSuccess");
   static constexpr int32_t kServiceReturnCodeError = 1;
 };  // class RecorderImpl
 
@@ -906,20 +977,41 @@ void RecorderImpl::create_control_services()
     [this](
       const std::shared_ptr<rmw_request_id_t>/* request_header */,
       const std::shared_ptr<rosbag2_interfaces::srv::Resume::Request> request,
-      const std::shared_ptr<rosbag2_interfaces::srv::Resume::Response>/* response */)
+      std::shared_ptr<rosbag2_interfaces::srv::Resume::Response> response)
     {
       auto resume_time = optional_time_from_request(request->resume_time);
-      if (should_execute_immediately(resume_time)) {
-        std::lock_guard<std::mutex> state_lock(start_stop_transition_mutex_);
-        this->resume();
-      } else {
-        auto action_task = [this]() {
-          std::lock_guard<std::mutex> state_lock(start_stop_transition_mutex_);
-          this->resume();
-        };
-        action_task_runner_.schedule(
-          resume_time.value(), std::move(action_task), "Resume recording");
+      const auto resume_mode = get_resume_mode(request->resume_mode);
+      if (!resume_mode.has_value()) {
+        RCLCPP_ERROR(node->get_logger(),
+                     "Invalid resume_mode %d for Resume request.", request->resume_mode);
+        set_service_error(response,
+                          "Invalid resume_mode for Resume request.",
+                          to_underlying_type(ResumeReturnCode::InvalidResumeMode));
+        return;
       }
+      if (resume_mode.value() == ResumeMode::NodeTime) {
+        handle_timer_resume_request(resume_time, response);
+        return;
+      }
+      std::string resume_tracking_topic_name;
+      if (!request->tracking_topic_name.empty()) {
+        try {
+          resume_tracking_topic_name = rclcpp::expand_topic_or_service_name(
+            request->tracking_topic_name, node->get_name(), node->get_namespace(), false);
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(node->get_logger(),
+                       "Invalid tracking topic name '%s' for Resume request: %s",
+                       request->tracking_topic_name.c_str(), e.what());
+          set_service_error(response,
+                            "Invalid tracking_topic_name for Resume request.",
+                            to_underlying_type(ResumeReturnCode::InvalidTrackingTopic));
+          return;
+        }
+      }
+      handle_timestamp_resume_request(resume_time,
+                                      resume_mode.value(),
+                                      resume_tracking_topic_name,
+                                      response);
     });
 
   srv_is_paused_ = node->create_service<rosbag2_interfaces::srv::IsPaused>(
@@ -956,6 +1048,20 @@ std::optional<RecorderImpl::SplitMode> RecorderImpl::get_split_mode(int32_t spli
   }
 }
 
+std::optional<RecorderImpl::ResumeMode> RecorderImpl::get_resume_mode(int32_t resume_mode)
+{
+  switch (resume_mode) {
+    case ResumeRequest::RESUME_MODE_NODE_TIME:
+      return ResumeMode::NodeTime;
+    case ResumeRequest::RESUME_MODE_PUBLISH_TIME:
+      return ResumeMode::PublishTime;
+    case ResumeRequest::RESUME_MODE_RECEIVE_TIME:
+      return ResumeMode::ReceiveTime;
+    default:
+      return std::nullopt;
+  }
+}
+
 const char * RecorderImpl::to_string(SplitMode split_mode)
 {
   switch (split_mode) {
@@ -970,12 +1076,108 @@ const char * RecorderImpl::to_string(SplitMode split_mode)
   }
 }
 
+const char * RecorderImpl::to_string(ResumeMode resume_mode)
+{
+  switch (resume_mode) {
+    case ResumeMode::NodeTime:
+      return "node";
+    case ResumeMode::PublishTime:
+      return "publish";
+    case ResumeMode::ReceiveTime:
+      return "receive";
+    default:
+      return "unknown";
+  }
+}
+
 bool RecorderImpl::should_execute_immediately(const std::optional<rclcpp::Time> & target_time) const
 {
   if (!target_time.has_value()) {
     return true;
   }
   return *target_time <= node->now();
+}
+
+void RecorderImpl::handle_timer_resume_request(
+  std::optional<rclcpp::Time> resume_time,
+  ResumeCallbackResponse & response)
+{
+  if (should_execute_immediately(resume_time)) {
+    this->resume();
+    set_service_success(response);
+  } else {
+    auto action_task = [this]() {
+        this->resume();
+      };
+    action_task_runner_.schedule(resume_time.value(), std::move(action_task), "Resume recording");
+    set_service_success(response);
+  }
+}
+
+void RecorderImpl::handle_timestamp_resume_request(
+  const std::optional<rclcpp::Time> & resume_time,
+  ResumeMode resume_mode,
+  const std::string & topic_name,
+  ResumeCallbackResponse & response)
+{
+  if (!resume_time.has_value()) {
+    this->resume();
+    set_service_success(response);
+    return;
+  }
+
+  if (resume_mode == ResumeMode::NodeTime) {  // Sanity check
+    // Should not happen; handled separately
+    RCLCPP_ERROR(node->get_logger(),
+                 "Internal error: NodeTime resume mode should be handled separately.");
+    set_service_error(response,
+                      "Internal error: NodeTime resume mode should be handled separately.",
+                      to_underlying_type(ResumeReturnCode::InvalidResumeMode));
+    return;
+  }
+
+  const auto resume_req_ns = resume_time->nanoseconds();
+  const bool use_receive_timestamp_for_resume = resume_mode == ResumeMode::ReceiveTime;
+  const std::string on_topic_str = topic_name.empty() ? "" : " on '" + topic_name + "' topic";
+
+  // Check if resume is already due
+  // Get last seen timestamps for the requested topic (or global if no topic specified)
+  auto [last_pub_timestamp, last_recv_timestamp] = last_seen_timestamps_.get(topic_name);
+  if ((!use_receive_timestamp_for_resume && last_pub_timestamp >= resume_req_ns) ||
+    (use_receive_timestamp_for_resume && last_recv_timestamp >= resume_req_ns))
+  {
+    // Resume is already due
+    RCLCPP_INFO(node->get_logger(),
+                "Timestamp-based resume request%s already due (req=%.9f s). Resuming now.",
+                on_topic_str.c_str(), resume_time->seconds());
+    this->resume();
+    set_service_success(response);
+    return;
+  }
+
+  {  // Schedule pending resume request
+    std::lock_guard<std::mutex> lock(pending_resume_request_mutex_);
+    if (pending_resume_request_) {
+      RCLCPP_WARN(node->get_logger(),
+                  "Overriding pending resume request (%.9f s) with newer request (%.9f s).",
+                  RCUTILS_NS_TO_S(static_cast<double>(pending_resume_request_->time_ns)),
+                  RCUTILS_NS_TO_S(static_cast<double>(resume_req_ns)));
+    }
+    pending_resume_request_ = std::make_unique<PendingResumeState>();
+    pending_resume_request_->tracking_topic_name = topic_name;
+    pending_resume_request_->mode = resume_mode;
+    pending_resume_request_->time_ns = resume_req_ns;
+  }
+
+  RCLCPP_INFO(node->get_logger(),
+              "Scheduled timestamp-based resume at %.9f seconds using %s timestamps%s.",
+              resume_time->seconds(), to_string(resume_mode), on_topic_str.c_str());
+
+  RCLCPP_DEBUG(node->get_logger(), "use_recv_for_resume = %s, last publish time: %ld ns, last "
+               "receive time: %ld ns, requested resume time: %ld ns",
+               use_receive_timestamp_for_resume ? "true" : "false",
+               last_pub_timestamp, last_recv_timestamp, resume_req_ns);
+  set_service_success(response);
 }
 
 void RecorderImpl::attempt_immediate_bag_split(SplitBagFileCallbackResponse & response)
@@ -998,9 +1200,6 @@ void RecorderImpl::handle_timer_bag_split_request(
   std::optional<rclcpp::Time> split_time,
   SplitBagFileCallbackResponse & response)
 {
-  if (!split_time.has_value()) {
-    split_time = node->now();
-  }
   if (should_execute_immediately(split_time)) {
     attempt_immediate_bag_split(response);
   } else {
@@ -1078,6 +1277,46 @@ void RecorderImpl::handle_timestamp_bag_split_request(
                use_receive_timestamp_for_split ? "true" : "false",
                last_pub_timestamp, last_recv_timestamp, split_req_ns);
   set_service_success(response);
+}
+
+void RecorderImpl::handle_pending_resume_request(
+  const std::string & topic_name,
+  const rcutils_time_point_value_t & publish_time,
+  const rcutils_time_point_value_t & receive_time) noexcept
+{
+  std::lock_guard<std::mutex> pending_resume_state_lock(pending_resume_request_mutex_);
+  // if we have a valid pending resume request, check if it applies to this message
+  if (pending_resume_request_ && pending_resume_request_->time_ns != kNoPendingResumeRequest) {
+    const bool matches_pending_topic =
+      pending_resume_request_->tracking_topic_name.empty() ||
+      pending_resume_request_->tracking_topic_name == topic_name;
+    if (!matches_pending_topic) {
+      return;
+    }
+    const bool use_pub_time = pending_resume_request_->mode == ResumeMode::PublishTime;
+    const rcutils_time_point_value_t & message_time = use_pub_time ? publish_time : receive_time;
+
+    if (message_time < 0) {
+      RCLCPP_WARN_ONCE(node->get_logger(),
+                       "Message timestamp is invalid; cannot evaluate resume request.");
+      return;
+    }
+
+    if (message_time >= pending_resume_request_->time_ns) {
+      RCLCPP_DEBUG(node->get_logger(),
+                   "Performing %s-time resume at message time %ld ns (threshold %ld ns).",
+                   to_string(pending_resume_request_->mode),
+                   message_time,
+                   pending_resume_request_->time_ns);
+      this->resume();
+      pending_resume_request_.reset();
+    } else {
+      // Not yet time to resume
+      RCLCPP_DEBUG(node->get_logger(),
+                   "Pending resume at %ld ns not yet reached (message time %ld ns).",
+                   pending_resume_request_->time_ns, message_time);
+    }
+  }
 }
 
 void RecorderImpl::handle_pending_bag_split_request(
@@ -1384,6 +1623,7 @@ void RecorderImpl::write_message(
   uint32_t sequence_number)
 {
   last_seen_timestamps_.update(topic_name, pub_timestamp, recv_timestamp);
+  handle_pending_resume_request(topic_name, pub_timestamp, recv_timestamp);
 
   if (!paused_.load()) {
     auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
@@ -1477,6 +1717,7 @@ RecorderImpl::create_subscription(
       send_timestamp = mi.get_rmw_message_info().source_timestamp;
 #endif
       last_seen_timestamps_.update(topic_name, send_timestamp, recv_timestamp);
+      handle_pending_resume_request(topic_name, send_timestamp, recv_timestamp);
 
       if (!paused_.load()) {
         writer_->write(std::move(message), topic_name, topic_type, recv_timestamp, send_timestamp);

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -626,7 +626,11 @@ void RecorderImpl::stop()
     std::lock_guard<std::mutex> lock(pending_bag_split_request_mutex_);
     pending_bag_split_request_.reset();
   }
-
+  {  // Clear pending resume request if any
+    std::lock_guard<std::mutex> lock(pending_resume_request_mutex_);
+    pending_resume_request_.reset();
+  }
+  
   last_seen_timestamps_.reset();  // Clear last seen timestamps
 
   in_recording_ = false;

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -789,23 +789,28 @@ TEST_F(RecordSrvsTest, pause_resume)
   auto request = std::make_shared<Resume::Request>();
   auto response = std::make_shared<Resume::Response>();
   EXPECT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
+  EXPECT_EQ(Resume::Response::RETURN_CODE_SUCCESS, response->return_code);
+  EXPECT_TRUE(response->error_string.empty());
   EXPECT_FALSE(recorder_->is_paused());
   is_paused_response = std::make_shared<IsPaused::Response>();
   EXPECT_TRUE(successful_service_request<IsPaused>(cli_is_paused_, is_paused_response));
   EXPECT_FALSE(is_paused_response->paused);
 }
 
-TEST_F(RecordSrvsSimTimeTest, resume_can_be_scheduled_in_future)
+TEST_F(RecordSrvsSimTimeTest, resume_by_node_time_respects_future_timestamp)
 {
-  ASSERT_TRUE(successful_service_request<Pause>(cli_pause_));
+  recorder_->pause();
   ASSERT_TRUE(recorder_->is_paused());
 
   // Schedule a resume in the future
   auto request = std::make_shared<Resume::Request>();
   auto target_resume_time = current_sim_time_ + rclcpp::Duration(std::chrono::milliseconds(200));
   request->resume_time = target_resume_time;
+  request->resume_mode = Resume::Request::RESUME_MODE_NODE_TIME;
   auto response = std::make_shared<Resume::Response>();
   ASSERT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
+  EXPECT_EQ(Resume::Response::RETURN_CODE_SUCCESS, response->return_code);
+  EXPECT_TRUE(response->error_string.empty());
 
   // Confirm that the recorder is still paused
   EXPECT_TRUE(recorder_->is_paused());
@@ -823,6 +828,265 @@ TEST_F(RecordSrvsSimTimeTest, resume_can_be_scheduled_in_future)
       [this]() {return !recorder_->is_paused();},
       std::chrono::seconds(10))
   ) << "Timed out waiting for scheduled resume.";
+}
+
+TEST_F(RecordSrvsSimTimeTest, resume_by_receive_time_immediate_due)
+{
+  auto string_message = get_messages_strings()[1];
+  auto tracked_pub =
+    client_node_->create_publisher<test_msgs::msg::Strings>(test_topic_,
+                                                            Rosbag2QoS::UnitTestQoS());
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&tracked_pub]() {return tracked_pub->get_subscription_count() > 0;},
+      std::chrono::seconds(10))
+  );
+
+  auto & writer = recorder_->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [this]() {return recorder_->now() >= current_sim_time_;},
+      std::chrono::seconds(10))
+  ) << "Recorder node failed to advance to the current sim time";
+
+  // Publish a message to establish a receive timestamp baseline.
+  tracked_pub->publish(*string_message);
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 0;},
+      std::chrono::seconds(5))
+  ) << "Failed to capture message in time";
+
+  recorder_->pause();
+  ASSERT_TRUE(recorder_->is_paused());
+
+  // Request a receive-time resume using a resume time in the past.
+  // Recorded messages have current_sim_time_ as their receive timestamp.
+  auto resume_time = current_sim_time_ - rclcpp::Duration(std::chrono::milliseconds(100));
+
+  auto request = std::make_shared<Resume::Request>();
+  request->resume_time = resume_time;
+  request->resume_mode = Resume::Request::RESUME_MODE_RECEIVE_TIME;
+  request->tracking_topic_name.clear();
+  auto response = std::make_shared<Resume::Response>();
+  ASSERT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
+  EXPECT_EQ(Resume::Response::RETURN_CODE_SUCCESS, response->return_code);
+  EXPECT_TRUE(response->error_string.empty());
+
+  // Since the resume time is in the past, resume should happen immediately before
+  // returning response to the service call.
+  EXPECT_FALSE(recorder_->is_paused());
+}
+
+TEST_F(RecordSrvsTest, resume_by_publish_time_immediate_due)
+{
+#ifdef _WIN32
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") !=
+    std::string::npos)
+  {
+    GTEST_SKIP() << "Skipping test on Windows with Connext due to known issue with send "
+      "timestamps being zero.";
+  }
+#endif
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  auto string_message = get_messages_strings()[1];
+  pub_manager.setup_publisher(test_topic_, string_message, 2);
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
+  pub_manager.run_publishers();
+
+  auto & writer = recorder_->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 1;},
+      std::chrono::seconds(10))
+  ) << "Failed to capture published messages in time";
+
+  recorder_->pause();
+  ASSERT_TRUE(recorder_->is_paused());
+
+  const auto first_publish_timestamp = mock_writer.get_messages().front()->send_timestamp;
+  // Request a publish-time split using a split time in the past. Note: we published at least two
+  // messages, so adding 1 nanosecond to the first message's timestamp guarantees that there is at
+  // least one message with a publish timestamp >= split_time
+  const auto resume_time =
+    rclcpp::Time(first_publish_timestamp + 1, client_node_->get_clock()->get_clock_type());
+
+  auto request = std::make_shared<Resume::Request>();
+  request->resume_time = resume_time;
+  request->resume_mode = Resume::Request::RESUME_MODE_PUBLISH_TIME;
+  request->tracking_topic_name = test_topic_;
+  auto response = std::make_shared<Resume::Response>();
+  ASSERT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
+  EXPECT_EQ(Resume::Response::RETURN_CODE_SUCCESS, response->return_code);
+  EXPECT_TRUE(response->error_string.empty());
+
+  // Since the resume time is in the past, resume should happen immediately before
+  // returning response to the service call.
+  EXPECT_FALSE(recorder_->is_paused());
+}
+
+TEST_F(RecordSrvsTest, resume_by_publish_time_scheduled)
+{
+#ifdef _WIN32
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") !=
+    std::string::npos)
+  {
+    GTEST_SKIP() << "Skipping test on Windows with Connext due to known issue with send "
+      "timestamps being zero.";
+  }
+#endif
+
+  auto string_message = get_messages_strings()[1];
+  auto tracked_pub =
+    client_node_->create_publisher<test_msgs::msg::Strings>(test_topic_,
+                                                            Rosbag2QoS::UnitTestQoS());
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&tracked_pub]() {return tracked_pub->get_subscription_count() > 0;},
+      std::chrono::seconds(10)
+    )
+  );
+
+  // Publish a message to establish a publish timestamp baseline.
+  tracked_pub->publish(*string_message);
+
+  auto & writer = recorder_->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 0;},
+      std::chrono::seconds(10))
+  ) << "Failed to capture message in time";
+
+  recorder_->pause();
+  ASSERT_TRUE(recorder_->is_paused());
+
+  const auto last_publish_timestamp = mock_writer.get_messages().back()->send_timestamp;
+  auto resume_time = rclcpp::Time(last_publish_timestamp + RCUTILS_MS_TO_NS(200), RCL_SYSTEM_TIME);
+
+  auto request = std::make_shared<Resume::Request>();
+  request->resume_time = resume_time;
+  request->resume_mode = Resume::Request::RESUME_MODE_PUBLISH_TIME;
+  request->tracking_topic_name = test_topic_;
+  auto response = std::make_shared<Resume::Response>();
+  ASSERT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
+  EXPECT_EQ(Resume::Response::RETURN_CODE_SUCCESS, response->return_code);
+  EXPECT_TRUE(response->error_string.empty());
+
+  // Confirm that recorder is still paused before reaching resume time.
+  EXPECT_TRUE(recorder_->is_paused());
+
+  // Wait until resume time is reached.
+  rclcpp::Clock system_clock(RCL_SYSTEM_TIME);
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [resume_time, &system_clock]() {return system_clock.now() >= resume_time;},
+      std::chrono::seconds(10))
+  ) << "System clock did not reach resume time in time";
+
+  // Publish on tracked topic to trigger resume from subscription callback.
+  // The publish timestamp of this message will be >= resume_time
+  tracked_pub->publish(*string_message);
+
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [this]() {return !recorder_->is_paused();},
+      std::chrono::seconds(10))
+  ) << "Timed out waiting for publish-time resume to occur.";
+}
+
+TEST_F(RecordSrvsPublishMultipleTopicsTest, resume_topic_filter_triggers_on_tracked_topic)
+{
+  auto string_message = get_messages_strings()[1];
+  auto tracked_pub =
+    client_node_->create_publisher<test_msgs::msg::Strings>(test_topic_,
+                                                            Rosbag2QoS::UnitTestQoS());
+  auto other_pub =
+    client_node_->create_publisher<test_msgs::msg::Strings>(kSplitOtherTopic,
+                                                            Rosbag2QoS::UnitTestQoS());
+
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&tracked_pub]() {return tracked_pub->get_subscription_count() > 0;},
+      std::chrono::seconds(10)));
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&other_pub]() {return other_pub->get_subscription_count() > 0;},
+      std::chrono::seconds(10)));
+
+  auto & writer = recorder_->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  const auto initial_tracked_count = mock_writer.get_messages_per_topic(test_topic_);
+
+  // Publish a message on each topic to establish a receive timestamp baseline.
+  other_pub->publish(*string_message);
+  tracked_pub->publish(*string_message);
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [this, &mock_writer, initial_tracked_count]() {
+        return  mock_writer.get_messages_per_topic(test_topic_) > initial_tracked_count &&
+               mock_writer.get_messages_per_topic(kSplitOtherTopic) > 0;
+      },
+      std::chrono::seconds(10))
+  ) << "Failed to capture messages in time";
+
+  // Pause the recorder
+  recorder_->pause();
+  ASSERT_TRUE(recorder_->is_paused());
+
+  auto request = std::make_shared<Resume::Request>();
+  const auto target_resume_time = current_sim_time_ +
+    rclcpp::Duration(std::chrono::milliseconds(200));
+  request->resume_time = target_resume_time;
+  request->resume_mode = Resume::Request::RESUME_MODE_RECEIVE_TIME;
+  request->tracking_topic_name = test_topic_;
+  auto response = std::make_shared<Resume::Response>();
+  ASSERT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
+  EXPECT_EQ(Resume::Response::RETURN_CODE_SUCCESS, response->return_code);
+  EXPECT_TRUE(response->error_string.empty());
+
+  // Advance simulated time past the resume time and publish a message on other topic first.
+  publish_clock(target_resume_time + rclcpp::Duration(std::chrono::milliseconds(10)));
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [this]() {return recorder_->now() >= current_sim_time_;},
+      std::chrono::seconds(10))
+  ) << "Recorder node failed to advance to the current sim time";
+
+  // Publish on other topic first, should not trigger resume.
+  other_pub->publish(*string_message);
+  EXPECT_FALSE(
+    rosbag2_test_common::wait_until_condition(
+      [this]() {return !recorder_->is_paused();},
+      std::chrono::milliseconds(500))
+  ) << "Resume should not trigger for messages on non-tracked topics.";
+
+  // Now publish on tracked topic, should trigger resume.
+  tracked_pub->publish(*string_message);
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [this]() {return !recorder_->is_paused();},
+      std::chrono::seconds(10))
+  ) << "Timed out waiting for receive-time resume to occur on tracked topic.";
+}
+
+TEST_F(RecordSrvsTest, resume_returns_invalid_mode_for_bad_request)
+{
+  recorder_->pause();
+  ASSERT_TRUE(recorder_->is_paused());
+
+  auto request = std::make_shared<Resume::Request>();
+  request->resume_mode = 99;  // Invalid resume mode
+  auto response = std::make_shared<Resume::Response>();
+  ASSERT_TRUE(successful_service_request<Resume>(cli_resume_, request, response));
+
+  EXPECT_EQ(Resume::Response::RETURN_CODE_INVALID_RESUME_MODE, response->return_code);
+  EXPECT_FALSE(response->error_string.empty());
+  EXPECT_TRUE(recorder_->is_paused());
 }
 
 TEST_F(RecordSrvsDiscoveryTest, stop_start_discovery)


### PR DESCRIPTION
## Description

As part of  https://github.com/ros2/rosbag2/pull/233 it was added support for message timestamp-based bag splitting.
This PR  adds the same modes to be supported for resume `rosbag2_interfaces/srv/Resume` service call.

 - Introduced resume modes (node_time, publish_time, receive_time) with tracking topic support and pending resume semantics.
 - Extended service responses with explicit return codes/error strings where applicable.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
- Relates https://github.com/ros2/rosbag2/issues/2337

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes, the following service changes:

rosbag2_interfaces/srv/Resume
- added new modes and return error codes

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes. OpenAI Codex (GPT‑5) was used to adapt patches from internal changes.

### Additional Information
Breaking API changes. i.e. we modify `Resume.srv`. Not backportable.
<!--
If applicable, provide any additional context or details about the changes.
-->
