### PR TITLE
 Add `--repeat-all-transient-local` flag for automatic transient-local topic detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ $ ros2 bag record -a --repeat-transient-local /tf_static=5 /map
 This option also works via node parameters as `record.repeat_transient_local`, accepting a list
 of strings in the same `<topic>` or `<topic>=<depth>` format.
 
+Alternatively, `--repeat-all-transient-local [<depth>]` can be used to automatically detect and
+repeat all topics whose publishers offer `TRANSIENT_LOCAL` durability. The depth defaults to `1`
+when omitted and specifies how many of the most recent messages per topic are retained.
+Per-topic entries from `--repeat-transient-local` take precedence over this default depth.
+
+```bash
+# Auto-detect and repeat all transient-local topics (depth 1)
+$ ros2 bag record -a --repeat-all-transient-local
+
+# Auto-detect with depth 5
+$ ros2 bag record -a --repeat-all-transient-local 5
+
+# Auto-detect all, but override /map to keep last 10 messages
+$ ros2 bag record -a --repeat-all-transient-local --repeat-transient-local /map=10
+```
+
 **Note**: If a topic has both a QoS profile override (via `--qos-profile-overrides-path`) and is
 listed in `--repeat-transient-local`, the QoS override takes precedence. Ensure the override
 includes `transient_local` durability to receive latched messages.

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -256,10 +256,11 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
     parser.add_argument(
         '--repeat-all-transient-local', type=int, default=0, const=1,
         nargs='?', metavar='Depth',
-        help='Automatically repeat last messages for all topics whose publishers offer '
-             'TRANSIENT_LOCAL durability QoS. Depth defaults to 1 when omitted. '
-             'Per-topic entries from --repeat-transient-local take precedence. '
-             '0 disables (default).')
+        help='Automatically detect all topics whose publishers offer TRANSIENT_LOCAL '
+             'durability QoS and retain the last <depth> messages per topic, prepending '
+             'them on bag split and snapshot writes. Depth defaults to 1 when omitted. '
+             'Per-topic entries from --repeat-transient-local take precedence over this '
+             'default depth. 0 disables (default).')
     parser.add_argument(
         '--log-level', type=str, default='info',
         choices=['debug', 'info', 'warn', 'error', 'fatal'],

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -254,9 +254,10 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
              'prepended on bag split and snapshot writes. Format: <topic> or <topic>=<depth>. '
              'Default depth is 1 when omitted.')
     parser.add_argument(
-        '--repeat-all-transient-local', type=int, default=0, metavar='Depth',
+        '--repeat-all-transient-local', type=int, default=0, const=1,
+        nargs='?', metavar='Depth',
         help='Automatically repeat last messages for all topics whose publishers offer '
-             'TRANSIENT_LOCAL durability QoS, with the specified depth. '
+             'TRANSIENT_LOCAL durability QoS. Depth defaults to 1 when omitted. '
              'Per-topic entries from --repeat-transient-local take precedence. '
              '0 disables (default).')
     parser.add_argument(

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -254,6 +254,12 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
              'prepended on bag split and snapshot writes. Format: <topic> or <topic>=<depth>. '
              'Default depth is 1 when omitted.')
     parser.add_argument(
+        '--repeat-all-transient-local', type=int, default=0, metavar='Depth',
+        help='Automatically repeat last messages for all topics whose publishers offer '
+             'TRANSIENT_LOCAL durability QoS, with the specified depth. '
+             'Per-topic entries from --repeat-transient-local take precedence. '
+             '0 disables (default).')
+    parser.add_argument(
         '--log-level', type=str, default='info',
         choices=['debug', 'info', 'warn', 'error', 'fatal'],
         help='Logging level.')
@@ -391,6 +397,9 @@ def validate_parsed_arguments(args, uri) -> str:
         return print_error('In snapshot mode, either the max_cache_duration or max_cache_size'
                            ' shall not be set to zero.')
 
+    if args.repeat_all_transient_local < 0:
+        return print_error('--repeat-all-transient-local depth must be a non-negative integer.')
+
     try:
         args.repeat_transient_local_messages = parse_repeat_transient_local_topics(
             args.repeat_transient_local)
