### PR TITLE
[3/3] Repeat transient-local topics: Recorder, CLI, and Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,41 @@ _Splitting by time_: `ros2 bag record -a -d 9000` will split the bag files after
 
 If both splitting by size and duration are enabled, the bag will split at whichever threshold is reached first.
 
+#### Repeating transient-local messages on split and snapshot
+
+When a bag file is split or a snapshot is taken, consumers of the new file may need certain
+transient-local (latched) messages — such as `/map` or `/tf_static` — to be present, even if
+they were not published again during the new file's timespan.
+
+The `--repeat-transient-local` option tells the recorder to retain the last N messages for
+specified topics and prepend them when a new bag file starts (on split) or when a snapshot is
+written.
+
+Format: `--repeat-transient-local <topic>[=<depth>] [...]`
+
+The depth controls how many of the most recent messages are retained per topic. If omitted, the
+default depth is `1`.
+
+Examples:
+
+```bash
+# Repeat last message of /map and /tf_static on each bag split
+$ ros2 bag record -a --repeat-transient-local /map /tf_static
+
+# Repeat last 5 messages of /tf_static, last 1 of /map
+$ ros2 bag record -a --repeat-transient-local /tf_static=5 /map
+
+# Combined with snapshot mode
+$ ros2 bag record -a --snapshot-mode --max-cache-size 100000000 --repeat-transient-local /map
+```
+
+This option also works via node parameters as `record.repeat_transient_local`, accepting a list
+of strings in the same `<topic>` or `<topic>=<depth>` format.
+
+**Note**: If a topic has both a QoS profile override (via `--qos-profile-overrides-path`) and is
+listed in `--repeat-transient-local`, the QoS override takes precedence. Ensure the override
+includes `transient_local` durability to receive latched messages.
+
 #### Recording with compression
 
 By default Rosbag2 does not record with compression enabled. However, compression can be specified using the following CLI options.

--- a/README.md
+++ b/README.md
@@ -133,9 +133,6 @@ $ ros2 bag record -a --repeat-transient-local /map /tf_static
 
 # Repeat last 5 messages of /tf_static, last 1 of /map
 $ ros2 bag record -a --repeat-transient-local /tf_static=5 /map
