### PR TITLE
Add "GetSubscribedTopics" recorder service request

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ The Rosbag2 recorder provides the following services for remote control, which c
   * Start topic discovery to automatically find and subscribe to new topics. Has no effect if discovery is already running or if the recorder is not in recording state.
 * `~/stop_discovery [rosbag2_interfaces/srv/StopDiscovery]`
   * Stop topic discovery. Existing subscriptions will be maintained, but new topics will not be discovered automatically.
+* `~/get_subscribed_topics [rosbag2_interfaces/srv/GetSubscribedTopics]`
+  * Returns the list of fully qualified names of topics currently subscribed by the recorder.
 
 These services enable full remote control of the recording process, allowing you to start and stop recording sessions, manage topic discovery, and control the recording state without restarting the recorder node.
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ The Rosbag2 recorder provides the following services for remote control, which c
   * Start topic discovery to automatically find and subscribe to new topics. Has no effect if discovery is already running or if the recorder is not in recording state.
 * `~/stop_discovery [rosbag2_interfaces/srv/StopDiscovery]`
   * Stop topic discovery. Existing subscriptions will be maintained, but new topics will not be discovered automatically.
+* `~/get_subscribed_topics [rosbag2_interfaces/srv/GetSubscribedTopics]`
+  * Returns the list of fully qualified names of topics currently subscribed by the recorder.
 
 These services enable full remote control of the recording process, allowing you to start and stop recording sessions, manage topic discovery, and control the recording state without restarting the recorder node.
 

--- a/rosbag2_interfaces/CMakeLists.txt
+++ b/rosbag2_interfaces/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/MessagesLostEvent.msg"
   "srv/Burst.srv"
   "srv/GetRate.srv"
+  "srv/GetSubscribedTopics.srv"
   "srv/IsDiscoveryRunning.srv"
   "srv/IsPaused.srv"
   "srv/Pause.srv"

--- a/rosbag2_interfaces/srv/GetSubscribedTopics.srv
+++ b/rosbag2_interfaces/srv/GetSubscribedTopics.srv
@@ -1,0 +1,3 @@
+---
+# Fully qualified names of topics currently subscribed by the recorder.
+string[] topics

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -282,6 +282,10 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   void set_on_start_recording_callback(OnStartRecordingCallback callback) const;
 
+  /// \return List of currently subscribed topics.
+  ROSBAG2_TRANSPORT_PUBLIC
+  std::vector<std::string> get_subscribed_topics() const;
+
   inline constexpr static const auto kPauseResumeToggleKey = KeyboardHandler::KeyCode::SPACE;
 
 protected:

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -38,6 +38,7 @@
 #include "rosbag2_cpp/bag_events.hpp"
 #include "rosbag2_cpp/service_utils.hpp"
 #include "rosbag2_cpp/writer.hpp"
+#include "rosbag2_interfaces/srv/get_subscribed_topics.hpp"
 #include "rosbag2_interfaces/srv/snapshot.hpp"
 #include "rosbag2_storage/qos.hpp"
 #include "logging.hpp"
@@ -193,6 +194,8 @@ public:
   std::unordered_map<std::string, std::string> get_requested_or_available_topics();
 
   void read_static_topics() noexcept;
+
+  std::vector<std::string> get_subscribed_topics() const;
 
   /// Public members for access by wrapper
   std::unordered_set<std::string> topics_warned_about_incompatibility_;
@@ -470,6 +473,8 @@ private:
   std::future<void> discovery_future_;
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides_;
   std::unordered_set<std::string> topic_unknown_types_;
+  rclcpp::Service<rosbag2_interfaces::srv::GetSubscribedTopics>::SharedPtr
+    srv_get_subscribed_topics_;
   rclcpp::Service<rosbag2_interfaces::srv::IsDiscoveryRunning>::SharedPtr srv_is_discovery_running_;
   rclcpp::Service<rosbag2_interfaces::srv::IsPaused>::SharedPtr srv_is_paused_;
   rclcpp::Service<rosbag2_interfaces::srv::Pause>::SharedPtr srv_pause_;
@@ -483,6 +488,7 @@ private:
 
   std::mutex start_stop_transition_mutex_;
   std::mutex discovery_mutex_;
+  mutable std::mutex subscriptions_mutex_;
   std::atomic<bool> discovery_running_ = false;
   std::atomic_uchar paused_ = 0;
   std::atomic<bool> in_recording_ = false;
