### PR TITLE
[1/3] Repeat transient-local topics: Core cache and RecordOptions

### DIFF
--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(${PROJECT_NAME} SHARED
   src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
   src/rosbag2_cpp/cache/message_cache.cpp
   src/rosbag2_cpp/cache/circular_message_cache.cpp
+  src/rosbag2_cpp/cache/transient_local_messages_cache.cpp
   src/rosbag2_cpp/clocks/time_controller_clock.cpp
   src/rosbag2_cpp/converter.cpp
   src/rosbag2_cpp/info.cpp
@@ -209,6 +210,12 @@ if(BUILD_TESTING)
       rcutils::rcutils
       rosbag2_storage::rosbag2_storage
     )
+  endif()
+
+  ament_add_gmock(test_transient_local_messages_cache
+    test/rosbag2_cpp/test_transient_local_messages_cache.cpp)
+  if(TARGET test_transient_local_messages_cache)
+    target_link_libraries(test_transient_local_messages_cache ${PROJECT_NAME})
   endif()
 
   # If compiling with gcc, run this test with sanitizers enabled

--- a/rosbag2_cpp/include/rosbag2_cpp/cache/transient_local_messages_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/transient_local_messages_cache.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 Dexory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_CPP__CACHE__TRANSIENT_LOCAL_MESSAGES_CACHE_HPP_
+#define ROSBAG2_CPP__CACHE__TRANSIENT_LOCAL_MESSAGES_CACHE_HPP_
+
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "rosbag2_cpp/visibility_control.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+
+namespace rosbag2_cpp
+{
+namespace cache
+{
+
+/// \brief Thread-safe cache for transient-local messages with per-topic FIFO queues.
+///
+/// Maintains per-topic circular queues of the last N messages, where N is a configurable
+/// depth per topic. Used to prepend transient-local messages on bag splits and snapshots.
+class ROSBAG2_CPP_PUBLIC TransientLocalMessagesCache
+{
+public:
+  /// \brief Add a topic to the cache with a specified queue depth.
+  /// If the topic already exists, its queue depth will be updated. If the new depth is smaller
+  /// than the current number of cached messages, the oldest messages will be discarded.
+  /// \param topic_name The name of the topic.
+  /// \param queue_depth The maximum number of messages to store for this topic.
+  /// \throws std::invalid_argument if the queue depth is zero.
+  void add_topic(const std::string & topic_name, size_t queue_depth);
+
+  /// \brief Remove a topic and all its cached messages from the cache.
+  /// \param topic_name The name of the topic to remove. No-op if the topic does not exist.
+  void remove_topic(const std::string & topic_name);
+
+  /// \brief Check whether a topic is registered in the cache.
+  /// \param topic_name The name of the topic.
+  /// \return true if the topic exists in the cache, false otherwise.
+  bool has_topic(const std::string & topic_name) const;
+
+  /// \brief Push a message into the cache for a given topic.
+  /// If the queue is full, the oldest message will be discarded.
+  /// \param topic_name The name of the topic.
+  /// \param message The serialized message to cache.
+  /// \throws std::runtime_error if the topic has not been registered via add_topic().
+  void push(
+    const std::string & topic_name,
+    rosbag2_storage::SerializedBagMessageConstSharedPtr message);
+
+  /// \brief Retrieve all cached messages across all topics, sorted by timestamp.
+  /// Messages are sorted by recv_timestamp first, then send_timestamp, then topic_name.
+  /// \return A vector of cached messages sorted by timestamp.
+  std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr>
+  get_messages_sorted_by_timestamp() const;
+
+  /// \brief Clear all cached messages from all topics without removing the topic registrations.
+  void clear();
+
+  /// \brief Get the total number of cached messages across all topics.
+  /// \return The total number of cached messages.
+  size_t size() const;
+
+private:
+  struct TopicQueue
+  {
+    size_t max_depth{0};
+    std::deque<rosbag2_storage::SerializedBagMessageConstSharedPtr> messages;
+  };
+
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, TopicQueue> topic_queues_;
+};
+
+}  // namespace cache
+}  // namespace rosbag2_cpp
+
+#endif  // ROSBAG2_CPP__CACHE__TRANSIENT_LOCAL_MESSAGES_CACHE_HPP_

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/transient_local_messages_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/transient_local_messages_cache.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Dexory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosbag2_cpp/cache/transient_local_messages_cache.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace rosbag2_cpp
+{
+namespace cache
+{
+
+void TransientLocalMessagesCache::add_topic(const std::string & topic_name, size_t queue_depth)
+{
+  if (queue_depth == 0) {
+    throw std::invalid_argument("Transient-local queue depth must be greater than 0");
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto & topic_queue = topic_queues_[topic_name];
+  topic_queue.max_depth = queue_depth;
+  while (topic_queue.messages.size() > topic_queue.max_depth) {
+    topic_queue.messages.pop_front();
+  }
+}
+
+void TransientLocalMessagesCache::remove_topic(const std::string & topic_name)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  topic_queues_.erase(topic_name);
+}
+
+bool TransientLocalMessagesCache::has_topic(const std::string & topic_name) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return topic_queues_.count(topic_name) > 0;
+}
+
+void TransientLocalMessagesCache::push(
+  const std::string & topic_name,
+  rosbag2_storage::SerializedBagMessageConstSharedPtr message)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = topic_queues_.find(topic_name);
+  if (it == topic_queues_.end()) {
+    throw std::runtime_error(
+            "Cannot push message to unregistered topic '" + topic_name +
+            "'. Call add_topic() first.");
+  }
+
+  auto & queue = it->second;
+  queue.messages.push_back(std::move(message));
+  while (queue.messages.size() > queue.max_depth) {
+    queue.messages.pop_front();
+  }
+}
+
+std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr>
+TransientLocalMessagesCache::get_messages_sorted_by_timestamp() const
+{
+  std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr> messages;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    size_t total_count = 0;
+    for (const auto & [_, topic_queue] : topic_queues_) {
+      total_count += topic_queue.messages.size();
+    }
+    messages.reserve(total_count);
+    for (const auto & [_, topic_queue] : topic_queues_) {
+      messages.insert(messages.end(), topic_queue.messages.begin(), topic_queue.messages.end());
+    }
+  }
+
+  std::stable_sort(
+    messages.begin(), messages.end(),
+    [](const auto & left, const auto & right) {
+      if (left->recv_timestamp != right->recv_timestamp) {
+        return left->recv_timestamp < right->recv_timestamp;
+      }
+      if (left->send_timestamp != right->send_timestamp) {
+        return left->send_timestamp < right->send_timestamp;
+      }
+      return left->topic_name < right->topic_name;
+    });
+
+  return messages;
+}
+
+void TransientLocalMessagesCache::clear()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto & [_, topic_queue] : topic_queues_) {
+    topic_queue.messages.clear();
+  }
+}
+
+size_t TransientLocalMessagesCache::size() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  size_t total_size = 0;
+  for (const auto & [_, topic_queue] : topic_queues_) {
+    total_size += topic_queue.messages.size();
+  }
+  return total_size;
+}
+
+}  // namespace cache
+}  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/transient_local_messages_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/transient_local_messages_cache.cpp
@@ -72,13 +72,9 @@ std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr>
 TransientLocalMessagesCache::get_messages_sorted_by_timestamp() const
 {
   std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr> messages;
+  messages.reserve(this->size());
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    size_t total_count = 0;
-    for (const auto & [_, topic_queue] : topic_queues_) {
-      total_count += topic_queue.messages.size();
-    }
-    messages.reserve(total_count);
     for (const auto & [_, topic_queue] : topic_queues_) {
       messages.insert(messages.end(), topic_queue.messages.begin(), topic_queue.messages.end());
     }

--- a/rosbag2_cpp/test/rosbag2_cpp/test_transient_local_messages_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_transient_local_messages_cache.cpp
@@ -1,0 +1,84 @@
+// Copyright 2026 Dexory
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosbag2_cpp/cache/transient_local_messages_cache.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+
+using namespace testing;  // NOLINT
+
+namespace
+{
+std::shared_ptr<rosbag2_storage::SerializedBagMessage> make_message(
+  const std::string & topic,
+  rcutils_time_point_value_t recv_timestamp,
+  rcutils_time_point_value_t send_timestamp)
+{
+  auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message->topic_name = topic;
+  message->recv_timestamp = recv_timestamp;
+  message->send_timestamp = send_timestamp;
+  return message;
+}
+}  // namespace
+
+TEST(TransientLocalMessagesCacheTest, keeps_only_last_n_messages_per_topic)
+{
+  rosbag2_cpp::cache::TransientLocalMessagesCache cache;
+  cache.add_topic("/map", 2);
+
+  cache.push("/map", make_message("/map", 1, 1));
+  cache.push("/map", make_message("/map", 2, 2));
+  cache.push("/map", make_message("/map", 3, 3));
+
+  auto messages = cache.get_messages_sorted_by_timestamp();
+  ASSERT_THAT(messages.size(), Eq(2u));
+  EXPECT_THAT(messages[0]->recv_timestamp, Eq(2));
+  EXPECT_THAT(messages[1]->recv_timestamp, Eq(3));
+}
+
+TEST(TransientLocalMessagesCacheTest, returns_messages_sorted_across_topics)
+{
+  rosbag2_cpp::cache::TransientLocalMessagesCache cache;
+  cache.add_topic("/tf_static", 2);
+  cache.add_topic("/map", 2);
+
+  cache.push("/tf_static", make_message("/tf_static", 30, 30));
+  cache.push("/map", make_message("/map", 10, 10));
+  cache.push("/tf_static", make_message("/tf_static", 20, 20));
+
+  auto messages = cache.get_messages_sorted_by_timestamp();
+  ASSERT_THAT(messages.size(), Eq(3u));
+  EXPECT_THAT(messages[0]->recv_timestamp, Eq(10));
+  EXPECT_THAT(messages[1]->recv_timestamp, Eq(20));
+  EXPECT_THAT(messages[2]->recv_timestamp, Eq(30));
+}
+
+TEST(TransientLocalMessagesCacheTest, throws_on_push_to_unregistered_topic)
+{
+  rosbag2_cpp::cache::TransientLocalMessagesCache cache;
+  cache.add_topic("/tf_static", 1);
+
+  EXPECT_THROW(
+    cache.push("/map", make_message("/map", 1, 1)),
+    std::runtime_error);
+
+  auto messages = cache.get_messages_sorted_by_timestamp();
+  EXPECT_THAT(messages, IsEmpty());
+}

--- a/rosbag2_storage/include/rosbag2_storage/yaml.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/yaml.hpp
@@ -79,6 +79,27 @@ struct convert<std::unordered_map<std::string, std::string>>
 };
 
 template<>
