### PR TITLE
Add examples for `rosbag2_transport::Recorder`

### DIFF
--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -24,20 +24,20 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_transport REQUIRED)
 find_package(example_interfaces REQUIRED)
 
-add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
-target_link_libraries(simple_bag_recorder
+add_executable(simple_bag_writer src/simple_bag_writer.cpp)
+target_link_libraries(simple_bag_writer
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
   ${example_interfaces_TARGETS}
 )
 
 install(TARGETS
-  simple_bag_recorder
+  simple_bag_writer
   DESTINATION lib/${PROJECT_NAME}
 )
 
-add_executable(compressed_bag_recorder src/compressed_bag_recorder.cpp)
-target_link_libraries(compressed_bag_recorder
+add_executable(compressed_bag_writer.cpp src/compressed_bag_writer.cpp)
+target_link_libraries(compressed_bag_writer.cpp
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
   rosbag2_compression::rosbag2_compression
@@ -45,7 +45,7 @@ target_link_libraries(compressed_bag_recorder
 )
 
 install(TARGETS
-  compressed_bag_recorder
+  compressed_bag_writer.cpp
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -24,6 +24,16 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_transport REQUIRED)
 find_package(example_interfaces REQUIRED)
 
+add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
+target_link_libraries(simple_bag_recorder
+  rosbag2_transport::rosbag2_transport
+)
+
+install(TARGETS
+  simple_bag_recorder
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 add_executable(simple_bag_writer src/simple_bag_writer.cpp)
 target_link_libraries(simple_bag_writer
   rclcpp::rclcpp

--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -24,6 +24,16 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_transport REQUIRED)
 find_package(example_interfaces REQUIRED)
 
+add_executable(compressed_bag_recorder src/compressed_bag_recorder.cpp)
+target_link_libraries(compressed_bag_recorder
+  rosbag2_transport::rosbag2_transport
+)
+
+install(TARGETS
+  compressed_bag_recorder
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
 target_link_libraries(simple_bag_recorder
   rosbag2_transport::rosbag2_transport

--- a/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_recorder.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_recorder.cpp
@@ -1,0 +1,42 @@
+// Copyright 2026 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_transport/reader_writer_factory.hpp"
+#include "rosbag2_transport/recorder.hpp"
+
+int main(int argc, char *argv[])
+{
+  rclcpp::init(argc, argv);
+
+  rosbag2_storage::StorageOptions storage_options;
+  storage_options.uri = "my_bag";
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.all_topics = true;
+  record_options.rmw_serialization_format = "cdr";
+  record_options.compression_format = "zstd";
+  record_options.compression_mode = "file";
+
+  // Calling ReaderWriterFactory creates a writer with compression parameters
+  auto writer = rosbag2_transport::ReaderWriterFactory::make_writer(record_options);
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer), storage_options, record_options);
+
+  recorder->record();
+  rclcpp::spin(recorder);
+
+  recorder->stop();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_writer.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/compressed_bag_writer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Open Source Robotics Foundation
+// Copyright 2025 Open Source Robotics Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,28 +17,38 @@
 #include "example_interfaces/msg/string.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "rosbag2_compression/compression_options.hpp"
+#include "rosbag2_compression/sequential_compression_writer.hpp"
+
 #include "rosbag2_cpp/writer.hpp"
 
 using std::placeholders::_1;
 
-class SimpleBagRecorder : public rclcpp::Node
-{
+class CompressedBagWriter : public rclcpp::Node {
 public:
-  SimpleBagRecorder()
-  : Node("simple_bag_recorder")
+  CompressedBagWriter()
+  : Node("compressed_bag_writer")
   {
-    writer_ = std::make_unique<rosbag2_cpp::Writer>();
+    rosbag2_compression::CompressionOptions compression_options;
 
+    compression_options.compression_format = "zstd";
+    compression_options.compression_mode = rosbag2_compression::CompressionMode::FILE;
+
+    auto compressed_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
+      compression_options);
+
+    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(compressed_writer));
     writer_->open("my_bag");
 
-    subscription_ = create_subscription<example_interfaces::msg::String>(
-      "chatter", 10, std::bind(&SimpleBagRecorder::topic_callback, this, _1));
+    subscription_ = this->create_subscription<example_interfaces::msg::String>(
+      "chatter", 10, std::bind(&CompressedBagWriter::topic_callback, this, _1));
   }
 
 private:
   void topic_callback(std::shared_ptr<const rclcpp::SerializedMessage> msg) const
   {
     rclcpp::Time time_stamp = this->now();
+
     writer_->write(msg, "chatter", "example_interfaces/msg/String", time_stamp);
   }
 
@@ -46,10 +56,10 @@ private:
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
 };
 
-int main(int argc, char * argv[])
+int main(int argc, char *argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<SimpleBagRecorder>());
+  rclcpp::spin(std::make_shared<CompressedBagWriter>());
   rclcpp::shutdown();
   return 0;
 }

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_recorder.cpp
@@ -1,0 +1,38 @@
+// Copyright 2026 Open Source Robotics Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_transport/recorder.hpp"
+
+int main(int argc, char *argv[])
+{
+  rclcpp::init(argc, argv);
+
+  rosbag2_storage::StorageOptions storage_options;
+  storage_options.uri = "my_bag";
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.all_topics = true;
+  record_options.rmw_serialization_format = "cdr";
+
+  auto writer = std::make_unique<rosbag2_cpp::Writer>();
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer), storage_options, record_options);
+
+  recorder->record();
+  rclcpp::spin(recorder);
+
+  recorder->stop();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_writer.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/simple_bag_writer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Open Source Robotics Foundation
+// Copyright 2021 Open Source Robotics Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,38 +17,28 @@
 #include "example_interfaces/msg/string.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "rosbag2_compression/compression_options.hpp"
-#include "rosbag2_compression/sequential_compression_writer.hpp"
-
 #include "rosbag2_cpp/writer.hpp"
 
 using std::placeholders::_1;
 
-class CompressedBagRecorder : public rclcpp::Node {
+class SimpleBagWriter : public rclcpp::Node
+{
 public:
-  CompressedBagRecorder()
-  : Node("compressed_bag_recorder")
+  SimpleBagWriter()
+  : Node("simple_bag_writer")
   {
-    rosbag2_compression::CompressionOptions compression_options;
+    writer_ = std::make_unique<rosbag2_cpp::Writer>();
 
-    compression_options.compression_format = "zstd";
-    compression_options.compression_mode = rosbag2_compression::CompressionMode::FILE;
-
-    auto compressed_writer = std::make_unique<rosbag2_compression::SequentialCompressionWriter>(
-      compression_options);
-
-    writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(compressed_writer));
     writer_->open("my_bag");
 
-    subscription_ = this->create_subscription<example_interfaces::msg::String>(
-      "chatter", 10, std::bind(&CompressedBagRecorder::topic_callback, this, _1));
+    subscription_ = create_subscription<example_interfaces::msg::String>(
+      "chatter", 10, std::bind(&SimpleBagWriter::topic_callback, this, _1));
   }
 
 private:
   void topic_callback(std::shared_ptr<const rclcpp::SerializedMessage> msg) const
   {
     rclcpp::Time time_stamp = this->now();
-
     writer_->write(msg, "chatter", "example_interfaces/msg/String", time_stamp);
   }
 
@@ -56,10 +46,10 @@ private:
   std::unique_ptr<rosbag2_cpp::Writer> writer_;
 };
 
-int main(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<CompressedBagRecorder>());
+  rclcpp::spin(std::make_shared<SimpleBagWriter>());
   rclcpp::shutdown();
   return 0;
 }

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/compressed_bag_recorder.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/compressed_bag_recorder.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import rclpy
+from rclpy.executors import ExternalShutdownException
+import rosbag2_py
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    storage_options = rosbag2_py.StorageOptions(uri='my_bag')
+
+    record_options = rosbag2_py.RecordOptions()
+    record_options.all_topics = True
+    record_options.is_discovery_disabled = False
+    record_options.rmw_serialization_format = 'cdr'
+    record_options.compression_format = 'zstd'
+    record_options.compression_mode = 'file'
+
+    recorder = rosbag2_py.Recorder(
+        storage_options,
+        record_options,
+        'info',
+        'compressed_recorder_demo')
+
+    recorder.start_spin()
+    recorder.record()
+
+    try:
+        while (rclpy.ok()):
+            pass
+    except (KeyboardInterrupt, ExternalShutdownException):
+        recorder.stop_spin()
+
+
+if __name__ == '__main__':
+    main()

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/compressed_bag_writer.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/compressed_bag_writer.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
@@ -19,24 +20,29 @@ import rosbag2_py
 from std_msgs.msg import String
 
 
-class SimpleBagRecorder(Node):
+class CompressedBagWriter(Node):
 
     def __init__(self):
-        super().__init__('simple_bag_recorder')
-        self.writer = rosbag2_py.SequentialWriter()
+        super().__init__('compressed_bag_recorder')
+
+        compression_options = rosbag2_py.CompressionOptions(
+            compression_format='zstd',
+            compression_mode=rosbag2_py.CompressionMode.MESSAGE)
 
         storage_options = rosbag2_py.StorageOptions(
             uri='my_bag',
             storage_id='sqlite3')
         converter_options = rosbag2_py.ConverterOptions('', '')
-        self.writer.open(storage_options, converter_options)
+
+        self.compressed_writer = rosbag2_py.SequentialCompressionWriter(compression_options)
+        self.compressed_writer.open(storage_options, converter_options)
 
         topic_info = rosbag2_py.TopicMetadata(
             id=0,
             name='chatter',
             type='std_msgs/msg/String',
             serialization_format='cdr')
-        self.writer.create_topic(topic_info)
+        self.compressed_writer.create_topic(topic_info)
 
         self.subscription = self.create_subscription(
             String,
@@ -46,7 +52,7 @@ class SimpleBagRecorder(Node):
         self.subscription
 
     def topic_callback(self, msg):
-        self.writer.write(
+        self.compressed_writer.write(
             'chatter',
             serialize_message(msg),
             self.get_clock().now().nanoseconds)
@@ -55,8 +61,8 @@ class SimpleBagRecorder(Node):
 def main(args=None):
     try:
         with rclpy.init(args=args):
-            sbr = SimpleBagRecorder()
-            rclpy.spin(sbr)
+            cbr = CompressedBagWriter()
+            rclpy.spin(cbr)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
 

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_recorder.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_recorder.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import rclpy
+from rclpy.executors import ExternalShutdownException
+import rosbag2_py
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    storage_options = rosbag2_py.StorageOptions(uri='my_bag')
+
+    record_options = rosbag2_py.RecordOptions()
+    record_options.all_topics = True
+    record_options.is_discovery_disabled = False
+    record_options.rmw_serialization_format = 'cdr'
+
+    recorder = rosbag2_py.Recorder(
+        storage_options,
+        record_options,
+        'info',
+        'simple_recorder_demo')
+
+    recorder.start_spin()
+    recorder.record()
+
+    try:
+        while rclpy.ok():
+            pass
+    except (KeyboardInterrupt, ExternalShutdownException):
+        recorder.stop_spin()
+
+
+if __name__ == '__main__':
+    main()

--- a/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_writer.py
+++ b/rosbag2_examples/rosbag2_examples_py/rosbag2_examples_py/simple_bag_writer.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Open Source Robotics Foundation, Inc.
+# Copyright 2023 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
@@ -20,29 +19,24 @@ import rosbag2_py
 from std_msgs.msg import String
 
 
-class CompressedBagRecorder(Node):
+class SimpleBagWriter(Node):
 
     def __init__(self):
-        super().__init__('compressed_bag_recorder')
-
-        compression_options = rosbag2_py.CompressionOptions(
-            compression_format='zstd',
-            compression_mode=rosbag2_py.CompressionMode.MESSAGE)
+        super().__init__('simple_bag_writer')
+        self.writer = rosbag2_py.SequentialWriter()
 
         storage_options = rosbag2_py.StorageOptions(
             uri='my_bag',
             storage_id='sqlite3')
         converter_options = rosbag2_py.ConverterOptions('', '')
-
-        self.compressed_writer = rosbag2_py.SequentialCompressionWriter(compression_options)
-        self.compressed_writer.open(storage_options, converter_options)
+        self.writer.open(storage_options, converter_options)
 
         topic_info = rosbag2_py.TopicMetadata(
             id=0,
             name='chatter',
             type='std_msgs/msg/String',
             serialization_format='cdr')
-        self.compressed_writer.create_topic(topic_info)
+        self.writer.create_topic(topic_info)
 
         self.subscription = self.create_subscription(
             String,
@@ -52,7 +46,7 @@ class CompressedBagRecorder(Node):
         self.subscription
 
     def topic_callback(self, msg):
-        self.compressed_writer.write(
+        self.writer.write(
             'chatter',
             serialize_message(msg),
             self.get_clock().now().nanoseconds)
@@ -61,8 +55,8 @@ class CompressedBagRecorder(Node):
 def main(args=None):
     try:
         with rclpy.init(args=args):
-            cbr = CompressedBagRecorder()
-            rclpy.spin(cbr)
+            sbw = SimpleBagWriter()
+            rclpy.spin(sbw)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
 

--- a/rosbag2_examples/rosbag2_examples_py/setup.py
+++ b/rosbag2_examples/rosbag2_examples_py/setup.py
@@ -27,6 +27,7 @@ setup(
             'rosbag2csv = rosbag2_examples_py.rosbag2csv:main',
             'simple_bag_writer = rosbag2_examples_py.simple_bag_writer:main',
             'simple_bag_reader = rosbag2_examples_py.simple_bag_reader:main',
+            'simple_bag_recorder = rosbag2_examples_py.simple_bag_recorder:main',
             'data_generator_node = rosbag2_examples_py.data_generator_node:main',
             'data_generator_executable = rosbag2_examples_py.data_generator_executable:main',
             'compressed_bag_writer = rosbag2_examples_py.compressed_bag_writer:main',

--- a/rosbag2_examples/rosbag2_examples_py/setup.py
+++ b/rosbag2_examples/rosbag2_examples_py/setup.py
@@ -25,11 +25,11 @@ setup(
     entry_points={
         'console_scripts': [
             'rosbag2csv = rosbag2_examples_py.rosbag2csv:main',
-            'simple_bag_recorder = rosbag2_examples_py.simple_bag_recorder:main',
+            'simple_bag_writer = rosbag2_examples_py.simple_bag_writer:main',
             'simple_bag_reader = rosbag2_examples_py.simple_bag_reader:main',
             'data_generator_node = rosbag2_examples_py.data_generator_node:main',
             'data_generator_executable = rosbag2_examples_py.data_generator_executable:main',
-            'compressed_bag_recorder = rosbag2_examples_py.compressed_bag_recorder:main',
+            'compressed_bag_writer = rosbag2_examples_py.compressed_bag_writer:main',
         ],
     },
 )

--- a/rosbag2_examples/rosbag2_examples_py/setup.py
+++ b/rosbag2_examples/rosbag2_examples_py/setup.py
@@ -28,6 +28,7 @@ setup(
             'simple_bag_writer = rosbag2_examples_py.simple_bag_writer:main',
             'simple_bag_reader = rosbag2_examples_py.simple_bag_reader:main',
             'simple_bag_recorder = rosbag2_examples_py.simple_bag_recorder:main',
+            'compressed_bag_recorder = rosbag2_examples_py.compressed_bag_recorder:main',
             'data_generator_node = rosbag2_examples_py.data_generator_node:main',
             'data_generator_executable = rosbag2_examples_py.data_generator_executable:main',
             'compressed_bag_writer = rosbag2_examples_py.compressed_bag_writer:main',


### PR DESCRIPTION
## Description

This PR includes/changes the following things:
- Add an example for a simple instance of `rosbag2_transport::Recorder` for both C++ and Python.
- Add an example for an instance of `rosbag2_transport::Recorder` for both C++ and Python with additional compression parameters.
- Rename old examples with `recording` in their name to `writer/rewriter` to avoid some confusion.

Related to #2347.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.
