### PR TITLE
address RHEL uncrustify warning.

### DIFF
--- a/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_circular_message_cache.cpp
@@ -164,7 +164,7 @@ TEST_F(CircularMessageCacheTest, time_only_buffer_drops_old_messages_by_duration
   // No size limit, keep ~1s window
   const uint32_t max_buffer_duration = 1;  // 1 second
   auto circular_message_cache = std::make_shared<rosbag2_cpp::cache::CircularMessageCache>(
-    /*max_buffer_size=*/0, max_buffer_duration);
+    /*max_buffer_size=*/ 0, max_buffer_duration);
 
   // Push messages with synthetic timestamps spaced 100ms
   const auto base = 1s;


### PR DESCRIPTION
## Description

see https://ci.ros2.org/job/ci_linux-rhel/8929/testReport/

```console
-- run_test.py: invoking following command in '/home/jenkins-agent/workspace/ci_linux-rhel/ws/src/ros2/rosbag2/rosbag2_cpp':
 - /home/jenkins-agent/workspace/ci_linux-rhel/ws/install/ament_uncrustify/bin/ament_uncrustify --xunit-file /home/jenkins-agent/workspace/ci_linux-rhel/ws/build/rosbag2_cpp/test_results/rosbag2_cpp/uncrustify.xunit.xml
Code style divergence in file 'test/rosbag2_cpp/test_circular_message_cache.cpp':

--- test/rosbag2_cpp/test_circular_message_cache.cpp
+++ test/rosbag2_cpp/test_circular_message_cache.cpp.uncrustify
@@ -167 +167 @@
-    /*max_buffer_size=*/0, max_buffer_duration);
+    /*max_buffer_size=*/ 0, max_buffer_duration);

1 files with code style divergence
```

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