+struct convert<std::unordered_map<std::string, size_t>>
+{
+  static Node encode(const std::unordered_map<std::string, size_t> & map)
+  {
+    Node node;
+    for (const auto & it : map) {
+      node[it.first] = it.second;
+    }
+    return node;
+  }
+
+  static bool decode(const Node & node, std::unordered_map<std::string, size_t> & map)
+  {
+    for (YAML::const_iterator it = node.begin(); it != node.end(); ++it) {
+      map.emplace(it->first.as<std::string>(), it->second.as<size_t>());
+    }
+    return true;
+  }
+};
+
+template<>
 struct convert<rclcpp::Duration>
 {
   static Node encode(const rclcpp::Duration & duration)

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -91,6 +91,10 @@ public:
   /// than or equal to 0 and less than or equal to 1000.
   float statistics_max_publishing_rate = 1.0f;
 
+  /// \brief Per-topic retention depth for repeating transient-local messages on split/snapshot.
+  /// Empty map disables the feature.
+  std::unordered_map<std::string, size_t> repeat_transient_local_messages{};
+
   /// Note: Please don't forget to update the YAML serialization and deserialization logic in
   /// `record_options.cpp` and the test case `test_yaml_serialization_deserialization`
   /// in `test_record_options.cpp` when updating the fields in RecordOptions.

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -39,7 +39,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
     compression_threads_priority, topic_qos_profile_overrides,
     include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
     start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
-    statistics_max_publishing_rate] = record_options;
+    statistics_max_publishing_rate, repeat_transient_local_messages] = record_options;
   Node node;
   node["all_topics"] = all_topics;
   node["all_services"] = all_services;
