### PR TITLE
Fix race condition in RecordSrvsSimTimeTest by waiting for subscriber

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -156,6 +156,10 @@ public:
       clock_pub_ =
         client_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock",
                                                                   Rosbag2QoS::UnitTestQoS());
+      ASSERT_TRUE(
+        rosbag2_test_common::wait_until_condition(
+          [this]() {return clock_pub_->get_subscription_count() > 0;},
+          std::chrono::seconds(10)));
       current_sim_time_ = rclcpp::Time(1, 0, RCL_ROS_TIME);
       publish_clock(current_sim_time_);
       ASSERT_TRUE(


### PR DESCRIPTION
## Description

Some tests using simulated time failed with `rmw_connextdds` on Windows. This might be caused by the initial `/clock` message being sent before the recorder node has fully discovered the publisher. Since `Rosbag2QoS::UnitTestQoS()` uses volatile durability, the publisher won't keep any messages for late-joining subscribers, and the recorder never receives the first time message, leading to a timeout in `SetUp()`.

This commit assumes the issue is a discovery race condition where the clock message is lost, and attempts to fix the issue by waiting for the clock publisher to have at least one subscriber before publishing the initial clock message.

(Commit message generated with Gemini)

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Only to write the description

### Additional Information


<details><summary>Failed test output from Windows</summary>

```
89: [----------] 6 tests from RecordSrvsSimTimeTest
89: [ RUN      ] RecordSrvsSimTimeTest.split_bagfile_by_receive_time_scheduled
89: stdin is not a terminal or console device. Keyboard handling disabled.[INFO] [1775724046.134209600] [rosbag2_recorder_for_test_srvs]: Press SPACE for pausing/resuming
89: [INFO] [1775724046.134724500] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Started
89: [INFO] [1775724046.146452400] [rosbag2_recorder_for_test_srvs]: Starting recording to 'uri'
89: [WARN] [1775724046.146504400] [rosbag2_recorder_for_test_srvs]: The rmw_serialization_format option is deprecated and will be removed in a future release.
89: Please use output_serialization_format instead.
89: [WARN] [1775724046.146530000] [rosbag2_recorder_for_test_srvs]: No input serialization format specified, using default rmw serialization format: 'cdr'.
89: [INFO] [1775724046.146877700] [rosbag2_recorder_for_test_srvs]: Listening for topics...
89: [INFO] [1775724046.146940400] [rosbag2_recorder_for_test_srvs]: Recording...
89: [INFO] [1775724046.147398200] [rosbag2_recorder_for_test_srvs]: Topics discovery started.
89: [INFO] [1775724046.147608500] [rosbag2_recorder_for_test_srvs]: use_sim_time set, waiting for /clock before starting recording...
89: [INFO] [1775724046.270022800] [rosbag2_recorder_for_test_srvs]: Sim time /clock found, starting recording.
89: [INFO] [1775724046.273408600] [rosbag2_recorder_for_test_srvs]: Subscribed to topic '/recorder_srvs_test_topic'
89: [INFO] [1775724046.273469000] [rosbag2_recorder_for_test_srvs]: All requested topics are subscribed. Stopping discovery...
89: [INFO] [1775724046.273494200] [rosbag2_recorder_for_test_srvs]: Topics discovery stopped.
89: [INFO] [1775724046.373162000] [rosbag2_recorder_for_test_srvs]: Scheduled timestamp-based split at 1.200000000 seconds using receive timestamps on '/recorder_srvs_test_topic' topic.
89: [INFO] [1775724046.378920200] [rosbag2_recorder_for_test_srvs]: Scheduled 'Split bag file' for 1.210000000 seconds
89: [INFO] [1775724046.489710900] [rosbag2_recorder_for_test_srvs]: Recording stopped
89: [INFO] [1775724046.489759700] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Exited
89: [       OK ] RecordSrvsSimTimeTest.split_bagfile_by_receive_time_scheduled (567 ms)
89: [ RUN      ] RecordSrvsSimTimeTest.split_bagfile_by_receive_time_immediate_due
89: stdin is not a terminal or console device. Keyboard handling disabled.[INFO] [1775724046.700441400] [rosbag2_recorder_for_test_srvs]: Press SPACE for pausing/resuming
89: [INFO] [1775724046.700708100] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Started
89: [INFO] [1775724046.712616200] [rosbag2_recorder_for_test_srvs]: Starting recording to 'uri'
89: [WARN] [1775724046.712677000] [rosbag2_recorder_for_test_srvs]: The rmw_serialization_format option is deprecated and will be removed in a future release.
89: Please use output_serialization_format instead.
89: [WARN] [1775724046.712711100] [rosbag2_recorder_for_test_srvs]: No input serialization format specified, using default rmw serialization format: 'cdr'.
89: [INFO] [1775724046.713033200] [rosbag2_recorder_for_test_srvs]: Listening for topics...
89: [INFO] [1775724046.713082700] [rosbag2_recorder_for_test_srvs]: Recording...
89: [INFO] [1775724046.714450500] [rosbag2_recorder_for_test_srvs]: Topics discovery started.
89: [INFO] [1775724046.714526500] [rosbag2_recorder_for_test_srvs]: use_sim_time set, waiting for /clock before starting recording...
89: [INFO] [1775724046.836719300] [rosbag2_recorder_for_test_srvs]: Sim time /clock found, starting recording.
89: [INFO] [1775724046.839085200] [rosbag2_recorder_for_test_srvs]: Subscribed to topic '/recorder_srvs_test_topic'
89: [INFO] [1775724046.839173400] [rosbag2_recorder_for_test_srvs]: All requested topics are subscribed. Stopping discovery...
89: [INFO] [1775724046.839213900] [rosbag2_recorder_for_test_srvs]: Topics discovery stopped.
89: [INFO] [1775724047.039125200] [rosbag2_recorder_for_test_srvs]: Timestamp-based split request on '/recorder_srvs_test_topic' topic already due (req=0.900000000 s). Splitting immediately.
89: [INFO] [1775724047.048527800] [rosbag2_recorder_for_test_srvs]: Recording stopped
89: [INFO] [1775724047.048570700] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Exited
89: [       OK ] RecordSrvsSimTimeTest.split_bagfile_by_receive_time_immediate_due (555 ms)
89: [ RUN      ] RecordSrvsSimTimeTest.split_bagfile_by_node_time_respects_future_timestamp
89: stdin is not a terminal or console device. Keyboard handling disabled.[INFO] [1775724047.245301100] [rosbag2_recorder_for_test_srvs]: Press SPACE for pausing/resuming
89: [INFO] [1775724047.246031900] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Started
89: [INFO] [1775724047.256138200] [rosbag2_recorder_for_test_srvs]: Starting recording to 'uri'
89: [WARN] [1775724047.256200200] [rosbag2_recorder_for_test_srvs]: The rmw_serialization_format option is deprecated and will be removed in a future release.
89: Please use output_serialization_format instead.
89: [WARN] [1775724047.256225600] [rosbag2_recorder_for_test_srvs]: No input serialization format specified, using default rmw serialization format: 'cdr'.
89: [INFO] [1775724047.256492400] [rosbag2_recorder_for_test_srvs]: Listening for topics...
89: [INFO] [1775724047.256539200] [rosbag2_recorder_for_test_srvs]: Recording...
89: [INFO] [1775724047.256925900] [rosbag2_recorder_for_test_srvs]: Topics discovery started.
89: [INFO] [1775724047.257090600] [rosbag2_recorder_for_test_srvs]: use_sim_time set, waiting for /clock before starting recording...
89: [INFO] [1775724047.378109300] [rosbag2_recorder_for_test_srvs]: Scheduled 'Split bag file' for 1.200000000 seconds
89: [INFO] [1775724047.379711100] [rosbag2_recorder_for_test_srvs]: Sim time /clock found, starting recording.
89: [INFO] [1775724047.383750000] [rosbag2_recorder_for_test_srvs]: Topics discovery stopped.
89: Failed to publish log message to rosout: publisher's context is invalid, at C:\ci\ws\src\ros2\rcl\rcl\src\rcl\publisher.c:427
89: [INFO] [1775724047.392927000] [rosbag2_recorder_for_test_srvs]: Recording stopped
89: [INFO] [1775724047.392965800] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Exited
89: [       OK ] RecordSrvsSimTimeTest.split_bagfile_by_node_time_respects_future_timestamp (343 ms)
89: [ RUN      ] RecordSrvsSimTimeTest.resume_by_node_time_respects_future_timestamp
89: stdin is not a terminal or console device. Keyboard handling disabled.[INFO] [1775724047.596819500] [rosbag2_recorder_for_test_srvs]: Press SPACE for pausing/resuming
89: [INFO] [1775724047.597762800] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Started
89: [INFO] [1775724047.609176100] [rosbag2_recorder_for_test_srvs]: Starting recording to 'uri'
89: [WARN] [1775724047.609234900] [rosbag2_recorder_for_test_srvs]: The rmw_serialization_format option is deprecated and will be removed in a future release.
89: Please use output_serialization_format instead.
89: [WARN] [1775724047.609266500] [rosbag2_recorder_for_test_srvs]: No input serialization format specified, using default rmw serialization format: 'cdr'.
89: [INFO] [1775724047.609533600] [rosbag2_recorder_for_test_srvs]: Listening for topics...
89: [INFO] [1775724047.609582400] [rosbag2_recorder_for_test_srvs]: Recording...
89: [INFO] [1775724047.609976600] [rosbag2_recorder_for_test_srvs]: Topics discovery started.
89: [INFO] [1775724047.610398200] [rosbag2_recorder_for_test_srvs]: use_sim_time set, waiting for /clock before starting recording...
89: [INFO] [1775724047.731794500] [rosbag2_recorder_for_test_srvs]: Pausing recording.
89: [INFO] [1775724047.732199600] [rosbag2_recorder_for_test_srvs]: Scheduled 'Resume recording' for 1.200000000 seconds
89: [INFO] [1775724047.732777200] [rosbag2_recorder_for_test_srvs]: Sim time /clock found, starting recording.
89: [INFO] [1775724047.737749700] [rosbag2_recorder_for_test_srvs]: Topics discovery stopped.
89: Failed to publish log message to rosout: publisher's context is invalid, at C:\ci\ws\src\ros2\rcl\rcl\src\rcl\publisher.c:427
89: [INFO] [1775724047.746376200] [rosbag2_recorder_for_test_srvs]: Recording stopped
89: [INFO] [1775724047.746418200] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Exited
89: [       OK ] RecordSrvsSimTimeTest.resume_by_node_time_respects_future_timestamp (354 ms)
89: [ RUN      ] RecordSrvsSimTimeTest.resume_by_receive_time_immediate_due
89: stdin is not a terminal or console device. Keyboard handling disabled.[INFO] [1775724047.949983200] [rosbag2_recorder_for_test_srvs]: Press SPACE for pausing/resuming
89: [INFO] [1775724047.950965300] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Started
89: [INFO] [1775724047.962747100] [rosbag2_recorder_for_test_srvs]: Starting recording to 'uri'
89: [WARN] [1775724047.962809900] [rosbag2_recorder_for_test_srvs]: The rmw_serialization_format option is deprecated and will be removed in a future release.
89: Please use output_serialization_format instead.
89: [WARN] [1775724047.962840000] [rosbag2_recorder_for_test_srvs]: No input serialization format specified, using default rmw serialization format: 'cdr'.
89: [INFO] [1775724047.963106200] [rosbag2_recorder_for_test_srvs]: Listening for topics...
89: [INFO] [1775724047.963154200] [rosbag2_recorder_for_test_srvs]: Recording...
89: [INFO] [1775724047.963553600] [rosbag2_recorder_for_test_srvs]: Topics discovery started.
89: [INFO] [1775724047.963791000] [rosbag2_recorder_for_test_srvs]: use_sim_time set, waiting for /clock before starting recording...
89: C:\ci\ws\src\ros2\rosbag2\rosbag2_transport\test\rosbag2_transport\test_record_services.cpp(164): error: Value of: rosbag2_test_common::wait_until_condition( [this]() {return recorder_->get_clock()->started();}, std::chrono::seconds(10))
89:   Actual: false
89: Expected: true
89: 
89: [INFO] [1775724058.088852600] [rosbag2_recorder_for_test_srvs]: Topics discovery stopped.
89: Failed to publish log message to rosout: publisher's context is invalid, at C:\ci\ws\src\ros2\rcl\rcl\src\rcl\publisher.c:427
89: [INFO] [1775724058.096743300] [rosbag2_recorder_for_test_srvs]: Recording stopped
89: [INFO] [1775724058.096793800] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Exited
89: [  FAILED  ] RecordSrvsSimTimeTest.resume_by_receive_time_immediate_due (10349 ms)
89: [ RUN      ] RecordSrvsSimTimeTest.record_can_be_scheduled_in_future
89: stdin is not a terminal or console device. Keyboard handling disabled.[INFO] [1775724058.295670800] [rosbag2_recorder_for_test_srvs]: Press SPACE for pausing/resuming
89: [INFO] [1775724058.295870800] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Started
89: [INFO] [1775724058.307804900] [rosbag2_recorder_for_test_srvs]: Starting recording to 'uri'
89: [WARN] [1775724058.307878200] [rosbag2_recorder_for_test_srvs]: The rmw_serialization_format option is deprecated and will be removed in a future release.
89: Please use output_serialization_format instead.
89: [WARN] [1775724058.307900500] [rosbag2_recorder_for_test_srvs]: No input serialization format specified, using default rmw serialization format: 'cdr'.
89: [INFO] [1775724058.308171600] [rosbag2_recorder_for_test_srvs]: Listening for topics...
89: [INFO] [1775724058.308224700] [rosbag2_recorder_for_test_srvs]: Recording...
89: [INFO] [1775724058.309385800] [rosbag2_recorder_for_test_srvs]: Topics discovery started.
89: [INFO] [1775724058.309525500] [rosbag2_recorder_for_test_srvs]: use_sim_time set, waiting for /clock before starting recording...
89: C:\ci\ws\src\ros2\rosbag2\rosbag2_transport\test\rosbag2_transport\test_record_services.cpp(164): error: Value of: rosbag2_test_common::wait_until_condition( [this]() {return recorder_->get_clock()->started();}, std::chrono::seconds(10))
89:   Actual: false
89: Expected: true
89: 
89: [INFO] [1775724068.489542400] [rosbag2_recorder_for_test_srvs]: Topics discovery stopped.
89: Failed to publish log message to rosout: publisher's context is invalid, at C:\ci\ws\src\ros2\rcl\rcl\src\rcl\publisher.c:427
89: [INFO] [1775724068.497886200] [rosbag2_recorder_for_test_srvs]: Recording stopped
89: [INFO] [1775724068.498041100] [rosbag2_recorder_for_test_srvs]: Event publisher thread: Exited
89: [  FAILED  ] RecordSrvsSimTimeTest.record_can_be_scheduled_in_future (10501 ms)
```
</details>

Looks like it failed once on Linux too

https://ci.ros2.org/view/nightly/job/nightly_linux_release/3852/testReport/junit/rosbag2_transport/RecordSrvsSimTimeTest/resume_by_receive_time_immediate_due/