-
-# Combined with snapshot mode
-$ ros2 bag record -a --snapshot-mode --max-cache-size 100000000 --repeat-transient-local /map
 ```
 
 This option also works via node parameters as `record.repeat_transient_local`, accepting a list

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -38,32 +38,36 @@ from rosbag2_py import StorageOptions
 import yaml
 
 
+def split_key_value(entry, default_value=''):
+    """Split a 'key=value' string. Returns (key, value) or (entry, default_value) if no '='."""
+    if '=' in entry:
+        key, value = entry.split('=', 1)
+        return key, value
+    return entry, default_value
+
+
 def parse_repeat_transient_local_topics(values):
     repeat_topics = {}
     if not values:
         return repeat_topics
 
     for value in values:
-        topic = value
-        depth = 1
-        if '=' in value:
-            topic, parsed_depth = value.split('=', 1)
-            if not parsed_depth:
-                raise ValueError(
-                    f'Invalid value for --repeat-transient-local: "{value}". '
-                    'Expected format <topic> or <topic>=<depth>.')
-            try:
-                depth = int(parsed_depth)
-            except ValueError as exc:
-                raise ValueError(
-                    f'Invalid depth for --repeat-transient-local: "{value}". '
-                    'Depth must be a positive integer.') from exc
+        topic, depth_str = split_key_value(value, '1')
 
         if not topic:
             raise ValueError(
                 f'Invalid value for --repeat-transient-local: "{value}". '
                 'Topic name must not be empty.')
-
+        if not depth_str:
+            raise ValueError(
+                f'Invalid value for --repeat-transient-local: "{value}". '
+                'Expected format <topic> or <topic>=<depth>.')
+        try:
+            depth = int(depth_str)
+        except ValueError as exc:
+            raise ValueError(
+                f'Invalid depth for --repeat-transient-local: "{value}". '
+                'Depth must be a positive integer.') from exc
         if depth <= 0:
             raise ValueError(
                 f'Invalid depth for --repeat-transient-local: "{value}". '
@@ -431,8 +435,7 @@ class RecordVerb(VerbExtension):
         # Prepare custom_data dictionary
         custom_data = {}
         if args.custom_data:
-            key_value_pairs = [pair.split('=') for pair in args.custom_data]
-            custom_data = {pair[0]: pair[1] for pair in key_value_pairs}
+            custom_data = dict(split_key_value(pair) for pair in args.custom_data)
 
         static_topics_uri = ''
         if args.static_topics_path:

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -38,6 +38,42 @@ from rosbag2_py import StorageOptions
 import yaml
 
 
+def parse_repeat_transient_local_topics(values):
+    repeat_topics = {}
+    if not values:
+        return repeat_topics
+
+    for value in values:
+        topic = value
+        depth = 1
+        if '=' in value:
+            topic, parsed_depth = value.split('=', 1)
+            if not parsed_depth:
+                raise ValueError(
+                    f'Invalid value for --repeat-transient-local: "{value}". '
+                    'Expected format <topic> or <topic>=<depth>.')
+            try:
+                depth = int(parsed_depth)
+            except ValueError as exc:
+                raise ValueError(
+                    f'Invalid depth for --repeat-transient-local: "{value}". '
+                    'Depth must be a positive integer.') from exc
+
+        if not topic:
+            raise ValueError(
+                f'Invalid value for --repeat-transient-local: "{value}". '
+                'Topic name must not be empty.')
+
+        if depth <= 0:
+            raise ValueError(
+                f'Invalid depth for --repeat-transient-local: "{value}". '
+                'Depth must be greater than 0.')
+
+        repeat_topics[topic] = depth
+
+    return repeat_topics
+
+
 def add_recorder_arguments(parser: ArgumentParser) -> None:
     parser.formatter_class = SplitLineFormatter
     writer_choices = get_registered_writers()
@@ -209,6 +245,11 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
              'the "/rosbag2_recorder/snapshot" service is called. e.g. \n '
              'ros2 service call /rosbag2_recorder/snapshot rosbag2_interfaces/Snapshot')
     parser.add_argument(
+        '--repeat-transient-local', type=str, default=[], metavar='Topic[=Depth]', nargs='+',
+        help='Space-delimited list of transient-local topics whose last messages should be '
+             'prepended on bag split and snapshot writes. Format: <topic> or <topic>=<depth>. '
+             'Default depth is 1 when omitted.')
+    parser.add_argument(
         '--log-level', type=str, default='info',
         choices=['debug', 'info', 'warn', 'error', 'fatal'],
         help='Logging level.')
@@ -346,6 +387,12 @@ def validate_parsed_arguments(args, uri) -> str:
         return print_error('In snapshot mode, either the max_cache_duration or max_cache_size'
                            ' shall not be set to zero.')
 
+    try:
+        args.repeat_transient_local_messages = parse_repeat_transient_local_topics(
+            args.repeat_transient_local)
+    except ValueError as exc:
+        return print_error(str(exc))
+
     return None
 
 
@@ -444,6 +491,7 @@ class RecordVerb(VerbExtension):
         record_options.use_sim_time = args.use_sim_time
         record_options.disable_keyboard_controls = args.disable_keyboard_controls
         record_options.statistics_max_publishing_rate = args.stats_max_publishing_rate
+        record_options.repeat_transient_local_messages = args.repeat_transient_local_messages
 
         recorder = Recorder(storage_options, record_options, args.log_level, args.node_name)
 

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -190,6 +190,36 @@ def test_recorder_custom_data_list_argument(test_arguments_parser):
     assert output_path.as_posix() == args.output
 
 
+def test_recorder_repeat_transient_local_list_argument(test_arguments_parser):
+    """Test recorder --repeat-transient-local list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--repeat-transient-local', '/map=2', '/tf_static', '--all-topics',
+         '--output', output_path.as_posix()]
+    )
+    assert ['/map=2', '/tf_static'] == args.repeat_transient_local
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is None
+    assert {'/map': 2, '/tf_static': 1} == args.repeat_transient_local_messages
+
+
+def test_recorder_repeat_transient_local_invalid_depth_argument(test_arguments_parser):
+    """Test recorder --repeat-transient-local invalid depth fails validation."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--repeat-transient-local', '/map=0', '--all-topics', '--output', output_path.as_posix()]
+    )
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is not None
+    expected_output = 'Depth must be greater than 0'
+    matches = expected_output in error_str
+    assert matches, ERROR_STRING_MSG.format(expected_output, error_str)
+
+
 def test_recorder_validate_exclude_regex_needs_inclusive_args(test_arguments_parser):
     """Test that --exclude-regex needs inclusive arguments."""
     output_path = RESOURCES_PATH / 'ros2bag_tmp_file'

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -1,7 +1,7 @@
 import datetime
 import rosbag2_py._storage
 from _typeshed import Incomplete
-from typing import Any, ClassVar, List, overload
+from typing import Any, ClassVar, Dict, List, overload
 
 class MessageOrder:
     __members__: ClassVar[dict] = ...  # read-only
@@ -120,6 +120,7 @@ class RecordOptions:
     is_discovery_disabled: bool
     node_prefix: str
     output_serialization_format: str
+    repeat_transient_local_messages: Dict[str, int]
     regex: str
     rmw_serialization_format: str
     services: List[str]

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -120,8 +120,8 @@ class RecordOptions:
     is_discovery_disabled: bool
     node_prefix: str
     output_serialization_format: str
-    repeat_transient_local_messages: Dict[str, int]
     regex: str
+    repeat_transient_local_messages: Dict[str, int]
     rmw_serialization_format: str
     services: List[str]
     start_paused: bool

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -1010,6 +1010,8 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("all_actions", &RecordOptions::all_actions)
   .def_readwrite("exclude_actions", &RecordOptions::exclude_actions)
   .def_readwrite("statistics_max_publishing_rate", &RecordOptions::statistics_max_publishing_rate)
+  .def_readwrite(
+    "repeat_transient_local_messages", &RecordOptions::repeat_transient_local_messages)
   ;
 
   py::class_<rosbag2_py::Player>(m, "Player")

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -1010,8 +1010,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("all_actions", &RecordOptions::all_actions)
   .def_readwrite("exclude_actions", &RecordOptions::exclude_actions)
   .def_readwrite("statistics_max_publishing_rate", &RecordOptions::statistics_max_publishing_rate)
-  .def_readwrite(
-    "repeat_transient_local_messages", &RecordOptions::repeat_transient_local_messages)
+  .def_readwrite("repeat_transient_local_messages", &RecordOptions::repeat_transient_local_messages)
   ;
 
   py::class_<rosbag2_py::Player>(m, "Player")

--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -53,6 +53,17 @@ rcl_interfaces::msg::ParameterDescriptor float_param_description(
   return d;
 }
 
+/// Split a "key=value" string into a pair. If no '=' is found, returns {entry, default_value}.
+std::pair<std::string, std::string> split_key_value(
+  const std::string & entry, const std::string & default_value = "")
+{
+  auto pos = entry.find('=');
+  if (pos == std::string::npos) {
+    return {entry, default_value};
+  }
+  return {entry.substr(0, pos), entry.substr(pos + 1)};
+}
+
 template<typename T>
 typename std::enable_if<std::numeric_limits<T>::is_integer, T>::type
 declare_integer_node_params(
@@ -383,29 +394,22 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
   auto repeat_transient_local = node.declare_parameter<std::vector<std::string>>(
     "record.repeat_transient_local", std::vector<std::string>());
   for (const auto & entry : repeat_transient_local) {
-    auto delimiter_pos = entry.find("=", 0);
-    std::string topic_name;
-    size_t queue_depth = 1;
-    if (delimiter_pos == std::string::npos) {
-      topic_name = entry;
-    } else {
-      topic_name = entry.substr(0, delimiter_pos);
-      auto depth_string = entry.substr(delimiter_pos + 1);
-      if (depth_string.empty()) {
-        throw std::invalid_argument(
-                "record.repeat_transient_local expects entries in <topic> or <topic>=<depth> "
-                "format.");
-      }
-      try {
-        queue_depth = std::stoul(depth_string);
-      } catch (const std::exception &) {
-        throw std::invalid_argument(
-                "record.repeat_transient_local depth must be a positive integer.");
-      }
-    }
+    auto [topic_name, depth_str] = param_utils::split_key_value(entry, "1");
     if (topic_name.empty()) {
       throw std::invalid_argument(
               "record.repeat_transient_local topic name cannot be empty.");
+    }
+    if (depth_str.empty()) {
+      throw std::invalid_argument(
+              "record.repeat_transient_local expects entries in <topic> or <topic>=<depth> "
+              "format.");
+    }
+    size_t queue_depth = 1;
+    try {
+      queue_depth = std::stoul(depth_str);
+    } catch (const std::exception &) {
+      throw std::invalid_argument(
+              "record.repeat_transient_local depth must be a positive integer.");
     }
     if (queue_depth == 0) {
       throw std::invalid_argument(
@@ -476,15 +480,12 @@ get_storage_options_from_node_params(rclcpp::Node & node)
     "storage.custom_data",
     std::vector<std::string>());
   for (const auto & key_value_string : list_of_key_value_strings) {
-    auto delimiter_pos = key_value_string.find("=", 0);
-    if (delimiter_pos == std::string::npos) {
-      std::stringstream ss;
-      ss << "The storage.custom_data expected to be as list of the key=value strings. "
-        "The `=` not found in the " << key_value_string;
-      throw std::invalid_argument(ss.str());
+    auto [key_string, value_string] = param_utils::split_key_value(key_value_string);
+    if (value_string.empty() && key_value_string.find('=') == std::string::npos) {
+      throw std::invalid_argument(
+        "The storage.custom_data expected to be as list of the key=value strings. "
+        "The `=` not found in the " + key_value_string);
     }
-    auto key_string = key_value_string.substr(0, delimiter_pos);
-    auto value_string = key_value_string.substr(delimiter_pos + 1);
     storage_options.custom_data[key_string] = value_string;
   }
 

--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -380,6 +380,40 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
   record_options.disable_keyboard_controls =
     node.declare_parameter<bool>("record.disable_keyboard_controls", false);
 
+  auto repeat_transient_local = node.declare_parameter<std::vector<std::string>>(
+    "record.repeat_transient_local", std::vector<std::string>());
+  for (const auto & entry : repeat_transient_local) {
+    auto delimiter_pos = entry.find("=", 0);
+    std::string topic_name;
+    size_t queue_depth = 1;
+    if (delimiter_pos == std::string::npos) {
+      topic_name = entry;
+    } else {
+      topic_name = entry.substr(0, delimiter_pos);
+      auto depth_string = entry.substr(delimiter_pos + 1);
+      if (depth_string.empty()) {
+        throw std::invalid_argument(
+                "record.repeat_transient_local expects entries in <topic> or <topic>=<depth> "
+                "format.");
+      }
+      try {
+        queue_depth = std::stoul(depth_string);
+      } catch (const std::exception &) {
+        throw std::invalid_argument(
+                "record.repeat_transient_local depth must be a positive integer.");
+      }
+    }
+    if (topic_name.empty()) {
+      throw std::invalid_argument(
+              "record.repeat_transient_local topic name cannot be empty.");
+    }
+    if (queue_depth == 0) {
+      throw std::invalid_argument(
+              "record.repeat_transient_local depth must be greater than 0.");
+    }
+    record_options.repeat_transient_local_messages[topic_name] = queue_depth;
+  }
+
   record_options.use_sim_time = node.get_parameter("use_sim_time").get_value<bool>();
 
   if (record_options.use_sim_time && record_options.is_discovery_disabled) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1829,8 +1829,8 @@ rclcpp::QoS RecorderImpl::subscription_qos_for_topic(const std::string & topic_n
       RCLCPP_WARN_STREAM(
         node->get_logger(),
         "Topic '" << topic_name << "' has both a QoS profile override and "
-        "repeat-transient-local enabled. The QoS override takes precedence; "
-        "ensure it includes transient_local durability to receive latched messages.");
+          "repeat-transient-local enabled. The QoS override takes precedence; "
+          "ensure it includes transient_local durability to receive latched messages.");
     }
     return topic_qos_profile_overrides_.at(topic_name);
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1825,25 +1825,34 @@ rclcpp::QoS RecorderImpl::subscription_qos_for_topic(const std::string & topic_n
     RCLCPP_INFO_STREAM(
       node->get_logger(),
       "Overriding subscription profile for " << topic_name);
-    if (record_options_.repeat_transient_local_messages.count(topic_name) > 0) {
+    if (record_options_.repeat_transient_local_messages.count(topic_name) > 0 &&
+      topic_qos_profile_overrides_.at(topic_name).get_rmw_qos_profile().durability !=
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+    {
       RCLCPP_WARN_STREAM(
         node->get_logger(),
-        "Topic '" << topic_name << "' has both a QoS profile override and "
-          "repeat-transient-local enabled. The QoS override takes precedence; "
-          "ensure it includes transient_local durability to receive latched messages.");
+        "Topic '" << topic_name << "' has a QoS profile override without transient_local "
+          "durability, but repeat-transient-local is enabled. The QoS override takes precedence; "
+          "repeat-transient-local will not work unless the override includes transient_local "
+          "durability.");
     }
     return topic_qos_profile_overrides_.at(topic_name);
   }
 
+  auto qos = rosbag2_storage::Rosbag2QoS::adapt_request_to_offers(
+    topic_name, node->get_publishers_info_by_topic(topic_name));
+
   if (record_options_.repeat_transient_local_messages.count(topic_name) > 0) {
-    auto qos = rosbag2_storage::Rosbag2QoS::adapt_request_to_offers(
-      topic_name, node->get_publishers_info_by_topic(topic_name));
+    if (qos.get_rmw_qos_profile().durability != RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
+      RCLCPP_WARN_STREAM(
+        node->get_logger(),
+        "Overriding QoS durability to transient_local for topic '" << topic_name <<
+          "' because repeat-transient-local is enabled.");
+    }
     qos.transient_local();
-    return qos;
   }
 
-  return rosbag2_storage::Rosbag2QoS::adapt_request_to_offers(
-    topic_name, node->get_publishers_info_by_topic(topic_name));
+  return qos;
 }
 
 void RecorderImpl::warn_if_new_qos_for_subscribed_topic(const std::string & topic_name)

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1825,6 +1825,13 @@ rclcpp::QoS RecorderImpl::subscription_qos_for_topic(const std::string & topic_n
     RCLCPP_INFO_STREAM(
       node->get_logger(),
       "Overriding subscription profile for " << topic_name);
+    if (record_options_.repeat_transient_local_messages.count(topic_name) > 0) {
+      RCLCPP_WARN_STREAM(
+        node->get_logger(),
+        "Topic '" << topic_name << "' has both a QoS profile override and "
+        "repeat-transient-local enabled. The QoS override takes precedence; "
+        "ensure it includes transient_local durability to receive latched messages.");
+    }
     return topic_qos_profile_overrides_.at(topic_name);
   }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -576,6 +576,16 @@ RecorderImpl::RecorderImpl(
       node->get_namespace(), false);
   }
 
+  std::unordered_map<std::string, size_t> expanded_repeat_transient_local_messages;
+  for (const auto & [topic_name, depth] : record_options_.repeat_transient_local_messages) {
+    auto expanded_topic_name = rclcpp::expand_topic_or_service_name(
+      topic_name, node->get_name(),
+      node->get_namespace(), false);
+    expanded_repeat_transient_local_messages[expanded_topic_name] = depth;
+  }
+  record_options_.repeat_transient_local_messages =
+    std::move(expanded_repeat_transient_local_messages);
+
   for (auto & service : record_options_.services) {
     service = rclcpp::expand_topic_or_service_name(
       service, node->get_name(),
@@ -1669,7 +1679,12 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   // Need to create topic in writer before we are trying to create subscription. Since in
   // callback for subscription we are calling writer_->write(bag_message); and it could happened
   // that callback called before we reached out the line: writer_->create_topic(topic)
-  writer_->create_topic(topic);
+  if (record_options_.repeat_transient_local_messages.count(topic.name) > 0) {
+    writer_->create_transient_local_topic(
+      topic, record_options_.repeat_transient_local_messages.at(topic.name));
+  } else {
+    writer_->create_topic(topic);
+  }
 
   rosbag2_storage::Rosbag2QoS subscription_qos{subscription_qos_for_topic(topic.name)};
 
@@ -1812,6 +1827,14 @@ rclcpp::QoS RecorderImpl::subscription_qos_for_topic(const std::string & topic_n
       "Overriding subscription profile for " << topic_name);
     return topic_qos_profile_overrides_.at(topic_name);
   }
+
+  if (record_options_.repeat_transient_local_messages.count(topic_name) > 0) {
+    auto qos = rosbag2_storage::Rosbag2QoS::adapt_request_to_offers(
+      topic_name, node->get_publishers_info_by_topic(topic_name));
+    qos.transient_local();
+    return qos;
+  }
+
   return rosbag2_storage::Rosbag2QoS::adapt_request_to_offers(
     topic_name, node->get_publishers_info_by_topic(topic_name));
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -425,7 +425,7 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   EXPECT_FALSE(recorded_messages.empty());
 }
 
-TEST_F(RecordIntegrationTestFixture, repeat_latched_topics_register_requested_depth)
+TEST_F(RecordIntegrationTestFixture, repeat_transient_local_topics_register_requested_depth)
 {
   auto string_message = get_messages_strings()[1];
   std::string topic = "/latched_chatter";

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -425,6 +425,43 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   EXPECT_FALSE(recorded_messages.empty());
 }
 
+TEST_F(RecordIntegrationTestFixture, repeat_latched_topics_register_requested_depth)
+{
+  auto string_message = get_messages_strings()[1];
+  std::string topic = "/latched_chatter";
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher(topic, string_message, 1, rclcpp::QoS(1).transient_local());
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.topics = {topic};
+  record_options.rmw_serialization_format = "rmw_format";
+  record_options.topic_polling_interval = 100ms;
+  record_options.repeat_transient_local_messages[topic] = 3;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(topic.c_str()));
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  auto ret = rosbag2_test_common::wait_until_condition(
+    [&mock_writer, &topic]() {
+      auto transient_local_topic_depths = mock_writer.transient_local_topic_depths();
+      auto topic_depth = transient_local_topic_depths.find(topic);
+      return topic_depth != transient_local_topic_depths.end() && topic_depth->second == 3;
+    },
+    std::chrono::seconds(5));
+  EXPECT_TRUE(ret) << "failed to register transient local repeat depth for topic";
+}
+
 TEST_F(RecordIntegrationTestFixture, mixed_qos_subscribes) {
   // Ensure that rosbag2 subscribes to publishers that offer different durability policies
   const size_t arbitrary_history = 5;


### PR DESCRIPTION
## Description

**Part 3 of 3** — Split from #2342 per review feedback. This PR wires the transient-local feature through to the user-facing layer.

### Changes

**Recorder** (`rosbag2_transport`)
- Expand topic names in `repeat_transient_local_messages` using `rclcpp::expand_topic_or_service_name()`
- Route `subscribe_topic()` to `writer_->create_transient_local_topic()` for matching topics
- Set `transient_local()` QoS for matching subscriptions

**ROS Parameter loading** (`config_options_from_node_params.cpp`)
- Parse `record.repeat_transient_local` parameter
- Format: `"topic"` (default depth=1) or `"topic=depth"`
- Validates non-empty topic names and positive depth values

**CLI** (`ros2bag`)
- New argument: `--repeat-transient-local Topic[=Depth] [Topic[=Depth] ...]`
- `parse_repeat_transient_local_topics()` validator function
- Example: `ros2 bag record --repeat-transient-local /tf_static=10 /map --all-topics`

**Python bindings** (`rosbag2_py`)
- pybind11: expose `repeat_transient_local_messages` on `RecordOptions`
- Type stub updated

### Tests
- Recorder integration test: verify `create_transient_local_topic()` called with correct depth + transient_local QoS
- CLI parser tests: valid format, invalid depth value

### PR Stack
1. #2385 — Core cache + RecordOptions
2. #2386 — Writer API + split/snapshot integration **(must merge first)**
3. **This PR** — Recorder + CLI + bindings

Fixes: #1159, #1886
Design document: #2327