### PR TITLE
Initialize topic endpoint info in rosbag2 test

### DIFF
--- a/rosbag2_transport/test/rosbag2_transport/test_type_description_hash.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_type_description_hash.cpp
@@ -54,7 +54,7 @@ TEST(TestTopicTypeHash, test_formatting) {
 
 rclcpp::TopicEndpointInfo make_info(rosidl_type_hash_t hash)
 {
-  rcl_topic_endpoint_info_t info;
+  rcl_topic_endpoint_info_t info = rmw_get_zero_initialized_topic_endpoint_info();
   info.topic_type_hash = hash;
   info.topic_type = "topic_type";
   info.node_name = "node_name";


### PR DESCRIPTION
## Description

Initialize `rcl_topic_endpoint_info_t` in `make_info()` with `rmw_get_zero_initialized_topic_endpoint_info()`.

This avoids leaving any endpoint info fields, including newly added ones in future changes, uninitialized in the test helper before constructing `rclcpp::TopicEndpointInfo`.

### Is this user-facing behavior change?
This PR avoids potential intermittent test failures in `rosbag2_transport` due to uninitialized fields in `rcl_topic_endpoint_info_t`.

 ### Did you use Generative AI?
No.

### Additional Information
This fix is needed for changes included in https://github.com/ros2/ros2cli/issues/1245 that adds `buffer_backend_metadata` field in `rcl_topic_endpoint_info_t`.