### PR TITLE
--repeat-all-transient-local small improvements

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1721,13 +1721,13 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
       RCLCPP_DEBUG_STREAM(node->get_logger(),
         "Subscribed to topic '" << topic.name << "'" <<
         (repeat_it != record_options_.repeat_transient_local_messages.end() ?
-          " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : "") <<
+        " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : "") <<
         " with QoS:\n" << subscription_qos.to_string());
     } else {
       RCLCPP_INFO_STREAM(node->get_logger(),
         "Subscribed to topic '" << topic.name << "'" <<
         (repeat_it != record_options_.repeat_transient_local_messages.end() ?
-          " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : ""));
+        " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : ""));
     }
 
   } else {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1687,24 +1687,17 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
         "', cannot determine if it is transient-local. "
         "Use --repeat-transient-local to explicitly specify this topic.");
     } else {
-      bool all_transient_local =
-        std::all_of(
+      bool any_transient_local =
+        std::any_of(
           endpoint_infos.begin(), endpoint_infos.end(),
         [](const rclcpp::TopicEndpointInfo & info) {
           return info.qos_profile().get_rmw_qos_profile().durability ==
                  RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
           }
         );
-      if (all_transient_local) {
-        RCLCPP_INFO_STREAM(node->get_logger(), "Auto-detected transient-local topic '" <<
-          topic.name << "', enabling repeat-transient-local with depth " <<
-          record_options_.repeat_all_transient_local_depth << ".");
+      if (any_transient_local) {
         record_options_.repeat_transient_local_messages[topic.name] =
           record_options_.repeat_all_transient_local_depth;
-      } else {
-        RCLCPP_WARN_STREAM(node->get_logger(),
-          "Topic '" << topic.name << "' has publishers that do not all offer "
-          "TRANSIENT_LOCAL durability. Skipping auto repeat-transient-local for this topic.");
       }
     }
   }
@@ -1723,11 +1716,18 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   auto subscription = create_subscription(topic.name, topic.type, subscription_qos);
   if (subscription) {
     subscriptions_.insert({topic.name, subscription});
+    auto repeat_it = record_options_.repeat_transient_local_messages.find(topic.name);
     if (node->get_logger().get_effective_level() == rclcpp::Logger::Level::Debug) {
       RCLCPP_DEBUG_STREAM(node->get_logger(),
-        "Subscribed to topic '" << topic.name << "' with QoS:\n" << subscription_qos.to_string());
+        "Subscribed to topic '" << topic.name << "'" <<
+        (repeat_it != record_options_.repeat_transient_local_messages.end() ?
+          " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : "") <<
+        " with QoS:\n" << subscription_qos.to_string());
     } else {
-      RCLCPP_INFO_STREAM(node->get_logger(), "Subscribed to topic '" << topic.name << "'");
+      RCLCPP_INFO_STREAM(node->get_logger(),
+        "Subscribed to topic '" << topic.name << "'" <<
+        (repeat_it != record_options_.repeat_transient_local_messages.end() ?
+          " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : ""));
     }
 
   } else {

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1716,18 +1716,21 @@ void RecorderImpl::subscribe_topic(const rosbag2_storage::TopicMetadata & topic)
   auto subscription = create_subscription(topic.name, topic.type, subscription_qos);
   if (subscription) {
     subscriptions_.insert({topic.name, subscription});
-    auto repeat_it = record_options_.repeat_transient_local_messages.find(topic.name);
+    std::optional<size_t> repeat_tl_depth =
+      record_options_.repeat_transient_local_messages.count(topic.name) > 0 ?
+      std::make_optional(record_options_.repeat_transient_local_messages.at(topic.name)) :
+      std::nullopt;
     if (node->get_logger().get_effective_level() == rclcpp::Logger::Level::Debug) {
       RCLCPP_DEBUG_STREAM(node->get_logger(),
         "Subscribed to topic '" << topic.name << "'" <<
-        (repeat_it != record_options_.repeat_transient_local_messages.end() ?
-        " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : "") <<
+        (repeat_tl_depth.has_value() ?
+        " (repeat-transient-local, depth=" + std::to_string(repeat_tl_depth.value()) + ")" : "") <<
         " with QoS:\n" << subscription_qos.to_string());
     } else {
       RCLCPP_INFO_STREAM(node->get_logger(),
         "Subscribed to topic '" << topic.name << "'" <<
-        (repeat_it != record_options_.repeat_transient_local_messages.end() ?
-        " (repeat-transient-local, depth=" + std::to_string(repeat_it->second) + ")" : ""));
+        (repeat_tl_depth.has_value() ?
+        " (repeat-transient-local, depth=" + std::to_string(repeat_tl_depth.value()) + ")" : ""));
     }
 
   } else {

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -498,7 +498,7 @@ TEST_F(RecordIntegrationTestFixture, repeat_all_transient_local_auto_detects_mix
       auto it = depths.find(topic);
       return it != depths.end() && it->second == expected_depth;
     },
-    std::chrono::seconds(5));
+    std::chrono::seconds(10));
   EXPECT_TRUE(ret)
     << "failed to auto-detect repeat-transient-local for mixed-durability topic";
 }
@@ -532,10 +532,10 @@ TEST_F(RecordIntegrationTestFixture, repeat_all_transient_local_skips_volatile_o
 
   // Wait for subscription to be established, then verify no transient-local depth was registered
   auto subscribed = rosbag2_test_common::wait_until_condition(
-    [&mock_writer]() {
-      return mock_writer.get_topics().size() >= 1;
+    [&mock_writer, &topic]() {
+      return mock_writer.get_topics().count(topic) > 0;
     },
-    std::chrono::seconds(5));
+    std::chrono::seconds(10));
   ASSERT_TRUE(subscribed) << "recorder did not subscribe to topic in time";
 
   auto depths = mock_writer.transient_local_topic_depths();

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -462,6 +462,87 @@ TEST_F(RecordIntegrationTestFixture, repeat_transient_local_topics_register_requ
   EXPECT_TRUE(ret) << "failed to register transient local repeat depth for topic";
 }
 
+TEST_F(RecordIntegrationTestFixture, repeat_all_transient_local_auto_detects_mixed_durability)
+{
+  // Verify that auto-detection enables repeat-transient-local for a topic when at least one
+  // publisher offers TRANSIENT_LOCAL, even if another publisher offers VOLATILE.
+  std::string topic = "/mixed_durability_topic";
+  const size_t expected_depth = 5;
+
+  auto publisher_node = std::make_shared<rclcpp::Node>("rosbag2_test_mixed_durability");
+  auto pub_volatile = publisher_node->create_publisher<test_msgs::msg::Strings>(
+    topic, rclcpp::QoS(1).reliable().durability_volatile());
+  auto pub_transient_local = publisher_node->create_publisher<test_msgs::msg::Strings>(
+    topic, rclcpp::QoS(1).reliable().transient_local());
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.topics = {topic};
+  record_options.rmw_serialization_format = "rmw_format";
+  record_options.topic_polling_interval = 100ms;
+  record_options.repeat_all_transient_local_depth = expected_depth;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  auto ret = rosbag2_test_common::wait_until_condition(
+    [&mock_writer, &topic, expected_depth]() {
+      auto depths = mock_writer.transient_local_topic_depths();
+      auto it = depths.find(topic);
+      return it != depths.end() && it->second == expected_depth;
+    },
+    std::chrono::seconds(5));
+  EXPECT_TRUE(ret)
+    << "failed to auto-detect repeat-transient-local for mixed-durability topic";
+}
+
+TEST_F(RecordIntegrationTestFixture, repeat_all_transient_local_skips_volatile_only_topic)
+{
+  // Verify that auto-detection does NOT enable repeat-transient-local for a topic where
+  // all publishers offer VOLATILE durability.
+  std::string topic = "/volatile_only_topic";
+
+  auto publisher_node = std::make_shared<rclcpp::Node>("rosbag2_test_volatile_only");
+  auto pub = publisher_node->create_publisher<test_msgs::msg::Strings>(
+    topic, rclcpp::QoS(1).reliable().durability_volatile());
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.topics = {topic};
+  record_options.rmw_serialization_format = "rmw_format";
+  record_options.topic_polling_interval = 100ms;
+  record_options.repeat_all_transient_local_depth = 5;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  // Wait for subscription to be established, then verify no transient-local depth was registered
+  auto subscribed = rosbag2_test_common::wait_until_condition(
+    [&mock_writer]() {
+      return mock_writer.get_topics().size() >= 1;
+    },
+    std::chrono::seconds(5));
+  ASSERT_TRUE(subscribed) << "recorder did not subscribe to topic in time";
+
+  auto depths = mock_writer.transient_local_topic_depths();
+  EXPECT_EQ(depths.find(topic), depths.end())
+    << "volatile-only topic should not be flagged as transient-local";
+}
+
 TEST_F(RecordIntegrationTestFixture, mixed_qos_subscribes) {
   // Ensure that rosbag2 subscribes to publishers that offer different durability policies
   const size_t arbitrary_history = 5;


### PR DESCRIPTION
## Changes

- Changed transient-local auto-detection from `std::all_of` to `std::any_of` — topics are now flagged for repeat if **any** publisher (not all) offers `TRANSIENT_LOCAL` durability.
- Removed the per-topic `WARN` log that fired for every topic where not all publishers offered transient-local (including topics with no TL publishers at all)
- Replaced the separate per-topic `INFO` log with inline depth info in the existing "Subscribed to topic" log (e.g. `Subscribed to topic '/plan' (repeat-transient-local, depth=1)`)


@MichaelOrlov do you see an issue with these new policies?