@@ -495,6 +504,7 @@ class RecordVerb(VerbExtension):
         record_options.disable_keyboard_controls = args.disable_keyboard_controls
         record_options.statistics_max_publishing_rate = args.stats_max_publishing_rate
         record_options.repeat_transient_local_messages = args.repeat_transient_local_messages
+        record_options.repeat_all_transient_local_depth = args.repeat_all_transient_local
 
         recorder = Recorder(storage_options, record_options, args.log_level, args.node_name)
 

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -261,7 +261,9 @@ def test_recorder_repeat_all_transient_local_with_per_topic(test_arguments_parse
     uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
     error_str = validate_parsed_arguments(args, uri)
     assert error_str is None
+    # Per-topic entry must take precedence over --repeat-all-transient-local depth
     assert {'/map': 10} == args.repeat_transient_local_messages
+    assert args.repeat_transient_local_messages['/map'] != args.repeat_all_transient_local
 
 
 def test_recorder_repeat_all_transient_local_default(test_arguments_parser):

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -220,6 +220,45 @@ def test_recorder_repeat_transient_local_invalid_depth_argument(test_arguments_p
     assert matches, ERROR_STRING_MSG.format(expected_output, error_str)
 
 
+def test_recorder_repeat_all_transient_local_argument(test_arguments_parser):
+    """Test recorder --repeat-all-transient-local argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--repeat-all-transient-local', '5', '--all-topics',
+         '--output', output_path.as_posix()]
+    )
+    assert 5 == args.repeat_all_transient_local
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is None
+
+
+def test_recorder_repeat_all_transient_local_with_per_topic(test_arguments_parser):
+    """Test --repeat-all-transient-local combined with --repeat-transient-local."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--repeat-all-transient-local', '5',
+         '--repeat-transient-local', '/map=10',
+         '--all-topics', '--output', output_path.as_posix()]
+    )
+    assert 5 == args.repeat_all_transient_local
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is None
+    assert {'/map': 10} == args.repeat_transient_local_messages
+
+
+def test_recorder_repeat_all_transient_local_default(test_arguments_parser):
+    """Test --repeat-all-transient-local defaults to 0."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--all-topics', '--output', output_path.as_posix()]
+    )
+    assert 0 == args.repeat_all_transient_local
+
+
 def test_recorder_validate_exclude_regex_needs_inclusive_args(test_arguments_parser):
     """Test that --exclude-regex needs inclusive arguments."""
     output_path = RESOURCES_PATH / 'ros2bag_tmp_file'

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -221,13 +221,27 @@ def test_recorder_repeat_transient_local_invalid_depth_argument(test_arguments_p
 
 
 def test_recorder_repeat_all_transient_local_argument(test_arguments_parser):
-    """Test recorder --repeat-all-transient-local argument parser."""
+    """Test recorder --repeat-all-transient-local argument parser with explicit depth."""
     output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
     args = test_arguments_parser.parse_args(
         ['--repeat-all-transient-local', '5', '--all-topics',
          '--output', output_path.as_posix()]
     )
     assert 5 == args.repeat_all_transient_local
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is None
+
+
+def test_recorder_repeat_all_transient_local_no_depth(test_arguments_parser):
+    """Test recorder --repeat-all-transient-local without depth defaults to 1."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--repeat-all-transient-local', '--all-topics',
+         '--output', output_path.as_posix()]
+    )
+    assert 1 == args.repeat_all_transient_local
 
     uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
     error_str = validate_parsed_arguments(args, uri)

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -122,6 +122,7 @@ class RecordOptions:
     output_serialization_format: str
     regex: str
     repeat_transient_local_messages: Dict[str, int]
+    repeat_all_transient_local_depth: int
     rmw_serialization_format: str
     services: List[str]
     start_paused: bool

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -121,8 +121,8 @@ class RecordOptions:
     node_prefix: str
     output_serialization_format: str
     regex: str
-    repeat_transient_local_messages: Dict[str, int]
     repeat_all_transient_local_depth: int
