### PR TITLE
[jazzy] Fix per-file message count for zero-cache writes

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -545,10 +545,6 @@ void SequentialWriter::write_messages(
   }
   storage_->write(messages);
 
-  if (!storage_options_.snapshot_mode) {
-    metadata_.files.back().message_count += messages.size();
-  }
-
   if (storage_options_.snapshot_mode) {
     // Update FileInformation about the last file in metadata in case of snapshot mode
     const auto first_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
@@ -557,8 +553,9 @@ void SequentialWriter::write_messages(
       std::chrono::nanoseconds(messages.back()->recv_timestamp));
     metadata_.files.back().starting_time = first_msg_timestamp;
     metadata_.files.back().duration = last_msg_timestamp - first_msg_timestamp;
-    metadata_.files.back().message_count = messages.size();
   }
+
+  metadata_.files.back().message_count += messages.size();
   metadata_.message_count += messages.size();
   std::lock_guard<std::mutex> lock(topics_info_mutex_);
   for (const auto & msg : messages) {

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -438,7 +438,6 @@ void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBa
 
   auto converted_msg = get_writeable_message(message);
 
-  metadata_.files.back().message_count++;
   if (storage_options_.max_cache_size == 0u) {
     // If cache size is set to zero, we write to storage directly
     storage_->write(converted_msg);
@@ -545,6 +544,11 @@ void SequentialWriter::write_messages(
     return;
   }
   storage_->write(messages);
+
+  if (!storage_options_.snapshot_mode) {
+    metadata_.files.back().message_count += messages.size();
+  }
+
   if (storage_options_.snapshot_mode) {
     // Update FileInformation about the last file in metadata in case of snapshot mode
     const auto first_msg_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(


### PR DESCRIPTION
## Description

Fix `files[].message_count` being incremented twice when `max_cache_size == 0`, which is the write path used by `ros2 bag convert`.

Per-file counts are now updated after messages are written to storage for both direct and buffered writes. Snapshot behavior is unchanged.

To reproduce, record 10 messages and convert the bag. Before this change, the converted metadata reports 20 messages for the output file while the top-level and topic counts remain 10.

### Is this user-facing behavior change?

Yes. `files[].message_count` in converted `metadata.yaml` files now matches the actual number of messages.

### Did you use Generative AI?

Yes. ChatGPT 5.5 was used to analyze the bug and draft the PR text. The code changes and tests were performed manually.

### Additional Information

Tested with:

- `colcon test --packages-select rosbag2_cpp`
- Recording and converting a 10-message MCAP bag
