### PR TITLE
Address flakiness in the "rosbag2_transport::test_record_services" tests

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -180,6 +180,9 @@ public:
     ASSERT_TRUE(cli_start_discovery_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_stop_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_stop_discovery_->wait_for_service(service_wait_timeout_));
+
+    // Remove client_node_ from the executor
+    exec_->remove_node(client_node_);
   }
 
   /// Send a service request, and expect it to successfully return within a reasonable timeout
@@ -189,13 +192,35 @@ public:
     typename Srv::Request::SharedPtr request,
     typename Srv::Response::SharedPtr & response)
   {
+    // Create a separate executor for service calls to avoid "already spinning" error
+    rclcpp::executors::SingleThreadedExecutor exec;
+    exec.add_node(client_node_);
+
     auto future = cli->async_send_request(request);
-    if (future.wait_for(service_call_timeout_) != std::future_status::ready) {
-      return ::testing::AssertionFailure() << "Service call timed out";
+
+    auto guard = rcpputils::make_scope_exit(
+      [&]() {
+      // Cleanup and remove node from executor to avoid potential issues with pending requests
+      // and dangling nodes in the executor. Required to avoid client internal state leak.
+        cli->remove_pending_request(future);
+    });
+
+    const auto ret = exec.spin_until_future_complete(future, service_call_timeout_);
+
+    if (ret != rclcpp::FutureReturnCode::SUCCESS) {
+      cli->remove_pending_request(future);
+      if (ret == rclcpp::FutureReturnCode::TIMEOUT) {
+        return ::testing::AssertionFailure() << "Service call timed out";
+      } else if (ret == rclcpp::FutureReturnCode::INTERRUPTED) {
+        return ::testing::AssertionFailure() << "Service call interrupted";
+      }
+      return ::testing::AssertionFailure() << "Service call failed with unknown error";
     }
+
     if (!future.valid()) {
       return ::testing::AssertionFailure() << "Service call returned invalid future";
     }
+
     response = future.get();
     if (!response) {
       return ::testing::AssertionFailure() << "Service call returned unsuccessful response";
@@ -246,8 +271,9 @@ public:
 public:
   // Basic configuration
   const std::string recorder_name_ = "rosbag2_recorder_for_test_srvs";
-  const std::chrono::seconds service_wait_timeout_ {2};
-  const std::chrono::seconds service_call_timeout_ {2};
+  // Wait longer due to potential service latency after pause/resume operations
+  const std::chrono::seconds service_wait_timeout_ {10};
+  const std::chrono::seconds service_call_timeout_ {10};
   const std::string test_topic_ = kTestTopic;
 
   // Orchestration

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -140,7 +140,6 @@ public:
     exec_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
     exec_->add_node(recorder_);
-    exec_->add_node(client_node_);
     spin_thread_ = std::thread(
       [this]() {
         exec_->spin();
@@ -180,9 +179,6 @@ public:
     ASSERT_TRUE(cli_start_discovery_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_stop_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_stop_discovery_->wait_for_service(service_wait_timeout_));
-
-    // Remove client_node_ from the executor
-    exec_->remove_node(client_node_);
   }
 
   /// Send a service request, and expect it to successfully return within a reasonable timeout
@@ -197,13 +193,6 @@ public:
     exec.add_node(client_node_);
 
     auto future = cli->async_send_request(request);
-
-    auto guard = rcpputils::make_scope_exit(
-      [&]() {
-      // Cleanup and remove node from executor to avoid potential issues with pending requests
-      // and dangling nodes in the executor. Required to avoid client internal state leak.
-        cli->remove_pending_request(future);
-    });
 
     const auto ret = exec.spin_until_future_complete(future, service_call_timeout_);
 


### PR DESCRIPTION
## Description
The `rosbag2_transport::test_record_services` is known to be flaky on CI run.
Please refer to the RCA in the relevant issue https://github.com/ros2/rosbag2/issues/2367#issuecomment-4057689265

Short description of changes:
1. Increase the default service_call_timeout_  to 10 seconds.
2. Use recommended `exec->spin_until_future_complete()` API in the `successful_service_request()` implementation using temporary created executor. Note: we can't reuse `exec_` because `spin_until_future_complete()` requires that the node shall not already be spinning.
3. Removed `client_node_` from adding to the "main" `exec_` executor.

- Fixes #2367

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. Codex 5.4
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported.