+    repeat_transient_local_messages: Dict[str, int]
     rmw_serialization_format: str
     services: List[str]
     start_paused: bool

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -1011,6 +1011,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("exclude_actions", &RecordOptions::exclude_actions)
   .def_readwrite("statistics_max_publishing_rate", &RecordOptions::statistics_max_publishing_rate)
   .def_readwrite("repeat_transient_local_messages", &RecordOptions::repeat_transient_local_messages)
+  .def_readwrite("repeat_all_transient_local_depth", &RecordOptions::repeat_all_transient_local_depth)
   ;
 
   py::class_<rosbag2_py::Player>(m, "Player")

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -1012,7 +1012,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("statistics_max_publishing_rate", &RecordOptions::statistics_max_publishing_rate)
   .def_readwrite("repeat_transient_local_messages", &RecordOptions::repeat_transient_local_messages)
   .def_readwrite("repeat_all_transient_local_depth",
-    &RecordOptions::repeat_all_transient_local_depth)
+                 &RecordOptions::repeat_all_transient_local_depth)
   ;
 
   py::class_<rosbag2_py::Player>(m, "Player")

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -1011,7 +1011,8 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("exclude_actions", &RecordOptions::exclude_actions)
   .def_readwrite("statistics_max_publishing_rate", &RecordOptions::statistics_max_publishing_rate)
   .def_readwrite("repeat_transient_local_messages", &RecordOptions::repeat_transient_local_messages)
-  .def_readwrite("repeat_all_transient_local_depth", &RecordOptions::repeat_all_transient_local_depth)
+  .def_readwrite("repeat_all_transient_local_depth",
+    &RecordOptions::repeat_all_transient_local_depth)
   ;
 
   py::class_<rosbag2_py::Player>(m, "Player")

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -95,6 +95,13 @@ public:
   /// Empty map disables the feature.
   std::unordered_map<std::string, size_t> repeat_transient_local_messages{};
 
+  /// \brief Global retention depth for auto-detecting and repeating all transient-local topics
+  /// on split/snapshot. When non-zero, any subscribed topic whose publishers all offer
+  /// TRANSIENT_LOCAL durability will automatically be treated as a repeat-transient-local topic
+  /// with this depth, unless an explicit per-topic entry exists in
+  /// repeat_transient_local_messages. 0 disables the feature.
+  size_t repeat_all_transient_local_depth = 0;
+
   /// Note: Please don't forget to update the YAML serialization and deserialization logic in
   /// `record_options.cpp` and the test case `test_yaml_serialization_deserialization`
   /// in `test_record_options.cpp` when updating the fields in RecordOptions.

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -100,7 +100,7 @@ public:
   /// TRANSIENT_LOCAL durability will automatically be treated as a repeat-transient-local topic
   /// with this depth, unless an explicit per-topic entry exists in
   /// repeat_transient_local_messages. 0 disables the feature.
-  size_t repeat_all_transient_local_depth = 0;
+  uint32_t repeat_all_transient_local_depth = 0;
 
   /// Note: Please don't forget to update the YAML serialization and deserialization logic in
   /// `record_options.cpp` and the test case `test_yaml_serialization_deserialization`

--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -425,7 +425,7 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
             "record.repeat_all_transient_local depth must be a non-negative integer.");
   }
   record_options.repeat_all_transient_local_depth =
-    static_cast<size_t>(repeat_all_transient_local_depth);
+    static_cast<uint32_t>(repeat_all_transient_local_depth);
 
   record_options.use_sim_time = node.get_parameter("use_sim_time").get_value<bool>();
 

--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -418,6 +418,15 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
     record_options.repeat_transient_local_messages[topic_name] = queue_depth;
   }
 
