### PR TITLE
docs: fix Reader usage examples

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/reader.hpp
@@ -124,7 +124,7 @@ public:
    * The message will be serialized in the format given to `open`.
    *
    * Expected usage:
-   * if (writer.has_next()) message = writer.read_next();
+   * if (reader.has_next()) message = reader.read_next();
    *
    * \return next message in serialized form
    * \throws runtime_error if the Reader is not open.
@@ -136,7 +136,7 @@ public:
    * The message will be serialized in the format given to `open`.
    *
    * Expected usage:
-   * if (writer.has_next()) message = writer.read_next();
+   * if (reader.has_next()) message = reader.read_next();
    *
    * \return next message in non-serialized form
    * \throws runtime_error if the Reader is not open.


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Fixes two Reader API usage examples in reader.hpp.
The examples referred to "writer.has_next()" and "writer.read_next()", but documented class is "Reader".
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
