### PR TITLE
Reduce flakiness in rosbag2 recorder end-to-end tests

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
@@ -131,12 +131,15 @@ public:
         return true;
       }
 
-      auto remaining = std::chrono::duration_cast<std::chrono::nanoseconds>(deadline -
-          clock::now());
-      if (remaining > max_wait_slice) {
-        remaining = max_wait_slice;
+      const auto now_time = clock::now();
+      if (now_time < deadline) {
+        auto remaining =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(deadline - now_time);
+        if (remaining > max_wait_slice) {
+          remaining = max_wait_slice;
+        }
+        pub_node_->wait_for_graph_change(graph_event, remaining);
       }
-      pub_node_->wait_for_graph_change(graph_event, remaining);
       (void)graph_event->check_and_clear();
     }
 

--- a/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common/publication_manager.hpp
@@ -110,50 +110,59 @@ public:
     std::chrono::duration<DurationRepT, DurationT> timeout = std::chrono::seconds(10),
     size_t n_subscribers_to_match = 1)
   {
-    rclcpp::PublisherBase::SharedPtr publisher = nullptr;
-    for (const auto pub : publishers_) {
-      if (!std::strcmp(
-          std::get<rclcpp::PublisherBase::SharedPtr>(pub)->get_topic_name(),
-          topic_name))
-      {
-        publisher = std::get<rclcpp::PublisherBase::SharedPtr>(pub);
-        break;
-      }
-    }
-
+    auto publisher = get_publisher_for_topic(topic_name);
     if (publisher == nullptr) {
       return false;
     }
 
-    if (publisher->get_subscription_count() +
-      publisher->get_intra_process_subscription_count() >= n_subscribers_to_match)
-    {
+    if (publisher_has_matching_subscriptions(publisher, n_subscribers_to_match)) {
       return true;
     }
 
-    auto sleep_time = std::chrono::milliseconds(10);
-
-    if (timeout < std::chrono::seconds(1)) {
-      sleep_time = timeout;
-    }
+    auto graph_event = pub_node_->get_graph_event();
+    (void)graph_event->check_and_clear();
 
     using clock = std::chrono::steady_clock;
-    auto start = clock::now();
+    const auto deadline = clock::now() + std::chrono::duration_cast<clock::duration>(timeout);
+    constexpr auto max_wait_slice = std::chrono::milliseconds(100);
 
-    do {
-      std::this_thread::sleep_for(sleep_time);
-
-      if (publisher->get_subscription_count() +
-        publisher->get_intra_process_subscription_count() >= n_subscribers_to_match)
-      {
+    while (clock::now() < deadline) {
+      if (publisher_has_matching_subscriptions(publisher, n_subscribers_to_match)) {
         return true;
       }
-    } while ((clock::now() - start) < timeout);
 
-    return false;
+      auto remaining = std::chrono::duration_cast<std::chrono::nanoseconds>(deadline -
+          clock::now());
+      if (remaining > max_wait_slice) {
+        remaining = max_wait_slice;
+      }
+      pub_node_->wait_for_graph_change(graph_event, remaining);
+      (void)graph_event->check_and_clear();
+    }
+
+    return publisher_has_matching_subscriptions(publisher, n_subscribers_to_match);
   }
 
 private:
+  rclcpp::PublisherBase::SharedPtr get_publisher_for_topic(const char * topic_name) const
+  {
+    for (const auto & pub : publishers_) {
+      auto publisher = std::get<rclcpp::PublisherBase::SharedPtr>(pub);
+      if (!std::strcmp(publisher->get_topic_name(), topic_name)) {
+        return publisher;
+      }
+    }
+    return nullptr;
+  }
+
+  static bool publisher_has_matching_subscriptions(
+    const rclcpp::PublisherBase::SharedPtr & publisher,
+    size_t n_subscribers_to_match)
+  {
+    return publisher->get_subscription_count() +
+           publisher->get_intra_process_subscription_count() >= n_subscribers_to_match;
+  }
+
   std::shared_ptr<rclcpp::Node> pub_node_;
   using PublicationF = std::function<void (bool)>;
   std::vector<std::pair<rclcpp::PublisherBase::SharedPtr, PublicationF>> publishers_;


### PR DESCRIPTION
## Description

Reduced flakiness in rosbag2 recorder tests by strengthening PublicationManager::wait_for_matched().

Please see RCA in the relevant issue https://github.com/ros2/rosbag2/issues/2369#issuecomment-4058831303

The helper `PublicationManager::wait_for_matched()` now waits on ROS graph events rather than relying solely on fixed sleep polling. It still preserves the existing API and boolean return behavior, but uses a hybrid loop:
• check the publisher’s current subscription count
• wait for a graph change
• re-check periodically with a short bounded wait slice
This improves readiness detection for recorder subscriptions that appear asynchronously during topic discovery, while still handling cases where graph notifications are delayed or not sufficient on their own.
No test call sites were changed. Existing recorder tests continue to use pub_manager.wait_for_matched(...), but they now benefit from the stronger synchronization automatically.

- Fixes #2369 

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. Codex gpt-5.4
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported.
<!--
If applicable, provide any additional context or details about the changes.
-->
