### PR TITLE
feat: Add support for writing custom metadata records to the bag

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_CPP__WRITER_HPP_
 
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -262,6 +263,15 @@ public:
    * \return True if there is any callback registered for the event, false otherwise.
    */
   [[nodiscard]] bool has_callback_for_event(bag_events::BagEvent event) const;
+
+  /**
+   * \brief Write a custom metadata record to the bag.
+   * \param name Identifier for this metadata record.
+   * \param kv Key-value pairs to store.
+   */
+  void write_custom_metadata(
+    const std::string & name,
+    const std::map<std::string, std::string> & kv);
 
 private:
   std::mutex writer_mutex_;

--- a/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
@@ -16,7 +16,9 @@
 #define ROSBAG2_CPP__WRITER_INTERFACES__BASE_WRITER_INTERFACE_HPP_
 
 #include <cstddef>
+#include <map>
 #include <memory>
+#include <string>
 
 #include "rosbag2_cpp/bag_events.hpp"
 #include "rosbag2_cpp/converter_options.hpp"
@@ -80,6 +82,15 @@ public:
    * \return True if there is any callback registered for the event, false otherwise.
    */
   [[nodiscard]] virtual bool has_callback_for_event(bag_events::BagEvent event) const = 0;
+
+  /**
+   * \brief Write a custom metadata record to the bag.
+   * \param name Identifier for this metadata record.
+   * \param kv Key-value pairs to store.
+   */
+  virtual void write_custom_metadata(
+    const std::string & name,
+    const std::map<std::string, std::string> & kv) = 0;
 };
 
 }  // namespace writer_interfaces

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_CPP__WRITERS__SEQUENTIAL_WRITER_HPP_
 
 #include <deque>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -161,6 +162,15 @@ public:
    * \return True if there is any callback registered for the event, false otherwise.
    */
   [[nodiscard]] bool has_callback_for_event(bag_events::BagEvent event) const override;
+
+  /**
+   * \brief Write a custom metadata record to the bag.
+   * \param name Identifier for this metadata record.
+   * \param kv Key-value pairs to store.
+   */
+  void write_custom_metadata(
+    const std::string & name,
+    const std::map<std::string, std::string> & kv) override;
 
 protected:
   std::string base_folder_;

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -195,4 +195,12 @@ bool Writer::has_callback_for_event(bag_events::BagEvent event) const
   return writer_impl_->has_callback_for_event(event);
 }
 
+void Writer::write_custom_metadata(
+  const std::string & name,
+  const std::map<std::string, std::string> & kv)
+{
+  std::lock_guard<std::mutex> writer_lock(writer_mutex_);
+  writer_impl_->write_custom_metadata(name, kv);
+}
+
 }  // namespace rosbag2_cpp

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -19,6 +19,7 @@
 #include <ctime>
 #include <filesystem>
 #include <iomanip>
+#include <map>
 #include <memory>
 #include <regex>
 #include <stdexcept>
@@ -889,6 +890,15 @@ void SequentialWriter::add_event_callbacks(const bag_events::WriterEventCallback
 bool SequentialWriter::has_callback_for_event(bag_events::BagEvent event) const
 {
   return callback_manager_.has_callback_for_event(event);
+}
+
+void SequentialWriter::write_custom_metadata(
+  const std::string & name,
+  const std::map<std::string, std::string> & kv)
+{
+  if (storage_) {
+    storage_->write_custom_metadata(name, kv);
+  }
 }
 
 }  // namespace writers

--- a/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/storage_interfaces/base_write_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_WRITE_INTERFACE_HPP_
 #define ROSBAG2_STORAGE__STORAGE_INTERFACES__BASE_WRITE_INTERFACE_HPP_
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -86,6 +87,14 @@ public:
   /// create_topic, which adds a topic to the internal storage references.
   /// \param topic - Metadata of the topic to remove.
   virtual void remove_topic(const TopicMetadata & topic) = 0;
+
+  /// \brief Writes a custom metadata record to the storage.
+  /// \param name - Identifier for this metadata record.
+  /// \param kv - Key-value pairs to store.
+  /// \note Not all storage backends support custom metadata. The default implementation is a no-op.
+  virtual void write_custom_metadata(
+    const std::string & /*name*/,
+    const std::map<std::string, std::string> & /*kv*/) {}
 };
 
 }  // namespace storage_interfaces

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -213,6 +213,8 @@ public:
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_UPDATE_METADATA
   void update_metadata(const rosbag2_storage::BagMetadata &) override;
 #endif
