### PR TITLE
Fix verbose info for standalone bag files

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_info.cpp
+++ b/rosbag2_py/src/rosbag2_py/_info.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -31,6 +32,8 @@
 
 namespace rosbag2_py
 {
+
+namespace fs = std::filesystem;
 
 class Info
 {
@@ -84,10 +87,12 @@ public:
   {
     std::vector<std::shared_ptr<rosbag2_cpp::rosbag2_service_info_t>> all_services_info;
     std::vector<std::shared_ptr<rosbag2_cpp::rosbag2_action_info_t>> all_actions_info;
+    const fs::path bag_path{uri};
+    const fs::path base_path = fs::is_directory(bag_path) ? bag_path : bag_path.parent_path();
 
     for (auto & file_info : metadata_info.files) {
       auto [service_info, action_info] = info_->read_service_and_action_info(
-        uri + "/" + file_info.path, metadata_info.storage_identifier);
+        (base_path / file_info.path).generic_string(), metadata_info.storage_identifier);
 
       all_services_info.insert(all_services_info.end(), service_info.begin(), service_info.end());
       all_actions_info.insert(all_actions_info.end(), action_info.begin(), action_info.end());
@@ -96,7 +101,7 @@ public:
     std::unordered_map<std::string, uint64_t> messages_size = {};
     for (const auto & file_info : metadata_info.files) {
       auto messages_size_tmp = info_->compute_messages_size_contribution(
-        uri + "/" + file_info.path,
+        (base_path / file_info.path).generic_string(),
         metadata_info.storage_identifier);
       for (const auto & topic_size_tmp : messages_size_tmp) {
         messages_size[topic_size_tmp.first] += topic_size_tmp.second;

--- a/rosbag2_py/test/test_transport.py
+++ b/rosbag2_py/test/test_transport.py
@@ -35,6 +35,22 @@ RESOURCES_PATH = Path(os.environ['ROSBAG2_PY_TEST_RESOURCES_DIR'])
 PLAYBACK_UNTIL_TIMESTAMP_REGEX_STRING = r'\[rosbag2_player]: Playback until timestamp: -1'
 
 
+def test_info_verbose_standalone_file(capfd):
+    bag_file = RESOURCES_PATH / 'mcap' / 'talker' / 'talker.mcap'
+    info = rosbag2_py.Info()
+    metadata = info.read_metadata(str(bag_file), 'mcap')
+    metadata.files = [rosbag2_py.FileInformation(
+        path=bag_file.name,
+        starting_time=metadata.starting_time,
+        duration=metadata.duration,
+        message_count=metadata.message_count,
+    )]
+
+    info.print_output_verbose(str(bag_file), metadata, 'name')
+
+    assert 'Topic information:' in capfd.readouterr().out
+
+
 def test_options_qos_conversion():
     # Tests that the to-and-from C++ conversions are working properly in the pybind structs
     simple_overrides = {


### PR DESCRIPTION
## Summary
- Resolve verbose-info storage paths relative to a bag directory or to the parent directory of a standalone bag file.
- Use `std::filesystem::path` composition instead of treating every input URI as a directory.
- Add a `rosbag2_py` regression using the existing standalone `talker.mcap` resource.

Closes #2341.

## Why
`Info::print_output_verbose()` appended each metadata file path directly to the input URI. That works when the URI is a bag directory, but an individual file such as `sample.mcap` became `sample.mcap/sample.mcap` and could not be opened.

## Testing
- Verified the legacy path for the standalone MCAP resource does not exist, while resolving from the file's parent directory produces the original existing file.
- `python -m py_compile rosbag2_py/test/test_transport.py`
- `python -m flake8 --ignore=E501 rosbag2_py/test/test_transport.py`
- `git diff origin/rolling...HEAD --check`
- Not run: the new pytest case and full package build, because this Windows workstation does not have pytest or the ROS 2/ament runtime and build dependencies installed.

## CI notes
- The current-head `Test rosbag2` and `Lint rosbag2` workflow runs are `action_required` with zero jobs, so they are waiting for maintainer workflow approval.
