### PR TITLE
[2/3] Repeat transient-local topics: Writer API and split/snapshot integration

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/cache/transient_local_messages_cache.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/cache/transient_local_messages_cache.hpp
@@ -67,7 +67,7 @@ public:
   /// \brief Retrieve all cached messages across all topics, sorted by timestamp.
   /// Messages are sorted by recv_timestamp first, then send_timestamp, then topic_name.
   /// \return A vector of cached messages sorted by timestamp.
-  std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr>
+  std::vector<rosbag2_storage::SerializedBagMessageSharedPtr>
   get_messages_sorted_by_timestamp() const;
 
   /// \brief Clear all cached messages from all topics without removing the topic registrations.

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_CPP__WRITER_HPP_
 #define ROSBAG2_CPP__WRITER_HPP_
 
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -114,6 +115,15 @@ public:
    */
   void create_topic(
     const rosbag2_storage::TopicMetadata & topic_with_type,
+    const rosbag2_storage::MessageDefinition & message_definition);
+
+  void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages);
+
+  void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages,
     const rosbag2_storage::MessageDefinition & message_definition);
 
   /**

--- a/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_CPP__WRITER_INTERFACES__BASE_WRITER_INTERFACE_HPP_
 #define ROSBAG2_CPP__WRITER_INTERFACES__BASE_WRITER_INTERFACE_HPP_
 
+#include <cstddef>
 #include <memory>
 
 #include "rosbag2_cpp/bag_events.hpp"
@@ -46,6 +47,15 @@ public:
 
   virtual void create_topic(
     const rosbag2_storage::TopicMetadata & topic_with_type,
+    const rosbag2_storage::MessageDefinition & message_definition) = 0;
+
+  virtual void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages) = 0;
+
+  virtual void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages,
     const rosbag2_storage::MessageDefinition & message_definition) = 0;
 
   virtual void remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type) = 0;

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -27,6 +27,7 @@
 #include "rosbag2_cpp/cache/circular_message_cache.hpp"
 #include "rosbag2_cpp/cache/message_cache.hpp"
 #include "rosbag2_cpp/cache/message_cache_interface.hpp"
+#include "rosbag2_cpp/cache/transient_local_messages_cache.hpp"
 #include "rosbag2_cpp/converter.hpp"
 #include "rosbag2_cpp/message_definitions/local_message_definition_source.hpp"
 #include "rosbag2_cpp/serialization_format_converter_factory.hpp"
@@ -112,6 +113,15 @@ public:
     const rosbag2_storage::TopicMetadata & topic_with_type,
     const rosbag2_storage::MessageDefinition & message_definition) override;
 
+  void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages) override;
+
+  void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages,
+    const rosbag2_storage::MessageDefinition & message_definition) override;
+
   /**
    * \brief Removes a new topic in the underlying storage.
    * \details Expected to be used if creation of subscription fails and cleanup is needed.
@@ -163,11 +173,16 @@ protected:
   bool use_cache_ {false};
   std::shared_ptr<rosbag2_cpp::cache::MessageCacheInterface> message_cache_;
   std::unique_ptr<rosbag2_cpp::cache::CacheConsumer> cache_consumer_;
+  std::shared_ptr<rosbag2_cpp::cache::TransientLocalMessagesCache> transient_local_cache_;
 
   /// \brief Flush the cache, update metadata and close the storage.
   void flush_cache_update_metadata_and_close_storage();
 
   std::string split_bagfile_local(bool execute_callbacks = true);
+
+  void prepend_transient_local_messages(
+    rcutils_time_point_value_t recv_timestamp,
+    rcutils_time_point_value_t send_timestamp);
 
   void execute_bag_split_callbacks(
     const std::string & closed_file, const std::string & opened_file);
@@ -252,7 +267,6 @@ protected:
    */
   void on_messages_lost(std::shared_ptr<std::vector<bag_events::MessagesLostInfo>> msgs_lost_info);
 
-private:
   /**
    * \brief Helper method to write messages while also updating tracked metadata.
    * \param messages The list of messages to write.
@@ -260,9 +274,12 @@ private:
   void write_messages(
     const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages);
 
+private:
   std::mutex lost_messages_callbacks_mutex_;
   bool is_first_message_ {true};
   std::atomic_bool is_open_{false};
+  rcutils_time_point_value_t last_received_timestamp_{0};
+  rcutils_time_point_value_t last_sent_timestamp_{0};
 
   bag_events::EventCallbackManager callback_manager_;
 };

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -180,7 +180,19 @@ protected:
 
   std::string split_bagfile_local(bool execute_callbacks = true);
 
-  void prepend_transient_local_messages(
+  /**
+   * \brief Write cached transient-local messages to the current storage.
+   *
+   * Retrieves all cached transient-local messages, adjusts their timestamps to the
+   * provided values, writes them to the current storage, and updates metadata
+   * (message counts, starting time) accordingly.
+   *
+   * Called after a bag split to ensure transient-local topics appear in the new bag file.
+   *
+   * \param recv_timestamp The receive timestamp to assign to all transient-local messages.
+   * \param send_timestamp The send timestamp to assign to all transient-local messages.
+   */
+  void write_transient_local_messages(
     rcutils_time_point_value_t recv_timestamp,
     rcutils_time_point_value_t send_timestamp);
 
@@ -278,7 +290,7 @@ private:
   std::mutex lost_messages_callbacks_mutex_;
   bool is_first_message_ {true};
   std::atomic_bool is_open_{false};
-  rcutils_time_point_value_t last_received_timestamp_{0};
+  rcutils_time_point_value_t last_recv_timestamp_{0};
   rcutils_time_point_value_t last_sent_timestamp_{0};
 
   bag_events::EventCallbackManager callback_manager_;

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/message_cache_circular_buffer.cpp
@@ -51,6 +51,9 @@ bool MessageCacheCircularBuffer::push(CacheBufferInterface::buffer_element_t msg
   }
 
   // Remove any old items until there is room for a new message