+  void write_custom_metadata(const std::string & name,
+                             const std::map<std::string, std::string> & kv) override;
 
 private:
   void read_metadata();
@@ -990,6 +992,19 @@ void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
     const auto & datatype = topic_it->second.topic_metadata.type;
     schema_ids_.erase(datatype);
     topics_.erase(topic.name);
+  }
+}
+
+void MCAPStorage::write_custom_metadata(const std::string & name,
+                                        const std::map<std::string, std::string> & kv)
+{
+  std::lock_guard<std::mutex> lock(mcap_storage_mutex_);
+  mcap::Metadata metadata;
+  metadata.name = name;
+  metadata.metadata.insert(kv.begin(), kv.end());
+  auto status = mcap_writer_->write(metadata);
+  if (!status.ok()) {
+    OnProblem(status);
   }
 }
 

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -16,6 +16,7 @@
 #define ROSBAG2_TRANSPORT__MOCK_SEQUENTIAL_WRITER_HPP_
 
 #include <atomic>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -124,6 +125,10 @@ public:
   {
     return callback_manager_.has_callback_for_event(event);
   }
+
+  void write_custom_metadata(
+    const std::string & /*name*/,
+    const std::map<std::string, std::string> & /*kv*/) override {}
 
   size_t get_number_of_recorded_messages() const
   {


### PR DESCRIPTION
## Description

Add `write_custom_metadata()` API to allow users to write arbitrary MCAP Metadata records through the rosbag2 writer stack.

Currently, there is no way to write custom metadata records to an MCAP bag through rosbag2. The only metadata written is the internal `"rosbag2"` summary record via `update_metadata()`. Users who need to annotate bags with custom key-value metadata (e.g., robot name, event markers, provenance info) must resort to binary surgery on the MCAP file after it is closed — reopening the file, truncating the summary section, appending metadata records, and rewriting the footer/index.

This PR adds a clean API path through the entire stack:

1. **`rosbag2_storage::BaseWriteInterface`** — new virtual `write_custom_metadata(name, kv)` with a default no-op (non-breaking for existing storage plugins like sqlite3)
2. **`rosbag2_storage_mcap::MCAPStorage`** — overrides it to write a native `mcap::Metadata` record
3. **`rosbag2_cpp::writer_interfaces::BaseWriterInterface`** — new pure virtual
4. **`rosbag2_cpp::writers::SequentialWriter`** — forwards to `storage_->write_custom_metadata()`
5. **`rosbag2_cpp::Writer`** — public thread-safe method

### Usage

```cpp
auto writer = std::make_shared<rosbag2_cpp::Writer>();
writer->open(storage_options);

// ... write messages ...

writer->write_custom_metadata("my_application", {
  {"robot_name", "arri-160"},
  {"created_at", "2026-05-06T08:00:00Z"},
  {"map_name", "warehouse_A"},
});

writer->close();
```

The metadata records appear in the MCAP summary section and are indexed for fast retrieval without scanning messages.

Fixes # (issue)

### Is this user-facing behavior change?

Yes. Users can now write custom MCAP Metadata records through `rosbag2_cpp::Writer::write_custom_metadata()`. This is additive — no existing behavior is changed. Storage plugins that don't support custom metadata (e.g., sqlite3) inherit the default no-op.

### Did you use Generative AI?

Yes — GitHub Copilot (Claude Opus 4.6) was used to implement and iterate on this change.

### Additional Information

- The `BaseWriteInterface` method has a default empty implementation (`{}`) so existing storage plugins (sqlite3, test mocks) are not broken.
- The `BaseWriterInterface` method is pure virtual since all writer implementations (SequentialWriter) must explicitly handle it.
- The MockSequentialWriter in rosbag2_transport tests has been updated with a no-op override.
- The MCAP implementation uses `metadata.metadata.insert(kv.begin(), kv.end())` to convert from `std::map` to the `std::unordered_map` used by `mcap::Metadata`.

FYI @doisyg
