### PR TITLE
[Kilted] Don't pause recorder after stop

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -273,7 +273,6 @@ void RecorderImpl::stop()
   }
 
   stop_discovery();
-  pause();
   subscriptions_.clear();
   writer_->close();  // Call writer->close() to finalize current bag file and write metadata
 


### PR DESCRIPTION
## Description

Removes pause from stop, as in #2313 from rolling.

Fixes [# 2409](https://github.com/ros2/rosbag2/issues/2409)

### Is this user-facing behavior change?

Yes, but should fix a regression.

### Did you use Generative AI?

Claude Opus 4.6 assisted with triage.

### Additional Information

Can be back ported to Jazzy as well.