### PR TITLE
Keep discovery running for mixed topic selectors

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -1523,6 +1523,16 @@ void RecorderImpl::topics_discovery() noexcept
         RCLCPP_INFO(node->get_logger(), "Sim time /clock found, starting recording.");
       }
     }
+    const bool only_explicit_topics_requested =
+      !record_options_.topics.empty() &&
+      !record_options_.all_topics &&
+      record_options_.topic_types.empty() &&
+      !record_options_.all_services &&
+      record_options_.services.empty() &&
+      !record_options_.all_actions &&
+      record_options_.actions.empty() &&
+      record_options_.regex.empty() &&
+      static_topics_.empty();
     bool should_update_subscriptions = true;
     while (rclcpp::ok() && discovery_running_) {
       size_t subscriptions_count = 0u;
@@ -1530,7 +1540,7 @@ void RecorderImpl::topics_discovery() noexcept
         std::lock_guard<std::mutex> subscriptions_lock(subscriptions_mutex_);
         subscriptions_count = subscriptions_.size();
       }
-      if (!record_options_.topics.empty() &&
+      if (only_explicit_topics_requested &&
         subscriptions_count == record_options_.topics.size())
       {
         RCLCPP_INFO(

--- a/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_regex.cpp
@@ -107,6 +107,33 @@ TEST_F(RecordIntegrationTestFixture, regex_topics_recording)
   EXPECT_TRUE(recorded_topics.find(v1) != recorded_topics.end());
 }
 
+TEST_F(RecordIntegrationTestFixture, topics_and_regex_keep_discovery_running)
+{
+  auto test_string_messages = get_messages_strings();
+  const std::string regex_topic = "/regex_topic";
+  const std::string explicit_topic = "/explicit_topic";
+
+  rosbag2_transport::RecordOptions record_options =
+  {false, false, false, false, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, "rmw_format", 10ms};
+  record_options.topics = {explicit_topic};
+  record_options.regex = "^/regex_topic$";
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher(regex_topic, test_string_messages[0], 1);
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(regex_topic.c_str()));
+
+  pub_manager.setup_publisher(explicit_topic, test_string_messages[1], 1);
+  ASSERT_TRUE(pub_manager.wait_for_matched(explicit_topic.c_str()));
+}
+
 TEST_F(RecordIntegrationTestFixture, regex_and_exclude_regex_topic_recording)
 {
   auto test_string_messages = get_messages_strings();


### PR DESCRIPTION
## Summary
- preserve the early-stop optimization only when explicit topics are the sole inclusive selector
- keep discovery active when topics are combined with regex, type, service, action, all, or static-topic selectors
- add a regression test where a regex topic is subscribed before a later explicit topic appears

Fixes #2417

## Testing
- `git diff --check` 
- not run locally: `test_record_regex` requires a ROS 2/colcon environment that is not available on this machine