@@ -75,6 +75,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
   node["static_topics_uri"] = static_topics_uri;
   node["disable_keyboard_controls"] = disable_keyboard_controls;
   node["statistics_max_publishing_rate"] = statistics_max_publishing_rate;
+  node["repeat_transient_local_messages"] = repeat_transient_local_messages;
   return node;
 }
 
@@ -94,7 +95,7 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
     compression_threads_priority, topic_qos_profile_overrides,
     include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
     start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
-    statistics_max_publishing_rate] = record_options;
+    statistics_max_publishing_rate, repeat_transient_local_messages] = record_options;
 
   optional_assign<bool>(node, "all_topics", all_topics);
   optional_assign<bool>(node, "all_services", all_services);
@@ -152,6 +153,8 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<std::string>(node, "static_topics_uri", static_topics_uri);
   optional_assign<bool>(node, "disable_keyboard_controls", disable_keyboard_controls);
   optional_assign<float>(node, "statistics_max_publishing_rate", statistics_max_publishing_rate);
+  optional_assign<std::unordered_map<std::string, size_t>>(
+    node, "repeat_transient_local_messages", repeat_transient_local_messages);
   return true;
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -56,6 +56,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   original.static_topics_uri = "/static/topics.yaml";
   original.disable_keyboard_controls = true;
   original.statistics_max_publishing_rate = 5.0f;
