### PR TITLE
[kilted] Add known limitations section to README regarding recorder restart behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,3 +634,24 @@ For example, you want a timestamp on the bag directory name, but want a custom p
 $ ros2 bag record -a -o mybag_"$(date +"%Y_%m_%d-%H_%M_%S")"
 ... creates e.g. mybag_2025_02_21-15_35_35
 ```
+
+## Known limitations
+
+### Recorder restart after `stop()`
+
+In Kilted and Jazzy, `Recorder::stop()` / `~/stop` intentionally enforces a pause as part of 
+shutdown to mitigate undefined behavior when subscription's callbacks are propagated to the 
+executor and may still be in the executor's queue after finishing the stop() operation.
+
+As a result, the recorder can remain in the paused state after `stop()` completes. If recording is
+started again with the same recorder instance via `Recorder::record()` / `~/record`, that paused
+state is reused and the restarted recorder will remain paused until it is explicitly resumed.
+
+Workaround: if you intend to restart recording with the same recorder instance, call
+`Recorder::resume()` / `~/resume` right after the next `record()` call.
+
+```cpp
+recorder->stop();
+recorder->record();
+recorder->resume();
+```

--- a/rosbag2_transport/include/rosbag2_transport/recorder.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/recorder.hpp
@@ -131,6 +131,10 @@ public:
   /// @brief Stopping recording.
   /// @details The stop() is opposite to the record() operation. It will stop recording, dump
   /// all buffers to the disk and close writer. The record() can be called again after stop().
+  /// @note The stop() also enforces a pause during shutdown to mitigate undefined behavior
+  /// while the recorder is stopping and finalizing the bag file. As a result, the recorder
+  /// remains paused after stop() completes. If recording is restarted with the same recorder
+  /// instance, call resume() after record() to clear that paused state.
   ROSBAG2_TRANSPORT_PUBLIC
   void stop();
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -71,6 +71,10 @@ public:
 
   /// @brief Stopping recording and closing writer.
   /// The record() can be called again after stop().
+  /// @note The stop() also enforces a pause during shutdown to mitigate undefined behavior
+  /// while the recorder is stopping and finalizing the bag file. As a result, the recorder
+  /// remains paused after stop() completes. If recording is restarted with the same recorder
+  /// instance, call resume() after record() to clear that paused state.
   void stop();
 
   const rosbag2_cpp::Writer & get_writer_handle();


### PR DESCRIPTION
## Description

This PR adds the known limitations section to the README file regarding recorder restart behavior.

In Kilted and Jazzy, `Recorder::stop()` / `~/stop` intentionally enforces a pause as part of shutdown to mitigate undefined behavior when subscription's callbacks are propagated to the executor and may still be in the executor's queue after finishing the stop() operation.

As a result, the recorder can remain in the paused state after `stop()` completes. If recording is started again with the same recorder instance via `Recorder::record()` / `~/record`, that paused state is reused, and the restarted recorder will remain paused until it is explicitly resumed.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes # N/A
- Relates https://github.com/ros2/rosbag2/pull/2410
- Relates https://github.com/ros2/rosbag2/issues/2409

### Is this user-facing behavior change?
No.
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Used Codex to help update README file
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported to Jazzy
<!--
If applicable, provide any additional context or details about the changes.
-->