@@ -641,7 +647,10 @@ void RecorderImpl::stop()
   for (auto & [_, subscription] : subscriptions_) {
     subscription->disable_callbacks();
   }
-  subscriptions_.clear();
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    subscriptions_.clear();
+  }
   writer_->close();  // Call writer->close() to finalize current bag file and write metadata
   {  // Clear pending split request if any
     std::lock_guard<std::mutex> lock(pending_bag_split_request_mutex_);
@@ -1050,6 +1059,17 @@ void RecorderImpl::create_control_services()
       const std::shared_ptr<rosbag2_interfaces::srv::IsPaused::Response> response)
     {
       response->paused = is_paused();
+    });
+
+  srv_get_subscribed_topics_ =
+    node->create_service<rosbag2_interfaces::srv::GetSubscribedTopics>(
+     "~/get_subscribed_topics",
+    [this](
+      const std::shared_ptr<rmw_request_id_t>/* request_header */,
+      const std::shared_ptr<rosbag2_interfaces::srv::GetSubscribedTopics::Request>/* request */,
+      std::shared_ptr<rosbag2_interfaces::srv::GetSubscribedTopics::Response> response)
+    {
+      response->topics = this->get_subscribed_topics();
     });
 }
 
@@ -1505,8 +1525,13 @@ void RecorderImpl::topics_discovery() noexcept
     }
     bool should_update_subscriptions = true;
     while (rclcpp::ok() && discovery_running_) {
+      size_t subscriptions_count = 0u;
+      {
+        std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+        subscriptions_count = subscriptions_.size();
+      }
       if (!record_options_.topics.empty() &&
-        subscriptions_.size() == record_options_.topics.size())
+        subscriptions_count == record_options_.topics.size())
       {
         RCLCPP_INFO(
           node->get_logger(), "All requested topics are subscribed. Stopping discovery...");
@@ -1559,12 +1584,31 @@ std::unordered_map<std::string, std::string>
 RecorderImpl::get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics)
 {
   std::unordered_map<std::string, std::string> missing_topics;
+  std::unordered_set<std::string> subscribed_topics;
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    for (const auto & [topic_name, _] : subscriptions_) {
+      subscribed_topics.insert(topic_name);
+    }
+  }
   for (const auto & [topic_name, topic_type] : all_topics) {
-    if (subscriptions_.find(topic_name) == subscriptions_.end()) {
+    if (subscribed_topics.find(topic_name) == subscribed_topics.end()) {
       missing_topics.emplace(topic_name, topic_type);
     }
   }
   return missing_topics;
+}
+
+std::vector<std::string> RecorderImpl::get_subscribed_topics() const
+{
+  std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+  std::vector<std::string> topics;
+  topics.reserve(subscriptions_.size());
+  for (const auto & [topic_name, _] : subscriptions_) {
+    topics.emplace_back(topic_name);
+  }
+  std::sort(topics.begin(), topics.end());
+  return topics;
 }
 
 