+  original.repeat_transient_local_messages = {{"/map", 1}, {"/tf_static", 5}};
 
   auto node = YAML::convert<rosbag2_transport::RecordOptions>::encode(original);
 
@@ -97,6 +98,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   CHECK(use_sim_time);
   CHECK(static_topics_uri);
   CHECK(disable_keyboard_controls);
+  CHECK(repeat_transient_local_messages);
   #undef CHECK
   ASSERT_FLOAT_EQ(original.statistics_max_publishing_rate,
                   reconstructed.statistics_max_publishing_rate);


### PR DESCRIPTION
## Description

**Part 1 of 3** — Split from #2342 per review feedback to make the feature more reviewable.

This PR introduces the foundational data structures for repeating transient-local messages on bag split and snapshot:

### Changes

**`TransientLocalMessagesCache` class** (new, `rosbag2_cpp`)
- Per-topic FIFO queues with configurable max depth
- Thread-safe push/retrieval with mutex protection
- `get_messages_sorted_by_timestamp()` returns messages across all topics sorted by `recv_timestamp`
- Automatic eviction when queue exceeds configured depth

**`RecordOptions` extension** (`rosbag2_transport`)
- New `repeat_transient_local_messages` field: `std::unordered_map<std::string, size_t>`
- Maps topic name → retention depth (number of last messages to cache)
- YAML serialization/deserialization support

### Tests
- `test_transient_local_messages_cache`: verifies eviction, cross-topic sorting, unregistered topic handling
- `test_record_options`: YAML roundtrip for the new field

Fixes (partially): #1159, #1886
Design document: #2327