### PR TITLE
Fallback to infile metadata for compressed bag files

### DIFF
--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_reader.cpp
@@ -95,12 +95,6 @@ void SequentialCompressionReader::open(
   const rosbag2_storage::StorageOptions & storage_options,
   const rosbag2_cpp::ConverterOptions & converter_options)
 {
-  if (!metadata_io_->metadata_file_exists(storage_options.uri)) {
-    std::stringstream errmsg;
-    errmsg << "Could not find metadata for bag: \"" << storage_options.uri <<
-      "\". Bags without metadata (such as from ROS 1) not supported by rosbag2 decompression.";
-    throw std::runtime_error{errmsg.str()};
-  }
   SequentialReader::open(storage_options, converter_options);
 }
 

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -110,25 +110,20 @@ void SequentialReader::open(
     current_file_iterator_ = file_paths_.begin();
     load_current_file();
   } else {
-    storage_ = storage_factory_->open_read_only(storage_options_);
-    if (!storage_) {
-      throw std::runtime_error("No storage could be initialized for the input URI: " +
-            storage_options.uri);
-    }
-    if (!set_read_order(read_order_)) {
-      ROSBAG2_CPP_LOG_WARN(
-        "Could not set read order on open(), falling back to file order");
-      if (!set_read_order(kFallbackOrder)) {
-        throw std::runtime_error("Could not set read order on open()");
-      }
-    }
+    ROSBAG2_CPP_LOG_WARN("No metadata.yaml file found. Assuming a single storage file and trying "
+                         "to read metadata from storage file.");
+    file_paths_ = {storage_options_.uri};
+    current_file_iterator_ = file_paths_.begin();
+    load_current_file();
     metadata_ = storage_->get_metadata();
     if (metadata_.relative_file_paths.empty()) {
       ROSBAG2_CPP_LOG_WARN("No file paths were found in metadata.");
       return;
     }
     file_paths_ = metadata_.relative_file_paths;
-    current_file_iterator_ = file_paths_.begin();
+    // Note: the current_file_iterator_ may have been initialized by the preprocess_current_file()
+    // for cases when we use decompressor to uncompress entire file. Do not initialize it again
+    // here with current_file_iterator_ = file_paths_.begin();
   }
   auto topics = metadata_.topics_with_message_count;
   if (topics.empty()) {
@@ -139,9 +134,8 @@ void SequentialReader::open(
 
   // Currently a bag file can only be played if all topics have the same serialization format.
   check_topics_serialization_formats(topics);
-  check_converter_serialization_format(
-    converter_options.output_serialization_format,
-    topics[0].topic_metadata.serialization_format);
+  check_converter_serialization_format(converter_options.output_serialization_format,
+                                       topics[0].topic_metadata.serialization_format);
 }
 
 bool SequentialReader::set_read_order(const rosbag2_storage::ReadOrder & order)
@@ -217,8 +211,7 @@ void SequentialReader::set_filter(
     storage_->set_filter(topics_filter_);
     return;
   }
-  throw std::runtime_error(
-          "Bag is not open. Call open() before setting filter.");
+  throw std::runtime_error("Bag is not open. Call open() before setting filter.");
 }
 
 void SequentialReader::reset_filter()
@@ -265,7 +258,7 @@ bool SequentialReader::has_prev_file() const
 
 void SequentialReader::load_current_file()
 {
-  // only preprocess if file hasn't been preprocessed before
+  // Only preprocess if file hasn't been preprocessed before
   // add path AFTER preprocessing since preprocessing may modify it
   if (preprocessed_file_paths_.find(get_current_file()) == preprocessed_file_paths_.end()) {
     preprocess_current_file();
@@ -275,10 +268,16 @@ void SequentialReader::load_current_file()
   storage_options_.uri = get_current_file();
   storage_ = storage_factory_->open_read_only(storage_options_);
   if (!storage_) {
-    throw std::runtime_error{"No storage could be initialized. Abort"};
+    throw std::runtime_error("No storage could be initialized for the input URI: " +
+                             storage_options_.uri);
   }
   // set filters
-  storage_->set_read_order(read_order_);
+  if (!set_read_order(read_order_)) {
+    ROSBAG2_CPP_LOG_WARN("Could not set read order on open(), falling back to file order");
+    if (!set_read_order(kFallbackOrder)) {
+      throw std::runtime_error("Could not set read order on open()");
+    }
+  }
   storage_->seek(seek_time_);
   set_filter(topics_filter_);
 }
@@ -288,7 +287,7 @@ void SequentialReader::load_next_file()
   assert(current_file_iterator_ != file_paths_.end());
   auto info = std::make_shared<bag_events::BagSplitInfo>();
   info->closed_file = get_current_file();
-  current_file_iterator_++;
+  ++current_file_iterator_;
   info->opened_file = get_current_file();
   load_current_file();
   callback_manager_.execute_callbacks(bag_events::BagEvent::READ_SPLIT, info);
@@ -299,7 +298,7 @@ void SequentialReader::load_prev_file()
   assert(current_file_iterator_ != file_paths_.begin());
   auto info = std::make_shared<bag_events::BagSplitInfo>();
   info->closed_file = get_current_file();
-  current_file_iterator_--;
+  --current_file_iterator_;
   info->opened_file = get_current_file();
   load_current_file();
   callback_manager_.execute_callbacks(bag_events::BagEvent::READ_SPLIT, info);

--- a/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/readers/sequential_reader.cpp
@@ -116,14 +116,6 @@ void SequentialReader::open(
     current_file_iterator_ = file_paths_.begin();
     load_current_file();
     metadata_ = storage_->get_metadata();
-    if (metadata_.relative_file_paths.empty()) {
-      ROSBAG2_CPP_LOG_WARN("No file paths were found in metadata.");
-      return;
-    }
-    file_paths_ = metadata_.relative_file_paths;
-    // Note: the current_file_iterator_ may have been initialized by the preprocess_current_file()
-    // for cases when we use decompressor to uncompress entire file. Do not initialize it again
-    // here with current_file_iterator_ = file_paths_.begin();
   }
   auto topics = metadata_.topics_with_message_count;
   if (topics.empty()) {


### PR DESCRIPTION
## Description
This PR introduces a fallback behavior for per-file compressed bag files by trying to open metadata from storage if a separate metadata.yaml file is not found. 
Rationale: 
1. To have the ability to open directly just one compressed file.
2. For consistency with the uncompressed files


<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes # N/A
- Relates #2445

### Is this user-facing behavior change?
Yes. Added the ability to open compressed bag files directly without metadata.yaml file.
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
Can be backported.
<!--
If applicable, provide any additional context or details about the changes.
-->
