### PR TITLE
Address flakiness in RecordSrvsSimTimeTest fixture

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -103,9 +103,6 @@ public:
   {
     RecordIntegrationTestFixture::SetUp();
     client_node_ = std::make_shared<rclcpp::Node>("test_record_client");
-    if (use_sim_time_) {
-      client_node_->set_parameter(rclcpp::Parameter("use_sim_time", true));
-    }
 
     auto record_topics =
       is_discovery_disabled_ ? std::vector<std::string>{} : topics_to_record_;
@@ -158,7 +155,11 @@ public:
                                                                   Rosbag2QoS::UnitTestQoS());
       ASSERT_TRUE(
         rosbag2_test_common::wait_until_condition(
-          [this]() {return clock_pub_->get_subscription_count() > 0;},
+          [this]()
+          {
+            return clock_pub_->get_subscription_count() +
+                   clock_pub_->get_intra_process_subscription_count() > 0;
+          },
           std::chrono::seconds(10)));
       current_sim_time_ = rclcpp::Time(1, 0, RCL_ROS_TIME);
       publish_clock(current_sim_time_);


### PR DESCRIPTION
## Description

This PR addresses flakiness in rosbag2_transport tests using `RecordSrvsSimTimeTest` fixture.

- Removed unnecessary sim time parameter and enhance subscription count check
- Using `client_node_->set_parameter(rclcpp::Parameter("use_sim_time", true));`  was causing the subscription for the `/clock` topic to appear on the `/clock`  publisher node. That was triggering 
```cpp
  ASSERT_TRUE(
         rosbag2_test_common::wait_until_condition(
           [this]() {return clock_pub_->get_subscription_count() > 0;},
           std::chrono::seconds(10)));
```
  before the recorder node got subscribed to the `/clock` topic as well.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes #2425

### Is this user-facing behavior change?
No.
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes. Codex gpt5.4 for issue analysis.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported
<!--
If applicable, provide any additional context or details about the changes.
-->
