### PR TITLE
Add validation for empty file path in compression process

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -333,12 +333,17 @@ void SequentialCompressionWriter::compress_file(
   BaseCompressorInterface & compressor,
   const std::string & file_relative_to_bag)
 {
+  if (file_relative_to_bag.empty()) {
+    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM("Cannot compress file with empty path relative to bag."
+                                         " Skipping compression.");
+    return;
+  }
   const auto file_relative_to_pwd = fs::path(base_folder_) / file_relative_to_bag;
-  ROSBAG2_COMPRESSION_LOG_INFO_STREAM("Compressing file: " << file_relative_to_pwd.string());
 
-  if (fs::exists(file_relative_to_pwd) &&
+  if (fs::exists(file_relative_to_pwd) && !fs::is_directory(file_relative_to_pwd) &&
     fs::file_size(file_relative_to_pwd) > 0u)
   {
+    ROSBAG2_COMPRESSION_LOG_INFO_STREAM("Compressing file: " << file_relative_to_pwd.string());
     const auto compressed_uri = compressor.compress_uri(file_relative_to_pwd.string());
     const auto relative_compressed_uri = fs::path(compressed_uri).filename();
     {
@@ -367,7 +372,7 @@ void SequentialCompressionWriter::compress_file(
           "will not be halted because the compressed output was successfully created.");
     }
   } else {
-    ROSBAG2_COMPRESSION_LOG_DEBUG_STREAM(
+    ROSBAG2_COMPRESSION_LOG_WARN_STREAM(
       "Removing last file: \"" << file_relative_to_pwd.string() <<
         "\" because it either is empty or does not exist.");
   }


### PR DESCRIPTION
## Description

This PR adds extra validation for an empty file path in the  `SequentialCompressionWriter::compress_file(compressor, file_relative_to_bag)`.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes https://github.com/ros2/rosbag2/issues/2397

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported 
<!--
If applicable, provide any additional context or details about the changes.
-->
