### PR TITLE
[Humble] Added option to change node name for the recorder from the Python API (backport #1180)

### DIFF
--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -171,6 +171,9 @@ class RecordVerb(VerbExtension):
             '--log-level', type=str, default='info',
             choices=['debug', 'info', 'warn', 'error', 'fatal'],
             help='Logging level.')
+        parser.add_argument(
+            '--node-name', type=str, default='rosbag2_recorder',
+            help='Specify the recorder node name. Default is rosbag2_recorder.')
         self._subparser = parser
 
     def main(self, *, args):  # noqa: D102
@@ -262,7 +265,7 @@ class RecordVerb(VerbExtension):
         recorder = Recorder(args.log_level)
 
         try:
-            recorder.record(storage_options, record_options)
+            recorder.record(storage_options, record_options, args.node_name)
         except KeyboardInterrupt:
             pass
 

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -187,7 +187,8 @@ public:
 
   void record(
     const rosbag2_storage::StorageOptions & storage_options,
-    RecordOptions & record_options)
+    RecordOptions & record_options,
+    std::string & node_name)
   {
     auto old_sigterm_handler = std::signal(
       SIGTERM, [](int /* signal */) {
@@ -207,7 +208,7 @@ public:
 
       auto writer = rosbag2_transport::ReaderWriterFactory::make_writer(record_options);
       auto recorder = std::make_shared<rosbag2_transport::Recorder>(
-        std::move(writer), storage_options, record_options);
+        std::move(writer), storage_options, record_options, node_name);
       recorder->record();
 
       exec->add_node(recorder);
@@ -376,7 +377,8 @@ PYBIND11_MODULE(_transport, m) {
   .def(py::init<>())
   .def(py::init<const std::string &>())
   .def(
-    "record", &rosbag2_py::Recorder::record, py::arg("storage_options"), py::arg("record_options"))
+    "record", &rosbag2_py::Recorder::record, py::arg("storage_options"), py::arg("record_options"),
+    py::arg("node_name") = "rosbag2_recorder")
   .def_static("cancel", &rosbag2_py::Recorder::cancel)
   ;
 


### PR DESCRIPTION
## Description

This is a backport of #1180 to use the option to give the recorder a custom node name.

### Is this user-facing behavior change?

No, previously existing behavior is not changed.

### Did you use Generative AI?

No

### Additional Information

None
