### PR TITLE
[don't merge!] min reproducer for fast dds shm memory leak

### DIFF
--- a/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
+++ b/rosbag2_examples/rosbag2_examples_cpp/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(example_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 
 add_executable(simple_bag_recorder src/simple_bag_recorder.cpp)
 target_link_libraries(simple_bag_recorder
@@ -55,6 +56,28 @@ target_link_libraries(data_generator_executable
 
 install(TARGETS
   data_generator_executable
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(byte_burst_publisher src/byte_burst_publisher.cpp)
+target_link_libraries(byte_burst_publisher
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS}
+)
+
+install(TARGETS
+  byte_burst_publisher
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+add_executable(byte_subscriber_probe src/byte_subscriber_probe.cpp)
+target_link_libraries(byte_subscriber_probe
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS}
+)
+
+install(TARGETS
+  byte_subscriber_probe
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rosbag2_examples/rosbag2_examples_cpp/package.xml
+++ b/rosbag2_examples/rosbag2_examples_cpp/package.xml
@@ -14,6 +14,7 @@
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>
   <depend>example_interfaces</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_examples/rosbag2_examples_cpp/src/byte_burst_publisher.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/byte_burst_publisher.cpp
@@ -1,0 +1,88 @@
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/byte_multi_array.hpp"
+
+using namespace std::chrono_literals;
+
+namespace
+{
+
+std::vector<uint8_t> random_bytes(size_t size)
+{
+  std::vector<uint8_t> data(size);
+  std::mt19937 gen(12345);
+  std::uniform_int_distribution<int> dist(0, 255);
+  for (auto & value : data) {
+    value = static_cast<uint8_t>(dist(gen));
+  }
+  return data;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rclcpp::Node>("byte_burst_publisher");
+
+  const auto mode = node->declare_parameter<std::string>("mode", "small");
+  const auto small_count = node->declare_parameter<int>("small_count", 1000000);
+  const auto big_mib = node->declare_parameter<int>("big_mib", 1);
+  const auto big_count = node->declare_parameter<int>("big_count", 512);
+  const auto create_many_topics = node->declare_parameter<bool>("create_many_topics", true);
+
+  if (mode == "small") {
+    auto pub = node->create_publisher<std_msgs::msg::ByteMultiArray>("/small_topic", 1);
+    rclcpp::sleep_for(500ms);
+    auto payload = random_bytes(64);
+    std_msgs::msg::ByteMultiArray msg;
+    msg.data = payload;
+    for (int i = 0; i < small_count; ++i) {
+      pub->publish(msg);
+    }
+    RCLCPP_INFO(node->get_logger(), "published %d small messages", small_count);
+  } else if (mode == "big") {
+    std::vector<rclcpp::Publisher<std_msgs::msg::ByteMultiArray>::SharedPtr> pubs;
+    if (create_many_topics) {
+      pubs.reserve(100);
+      for (int i = 0; i < 100; ++i) {
+        pubs.push_back(
+          node->create_publisher<std_msgs::msg::ByteMultiArray>("/many/t" + std::to_string(i), 1));
+      }
+    }
+    auto big_pub = node->create_publisher<std_msgs::msg::ByteMultiArray>("/big_topic", 10);
+    rclcpp::sleep_for(500ms);
+
+    if (create_many_topics) {
+      auto tiny_payload = random_bytes(16);
+      std_msgs::msg::ByteMultiArray tiny_msg;
+      tiny_msg.data = tiny_payload;
+      for (const auto & pub : pubs) {
+        pub->publish(tiny_msg);
+      }
+    }
+
+    auto payload = random_bytes(static_cast<size_t>(big_mib) * 1024u * 1024u);
+    std_msgs::msg::ByteMultiArray msg;
+    msg.data = payload;
+    for (int i = 0; i < big_count; ++i) {
+      big_pub->publish(msg);
+    }
+    RCLCPP_INFO(
+      node->get_logger(), "published %d big messages of %d MiB", big_count, big_mib);
+  } else {
+    RCLCPP_ERROR(node->get_logger(), "unknown mode: %s", mode.c_str());
+    rclcpp::shutdown();
+    return 1;
+  }
+
+  rclcpp::sleep_for(1s);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rosbag2_examples/rosbag2_examples_cpp/src/byte_burst_publisher.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/byte_burst_publisher.cpp
@@ -46,7 +46,7 @@ int main(int argc, char ** argv)
     for (int i = 0; i < small_count; ++i) {
       pub->publish(msg);
     }
-    RCLCPP_INFO(node->get_logger(), "published %d small messages", small_count);
+    RCLCPP_INFO(node->get_logger(), "published %ld small messages", small_count);
   } else if (mode == "big") {
     std::vector<rclcpp::Publisher<std_msgs::msg::ByteMultiArray>::SharedPtr> pubs;
     if (create_many_topics) {
@@ -75,7 +75,7 @@ int main(int argc, char ** argv)
       big_pub->publish(msg);
     }
     RCLCPP_INFO(
-      node->get_logger(), "published %d big messages of %d MiB", big_count, big_mib);
+      node->get_logger(), "published %ld big messages of %ld MiB", big_count, big_mib);
   } else {
     RCLCPP_ERROR(node->get_logger(), "unknown mode: %s", mode.c_str());
     rclcpp::shutdown();

--- a/rosbag2_examples/rosbag2_examples_cpp/src/byte_subscriber_probe.cpp
+++ b/rosbag2_examples/rosbag2_examples_cpp/src/byte_subscriber_probe.cpp
@@ -1,0 +1,55 @@
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/byte_multi_array.hpp"
+
+using namespace std::chrono_literals;
+
+class ByteSubscriberProbe : public rclcpp::Node
+{
+public:
+  ByteSubscriberProbe()
+  : Node("byte_subscriber_probe")
+  {
+    const auto topic = this->declare_parameter<std::string>("topic", "/big_topic");
+    auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable();
+    sub_ = this->create_subscription<std_msgs::msg::ByteMultiArray>(
+      topic, qos,
+      [this](std_msgs::msg::ByteMultiArray::ConstSharedPtr msg) {
+        message_count_.fetch_add(1, std::memory_order_relaxed);
+        const auto size = msg->data.size();
+        auto current = max_payload_bytes_.load(std::memory_order_relaxed);
+        while (
+          size > current &&
+          !max_payload_bytes_.compare_exchange_weak(current, size, std::memory_order_relaxed))
+        {
+        }
+      });
+
+    timer_ = this->create_wall_timer(5s, [this]() {
+      RCLCPP_INFO(
+        this->get_logger(), "messages=%zu max_payload_bytes=%zu",
+        message_count_.load(std::memory_order_relaxed),
+        max_payload_bytes_.load(std::memory_order_relaxed));
+    });
+  }
+
+private:
+  std::atomic<size_t> message_count_{0};
+  std::atomic<size_t> max_payload_bytes_{0};
+  rclcpp::Subscription<std_msgs::msg::ByteMultiArray>::SharedPtr sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ByteSubscriberProbe>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Description

- This PR is a Minimal Reproducer for the issue with the memory leak reported in the  https://github.com/ros2/rosbag2/issues/2366.

It adds two small executables in `rosbag2_examples_cpp`:

- `byte_burst_publisher`
- `byte_subscriber_probe`

Files:
- [`rosbag2_examples/rosbag2_examples_cpp/src/byte_burst_publisher.cpp`](./rosbag2_examples/rosbag2_examples_cpp/src/byte_burst_publisher.cpp)
- [`rosbag2_examples/rosbag2_examples_cpp/src/byte_subscriber_probe.cpp`](./rosbag2_examples/rosbag2_examples_cpp/src/byte_subscriber_probe.cpp)

### What they do

- `byte_burst_publisher` publishes:
  - many small messages on `/small_topic`, or
  - large `std_msgs/msg/ByteMultiArray` messages on `/big_topic`
  - optionally creates transient `/many/t*` topics to mimic topic churn from the original report
- `byte_subscriber_probe` is a minimal non-rosbag2 subscriber for `/big_topic`
  - it only subscribes
  - counts messages
  - reports the largest payload received
  - this is useful to check whether memory growth reproduces without rosbag2 in-process

## Build

If `example_interfaces` is already available in your environment, just build `rosbag2_examples_cpp`.

```bash
source <your_ros_setup>/setup.bash
colcon build --packages-select rosbag2_examples_cpp
```

If `example_interfaces` is present in source but not installed in your current environment, build it first and source that prefix:

```bash
source /home/morlov/ros2_jazzy/install/setup.bash

colcon build \
  --packages-select example_interfaces \
  --base-paths /home/morlov/ros2_jazzy/src/ros2 \
  --build-base /tmp/example_interfaces_build \
  --install-base /tmp/example_interfaces_install

source /tmp/example_interfaces_install/setup.bash

colcon build \
  --packages-select rosbag2_examples_cpp \
  --base-paths /home/morlov/ros2_jazzy/src/ros2/rosbag2 \
  --build-base /tmp/rosbag2_examples_build \
  --install-base /tmp/rosbag2_examples_install
```

## Run the minimal non-rosbag2 reproducer

Terminal 1, start the subscriber probe:

```bash
source /tmp/rosbag2_examples_install/setup.bash
source /tmp/example_interfaces_install/setup.bash

export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
unset FASTDDS_BUILTIN_TRANSPORTS

ros2 run rosbag2_examples_cpp byte_subscriber_probe
```

Terminal 2, publish large messages in bursts:

```bash
source /tmp/rosbag2_examples_install/setup.bash
source /tmp/example_interfaces_install/setup.bash

export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
unset FASTDDS_BUILTIN_TRANSPORTS

for i in 1 2 3 4 5; do
  ros2 run rosbag2_examples_cpp byte_burst_publisher --ros-args \
    -p mode:=big \
    -p big_mib:=10 \
    -p big_count:=20 \
    -p create_many_topics:=false
  sleep 2
done
```

In a third terminal, monitor RSS of the subscriber process:

```bash
watch -n 1 'ps -o pid,rss,cmd -C byte_subscriber_probe'
```

## Compare RMW / transport behavior

### Fast DDS with SHM enabled

```bash
export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
unset FASTDDS_BUILTIN_TRANSPORTS
```

This is the configuration that reproduced the large RSS jump in testing.

### Fast DDS with SHM disabled

```bash
export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
export FASTDDS_BUILTIN_TRANSPORTS=UDPv4
```

This should keep RSS much flatter.

### Cyclone DDS

```bash
export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
unset FASTDDS_BUILTIN_TRANSPORTS
```

This should also stay much flatter.

## Optional rosbag2-style publisher behavior

To include transient `/many/t*` topic churn:

```bash
ros2 run rosbag2_examples_cpp byte_burst_publisher --ros-args \
  -p mode:=big \
  -p big_mib:=10 \
  -p big_count:=20 \
  -p create_many_topics:=true
```

To generate only the small-message stream:

```bash
ros2 run rosbag2_examples_cpp byte_burst_publisher --ros-args \
  -p mode:=small \
  -p small_count:=1000000
```

## Expected result

The minimal subscriber reproducer is intended to show that:
- large-message memory growth can be observed without rosbag2 in-process
- the effect is much stronger with `rmw_fastrtps_cpp` + SHM enabled
- the effect is much smaller or flat with:
  - `rmw_fastrtps_cpp` + SHM disabled
  - `rmw_cyclonedds_cpp`

This helps separate rosbag2 behavior from middleware receive-path behavior.