@@ -1682,8 +1726,11 @@ uint64_t RecorderImpl::get_total_num_messages_lost_in_transport() const
 
 void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 {
-  if (subscriptions_.find(topic.name) != subscriptions_.end()) {
-    return;
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    if (subscriptions_.find(topic.name) != subscriptions_.end()) {
+      return;
+    }
   }
   // Auto-detect transient-local topics when repeat_all_transient_local_depth is set
   if (record_options_.repeat_all_transient_local_depth > 0 &&
@@ -1724,7 +1771,10 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 
   auto subscription = create_subscription(topic.name, topic.type, subscription_qos);
   if (subscription) {
-    subscriptions_.insert({topic.name, subscription});
+    {
+      std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+      subscriptions_.insert({topic.name, subscription});
+    }
     std::optional<size_t> repeat_tl_depth =
       record_options_.repeat_transient_local_messages.count(topic.name) > 0 ?
       std::make_optional(record_options_.repeat_transient_local_messages.at(topic.name)) :
@@ -1903,16 +1953,20 @@ rclcpp::QoS RecorderImpl::subscription_qos_for_topic(const std::string & topic_n
 
 void RecorderImpl::warn_if_new_qos_for_subscribed_topic(const std::string & topic_name)
 {
-  auto existing_subscription = subscriptions_.find(topic_name);
-  if (existing_subscription == subscriptions_.end()) {
-    // Not subscribed yet
-    return;
+  std::shared_ptr<rclcpp::SubscriptionBase> existing_subscription;
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    auto iterator = subscriptions_.find(topic_name);
+    if (iterator == subscriptions_.end()) {
+      return;
+    }
+    existing_subscription = iterator->second;
   }
   if (topics_warned_about_incompatibility_.count(topic_name) > 0) {
     // Already warned about this topic
     return;
   }
-  const auto actual_qos = existing_subscription->second->get_actual_qos();
+  const auto actual_qos = existing_subscription->get_actual_qos();
   const auto & used_profile = actual_qos.get_rmw_qos_profile();
   auto publishers_info = node->get_publishers_info_by_topic(topic_name);
   for (const auto & info : publishers_info) {
@@ -2171,6 +2225,12 @@ Recorder::is_discovery_running() const
 void Recorder::set_on_start_recording_callback(OnStartRecordingCallback callback) const
 {
   pimpl_->on_start_recording_callback_ = std::move(callback);
+}
+
+std::vector<std::string>
+Recorder::get_subscribed_topics() const
+{
+  return pimpl_->get_subscribed_topics();
 }
 
 void Recorder::read_static_topics() noexcept

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -641,14 +641,14 @@ void RecorderImpl::stop()
   }
 
   stop_discovery();
-  // Explicitly disable all subscription's callbacks to avoid UB and receiving new messages on
-  // deleted subscriptions. Note: The callbacks propagated to the executor and may still be in the
-  // executor's queue, but they will no longer be called after this point.
-  for (auto & [_, subscription] : subscriptions_) {
-    subscription->disable_callbacks();
-  }
   {
+    // Explicitly disable all subscription's callbacks to avoid UB and receiving new messages on
+    // deleted subscriptions. Note: The callbacks propagated to the executor and may still be in the
+    // executor's queue, but they will no longer be called after this point.
     std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    for (auto & [_, subscription] : subscriptions_) {
+      subscription->disable_callbacks();
+    }
     subscriptions_.clear();
   }
   writer_->close();  // Call writer->close() to finalize current bag file and write metadata

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -38,6 +38,7 @@
 #include "rosbag2_cpp/bag_events.hpp"
 #include "rosbag2_cpp/service_utils.hpp"
 #include "rosbag2_cpp/writer.hpp"
+#include "rosbag2_interfaces/srv/get_subscribed_topics.hpp"
 #include "rosbag2_interfaces/srv/snapshot.hpp"
 #include "rosbag2_storage/qos.hpp"
 #include "logging.hpp"
@@ -193,6 +194,8 @@ public:
   std::unordered_map<std::string, std::string> get_requested_or_available_topics();
 
   void read_static_topics() noexcept;
+
+  std::vector<std::string> get_subscribed_topics() const;
 
   /// Public members for access by wrapper
   std::unordered_set<std::string> topics_warned_about_incompatibility_;
@@ -409,6 +412,8 @@ private:
   std::future<void> discovery_future_;
   std::unordered_map<std::string, rclcpp::QoS> topic_qos_profile_overrides_;
   std::unordered_set<std::string> topic_unknown_types_;
+  rclcpp::Service<rosbag2_interfaces::srv::GetSubscribedTopics>::SharedPtr
+    srv_get_subscribed_topics_;
   rclcpp::Service<rosbag2_interfaces::srv::IsDiscoveryRunning>::SharedPtr srv_is_discovery_running_;
   rclcpp::Service<rosbag2_interfaces::srv::IsPaused>::SharedPtr srv_is_paused_;
   rclcpp::Service<rosbag2_interfaces::srv::Pause>::SharedPtr srv_pause_;
@@ -422,6 +427,7 @@ private:
 
   std::mutex start_stop_transition_mutex_;
   std::mutex discovery_mutex_;
+  mutable std::mutex subscriptions_mutex_;
   std::atomic<bool> discovery_running_ = false;
   std::atomic_uchar paused_ = 0;
   std::atomic<bool> in_recording_ = false;
@@ -550,7 +556,10 @@ void RecorderImpl::stop()
   for (auto & [_, subscription] : subscriptions_) {
     subscription->disable_callbacks();
   }
-  subscriptions_.clear();
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    subscriptions_.clear();
+  }
   writer_->close();  // Call writer->close() to finalize current bag file and write metadata
   {  // Clear pending split request if any
     std::lock_guard<std::mutex> lock(pending_bag_split_request_mutex_);
@@ -936,6 +945,17 @@ void RecorderImpl::create_control_services()
     {
       response->paused = is_paused();
     });
+
+  srv_get_subscribed_topics_ =
+    node->create_service<rosbag2_interfaces::srv::GetSubscribedTopics>(
+     "~/get_subscribed_topics",
+    [this](
+      const std::shared_ptr<rmw_request_id_t>/* request_header */,
+      const std::shared_ptr<rosbag2_interfaces::srv::GetSubscribedTopics::Request>/* request */,
+      std::shared_ptr<rosbag2_interfaces::srv::GetSubscribedTopics::Response> response)
+    {
+      response->topics = this->get_subscribed_topics();
+    });
 }
 
 std::optional<rclcpp::Time> RecorderImpl::optional_time_from_request(
@@ -1243,8 +1263,13 @@ void RecorderImpl::topics_discovery() noexcept
     }
     bool should_update_subscriptions = true;
     while (rclcpp::ok() && discovery_running_) {
+      size_t subscriptions_count = 0u;
+      {
+        std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+        subscriptions_count = subscriptions_.size();
+      }
       if (!record_options_.topics.empty() &&
-        subscriptions_.size() == record_options_.topics.size())
+        subscriptions_count == record_options_.topics.size())
       {
         RCLCPP_INFO(
           node->get_logger(), "All requested topics are subscribed. Stopping discovery...");
@@ -1297,12 +1322,31 @@ std::unordered_map<std::string, std::string>
 RecorderImpl::get_missing_topics(const std::unordered_map<std::string, std::string> & all_topics)
 {
   std::unordered_map<std::string, std::string> missing_topics;
+  std::unordered_set<std::string> subscribed_topics;
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    for (const auto & [topic_name, _] : subscriptions_) {
+      subscribed_topics.insert(topic_name);
+    }
+  }
   for (const auto & [topic_name, topic_type] : all_topics) {
-    if (subscriptions_.find(topic_name) == subscriptions_.end()) {
+    if (subscribed_topics.find(topic_name) == subscribed_topics.end()) {
       missing_topics.emplace(topic_name, topic_type);
     }
   }
   return missing_topics;
+}
+
+std::vector<std::string> RecorderImpl::get_subscribed_topics() const
+{
+  std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+  std::vector<std::string> topics;
+  topics.reserve(subscriptions_.size());
+  for (const auto & [topic_name, _] : subscriptions_) {
+    topics.emplace_back(topic_name);
+  }
+  std::sort(topics.begin(), topics.end());
+  return topics;
 }
 
 
@@ -1419,8 +1463,11 @@ uint64_t RecorderImpl::get_total_num_messages_lost_in_transport() const
 
 void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 {
-  if (subscriptions_.find(topic.name) != subscriptions_.end()) {
-    return;
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    if (subscriptions_.find(topic.name) != subscriptions_.end()) {
+      return;
+    }
   }
   // Need to create topic in writer before we are trying to create subscription. Since in
   // callback for subscription we are calling writer_->write(bag_message); and it could happened
@@ -1431,7 +1478,10 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
 
   auto subscription = create_subscription(topic.name, topic.type, subscription_qos);
   if (subscription) {
-    subscriptions_.insert({topic.name, subscription});
+    {
+      std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+      subscriptions_.insert({topic.name, subscription});
+    }
     if (node->get_logger().get_effective_level() == rclcpp::Logger::Level::Debug) {
       RCLCPP_DEBUG_STREAM(node->get_logger(),
         "Subscribed to topic '" << topic.name << "' with QoS:\n" << subscription_qos.to_string());
@@ -1573,16 +1623,20 @@ rclcpp::QoS RecorderImpl::subscription_qos_for_topic(const std::string & topic_n
 
 void RecorderImpl::warn_if_new_qos_for_subscribed_topic(const std::string & topic_name)
 {
-  auto existing_subscription = subscriptions_.find(topic_name);
-  if (existing_subscription == subscriptions_.end()) {
-    // Not subscribed yet
-    return;
+  std::shared_ptr<rclcpp::SubscriptionBase> existing_subscription;
+  {
+    std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
+    auto iterator = subscriptions_.find(topic_name);
+    if (iterator == subscriptions_.end()) {
+      return;
+    }
+    existing_subscription = iterator->second;
   }
   if (topics_warned_about_incompatibility_.count(topic_name) > 0) {
     // Already warned about this topic
     return;
   }
-  const auto actual_qos = existing_subscription->second->get_actual_qos();
+  const auto actual_qos = existing_subscription->get_actual_qos();
   const auto & used_profile = actual_qos.get_rmw_qos_profile();
   auto publishers_info = node->get_publishers_info_by_topic(topic_name);
   for (const auto & info : publishers_info) {
@@ -1841,6 +1895,12 @@ Recorder::is_discovery_running() const
 void Recorder::set_on_start_recording_callback(OnStartRecordingCallback callback) const
 {
   pimpl_->on_start_recording_callback_ = std::move(callback);
+}
+
+std::vector<std::string>
+Recorder::get_subscribed_topics() const
+{
+  return pimpl_->get_subscribed_topics();
 }
 
 void Recorder::read_static_topics() noexcept

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <memory>
@@ -771,6 +772,42 @@ TEST_F(RecordIntegrationTestFixture, add_channel_with_message_definition)
     encoded_message_definition
   );
   recorder->stop();
+}
+
+TEST_F(RecordIntegrationTestFixture, get_subscribed_topics_reflects_subscription_state)
+{
+  auto string_message = get_messages_strings()[0];
+  const std::string test_topic = "/get_subscribed_topics_topic";
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher(test_topic, string_message, 5);
+
+  rosbag2_transport::RecordOptions record_options{};
+  record_options.topics = {test_topic};
+  record_options.input_serialization_format = "rmw_format";
+  record_options.output_serialization_format = "rmw_format";
+  record_options.topic_polling_interval = 50ms;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic.c_str()));
+  pub_manager.run_publishers();
+
+  auto observed = rosbag2_test_common::wait_until_condition(
+    [&recorder, &test_topic]() {
+      auto topics = recorder->get_subscribed_topics();
+      return std::find(topics.begin(), topics.end(), test_topic) != topics.end();
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(observed) << "Recorder did not report expected subscription in time";
+
+  auto topics = recorder->get_subscribed_topics();
+  EXPECT_THAT(topics, Contains(test_topic));
+
+  recorder->stop();
+  EXPECT_THAT(recorder->get_subscribed_topics(), IsEmpty());
 }
 
 TEST_F(RecordIntegrationTestFixture, write_message_writes_to_bag)

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <memory>
@@ -653,6 +654,42 @@ TEST_F(RecordIntegrationTestFixture, add_channel_with_message_definition)
     encoded_message_definition
   );
   recorder->stop();
+}
+
+TEST_F(RecordIntegrationTestFixture, get_subscribed_topics_reflects_subscription_state)
+{
+  auto string_message = get_messages_strings()[0];
+  const std::string test_topic = "/get_subscribed_topics_topic";
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher(test_topic, string_message, 5);
+
+  rosbag2_transport::RecordOptions record_options{};
+  record_options.topics = {test_topic};
+  record_options.input_serialization_format = "rmw_format";
+  record_options.output_serialization_format = "rmw_format";
+  record_options.topic_polling_interval = 50ms;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic.c_str()));
+  pub_manager.run_publishers();
+
+  auto observed = rosbag2_test_common::wait_until_condition(
+    [&recorder, &test_topic]() {
+      auto topics = recorder->get_subscribed_topics();
+      return std::find(topics.begin(), topics.end(), test_topic) != topics.end();
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(observed) << "Recorder did not report expected subscription in time";
+
+  auto topics = recorder->get_subscribed_topics();
+  EXPECT_THAT(topics, Contains(test_topic));
+
+  recorder->stop();
+  EXPECT_THAT(recorder->get_subscribed_topics(), IsEmpty());
 }
 
 TEST_F(RecordIntegrationTestFixture, write_message_writes_to_bag)

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <string>
@@ -26,6 +27,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rosgraph_msgs/msg/clock.hpp"
 
+#include "rosbag2_interfaces/srv/get_subscribed_topics.hpp"
 #include "rosbag2_interfaces/srv/is_discovery_running.hpp"
 #include "rosbag2_interfaces/srv/is_paused.hpp"
 #include "rosbag2_interfaces/srv/pause.hpp"
@@ -66,6 +68,7 @@ struct type_has_return_code<T, std::void_t<decltype(std::declval<T &>().return_c
 class RecordSrvsTest : public RecordIntegrationTestFixture
 {
 public:
+  using GetSubscribedTopics = rosbag2_interfaces::srv::GetSubscribedTopics;
   using IsDiscoveryRunning = rosbag2_interfaces::srv::IsDiscoveryRunning;
   using IsPaused = rosbag2_interfaces::srv::IsPaused;
   using Pause = rosbag2_interfaces::srv::Pause;
@@ -126,6 +129,8 @@ public:
     recorder_->record();
 
     const std::string ns = "/" + recorder_name_;
+    cli_get_subscribed_topics_ = client_node_->create_client<GetSubscribedTopics>(
+      ns + "/get_subscribed_topics");
     cli_is_discovery_running_ = client_node_->create_client<IsDiscoveryRunning>(
       ns + "/is_discovery_running");
     cli_is_paused_ = client_node_->create_client<IsPaused>(ns + "/is_paused");
@@ -171,6 +176,7 @@ public:
     if (snapshot_mode_) {
       ASSERT_TRUE(cli_snapshot_->wait_for_service(service_wait_timeout_));
     }
+    ASSERT_TRUE(cli_get_subscribed_topics_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_is_discovery_running_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_is_paused_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_pause_->wait_for_service(service_wait_timeout_));
@@ -257,6 +263,7 @@ public:
 
   // Service clients
   rclcpp::Node::SharedPtr client_node_;
+  rclcpp::Client<GetSubscribedTopics>::SharedPtr cli_get_subscribed_topics_;
   rclcpp::Client<IsDiscoveryRunning>::SharedPtr cli_is_discovery_running_;
   rclcpp::Client<IsPaused>::SharedPtr cli_is_paused_;
   rclcpp::Client<Pause>::SharedPtr cli_pause_;
@@ -299,6 +306,39 @@ protected:
       true /*use_sim_time*/, {kTestTopic, kSplitOtherTopic})
   {}
 };
+
+TEST_F(RecordSrvsTest, get_subscribed_topics_reports_active_topics)
+{
+  rosbag2_test_common::PublicationManager pub_manager;
+  auto string_message = get_messages_strings()[1];
+  pub_manager.setup_publisher(test_topic_, string_message, 3);
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
+  pub_manager.run_publishers();
+
+  auto response = std::make_shared<GetSubscribedTopics::Response>();
+  ASSERT_TRUE(
+    successful_service_request<GetSubscribedTopics>(cli_get_subscribed_topics_, response)
+  );
+  EXPECT_THAT(response->topics, Contains(test_topic_));
+  EXPECT_EQ(recorder_->get_subscribed_topics(), response->topics);
+}
+
+TEST_F(RecordSrvsTest, get_subscribed_topics_empty_when_not_recording)
+{
+  rosbag2_test_common::PublicationManager pub_manager;
+  auto string_message = get_messages_strings()[1];
+  pub_manager.setup_publisher(test_topic_, string_message, 3);
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
+  pub_manager.run_publishers();
+
+  recorder_->stop();
+  auto response = std::make_shared<GetSubscribedTopics::Response>();
+  ASSERT_TRUE(
+    successful_service_request<GetSubscribedTopics>(cli_get_subscribed_topics_, response)
+  );
+  EXPECT_THAT(response->topics, IsEmpty());
+  EXPECT_EQ(recorder_->get_subscribed_topics(), response->topics);
+}
 
 class RecordSrvsDiscoveryTest : public RecordSrvsTest
 {

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <string>
@@ -26,6 +27,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rosgraph_msgs/msg/clock.hpp"
 
+#include "rosbag2_interfaces/srv/get_subscribed_topics.hpp"
 #include "rosbag2_interfaces/srv/is_discovery_running.hpp"
 #include "rosbag2_interfaces/srv/is_paused.hpp"
 #include "rosbag2_interfaces/srv/pause.hpp"
@@ -66,6 +68,7 @@ struct type_has_return_code<T, std::void_t<decltype(std::declval<T &>().return_c
 class RecordSrvsTest : public RecordIntegrationTestFixture
 {
 public:
+  using GetSubscribedTopics = rosbag2_interfaces::srv::GetSubscribedTopics;
   using IsDiscoveryRunning = rosbag2_interfaces::srv::IsDiscoveryRunning;
   using IsPaused = rosbag2_interfaces::srv::IsPaused;
   using Pause = rosbag2_interfaces::srv::Pause;
@@ -126,6 +129,8 @@ public:
     recorder_->record();
 
     const std::string ns = "/" + recorder_name_;
+    cli_get_subscribed_topics_ = client_node_->create_client<GetSubscribedTopics>(
+      ns + "/get_subscribed_topics");
     cli_is_discovery_running_ = client_node_->create_client<IsDiscoveryRunning>(
       ns + "/is_discovery_running");
     cli_is_paused_ = client_node_->create_client<IsPaused>(ns + "/is_paused");
@@ -174,6 +179,7 @@ public:
     if (snapshot_mode_) {
       ASSERT_TRUE(cli_snapshot_->wait_for_service(service_wait_timeout_));
     }
+    ASSERT_TRUE(cli_get_subscribed_topics_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_is_discovery_running_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_is_paused_->wait_for_service(service_wait_timeout_));
     ASSERT_TRUE(cli_pause_->wait_for_service(service_wait_timeout_));
@@ -276,6 +282,7 @@ public:
 
   // Service clients
   rclcpp::Node::SharedPtr client_node_;
+  rclcpp::Client<GetSubscribedTopics>::SharedPtr cli_get_subscribed_topics_;
   rclcpp::Client<IsDiscoveryRunning>::SharedPtr cli_is_discovery_running_;
   rclcpp::Client<IsPaused>::SharedPtr cli_is_paused_;
   rclcpp::Client<Pause>::SharedPtr cli_pause_;
@@ -318,6 +325,39 @@ protected:
       true /*use_sim_time*/, {kTestTopic, kSplitOtherTopic})
   {}
 };
+
+TEST_F(RecordSrvsTest, get_subscribed_topics_reports_active_topics)
+{
+  rosbag2_test_common::PublicationManager pub_manager;
+  auto string_message = get_messages_strings()[1];
+  pub_manager.setup_publisher(test_topic_, string_message, 3);
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
+  pub_manager.run_publishers();
+
+  auto response = std::make_shared<GetSubscribedTopics::Response>();
+  ASSERT_TRUE(
+    successful_service_request<GetSubscribedTopics>(cli_get_subscribed_topics_, response)
+  );
+  EXPECT_THAT(response->topics, Contains(test_topic_));
+  EXPECT_EQ(recorder_->get_subscribed_topics(), response->topics);
+}
+
+TEST_F(RecordSrvsTest, get_subscribed_topics_empty_when_not_recording)
+{
+  rosbag2_test_common::PublicationManager pub_manager;
+  auto string_message = get_messages_strings()[1];
+  pub_manager.setup_publisher(test_topic_, string_message, 3);
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
+  pub_manager.run_publishers();
+
+  recorder_->stop();
+  auto response = std::make_shared<GetSubscribedTopics::Response>();
+  ASSERT_TRUE(
+    successful_service_request<GetSubscribedTopics>(cli_get_subscribed_topics_, response)
+  );
+  EXPECT_THAT(response->topics, IsEmpty());
+  EXPECT_EQ(recorder_->get_subscribed_topics(), response->topics);
+}
 
 class RecordSrvsDiscoveryTest : public RecordSrvsTest
 {

--- a/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_recorder_event_notifier.cpp
@@ -95,14 +95,14 @@ TEST_F(TestRecorderEventNotifier, get_current_events_topic_names)
   const auto fqn_default_write_split =
     node_->get_node_base_interface()->resolve_topic_or_service_name(
       RecorderEventNotifier::get_default_write_split_topic_name(),
-      /*is_service=*/false,
-      /*only_expand=*/false);
+      /*is_service=*/ false,
+      /*only_expand=*/ false);
 
   const auto fqn_default_msgs_lost =
     node_->get_node_base_interface()->resolve_topic_or_service_name(
       RecorderEventNotifier::get_default_messages_lost_topic_name(),
-      /*is_service=*/false,
-      /*only_expand=*/false);
+      /*is_service=*/ false,
+      /*only_expand=*/ false);
 
   EXPECT_STREQ(notifier_->get_write_split_topic_name().data(), fqn_default_write_split.c_str());
   EXPECT_STREQ(notifier_->get_messages_lost_topic_name().data(), fqn_default_msgs_lost.c_str());


### PR DESCRIPTION
## Description

This PR adds a new `GetSubscribedTopics` recorder service request, which returns a list of fully qualified names of topics currently subscribed by the recorder.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Relates #2373 

### Is this user-facing behavior change?
Yes, the user can now request the list of currently subscribed topics remotely via service request.

### Did you use Generative AI?
Yes. GitHub Copilot, GPT-4.2 and Codex gpt-4.2
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
This PR can be backported
