### PR TITLE
Fix standalone SQLite exclusion filters

### DIFF
--- a/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
+++ b/rosbag2_storage_sqlite3/src/rosbag2_storage_sqlite3/sqlite_storage.cpp
@@ -693,7 +693,9 @@ void prepare_excluded_topics_filter(
 
   // Add service event topic name
   if (!storage_filter.exclude_service_events.empty()) {
-    excluded_topic_names_str += ",";
+    if (!excluded_topic_names_str.empty()) {
+      excluded_topic_names_str += ",";
+    }
     for (auto & service : storage_filter.exclude_service_events) {
       excluded_topic_names_str += "'" + service + "'";
       if (&service != &storage_filter.exclude_service_events.back()) {
@@ -704,7 +706,9 @@ void prepare_excluded_topics_filter(
 
   // Add topic name related to actions
   if (!storage_filter.exclude_actions_interfaces.empty()) {
-    excluded_topic_names_str += ",";
+    if (!excluded_topic_names_str.empty()) {
+      excluded_topic_names_str += ",";
+    }
     for (auto & action_topic : storage_filter.exclude_actions_interfaces) {
       excluded_topic_names_str += "'" + action_topic + "'";
       if (&action_topic != &storage_filter.exclude_actions_interfaces.back()) {

--- a/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_topic_filter.cpp
+++ b/rosbag2_storage_sqlite3/test/rosbag2_storage_sqlite3/test_sqlite_topic_filter.cpp
@@ -383,6 +383,31 @@ TEST_F(SQLiteTopicFilterTestFixture, TestResetFilter)
   EXPECT_FALSE(readable_storage->has_next());
 }
 
+TEST_F(SQLiteTopicFilterTestFixture, FilterWithServiceOrActionBlacklistOnly)
+{
+  auto read_topic_names = [this](const rosbag2_storage::StorageFilter & storage_filter) {
+    auto readable_storage = open_test_bag_for_read_only();
+    readable_storage->set_filter(storage_filter);
+    std::vector<std::string> topic_names;
+    while (readable_storage->has_next()) {
+      topic_names.push_back(readable_storage->read_next()->topic_name);
+    }
+    return topic_names;
+  };
+
+  rosbag2_storage::StorageFilter service_filter{};
+  service_filter.exclude_service_events = {"service_topic2/_service_event"};
+  auto service_topic_names = read_topic_names(service_filter);
+  EXPECT_THAT(service_topic_names, SizeIs(9));
+  EXPECT_THAT(service_topic_names, Not(Contains("service_topic2/_service_event")));
+
+  rosbag2_storage::StorageFilter action_filter{};
+  action_filter.exclude_actions_interfaces = {"action1/_action/status"};
+  auto action_topic_names = read_topic_names(action_filter);
+  EXPECT_THAT(action_topic_names, SizeIs(9));
+  EXPECT_THAT(action_topic_names, Not(Contains("action1/_action/status")));
+}
+
 TEST_F(SQLiteTopicFilterTestFixture, CanSelectFromTopicsListAndRegexWithServices)
 {
   auto readable_storage = open_test_bag_for_read_only();


### PR DESCRIPTION
## Summary
- avoid leading commas when SQLite exclusion filters contain service events but no ordinary topics
- apply the same delimiter rule when action interfaces are the first populated exclusion list
- add real SQLite storage coverage for service-only and action-only blacklists

## Testing
- reproduced the generated `NOT IN (,'...')` query failing with `near ,: syntax error` in native SQLite
- verified corrected service-only and action-only `NOT IN ('...')` queries execute successfully and remove only the requested item
- verified both regression cases read nine of the ten fixture topics and omit the selected service/action interface
- UTF-8 without BOM and CRLF checks
- 100-column check
- `git diff --check`

The repository-native C++ test was not run locally because this Windows environment does not have the ROS 2 build dependencies or colcon. Repository CI covers the SQLite storage test.
