### PR TITLE
Update README.md with updated topic recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This auto-discovery of new topics can be disabled by given the command line argu
 To record a set of predefined topics, one can specify them on the command line explicitly.
 
 ```
-$ ros2 bag record <topic1> <topic2> … <topicN>
+$ ros2 bag record --topics <topic1> <topic2> … <topicN>
 ```
 
 Press `Ctrl+C` to stop the recording.


### PR DESCRIPTION
## Description

When running lyrical testing, the current command gives the following error:
```
/# ros2 bag record /number /topic
usage: ros2 [-h] [--use-python-default-buffering] Call `ros2 <command> -h` for more detailed usage. ...
ros2: error: unrecognized arguments: /number /topic
```

This is the correct command:
```
ros2 bag record --topics /number /topic
```

### Is this user-facing behavior change?
Yes, users need to include `--topic` if they want to specify specific topics.

### Did you use Generative AI?
No