+  auto repeat_all_transient_local_depth = node.declare_parameter<int>(
+    "record.repeat_all_transient_local", 0);
+  if (repeat_all_transient_local_depth < 0) {
+    throw std::invalid_argument(
+            "record.repeat_all_transient_local depth must be a non-negative integer.");
+  }
+  record_options.repeat_all_transient_local_depth =
+    static_cast<size_t>(repeat_all_transient_local_depth);
+
   record_options.use_sim_time = node.get_parameter("use_sim_time").get_value<bool>();
 
   if (record_options.use_sim_time && record_options.is_discovery_disabled) {

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -39,7 +39,8 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
     compression_threads_priority, topic_qos_profile_overrides,
     include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
     start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
-    statistics_max_publishing_rate, repeat_transient_local_messages] = record_options;
+    statistics_max_publishing_rate, repeat_transient_local_messages,
+    repeat_all_transient_local_depth] = record_options;
   Node node;
   node["all_topics"] = all_topics;
   node["all_services"] = all_services;
@@ -76,6 +77,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
   node["disable_keyboard_controls"] = disable_keyboard_controls;
   node["statistics_max_publishing_rate"] = statistics_max_publishing_rate;
   node["repeat_transient_local_messages"] = repeat_transient_local_messages;
+  node["repeat_all_transient_local_depth"] = repeat_all_transient_local_depth;
   return node;
 }
 
@@ -95,7 +97,8 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
     compression_threads_priority, topic_qos_profile_overrides,
     include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
     start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
-    statistics_max_publishing_rate, repeat_transient_local_messages] = record_options;
+    statistics_max_publishing_rate, repeat_transient_local_messages,
+    repeat_all_transient_local_depth] = record_options;
 
   optional_assign<bool>(node, "all_topics", all_topics);
   optional_assign<bool>(node, "all_services", all_services);
@@ -155,6 +158,8 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<float>(node, "statistics_max_publishing_rate", statistics_max_publishing_rate);
   optional_assign<std::unordered_map<std::string, size_t>>(
     node, "repeat_transient_local_messages", repeat_transient_local_messages);
+  optional_assign<size_t>(node, "repeat_all_transient_local_depth",
+    repeat_all_transient_local_depth);
   return true;
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -158,7 +158,7 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
   optional_assign<float>(node, "statistics_max_publishing_rate", statistics_max_publishing_rate);
   optional_assign<std::unordered_map<std::string, size_t>>(
     node, "repeat_transient_local_messages", repeat_transient_local_messages);
