### PR TITLE
Apply /bigobj to all MSVC builds in rosbag2_transport

### DIFF
--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -15,10 +15,10 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND MSVC)
+if(MSVC)
   # /bigobj is needed to avoid error C1128:
   #   https://msdn.microsoft.com/en-us/library/8578y171.aspx
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+  add_compile_options(/bigobj)
 endif()
 
 # Windows supplies macros for min and max by default. We should only use min and max from stl


### PR DESCRIPTION
This PR applies the `/bigobj` compiler flag to all MSVC builds in `rosbag2_transport`.

### **The Problem**
In some Windows CI jobs (likely using `RelWithDebInfo` or `Release`), the compiler hits the object file section limit in `test_play.cpp`:
```
error C1128: number of sections exceeded object file format limit: compile with /bigobj
```

Ref: https://ci.ros2.org/job/ci_windows/27839/console

Previously, the flag was only applied to `Debug` builds.

### **The Fix**
Removed the `CMAKE_BUILD_TYPE STREQUAL "Debug"` constraint and switched to `add_compile_options(/bigobj)` for all MSVC builds to ensure large test objects are handled correctly across all build types.

This is a port of the same fix applied to Humble in https://github.com/ros2/rosbag2/pull/1571.

Assisted-by: Gemini CLI:2.0-Flash [run_shell_command, read_file, replace, write_file, git]
