### PR TITLE
Fix for incorrect serialization format in metadata

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/converter.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/converter.hpp
@@ -69,24 +69,32 @@ public:
 
   ~Converter();
 
-  /**
-   * Converts the given SerializedBagMessage into the output format of the converter. The
-   * serialization format of the input message must be identical to the input format of the
-   * converter.
-   *
-   * \param message Message to convert
-   * \returns Converted message
-   */
+  /// \brief Converts the given SerializedBagMessage into the output format of the converter. The
+  /// serialization format of the input message must be identical to the input format of the
+  /// converter.
+  /// \param message Message to convert
+  /// \returns Converted message
   std::shared_ptr<rosbag2_storage::SerializedBagMessage>
   convert(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message);
 
+  /// \brief Register a topic and its type with the converter.
+  /// \param topic The name of the topic.
+  /// \param type The type of the topic.
   void add_topic(const std::string & topic, const std::string & type);
+
+  /// \return The input serialization format of the converter.
+  std::string get_input_serialization_format() const;
+
+  /// \return The output serialization format of the converter.
+  std::string get_output_serialization_format() const;
 
 private:
   std::shared_ptr<SerializationFormatConverterFactoryInterface> converter_factory_;
   std::unique_ptr<converter_interfaces::SerializationFormatDeserializer> input_converter_;
   std::unique_ptr<converter_interfaces::SerializationFormatSerializer> output_converter_;
   std::unordered_map<std::string, ConverterTypeSupport> topics_and_types_;
+  std::string input_serialization_format_;
+  std::string output_serialization_format_;
 };
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/converter.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/converter.cpp
@@ -54,6 +54,8 @@ Converter::Converter(
     throw std::runtime_error(
             "Could not find converter for format " + converter_options.output_serialization_format);
   }
+  input_serialization_format_ = converter_options.input_serialization_format;
+  output_serialization_format_ = converter_options.output_serialization_format;
 }
 
 Converter::~Converter()
@@ -105,6 +107,16 @@ void Converter::add_topic(const std::string & topic, const std::string & type)
     *type_support.introspection_type_support_library);
 
   topics_and_types_.insert({topic, type_support});
+}
+
+std::string Converter::get_input_serialization_format() const
+{
+  return input_serialization_format_;
+}
+
+std::string Converter::get_output_serialization_format() const
+{
+  return output_serialization_format_;
 }
 
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -180,12 +180,18 @@ void SequentialWriter::open(
   metadata_.topics_with_message_count.reserve(topics_names_to_info_.size());
   for (auto & [topic_name, topic_info] : topics_names_to_info_) {
     topic_info.message_count = 0U;
-    auto const & md = topic_names_to_message_definitions_[topic_name];
-    storage_->create_topic(topic_info.topic_metadata, md);
+
     metadata_.topics_with_message_count.push_back(topic_info);
+    // Adjust serialization format if converter is used. Note: Do not modify the serialization
+    // format in the original topics_names_to_info_ map, since it is persist
+    // across close()->open() calls.
+    auto & topic_metadata = metadata_.topics_with_message_count.back().topic_metadata;
     if (converter_) {
+      topic_metadata.serialization_format = converter_->get_output_serialization_format();
       converter_->add_topic(topic_name, topic_info.topic_metadata.type);
     }
+    auto const & md = topic_names_to_message_definitions_[topic_name];
+    storage_->create_topic(topic_metadata, md);
   }
   storage_->update_metadata(metadata_);
   next_file_index_ = 1;  // First file is 0, next will be 1
@@ -273,11 +279,13 @@ void SequentialWriter::create_topic(
   }
 
   if (is_open_.load()) {
-    storage_->create_topic(topic_with_type, message_definition);
-    metadata_.topics_with_message_count.push_back(info);
+    // Adjust serialization format if converter is used
     if (converter_) {
-      converter_->add_topic(topic_with_type.name, topic_with_type.type);
+      info.topic_metadata.serialization_format = converter_->get_output_serialization_format();
+      converter_->add_topic(info.topic_metadata.name, info.topic_metadata.type);
     }
+    storage_->create_topic(info.topic_metadata, message_definition);
+    metadata_.topics_with_message_count.push_back(info);
   }
 }
 
@@ -632,9 +640,16 @@ void SequentialWriter::finalize_metadata()
   metadata_.topics_with_message_count.reserve(topics_names_to_info_.size());
   metadata_.message_count = 0;
 
