### PR TITLE
Fix excluded action filtering in player

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -1405,7 +1405,7 @@ bool allow_topic(
       }
     case TopicKind::ACTION_INTERFACE_TOPIC:
       {
-        if (!exclude_topics.empty()) {
+        if (!exclude_actions.empty()) {
           auto it = std::find(exclude_actions.begin(), exclude_actions.end(), topic_name);
           if (it != exclude_actions.end()) {
             return false;

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -1774,7 +1774,8 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_actions
   };
 
   // send actions as client
-  play_options_.actions_to_filter = {action_name2};
+  play_options_.actions_to_filter = {action_name1, action_name2};
+  play_options_.exclude_actions_to_filter = {action_name1};
   play_options_.send_actions_as_client = true;
   auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
   prepared_mock_reader->prepare(messages, actions_types);
@@ -1803,6 +1804,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_actions
   EXPECT_EQ(action1_cancel_count, 0);
   ASSERT_EQ(action2_request_count, 1);
   EXPECT_EQ(action2_cancel_count, 0);
+  EXPECT_THAT(player->get_list_of_action_clients(), SizeIs(1));
 
   // There is no direct interface to confirm that rosbag2 received the get_result response.
   // Here, the logic of handling actions in rosbag2 is used to make this determination. If


### PR DESCRIPTION
## Summary
- check the action exclusion list before filtering action-interface topics instead of checking the unrelated topic exclusion list
- preserve include filtering while making action exclusions take precedence during publisher/client preparation
- extend the existing action playback test to verify that only the non-excluded action client is created

## Testing
- compiled and ran a focused C++ probe reproducing `baseline=allowed` and confirming `fixed=excluded` when only the action exclusion list is populated
- verified the generic, service, and action branches each use their owning exclusion list
- verified the regression scenario includes both actions, excludes one, and expects exactly one action client
- `git diff --check`

The repository-native C++ test was not run locally because this Windows environment does not have the ROS 2 build dependencies or colcon. Repository CI covers the full integration test.
