### PR TITLE
feat(rosbag2_transport): add progress reporting to ros2 bag convert

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/bag_rewrite.cpp
@@ -21,11 +21,14 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <cstdio>
+#include <cinttypes>
 
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/writer.hpp"
 #include "rosbag2_transport/reader_writer_factory.hpp"
 #include "rosbag2_transport/topic_filter.hpp"
+
 
 namespace
 {
@@ -177,8 +180,30 @@ void perform_rewrite(
 
   auto topic_outputs = setup_topic_filtering(input_bags, output_bags);
 
+  // Sum total message count across all input bags for progress reporting
+  // Sum total message count across all input bags for progress reporting
+  uint64_t total_messages = 0;
+  for (const auto & [reader, storage_options] : input_bags) {
+    if (reader) {
+      const auto & metadata = reader->get_metadata();
+      for (const auto & topic_info : metadata.topics_with_message_count) {
+        total_messages += topic_info.message_count;
+      }
+    }
+  }
+  if (total_messages > 0) {
+    fprintf(stdout, "Converting bag:   0%% (0 / %" PRIu64 " messages)", total_messages);
+    fflush(stdout);
+  } else {
+    fprintf(stdout, "Converting bag: starting (total unknown)...");
+    fflush(stdout);
+  }
+
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> next_messages;
   next_messages.resize(input_bags.size(), nullptr);
+
+  uint64_t processed = 0;
+  int last_printed_pct = 0;
 
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> next_msg;
   while ((next_msg = get_next(input_bags, next_messages))) {
@@ -188,7 +213,21 @@ void perform_rewrite(
         writer->write(next_msg);
       }
     }
+    ++processed;
+
+    if (total_messages > 0) {
+      int pct = static_cast<int>((processed * 100) / total_messages);
+      if (pct > last_printed_pct) {
+        fprintf(
+          stdout, "\rConverting bag: %3d%% (%" PRIu64 " / %" PRIu64 " messages)   ",
+          pct, processed, total_messages);
+        fflush(stdout);
+        last_printed_pct = pct;
+      }
+    }
   }
+  fprintf(
+    stdout, "\nConverting bag: done (%" PRIu64 " messages written)\n", processed);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description
Add progress reporting to `ros2 bag convert` so users can gauge how long
large bag conversions will take.

Previously, the convert command gave no feedback during conversion, making
it impossible to estimate remaining time for large bags.

Changes:
- Sum total message count from input bag metadata before conversion starts
- Print progress at each 1% increment with message count
- Handle edge case where total message count is unknown
- Print final done message with total messages written

Example output:
```
[INFO] [rosbag2_transport]: Converting bag: 0% (0 / 30 messages)
[INFO] [rosbag2_transport]: Converting bag: 50% (15 / 30 messages)
[INFO] [rosbag2_transport]: Converting bag: 100% (30 / 30 messages)
[INFO] [rosbag2_transport]: Converting bag: done (30 messages written)
```

Fixes #2435

### Is this user-facing behavior change?
Yes. Users will now see progress output when running `ros2 bag convert`.

### Did you use Generative AI?
No.

### Additional Information
Tested manually with a recorded bag on Rolling (Lyrical Luth tarball).