-  optional_assign<size_t>(node, "repeat_all_transient_local_depth",
+  optional_assign<uint32_t>(node, "repeat_all_transient_local_depth",
     repeat_all_transient_local_depth);
   return true;
 }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1681,20 +1681,30 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
     record_options_.repeat_transient_local_messages.count(topic.name) == 0)
   {
     auto endpoint_infos = node->get_publishers_info_by_topic(topic.name);
-    if (!endpoint_infos.empty()) {
-      bool all_transient_local = std::all_of(
-        endpoint_infos.begin(), endpoint_infos.end(),
-        [](const rclcpp::TopicEndpointInfo & info) {
-          return info.qos_profile().get_rmw_qos_profile().durability ==
-                 RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-        });
+    if (endpoint_infos.empty()) {
+      RCLCPP_WARN_STREAM(node->get_logger(),
+        "No publishers found for topic '" << topic.name <<
+        "', cannot determine if it is transient-local. "
+        "Use --repeat-transient-local to explicitly specify this topic.");
+    } else {
+      bool all_transient_local =
+        std::all_of(
+          endpoint_infos.begin(), endpoint_infos.end(),
+          [](const rclcpp::TopicEndpointInfo & info) {
+            return info.qos_profile().get_rmw_qos_profile().durability ==
+              RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+          }
+        );
       if (all_transient_local) {
-        RCLCPP_INFO_STREAM(node->get_logger(),
-          "Auto-detected transient-local topic '" << topic.name <<
-          "', enabling repeat-transient-local with depth " <<
+        RCLCPP_INFO_STREAM(node->get_logger(), "Auto-detected transient-local topic '" <<
+          topic.name << "', enabling repeat-transient-local with depth " <<
           record_options_.repeat_all_transient_local_depth << ".");
         record_options_.repeat_transient_local_messages[topic.name] =
           record_options_.repeat_all_transient_local_depth;
+      } else {
+        RCLCPP_WARN_STREAM(node->get_logger(),
+          "Topic '" << topic.name << "' has publishers that do not all offer "
+          "TRANSIENT_LOCAL durability. Skipping auto repeat-transient-local for this topic.");
       }
     }
   }

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1690,9 +1690,9 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
       bool all_transient_local =
         std::all_of(
           endpoint_infos.begin(), endpoint_infos.end(),
-          [](const rclcpp::TopicEndpointInfo & info) {
-            return info.qos_profile().get_rmw_qos_profile().durability ==
-              RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+        [](const rclcpp::TopicEndpointInfo & info) {
+          return info.qos_profile().get_rmw_qos_profile().durability ==
+                 RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
           }
         );
       if (all_transient_local) {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1676,6 +1676,28 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   if (subscriptions_.find(topic.name) != subscriptions_.end()) {
     return;
   }
+  // Auto-detect transient-local topics when repeat_all_transient_local_depth is set
+  if (record_options_.repeat_all_transient_local_depth > 0 &&
+    record_options_.repeat_transient_local_messages.count(topic.name) == 0)
+  {
+    auto endpoint_infos = node->get_publishers_info_by_topic(topic.name);
+    if (!endpoint_infos.empty()) {
+      bool all_transient_local = std::all_of(
+        endpoint_infos.begin(), endpoint_infos.end(),
+        [](const rclcpp::TopicEndpointInfo & info) {
+          return info.qos_profile().get_rmw_qos_profile().durability ==
+                 RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+        });
+      if (all_transient_local) {
+        RCLCPP_INFO_STREAM(node->get_logger(),
+          "Auto-detected transient-local topic '" << topic.name <<
+          "', enabling repeat-transient-local with depth " <<
+          record_options_.repeat_all_transient_local_depth << ".");
+        record_options_.repeat_transient_local_messages[topic.name] =
+          record_options_.repeat_all_transient_local_depth;
+      }
+    }
+  }
   // Need to create topic in writer before we are trying to create subscription. Since in
   // callback for subscription we are calling writer_->write(bag_message); and it could happened
   // that callback called before we reached out the line: writer_->create_topic(topic)

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -57,6 +57,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   original.disable_keyboard_controls = true;
   original.statistics_max_publishing_rate = 5.0f;
   original.repeat_transient_local_messages = {{"/map", 1}, {"/tf_static", 5}};
+  original.repeat_all_transient_local_depth = 3;
 
   auto node = YAML::convert<rosbag2_transport::RecordOptions>::encode(original);
 
@@ -99,6 +100,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   CHECK(static_topics_uri);
   CHECK(disable_keyboard_controls);
   CHECK(repeat_transient_local_messages);
+  CHECK(repeat_all_transient_local_depth);
   #undef CHECK
   ASSERT_FLOAT_EQ(original.statistics_max_publishing_rate,
                   reconstructed.statistics_max_publishing_rate);


### PR DESCRIPTION
## Description

Add a new `--repeat-all-transient-local <depth>` CLI flag that automatically enables repeat-transient-local behavior for all topics whose publishers offer `TRANSIENT_LOCAL` durability QoS, removing the need to list each topic individually.

At subscription time, the recorder queries publisher endpoint QoS. If all publishers for a topic offer `TRANSIENT_LOCAL` durability, it is automatically treated as a repeat-transient-local topic with the specified depth. Per-topic entries from `--repeat-transient-local` take precedence.

Fixes https://github.com/ros2/rosbag2/issues/2390

### Is this user-facing behavior change?

```bash
# Today (must list every topic):
ros2 bag record --all-topics --repeat-transient-local /tf_static /map=3 /robot_description

# With this feature (one flag covers all transient-local topics):
ros2 bag record --all-topics --repeat-all-transient-local 1

# Can still override specific topics:
ros2 bag record --all-topics --repeat-all-transient-local 1 --repeat-transient-local /map=5
```

### Did you use Generative AI?

Yes, Claude Opus 4.6

### Additional Information

- Static topics (from `--static-topics-uri`) with no publishers at subscribe time won't be auto-detected — use explicit `--repeat-transient-local` for those.
- Late-joining publishers after initial subscription won't retroactively trigger the feature (existing QoS adaptation limitation).