+  // Note that the possible size_t underflow during subtraction guarded by the check
+  // msg->serialized_data->buffer_length > max_bytes_size_ above, which guarantees that
+  // msg->serialized_data->buffer_length is less than or equal to max_bytes_size_.
   while (max_bytes_size_ > 0 &&
     buffer_bytes_size_ > (max_bytes_size_ - msg->serialized_data->buffer_length))
   {
@@ -59,7 +62,7 @@ bool MessageCacheCircularBuffer::push(CacheBufferInterface::buffer_element_t msg
   }
   // Remove old messages until the time span between the oldest and newest message
   // is less than or equal to max_cache_duration_ns_.
-  if (max_cache_duration_ns_ > 0 && buffer_.size() > 0) {
+  if (max_cache_duration_ns_ > 0 && !buffer_.empty()) {
     // Note: the oldest messages are at the front of the deque
     auto prospected_buffer_duration = msg->recv_timestamp - buffer_.front()->recv_timestamp;
     if (prospected_buffer_duration < 0) {
@@ -84,11 +87,12 @@ bool MessageCacheCircularBuffer::push(CacheBufferInterface::buffer_element_t msg
         return static_cast<uint64_t>(prospected_buffer_duration) > max_cache_duration_ns_;
       };
 
-    while (buffer_.size() > 0 && prospected_buffer_duration_exceed_limit()) {
+    while (!buffer_.empty() && prospected_buffer_duration_exceed_limit()) {
       buffer_bytes_size_ -= buffer_.front()->serialized_data->buffer_length;
       buffer_.pop_front();
       // Note: the oldest messages are at the front of the deque
-      prospected_buffer_duration = msg->recv_timestamp - buffer_.front()->recv_timestamp;
+      prospected_buffer_duration =
+        buffer_.empty() ? 0 : msg->recv_timestamp - buffer_.front()->recv_timestamp;
     }
   }
   // Add a new message to the end of the buffer

--- a/rosbag2_cpp/src/rosbag2_cpp/cache/transient_local_messages_cache.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/cache/transient_local_messages_cache.cpp
@@ -68,15 +68,17 @@ void TransientLocalMessagesCache::push(
   }
 }
 
-std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr>
+std::vector<rosbag2_storage::SerializedBagMessageSharedPtr>
 TransientLocalMessagesCache::get_messages_sorted_by_timestamp() const
 {
-  std::vector<rosbag2_storage::SerializedBagMessageConstSharedPtr> messages;
+  std::vector<rosbag2_storage::SerializedBagMessageSharedPtr> messages;
   messages.reserve(this->size());
   {
     std::lock_guard<std::mutex> lock(mutex_);
     for (const auto & [_, topic_queue] : topic_queues_) {
-      messages.insert(messages.end(), topic_queue.messages.begin(), topic_queue.messages.end());
+      for (const auto & msg : topic_queue.messages) {
+        messages.emplace_back(std::make_shared<rosbag2_storage::SerializedBagMessage>(*msg));
+      }
     }
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -86,6 +86,24 @@ void Writer::create_topic(
   writer_impl_->create_topic(topic_with_type, message_definition);
 }
 
+void Writer::create_transient_local_topic(
+  const rosbag2_storage::TopicMetadata & topic_with_type,
+  size_t num_last_messages)
+{
+  std::lock_guard<std::mutex> writer_lock(writer_mutex_);
+  writer_impl_->create_transient_local_topic(topic_with_type, num_last_messages);
+}
+
+void Writer::create_transient_local_topic(
+  const rosbag2_storage::TopicMetadata & topic_with_type,
+  size_t num_last_messages,
+  const rosbag2_storage::MessageDefinition & message_definition)
+{
+  std::lock_guard<std::mutex> writer_lock(writer_mutex_);
+  writer_impl_->create_transient_local_topic(
+    topic_with_type, num_last_messages, message_definition);
+}
+
 void Writer::remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
 {
   std::lock_guard<std::mutex> writer_lock(writer_mutex_);

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -59,6 +59,7 @@ SequentialWriter::SequentialWriter(
   storage_(nullptr),
   metadata_io_(std::move(metadata_io)),
   converter_(nullptr),
+  transient_local_cache_(std::make_shared<rosbag2_cpp::cache::TransientLocalMessagesCache>()),
   metadata_()
 {}
 
@@ -293,8 +294,26 @@ void SequentialWriter::create_topic(
   }
 }
 
+void SequentialWriter::create_transient_local_topic(
+  const rosbag2_storage::TopicMetadata & topic_with_type,
+  size_t num_last_messages)
+{
+  transient_local_cache_->add_topic(topic_with_type.name, num_last_messages);
+  create_topic(topic_with_type);
+}
+
+void SequentialWriter::create_transient_local_topic(
+  const rosbag2_storage::TopicMetadata & topic_with_type,
+  size_t num_last_messages,
+  const rosbag2_storage::MessageDefinition & message_definition)
+{
+  transient_local_cache_->add_topic(topic_with_type.name, num_last_messages);
+  create_topic(topic_with_type, message_definition);
+}
+
 void SequentialWriter::remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
 {
+  transient_local_cache_->remove_topic(topic_with_type.name);
   std::lock_guard<std::mutex> lock(topics_info_mutex_);
   bool erased = topics_names_to_info_.erase(topic_with_type.name) > 0;
   erased = erased && (topic_names_to_message_definitions_.erase(topic_with_type.name) > 0);
@@ -412,6 +431,12 @@ std::string SequentialWriter::split_bagfile_local(bool execute_callbacks)
 {
   auto closed_file = storage_->get_relative_file_path();
   switch_to_next_storage();
+  // In non-snapshot mode, prepend cached transient-local messages to the new bag file so that
+  // transient-local topics appear in every split. In snapshot mode the merge happens
+  // later inside write_messages() where the circular buffer is flushed together with the snapshot.
+  if (!storage_options_.snapshot_mode) {
+    prepend_transient_local_messages(last_received_timestamp_, last_sent_timestamp_);
+  }
   auto opened_file = storage_->get_relative_file_path();
 
   if (execute_callbacks) {
@@ -482,6 +507,9 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
     std::max(metadata_.files.back().duration, file_duration);
 
   auto converted_msg = get_writeable_message(message);
+  if (transient_local_cache_->has_topic(topic_name)) {
+    transient_local_cache_->push(topic_name, converted_msg);
+  }
 
   bool message_lost = false;
   if (storage_options_.max_cache_size == 0u) {
@@ -504,6 +532,9 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
     msgs_lost_info->emplace_back(bag_events::MessagesLostInfo{message->topic_name, 1});
     on_messages_lost(std::move(msgs_lost_info));
   }
+
+  last_received_timestamp_ = message->recv_timestamp;
+  last_sent_timestamp_ = message->send_timestamp;
 }
 
 bool SequentialWriter::take_snapshot()
@@ -524,6 +555,41 @@ SequentialWriter::get_writeable_message(
   std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
 {
   return converter_ ? converter_->convert(message) : message;
+}
+
+void SequentialWriter::prepend_transient_local_messages(
+  rcutils_time_point_value_t recv_timestamp,
+  rcutils_time_point_value_t send_timestamp)
+{
+  auto transient_messages = transient_local_cache_->get_messages_sorted_by_timestamp();
+  if (transient_messages.empty()) {
+    return;
+  }
+
+  // Adjust timestamps directly in the transient_messages vector to avoid an extra allocation.
+  for (auto & msg_ptr : transient_messages) {
+    auto mutable_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>(*msg_ptr);
+    mutable_msg->recv_timestamp = recv_timestamp;
+    mutable_msg->send_timestamp = send_timestamp;
+    msg_ptr = std::move(mutable_msg);
+  }
+
+  storage_->write_messages(transient_messages);
+  metadata_.message_count += transient_messages.size();
+  metadata_.files.back().message_count += transient_messages.size();
+  const auto prepend_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
+    std::chrono::nanoseconds(recv_timestamp));
+  metadata_.starting_time = std::min(metadata_.starting_time, prepend_time);
+  metadata_.files.back().starting_time = std::min(metadata_.files.back().starting_time,
+        prepend_time);
+
+  std::lock_guard<std::mutex> lock(topics_info_mutex_);
+  for (const auto & message : transient_messages) {
+    if (topics_names_to_info_.find(message->topic_name) != topics_names_to_info_.end()) {
+      topics_names_to_info_[message->topic_name].message_count++;
+      per_file_topic_message_counts_.back()[message->topic_name]++;
+    }
+  }
 }
 
 bool SequentialWriter::should_split_bagfile(
@@ -663,14 +729,41 @@ void SequentialWriter::write_messages(
   if (messages.empty()) {
     return;
   }
-  auto lost_messages_idx = storage_->write_messages(messages);
-  auto written_messages_count = messages.size() - lost_messages_idx.size();
+  std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> merged_messages;
+  const auto * messages_to_write = &messages;
+
+  if (storage_options_.snapshot_mode && transient_local_cache_) {
+    const auto snapshot_earliest_recv_timestamp = messages.front()->recv_timestamp;
+    const auto snapshot_earliest_send_timestamp = messages.front()->send_timestamp;
+    auto transient_messages = transient_local_cache_->get_messages_sorted_by_timestamp();
+    merged_messages.reserve(messages.size() + transient_messages.size());
+
+    // Only prepend transient messages whose timestamps predate the snapshot window.
+    // Messages inside the window are already present in the snapshot buffer.
+    // Adjusted transient messages all receive the snapshot-earliest timestamp, so they
+    // naturally sort before (or equal to) the first snapshot message — no extra sort needed.
+    for (const auto & transient_message : transient_messages) {
+      if (transient_message->recv_timestamp < snapshot_earliest_recv_timestamp) {
+        auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>(*transient_message);
+        msg->recv_timestamp = snapshot_earliest_recv_timestamp;
+        msg->send_timestamp = snapshot_earliest_send_timestamp;
+        merged_messages.emplace_back(std::move(msg));
+      }
+    }
+
+    merged_messages.insert(merged_messages.end(), messages.begin(), messages.end());
+    messages_to_write = &merged_messages;
+  }
+
+  auto lost_messages_idx = storage_->write_messages(*messages_to_write);
+  auto written_messages_count = messages_to_write->size() - lost_messages_idx.size();
+
   if (storage_options_.snapshot_mode && written_messages_count > 0) {
     // Update FileInformation about the last file in metadata in case of snapshot mode
     size_t first_msg_index = 0;
     // If some messages were lost, we need to find the first message that was written
     if (!lost_messages_idx.empty()) {
-      for (size_t i = 0; i < messages.size(); ++i) {
+      for (size_t i = 0; i < messages_to_write->size(); ++i) {
         auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
         if (!is_lost) {
           first_msg_index = i;
@@ -678,10 +771,10 @@ void SequentialWriter::write_messages(
         }
       }
     }
-    size_t last_msg_index = messages.size() - 1;
+    size_t last_msg_index = messages_to_write->size() - 1;
     // If some messages were lost, we need to find the last message that was written
     if (!lost_messages_idx.empty()) {
-      for (size_t i = messages.size() - 1; i >= first_msg_index; i--) {
+      for (size_t i = messages_to_write->size(); i-- > first_msg_index; ) {
         auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
         if (!is_lost) {
           last_msg_index = i;
@@ -691,29 +784,31 @@ void SequentialWriter::write_messages(
     }
 
     const auto first_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
-      std::chrono::nanoseconds(messages[first_msg_index]->recv_timestamp));
+      std::chrono::nanoseconds((*messages_to_write)[first_msg_index]->recv_timestamp));
     const auto last_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
-      std::chrono::nanoseconds(messages[last_msg_index]->recv_timestamp));
+      std::chrono::nanoseconds((*messages_to_write)[last_msg_index]->recv_timestamp));
     metadata_.files.back().starting_time = first_msg_timestamp;
     metadata_.files.back().duration = last_msg_timestamp - first_msg_timestamp;
   }
+
   metadata_.files.back().message_count += written_messages_count;
   metadata_.message_count += written_messages_count;
 
   {  // Update message count for each topic in metadata
     std::lock_guard<std::mutex> lock(topics_info_mutex_);
-    for (size_t i = 0; i < messages.size(); i++) {
-      // If some messages were lost, we need to skip them
+    for (size_t i = 0; i < messages_to_write->size(); i++) {
       if (!lost_messages_idx.empty()) {
         auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
         if (is_lost) {
-          continue;  // Skip lost messages
+          continue;
         }
       }
-      auto topic_info_it = topics_names_to_info_.find(messages[i]->topic_name);
+
+      const auto & msg = (*messages_to_write)[i];
+      auto topic_info_it = topics_names_to_info_.find(msg->topic_name);
       if (topic_info_it != topics_names_to_info_.end()) {
         topic_info_it->second.message_count++;
-        per_file_topic_message_counts_.back()[messages[i]->topic_name]++;
+        per_file_topic_message_counts_.back()[msg->topic_name]++;
       }
     }
   }
@@ -722,7 +817,7 @@ void SequentialWriter::write_messages(
   if (!lost_messages_idx.empty()) {
     std::unordered_map<std::string, size_t> lost_messages_count;
     for (const auto & lost_message_index : lost_messages_idx) {
-      const auto & topic_name = messages[lost_message_index]->topic_name;
+      const auto & topic_name = (*messages_to_write)[lost_message_index]->topic_name;
       lost_messages_count[topic_name]++;
     }
     auto msgs_lost_info = std::make_shared<std::vector<bag_events::MessagesLostInfo>>();

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -431,11 +431,11 @@ std::string SequentialWriter::split_bagfile_local(bool execute_callbacks)
 {
   auto closed_file = storage_->get_relative_file_path();
   switch_to_next_storage();
-  // In non-snapshot mode, prepend cached transient-local messages to the new bag file so that
+  // In non-snapshot mode, write cached transient-local messages to the new bag file so that
   // transient-local topics appear in every split. In snapshot mode the merge happens
   // later inside write_messages() where the circular buffer is flushed together with the snapshot.
   if (!storage_options_.snapshot_mode) {
-    prepend_transient_local_messages(last_received_timestamp_, last_sent_timestamp_);
+    write_transient_local_messages(last_recv_timestamp_, last_sent_timestamp_);
   }
   auto opened_file = storage_->get_relative_file_path();
 
@@ -533,7 +533,7 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
     on_messages_lost(std::move(msgs_lost_info));
   }
 
-  last_received_timestamp_ = message->recv_timestamp;
+  last_recv_timestamp_ = message->recv_timestamp;
   last_sent_timestamp_ = message->send_timestamp;
 }
 
@@ -557,7 +557,7 @@ SequentialWriter::get_writeable_message(
   return converter_ ? converter_->convert(message) : message;
 }
 
-void SequentialWriter::prepend_transient_local_messages(
+void SequentialWriter::write_transient_local_messages(
   rcutils_time_point_value_t recv_timestamp,
   rcutils_time_point_value_t send_timestamp)
 {

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -574,9 +574,11 @@ void SequentialWriter::write_transient_local_messages(
     msg->send_timestamp = send_timestamp;
   }
 
-  storage_->write_messages(transient_messages);
-  metadata_.message_count += transient_messages.size();
-  metadata_.files.back().message_count += transient_messages.size();
+  rosbag2_storage::SerializedBagMessages const_messages(
+    transient_messages.begin(), transient_messages.end());
+  storage_->write_messages(const_messages);
+  metadata_.message_count += const_messages.size();
+  metadata_.files.back().message_count += const_messages.size();
   const auto prepend_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
     std::chrono::nanoseconds(recv_timestamp));
   metadata_.starting_time = std::min(metadata_.starting_time, prepend_time);
@@ -584,7 +586,7 @@ void SequentialWriter::write_transient_local_messages(
     std::min(metadata_.files.back().starting_time, prepend_time);
 
   std::lock_guard<std::mutex> lock(topics_info_mutex_);
-  for (const auto & message : transient_messages) {
+  for (const auto & message : const_messages) {
     if (topics_names_to_info_.find(message->topic_name) != topics_names_to_info_.end()) {
       topics_names_to_info_[message->topic_name].message_count++;
       per_file_topic_message_counts_.back()[message->topic_name]++;

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -568,12 +568,10 @@ void SequentialWriter::write_transient_local_messages(
     return;
   }
 
-  // Adjust timestamps directly in the transient_messages vector to avoid an extra allocation.
-  for (auto & msg_ptr : transient_messages) {
-    auto mutable_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>(*msg_ptr);
-    mutable_msg->recv_timestamp = recv_timestamp;
-    mutable_msg->send_timestamp = send_timestamp;
-    msg_ptr = std::move(mutable_msg);
+  // Adjust timestamps directly on the mutable messages returned by the cache.
+  for (auto & msg : transient_messages) {
+    msg->recv_timestamp = recv_timestamp;
+    msg->send_timestamp = send_timestamp;
   }
 
   storage_->write_messages(transient_messages);
@@ -744,12 +742,11 @@ void SequentialWriter::write_messages(
     // Messages inside the window are already present in the snapshot buffer.
     // Adjusted transient messages all receive the snapshot-earliest timestamp, so they
     // naturally sort before (or equal to) the first snapshot message — no extra sort needed.
-    for (const auto & transient_message : transient_messages) {
+    for (auto & transient_message : transient_messages) {
       if (transient_message->recv_timestamp < snapshot_earliest_recv_timestamp) {
-        auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>(*transient_message);
-        msg->recv_timestamp = snapshot_earliest_recv_timestamp;
-        msg->send_timestamp = snapshot_earliest_send_timestamp;
-        merged_messages.emplace_back(std::move(msg));
+        transient_message->recv_timestamp = snapshot_earliest_recv_timestamp;
+        transient_message->send_timestamp = snapshot_earliest_send_timestamp;
+        merged_messages.emplace_back(std::move(transient_message));
       }
     }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -313,7 +313,9 @@ void SequentialWriter::create_transient_local_topic(
 
 void SequentialWriter::remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type)
 {
-  transient_local_cache_->remove_topic(topic_with_type.name);
+  if (transient_local_cache_->has_topic(topic_with_type.name)) {
+    transient_local_cache_->remove_topic(topic_with_type.name);
+  }
   std::lock_guard<std::mutex> lock(topics_info_mutex_);
   bool erased = topics_names_to_info_.erase(topic_with_type.name) > 0;
   erased = erased && (topic_names_to_message_definitions_.erase(topic_with_type.name) > 0);

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -576,21 +576,49 @@ void SequentialWriter::write_transient_local_messages(
 
   rosbag2_storage::SerializedBagMessages const_messages(
     transient_messages.begin(), transient_messages.end());
-  storage_->write_messages(const_messages);
-  metadata_.message_count += const_messages.size();
-  metadata_.files.back().message_count += const_messages.size();
+  auto lost_messages_idx = storage_->write_messages(const_messages);
+  auto written_messages_count = const_messages.size() - lost_messages_idx.size();
+
+  metadata_.message_count += written_messages_count;
+  metadata_.files.back().message_count += written_messages_count;
   const auto prepend_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
     std::chrono::nanoseconds(recv_timestamp));
   metadata_.starting_time = std::min(metadata_.starting_time, prepend_time);
   metadata_.files.back().starting_time =
     std::min(metadata_.files.back().starting_time, prepend_time);
 
-  std::lock_guard<std::mutex> lock(topics_info_mutex_);
-  for (const auto & message : const_messages) {
-    if (topics_names_to_info_.find(message->topic_name) != topics_names_to_info_.end()) {
-      topics_names_to_info_[message->topic_name].message_count++;
-      per_file_topic_message_counts_.back()[message->topic_name]++;
+  {
+    std::lock_guard<std::mutex> lock(topics_info_mutex_);
+    for (size_t i = 0; i < const_messages.size(); i++) {
+      if (!lost_messages_idx.empty()) {
+        auto is_lost = std::binary_search(lost_messages_idx.begin(), lost_messages_idx.end(), i);
+        if (is_lost) {
+          continue;
+        }
+      }
+
+      const auto & message = const_messages[i];
+      auto topic_info_it = topics_names_to_info_.find(message->topic_name);
+      if (topic_info_it != topics_names_to_info_.end()) {
+        topic_info_it->second.message_count++;
+        per_file_topic_message_counts_.back()[message->topic_name]++;
+      }
     }
+  }
+
+  // Notify about lost messages via callback
+  if (!lost_messages_idx.empty()) {
+    std::unordered_map<std::string, size_t> lost_messages_count;
+    for (const auto & lost_message_index : lost_messages_idx) {
+      const auto & topic_name = const_messages[lost_message_index]->topic_name;
+      lost_messages_count[topic_name]++;
+    }
+    auto msgs_lost_info = std::make_shared<std::vector<bag_events::MessagesLostInfo>>();
+    msgs_lost_info->reserve(lost_messages_count.size());
+    for (const auto & [topic_name, count] : lost_messages_count) {
+      msgs_lost_info->emplace_back(bag_events::MessagesLostInfo{topic_name, count});
+    }
+    on_messages_lost(std::move(msgs_lost_info));
   }
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -780,7 +780,7 @@ void SequentialWriter::write_messages(
       }
     }
 
-    merged_messages.insert(merged_messages.end(), messages.begin(), messages.end());
+    std::copy(messages.begin(), messages.end(), std::back_inserter(merged_messages));
     messages_to_write = &merged_messages;
   }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -514,7 +514,7 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
   }
 
   bool message_lost = false;
-  if (storage_options_.max_cache_size == 0u) {
+  if (storage_options_.max_cache_size == 0u && storage_options_.max_cache_duration == 0u) {
     // If cache size is set to zero, we write to storage directly
     if (storage_->write_message(converted_msg)) {
       metadata_.files.back().message_count++;

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -582,8 +582,8 @@ void SequentialWriter::write_transient_local_messages(
   const auto prepend_time = std::chrono::time_point<std::chrono::high_resolution_clock>(
     std::chrono::nanoseconds(recv_timestamp));
   metadata_.starting_time = std::min(metadata_.starting_time, prepend_time);
-  metadata_.files.back().starting_time = std::min(metadata_.files.back().starting_time,
-        prepend_time);
+  metadata_.files.back().starting_time =
+    std::min(metadata_.files.back().starting_time, prepend_time);
 
   std::lock_guard<std::mutex> lock(topics_info_mutex_);
   for (const auto & message : transient_messages) {

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -1294,14 +1294,15 @@ TEST_F(SequentialWriterTest, split_prepends_transient_local_messages_to_next_bag
   writer_->write(first_message);
   writer_->write(second_message);
 
-  std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> prepended_messages;
+  rosbag2_storage::SerializedBagMessages prepended_messages;
   EXPECT_CALL(*storage_,
-    write(An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>()))
+    write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
   .WillOnce(Invoke(
       [&prepended_messages](
-        const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
+        const rosbag2_storage::SerializedBagMessages & messages)
       {
         prepended_messages = messages;
+        return std::vector<size_t>{};
       }));
 
   writer_->split_bagfile();
@@ -1356,14 +1357,13 @@ TEST_F(SequentialWriterTest, snapshot_merge_prepends_transient_local_messages)
   sequential_writer->test_write_messages({data_msg});
 
   // Verify: latched message was merged in with adjusted timestamps.
-  // Both messages end up with recv_timestamp=200 (latched adjusted to T_earliest),
-  // so stable_sort orders by topic name: "data_topic" < "latched_topic".
+  // Transient messages are prepended before snapshot messages, so latched comes first.
   ASSERT_EQ(written.size(), 2u);
-  EXPECT_EQ(written[0]->topic_name, data_topic);
-  EXPECT_EQ(written[0]->recv_timestamp, 200);
-  EXPECT_EQ(written[1]->topic_name, latched_topic);
-  EXPECT_EQ(written[1]->recv_timestamp, 200);  // adjusted to T_earliest
-  EXPECT_EQ(written[1]->send_timestamp, 200);
+  EXPECT_EQ(written[0]->topic_name, latched_topic);
+  EXPECT_EQ(written[0]->recv_timestamp, 200);  // adjusted to T_earliest
+  EXPECT_EQ(written[0]->send_timestamp, 200);
+  EXPECT_EQ(written[1]->topic_name, data_topic);
+  EXPECT_EQ(written[1]->recv_timestamp, 200);
 }
 
 TEST_F(SequentialWriterTest, circular_logging_limits_number_of_files_by_max_bag_files)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -68,12 +68,6 @@ public:
     message_cache_ = std::move(message_cache);
     cache_consumer_ = std::move(cache_consumer);
   }
-
-  void test_write_messages(
-    const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
-  {
-    write_messages(messages);
-  }
 };
 
 class SequentialWriterTest : public Test
@@ -1291,19 +1285,23 @@ TEST_F(SequentialWriterTest, split_prepends_transient_local_messages_to_next_bag
   second_message->recv_timestamp = 200;
   second_message->send_timestamp = 200;
 
-  writer_->write(first_message);
-  writer_->write(second_message);
-
   rosbag2_storage::SerializedBagMessages prepended_messages;
-  EXPECT_CALL(*storage_,
-    write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
+  // Expected to call storage_->write_messages(msgs) once from write_transient_local_messages()
+  // because we configured writer to not use cache and messages before split will be written with
+  // via storage_->write_message(msg) directly.
+  EXPECT_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
   .WillOnce(Invoke(
-      [&prepended_messages](
-        const rosbag2_storage::SerializedBagMessages & messages)
+      [&prepended_messages](const rosbag2_storage::SerializedBagMessages & messages)
       {
         prepended_messages = messages;
         return std::vector<size_t>{};
-      }));
+      })
+  );
+  EXPECT_CALL(*storage_,
+    write_message(An<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>())).Times(2);
+
+  writer_->write(first_message);
+  writer_->write(second_message);
 
   writer_->split_bagfile();
 
@@ -1315,10 +1313,22 @@ TEST_F(SequentialWriterTest, split_prepends_transient_local_messages_to_next_bag
 
 TEST_F(SequentialWriterTest, snapshot_merge_prepends_transient_local_messages)
 {
+  rosbag2_storage::SerializedBagMessages written_msgs;
+
+  EXPECT_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
+  .WillOnce(Invoke(
+      [&written_msgs](const rosbag2_storage::SerializedBagMessages & messages)
+      {
+        written_msgs = messages;
+        return std::vector<size_t>{};
+      })
+  );
+
   auto sequential_writer = std::make_unique<SequentialWriterForTest>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
 
-  storage_options_.max_cache_size = 1024;
+  storage_options_.max_cache_size = 0;  // Limit cache only by duration
+  storage_options_.max_cache_duration = 1;  // Limit cache duration to 1 second
   storage_options_.snapshot_mode = true;
   sequential_writer->open(storage_options_, {"rmw_format", "rmw_format"});
 
@@ -1326,7 +1336,7 @@ TEST_F(SequentialWriterTest, snapshot_merge_prepends_transient_local_messages)
   const std::string data_topic = "data_topic";
 
   sequential_writer->create_transient_local_topic(
-    {0u, latched_topic, "test_msgs/BasicTypes", "", {}, ""}, 1);
+    {0u, latched_topic, "test_msgs/BasicTypes", "", {}, ""}, 2);
   sequential_writer->create_topic({0u, data_topic, "test_msgs/BasicTypes", "", {}, ""});
 
   // Write a latched message to populate the transient local cache
@@ -1334,36 +1344,52 @@ TEST_F(SequentialWriterTest, snapshot_merge_prepends_transient_local_messages)
   latched_msg->topic_name = latched_topic;
   latched_msg->recv_timestamp = 100;
   latched_msg->send_timestamp = 100;
-  latched_msg->serialized_data = rosbag2_storage::make_serialized_message("L", 1);
+  latched_msg->serialized_data = rosbag2_storage::make_serialized_message("A", 1);
   sequential_writer->write(latched_msg);
 
-  // Simulate a snapshot buffer where the latched message was evicted
-  // (buffer starts at timestamp 200 > latched message timestamp 100)
+  // Simulate a snapshot buffer where the latched message was evicted due to cache duration limit,
+  // but still exists in the transient local cache.
   auto data_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   data_msg->topic_name = data_topic;
-  data_msg->recv_timestamp = 200;
-  data_msg->send_timestamp = 200;
+  data_msg->recv_timestamp = RCUTILS_S_TO_NS(2);
+  data_msg->send_timestamp = RCUTILS_S_TO_NS(2);
+  data_msg->serialized_data = rosbag2_storage::make_serialized_message("B", 1);
+  sequential_writer->write(data_msg);
+
+  latched_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  latched_msg->topic_name = latched_topic;
+  latched_msg->recv_timestamp = RCUTILS_S_TO_NS(2.5);
+  latched_msg->send_timestamp = RCUTILS_S_TO_NS(2.5);
+  latched_msg->serialized_data = rosbag2_storage::make_serialized_message("C", 1);
+  sequential_writer->write(latched_msg);
+
+  data_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  data_msg->topic_name = data_topic;
+  data_msg->recv_timestamp = RCUTILS_S_TO_NS(3);
+  data_msg->send_timestamp = RCUTILS_S_TO_NS(3);
   data_msg->serialized_data = rosbag2_storage::make_serialized_message("D", 1);
+  sequential_writer->write(data_msg);
 
-  rosbag2_storage::SerializedBagMessages written;
-  ON_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
-  .WillByDefault(
-    [&written](const rosbag2_storage::SerializedBagMessages & msgs) {
-      written = msgs;
-      return std::vector<size_t>{};
-    });
+  sequential_writer->take_snapshot();
 
-  // Directly invoke write_messages with a buffer that doesn't contain the latched msg
-  sequential_writer->test_write_messages({data_msg});
+  // Verify: Transient local message was merged in with adjusted timestamps.
+  // Transient messages are prepended before snapshot messages, so transient messages comes first.
+  ASSERT_EQ(written_msgs.size(), 4u);
+  EXPECT_EQ(written_msgs[0]->topic_name, latched_topic);
+  EXPECT_EQ(written_msgs[0]->recv_timestamp, RCUTILS_S_TO_NS(2));  // adjusted to T_earliest
+  EXPECT_EQ(written_msgs[0]->send_timestamp, RCUTILS_S_TO_NS(2));
 
-  // Verify: latched message was merged in with adjusted timestamps.
-  // Transient messages are prepended before snapshot messages, so latched comes first.
-  ASSERT_EQ(written.size(), 2u);
-  EXPECT_EQ(written[0]->topic_name, latched_topic);
-  EXPECT_EQ(written[0]->recv_timestamp, 200);  // adjusted to T_earliest
-  EXPECT_EQ(written[0]->send_timestamp, 200);
-  EXPECT_EQ(written[1]->topic_name, data_topic);
-  EXPECT_EQ(written[1]->recv_timestamp, 200);
+  EXPECT_EQ(written_msgs[1]->topic_name, data_topic);
+  EXPECT_EQ(written_msgs[1]->recv_timestamp, RCUTILS_S_TO_NS(2));
+  EXPECT_EQ(written_msgs[1]->send_timestamp, RCUTILS_S_TO_NS(2));
+
+  EXPECT_EQ(written_msgs[2]->topic_name, latched_topic);
+  EXPECT_EQ(written_msgs[2]->recv_timestamp, RCUTILS_S_TO_NS(2.5));
+  EXPECT_EQ(written_msgs[2]->send_timestamp, RCUTILS_S_TO_NS(2.5));
+
+  EXPECT_EQ(written_msgs[3]->topic_name, data_topic);
+  EXPECT_EQ(written_msgs[3]->recv_timestamp, RCUTILS_S_TO_NS(3));
+  EXPECT_EQ(written_msgs[3]->send_timestamp, RCUTILS_S_TO_NS(3));
 }
 
 TEST_F(SequentialWriterTest, circular_logging_limits_number_of_files_by_max_bag_files)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -68,6 +68,12 @@ public:
     message_cache_ = std::move(message_cache);
     cache_consumer_ = std::move(cache_consumer);
   }
+
+  void test_write_messages(
+    const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
+  {
+    write_messages(messages);
+  }
 };
 
 class SequentialWriterTest : public Test
@@ -1261,6 +1267,103 @@ TEST_F(SequentialWriterTest, split_event_calls_on_writer_close)
   EXPECT_EQ(extract_counter_from_filename(closed_file), 0u)
     << "Counter in closed filename '" << closed_file << "' does not match expected value";
   EXPECT_TRUE(opened_file.empty());
+}
+
+TEST_F(SequentialWriterTest, split_prepends_transient_local_messages_to_next_bag)
+{
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  storage_options_.max_cache_size = 0;
+  writer_->open(storage_options_, {"rmw_format", "rmw_format"});
+
+  const std::string topic_name = "latched_topic";
+  writer_->create_transient_local_topic({0u, topic_name, "test_msgs/BasicTypes", "", {}, ""}, 1);
+
+  auto first_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  first_message->topic_name = topic_name;
+  first_message->recv_timestamp = 100;
+  first_message->send_timestamp = 100;
+
+  auto second_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  second_message->topic_name = topic_name;
+  second_message->recv_timestamp = 200;
+  second_message->send_timestamp = 200;
+
+  writer_->write(first_message);
+  writer_->write(second_message);
+
+  std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> prepended_messages;
+  EXPECT_CALL(*storage_,
+    write(An<const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> &>()))
+  .WillOnce(Invoke(
+      [&prepended_messages](
+        const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & messages)
+      {
+        prepended_messages = messages;
+      }));
+
+  writer_->split_bagfile();
+
+  ASSERT_EQ(prepended_messages.size(), 1u);
+  EXPECT_EQ(prepended_messages[0]->topic_name, topic_name);
+  EXPECT_EQ(prepended_messages[0]->recv_timestamp, 200);
+  EXPECT_EQ(prepended_messages[0]->send_timestamp, 200);
+}
+
+TEST_F(SequentialWriterTest, snapshot_merge_prepends_transient_local_messages)
+{
+  auto sequential_writer = std::make_unique<SequentialWriterForTest>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+
+  storage_options_.max_cache_size = 1024;
+  storage_options_.snapshot_mode = true;
+  sequential_writer->open(storage_options_, {"rmw_format", "rmw_format"});
+
+  const std::string latched_topic = "latched_topic";
+  const std::string data_topic = "data_topic";
+
+  sequential_writer->create_transient_local_topic(
+    {0u, latched_topic, "test_msgs/BasicTypes", "", {}, ""}, 1);
+  sequential_writer->create_topic({0u, data_topic, "test_msgs/BasicTypes", "", {}, ""});
+
+  // Write a latched message to populate the transient local cache
+  auto latched_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  latched_msg->topic_name = latched_topic;
+  latched_msg->recv_timestamp = 100;
+  latched_msg->send_timestamp = 100;
+  latched_msg->serialized_data = rosbag2_storage::make_serialized_message("L", 1);
+  sequential_writer->write(latched_msg);
+
+  // Simulate a snapshot buffer where the latched message was evicted
+  // (buffer starts at timestamp 200 > latched message timestamp 100)
+  auto data_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  data_msg->topic_name = data_topic;
+  data_msg->recv_timestamp = 200;
+  data_msg->send_timestamp = 200;
+  data_msg->serialized_data = rosbag2_storage::make_serialized_message("D", 1);
+
+  rosbag2_storage::SerializedBagMessages written;
+  ON_CALL(*storage_, write_messages(An<const rosbag2_storage::SerializedBagMessages &>()))
+  .WillByDefault(
+    [&written](const rosbag2_storage::SerializedBagMessages & msgs) {
+      written = msgs;
+      return std::vector<size_t>{};
+    });
+
+  // Directly invoke write_messages with a buffer that doesn't contain the latched msg
+  sequential_writer->test_write_messages({data_msg});
+
+  // Verify: latched message was merged in with adjusted timestamps.
+  // Both messages end up with recv_timestamp=200 (latched adjusted to T_earliest),
+  // so stable_sort orders by topic name: "data_topic" < "latched_topic".
+  ASSERT_EQ(written.size(), 2u);
+  EXPECT_EQ(written[0]->topic_name, data_topic);
+  EXPECT_EQ(written[0]->recv_timestamp, 200);
+  EXPECT_EQ(written[1]->topic_name, latched_topic);
+  EXPECT_EQ(written[1]->recv_timestamp, 200);  // adjusted to T_earliest
+  EXPECT_EQ(written[1]->send_timestamp, 200);
 }
 
 TEST_F(SequentialWriterTest, circular_logging_limits_number_of_files_by_max_bag_files)

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -55,6 +55,23 @@ public:
     topics_.emplace(topic_with_type.name, std::make_pair(topic_with_type, message_definition));
   }
 
+  void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages) override
+  {
+    transient_local_topic_depths_[topic_with_type.name] = num_last_messages;
+    create_topic(topic_with_type);
+  }
+
+  void create_transient_local_topic(
+    const rosbag2_storage::TopicMetadata & topic_with_type,
+    size_t num_last_messages,
+    const rosbag2_storage::MessageDefinition & message_definition) override
+  {
+    transient_local_topic_depths_[topic_with_type.name] = num_last_messages;
+    create_topic(topic_with_type, message_definition);
+  }
+
   void remove_topic(const rosbag2_storage::TopicMetadata & topic_with_type) override
   {
     (void) topic_with_type;
@@ -141,6 +158,13 @@ public:
     return copy_of_messages_per_topic;
   }
 
+  std::unordered_map<std::string, size_t> transient_local_topic_depths() const
+  {
+    std::lock_guard<std::mutex> lock(messages_mutex_);
+    auto copy_of_transient_local_topic_depths = transient_local_topic_depths_;
+    return copy_of_transient_local_topic_depths;
+  }
+
   size_t get_messages_per_topic(const std::string & topic_name) const
   {
     std::lock_guard<std::mutex> lock(messages_mutex_);
@@ -186,6 +210,7 @@ private:
   std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> messages_;
   std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> snapshot_buffer_;
   std::unordered_map<std::string, size_t> messages_per_topic_;
+  std::unordered_map<std::string, size_t> transient_local_topic_depths_;
   size_t messages_per_file_ = 0;
   mutable std::mutex messages_mutex_;
   rosbag2_cpp::bag_events::EventCallbackManager callback_manager_;


### PR DESCRIPTION
## Description

**Part 2 of 3** — Split from #2342 per review feedback.

This PR extends the writer layer to support transient-local message caching, prepending on bag split, and merging on snapshot.

### Changes

**`BaseWriterInterface`** — New pure virtual methods:
- `create_transient_local_topic(TopicMetadata, depth)` — with and without `MessageDefinition` overload

**`SequentialWriter`** — Core implementation:
- `create_transient_local_topic()`: registers topic in `TransientLocalMessagesCache` + delegates to `create_topic()`
- `remove_topic()`: cleans up cache entry
- `write()`: dual-writes messages to cache for transient-local topics
- `prepend_transient_local_messages()`: on split, retrieves cached messages, adjusts timestamps to the last-message edge, batch-writes to new storage
- `write_messages()`: on snapshot, merges transient-local cache with circular buffer, deduplicates messages inside the snapshot window, stable-sorts by timestamp

**`Writer`** — Forwarding wrappers for `create_transient_local_topic()`

### Tests
- `split_prepends_transient_local_messages_to_next_bag` — verifies messages appear at start of split bag with adjusted timestamps
- `snapshot_merge_prepends_transient_local_messages` — verifies merge, deduplication, and timestamp adjustment in snapshot mode
- `mock_sequential_writer.hpp` — tracks `create_transient_local_topic()` calls for recorder-level tests

Fixes (partially): #1159, #1886
Design document: #2327