-  for (const auto & topic : topics_names_to_info_) {
-    metadata_.topics_with_message_count.push_back(topic.second);
-    metadata_.message_count += topic.second.message_count;
+  for (const auto & [_, topic_info] : topics_names_to_info_) {
+    metadata_.topics_with_message_count.push_back(topic_info);
+    metadata_.message_count += topic_info.message_count;
+    if (converter_) {
+      // Adjust serialization format if converter is used. Note: Do not modify the serialization
+      // format in the original topics_names_to_info_ map, since it is persist
+      // across close()->open() calls.
+      metadata_.topics_with_message_count.back().topic_metadata.serialization_format =
+        converter_->get_output_serialization_format();
+    }
   }
 }
 

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -336,6 +336,65 @@ TEST_F(SequentialWriterTest, write_does_not_use_converters_if_input_and_output_f
   writer_->write(message);
 }
 
+TEST_F(SequentialWriterTest, writer_uses_correct_serialization_format_in_metadata) {
+  // First open writer with conversion and verify metadata uses the output serialization format.
+  // Then open again with no conversion and verify metadata uses the input serialization format
+  // for both yaml file and storage.
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  std::string storage_serialization_format = "rmw2_format";
+  std::string input_format = "rmw1_format";
+
+  auto format1_converter = std::make_unique<StrictMock<MockConverter>>();
+  auto format2_converter = std::make_unique<StrictMock<MockConverter>>();
+  EXPECT_CALL(*format1_converter, serialize(_, _, _)).Times(2);
+  EXPECT_CALL(*format2_converter, deserialize(_, _, _)).Times(2);
+
+  EXPECT_CALL(*converter_factory_, load_serializer(storage_serialization_format))
+  .WillOnce(Return(ByMove(std::move(format1_converter))));
+  EXPECT_CALL(*converter_factory_, load_deserializer(input_format))
+  .WillOnce(Return(ByMove(std::move(format2_converter))));
+
+  auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+  std::string msg_content = "Hello";
+  message->serialized_data =
+    rosbag2_storage::make_serialized_message(msg_content.c_str(), msg_content.length());
+
+  writer_->create_topic({0u, "test_topic", "test_msgs/msg/BasicTypes", input_format, {}, ""});
+  writer_->open(storage_options_, {input_format, storage_serialization_format});
+  writer_->write(message);
+  writer_->write(message);
+  writer_->close();
+
+  ASSERT_EQ(fake_metadata_.topics_with_message_count.size(), 1u);
+  EXPECT_EQ(fake_metadata_.topics_with_message_count[0].topic_metadata.serialization_format,
+            storage_serialization_format);
+
+  for (const auto & metadata : v_intercepted_update_metadata_) {
+    ASSERT_EQ(metadata.topics_with_message_count.size(), 1u);
+    EXPECT_EQ(metadata.topics_with_message_count[0].topic_metadata.serialization_format,
+              storage_serialization_format);
+  }
+
+  // Open again with no conversion and verify metadata uses the input serialization format
+  storage_options_.uri += "(1)";  // Add suffix to create a new bag folder in the scope of the test
+  writer_->open(storage_options_, {input_format, input_format});
+  writer_->write(message);
+  const auto & metadata = v_intercepted_update_metadata_.back();
+  ASSERT_EQ(metadata.topics_with_message_count.size(), 1u);
+  EXPECT_EQ(metadata.topics_with_message_count[0].topic_metadata.serialization_format,
+            input_format);
+
+  writer_->close();
+
+  ASSERT_EQ(fake_metadata_.topics_with_message_count.size(), 1u);
+  EXPECT_EQ(fake_metadata_.topics_with_message_count[0].topic_metadata.serialization_format,
+            input_format);
+}
+
 TEST_F(SequentialWriterTest, metadata_io_writes_metadata_file_in_destructor) {
   EXPECT_CALL(*metadata_io_, write_metadata(_, _)).Times(1);
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(


### PR DESCRIPTION
## Description

Fix for incorrect serialization format in metadata

- Remap serialization format for storage and metadata if a serialization converter exists in the writer class.

- Fixes #2371

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes, GitHub Copilot, GPT-4.2
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Has ABI breaking changes in the `rosbag2_cpp/include/rosbag2_cpp/converter.hpp`; therefore, this PR **can't be backported**.
