### PR TITLE
Add an optional output URI to the SplitBagfile service

### DIFF
--- a/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
+++ b/rosbag2_compression/include/rosbag2_compression/sequential_compression_writer.hpp
@@ -125,13 +125,13 @@ public:
     const rosbag2_storage::StorageOptions & storage_options,
     const rosbag2_cpp::ConverterOptions & converter_options) override;
 
+protected:
   /**
    * Attempt to compress the last open file and reset the storage and storage factory.
    * This method must be exception safe because it is called by the destructor.
    */
-  void close() override;
+  void close_impl(bool execute_split_callback) override;
 
-protected:
   /**
    * Compress a file and update the metadata file path.
    *

--- a/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
+++ b/rosbag2_compression/src/rosbag2_compression/sequential_compression_writer.cpp
@@ -261,7 +261,7 @@ void SequentialCompressionWriter::open(
   this->is_open_ = true;
 }
 
-void SequentialCompressionWriter::close()
+void SequentialCompressionWriter::close_impl(bool execute_split_callback)
 {
   // Note. close and open methods protected with mutex on upper rosbag2_cpp::writer level.
   if (!this->is_open_.exchange(false)) {
@@ -300,11 +300,11 @@ void SequentialCompressionWriter::close()
   stop_compressor_threads();  // Note: The metadata_.relative_file_paths will be updated with
   // compressed filename when compressor threads will finish.
 
-  //  Note: We need to call the base class close() after compressing the last file because the
-  //  base class close() will call the execute_bag_split_callbacks(closed_file, ""); with the last
-  //  file, and if we called it before compressing the last file, the callback would be called
-  //  with the uncompressed file name, which is not the desired behavior.
-  SequentialWriter::close();
+  //  Note: We need to call the base class close_impl() after compressing the last file because
+  //  the base class will report the closed file with the last file, and if we called it before
+  //  compressing the last file, it would report the uncompressed file name, which is not the
+  //  desired behavior.
+  SequentialWriter::close_impl(execute_split_callback);
 }
 
 void SequentialCompressionWriter::create_topic(
@@ -403,6 +403,7 @@ void SequentialCompressionWriter::split_bagfile()
     should_compress_last_file_ = false;
   }
 }
+
 
 std::shared_ptr<rosbag2_storage::SerializedBagMessage>
 SequentialCompressionWriter::compress_message(

--- a/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
+++ b/rosbag2_compression/test/rosbag2_compression/test_sequential_compression_writer.cpp
@@ -696,6 +696,62 @@ TEST_P(SequentialCompressionWriterTest, split_event_calls_callback_with_file_com
   }
 }
 
+TEST_F(SequentialCompressionWriterTest, split_bagfile_to_new_uri_compresses_the_closed_file)
+{
+  rosbag2_compression::CompressionOptions compression_options {
+    DefaultTestCompressor,
+    rosbag2_compression::CompressionMode::FILE,
+    0,
+    1,
+    kDefaultCompressionQueueThreadsPriority
+  };
+
+  initializeFakeFileStorage();
+  initializeWriter(compression_options);
+
+  std::vector<std::string> closed_files;
+  std::vector<std::string> opened_files;
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  callbacks.write_split_callback =
+    [&closed_files, &opened_files](rosbag2_cpp::bag_events::BagSplitInfo & info) {
+      closed_files.emplace_back(info.closed_file);
+      opened_files.emplace_back(info.opened_file);
+    };
+  writer_->add_event_callbacks(callbacks);
+
+  writer_->open(tmp_dir_storage_options_);
+  writer_->create_topic({0u, "test_topic", "test_msgs/BasicTypes", "", {}, ""});
+
+  auto message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+  message->topic_name = "test_topic";
+  for (auto i = 0; i < 3; ++i) {
+    writer_->write(message);
+  }
+
+  const std::string new_bag_dir = "new_bag";
+  const auto new_uri = (tmp_dir_ / new_bag_dir).string();
+  writer_->split_bagfile(new_uri);
+
+  EXPECT_NO_THROW(writer_->write(message));
+  EXPECT_TRUE(fs::is_directory(new_uri));
+
+  ASSERT_EQ(closed_files.size(), 1u);
+  ASSERT_EQ(opened_files.size(), 1u);
+
+  // The closed file must be reported under its compressed name
+  const std::string closed_filename = fs::path(closed_files[0]).filename().generic_string();
+  EXPECT_TRUE(path_match_expected_compressed_file_regex(closed_filename)) <<
+    "Closed file '" << closed_filename << "' is not the compressed file";
+  EXPECT_TRUE(file_counter_at_start(closed_filename, 0));
+
+  EXPECT_EQ(fs::path(opened_files[0]).parent_path().generic_string(),
+            fs::path(new_uri).generic_string());
+  EXPECT_EQ(fs::path(opened_files[0]).filename().generic_string().find("0_" + new_bag_dir + "_"),
+            0u);
+
+  writer_->close();
+}
+
 TEST_F(SequentialCompressionWriterTest,
   circular_logging_limits_number_of_files_by_max_bag_files_with_file_compression)
 {

--- a/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer.hpp
@@ -138,6 +138,13 @@ public:
   void split_bagfile();
 
   /**
+   * Close the current bag and open a new one in the new_uri directory, which must not exist yet.
+   * The new bag gets its own metadata.yaml and its file counter restarted at 0.
+   * \throws std::runtime_error if new_uri can't be used. The current bag keeps recording.
+   */
+  void split_bagfile(const std::string & new_uri);
+
+  /**
    * \brief Removes a new topic in the underlying storage.
    * \details Expected to be used if creation of subscription fails and cleanup is needed.
    * \note If writer is not open, this will just remove the topic information locally.

--- a/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writer_interfaces/base_writer_interface.hpp
@@ -17,6 +17,8 @@
 
 #include <cstddef>
 #include <memory>
+#include <stdexcept>
+#include <string>
 
 #include "rosbag2_cpp/bag_events.hpp"
 #include "rosbag2_cpp/converter_options.hpp"
@@ -72,6 +74,17 @@ public:
    * Close the current bagfile and opens the next bagfile.
    */
   virtual void split_bagfile() = 0;
+
+  /**
+   * Close the current bag and open a new one in the new_uri directory.
+   * \throws std::runtime_error if the writer does not support splitting to a new URI.
+   */
+  virtual void split_bagfile(const std::string & new_uri)
+  {
+    (void)new_uri;
+    throw std::runtime_error(
+      "Splitting the bag file to a new output URI is not supported by this writer.");
+  }
 
   virtual void add_event_callbacks(const bag_events::WriterEventCallbacks & callbacks) = 0;
 

--- a/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/writers/sequential_writer.hpp
@@ -157,6 +157,12 @@ public:
   void split_bagfile() override;
 
   /**
+   * \brief Finalizes the current bag and opens a new one in the new_uri directory.
+   * \throws std::runtime_error if new_uri can't be used. The current bag keeps recording.
+   */
+  void split_bagfile(const std::string & new_uri) override;
+
+  /**
    * \brief Check if a callback is registered for the given event.
    * \return True if there is any callback registered for the event, false otherwise.
    */
@@ -177,6 +183,10 @@ protected:
 
   /// \brief Flush the cache, update metadata and close the storage.
   void flush_cache_update_metadata_and_close_storage();
+
+  /// \brief Common implementation of close(), also used by split_bagfile(new_uri).
+  /// \param execute_split_callback whether to emit the WRITE_SPLIT event for the closed file.
+  virtual void close_impl(bool execute_split_callback);
 
   std::string split_bagfile_local(bool execute_callbacks = true);
 
@@ -215,6 +225,9 @@ protected:
   static std::string format_storage_uri(const std::string & base_folder, uint64_t storage_count);
 
   rosbag2_storage::StorageOptions storage_options_;
+
+  /// \brief Converter options, kept to reopen the writer on split_bagfile(new_uri).
+  ConverterOptions converter_options_;
 
   /// \brief Topic name to the TopicInformation map.
   /// Used to keep topic list and track message counts. If cache is present, the message

--- a/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writer.cpp
@@ -122,6 +122,12 @@ void Writer::split_bagfile()
   return writer_impl_->split_bagfile();
 }
 
+void Writer::split_bagfile(const std::string & new_uri)
+{
+  std::lock_guard<std::mutex> writer_lock(writer_mutex_);
+  return writer_impl_->split_bagfile(new_uri);
+}
+
 void Writer::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)
 {
   std::lock_guard<std::mutex> writer_lock(writer_mutex_);

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -111,6 +111,7 @@ void SequentialWriter::open(
 
   base_folder_ = storage_options.uri;
   storage_options_ = storage_options;
+  converter_options_ = converter_options;
 
   if (storage_options_.storage_id.empty()) {
     storage_options_.storage_id = rosbag2_storage::get_default_storage_id();
@@ -216,6 +217,11 @@ void SequentialWriter::flush_cache_update_metadata_and_close_storage()
 
 void SequentialWriter::close()
 {
+  close_impl(true);
+}
+
+void SequentialWriter::close_impl(bool execute_split_callback)
+{
   // Note. close and open methods protected with mutex on upper rosbag2_cpp::writer level.
   if (!is_open_.exchange(false)) {
     return;  // The writer is not open
@@ -223,7 +229,7 @@ void SequentialWriter::close()
 
   flush_cache_update_metadata_and_close_storage();
 
-  if (!metadata_.relative_file_paths.empty()) {
+  if (execute_split_callback && !metadata_.relative_file_paths.empty()) {
     // Take the latest file name from metadata in case if it was updated after compression in
     // derived class
     auto closed_file =
@@ -459,6 +465,46 @@ void SequentialWriter::execute_bag_split_callbacks(
 void SequentialWriter::split_bagfile()
 {
   (void)split_bagfile_local();
+}
+
+void SequentialWriter::split_bagfile(const std::string & new_uri)
+{
+  if (!is_open_) {
+    throw std::runtime_error("Bag is not open. Call open() before splitting the bag file.");
+  }
+  if (new_uri.empty()) {
+    throw std::runtime_error("Can't split the bag file to a new URI. The new URI is empty");
+  }
+  // Checked again in open(), but by then the current bag is closed and there would be nothing
+  // left to record into.
+  if (fs::is_directory(fs::path(new_uri))) {
+    std::stringstream error;
+    error << "Bag directory already exists (" << new_uri <<
+      "), can't overwrite existing bag";
+    throw std::runtime_error{error.str()};
+  }
+
+  auto new_storage_options = storage_options_;
+  new_storage_options.uri = new_uri;
+
+  close_impl(false);  // The WRITE_SPLIT event is emitted below, with the newly opened file
+
+  // Read after closing: a derived writer may rename the last file while closing it, and
+  // base_folder_ still points to the closed bag until open() below.
+  std::string closed_file;
+  if (!metadata_.relative_file_paths.empty()) {
+    closed_file =
+      (fs::path(base_folder_) / metadata_.relative_file_paths.back()).generic_string();
+  }
+
+  open(new_storage_options, converter_options_);
+
+  // Same as split_bagfile(): make transient-local topics appear in the new bag as well.
+  if (!storage_options_.snapshot_mode) {
+    write_transient_local_messages(last_recv_timestamp_, last_sent_timestamp_);
+  }
+
+  execute_bag_split_callbacks(closed_file, storage_->get_relative_file_path());
 }
 
 void SequentialWriter::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> message)

--- a/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_sequential_writer.cpp
@@ -474,6 +474,84 @@ TEST_F(SequentialWriterTest, sequantial_writer_call_metadata_update_on_bag_split
   EXPECT_EQ(v_intercepted_update_metadata_[3].message_count, 2 * kNumMessagesToWrite);
 }
 
+TEST_F(SequentialWriterTest, split_bagfile_to_new_uri_starts_a_new_bag)
+{
+  const std::string test_topic_name = "test_topic";
+  const std::string test_topic_type = "test_msgs/BasicTypes";
+
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  std::string rmw_format = "rmw_format";
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+  writer_->create_topic({0u, test_topic_name, test_topic_type, "", {}, ""});
+
+  std::vector<std::string> closed_files;
+  std::vector<std::string> opened_files;
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  callbacks.write_split_callback = [&](rosbag2_cpp::bag_events::BagSplitInfo & info) {
+      closed_files.emplace_back(info.closed_file);
+      opened_files.emplace_back(info.opened_file);
+    };
+  writer_->add_event_callbacks(callbacks);
+
+  writer_->write(make_test_msg());
+
+  const auto new_uri = (tmp_dir_ / "new_bag").string();
+  writer_->split_bagfile(new_uri);
+
+  EXPECT_NO_THROW(writer_->write(make_test_msg()));
+  EXPECT_TRUE(fs::is_directory(new_uri));
+
+  EXPECT_EQ(fake_storage_uri_, (fs::path(new_uri) / "new_bag_0").string());
+
+  ASSERT_EQ(closed_files.size(), 1u);
+  EXPECT_EQ(closed_files[0], (tmp_dir_ / bag_base_dir_ / (bag_base_dir_ + "_0")).string());
+  EXPECT_EQ(opened_files[0], (fs::path(new_uri) / "new_bag_0").string());
+
+  writer_->close();
+}
+
+TEST_F(SequentialWriterTest, split_bagfile_to_new_uri_leaves_writer_usable_when_it_fails)
+{
+  const std::string test_topic_name = "test_topic";
+  const std::string test_topic_type = "test_msgs/BasicTypes";
+
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  std::string rmw_format = "rmw_format";
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+  writer_->create_topic({0u, test_topic_name, test_topic_type, "", {}, ""});
+
+  writer_->write(make_test_msg());
+
+  const auto occupied_uri = tmp_dir_ / "already_there";
+  ASSERT_TRUE(fs::create_directories(occupied_uri));
+
+  EXPECT_THROW(writer_->split_bagfile(occupied_uri.string()), std::runtime_error);
+
+  // The failed split must leave the writer recording into the original bag
+  EXPECT_NO_THROW(writer_->write(make_test_msg()));
+  EXPECT_EQ(fake_storage_uri_, (tmp_dir_ / bag_base_dir_ / (bag_base_dir_ + "_0")).string());
+  EXPECT_NO_THROW(writer_->close());
+}
+
+TEST_F(SequentialWriterTest, split_bagfile_to_new_uri_throws_on_empty_uri)
+{
+  auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
+    std::move(storage_factory_), converter_factory_, std::move(metadata_io_));
+  writer_ = std::make_unique<rosbag2_cpp::Writer>(std::move(sequential_writer));
+
+  std::string rmw_format = "rmw_format";
+  writer_->open(storage_options_, {rmw_format, rmw_format});
+
+  EXPECT_THROW(writer_->split_bagfile(""), std::runtime_error);
+  EXPECT_NO_THROW(writer_->close());
+}
+
 TEST_F(SequentialWriterTest, open_throws_error_if_converter_plugin_does_not_exist) {
   auto sequential_writer = std::make_unique<rosbag2_cpp::writers::SequentialWriter>(
     std::move(storage_factory_), converter_factory_, std::move(metadata_io_));

--- a/rosbag2_interfaces/srv/SplitBagfile.srv
+++ b/rosbag2_interfaces/srv/SplitBagfile.srv
@@ -14,6 +14,12 @@ int32 split_mode
 # Topic name to use for timestamp-based split evaluation.
 # If empty, evaluate using messages from all topics.
 string tracking_topic_name
+
+# Directory to record the new bag into, instead of rolling over to the next file in the current
+# bag directory. The directory must not exist yet. The new bag gets its own metadata.yaml and its
+# file counter restarts at 0.
+# If empty, the recorder rolls over to the next file in the current bag directory as usual.
+string output_uri
 ---
 # Return codes for SplitBagfile response.
 int32 RETURN_CODE_SUCCESS=0

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -163,9 +163,11 @@ public:
   void stop();
 
   //// @brief Split the current bagfile and open a new one.
+  /// @param output_uri Directory to record the new bag into. If empty, roll over to the next
+  /// file in the current bag directory.
   /// @return true if split was successful, false if recording is not active.
   /// \throws std::exception if underlying writer fails to split the bagfile.
-  bool split_bagfile();
+  bool split_bagfile(const std::string & output_uri = "");
 
   /// Get a const reference to the underlying rosbag2 writer.
   const rosbag2_cpp::Writer & get_writer_handle();
@@ -255,6 +257,7 @@ private:
     std::string tracking_topic_name{};
     int64_t time_ns = kNoPendingPublishSplit;
     SplitMode mode = SplitMode::NodeTime;
+    std::string output_uri{};
   };
 
   /// \brief Pending resume state for timestamp-based resume requests.
@@ -449,23 +452,29 @@ private:
 
   /// \brief Handle a timer-based bag split request.
   /// \param split_time The time at which to split the bag file. If std::nullopt, split immediately.
+  /// \param output_uri Directory to record the new bag into. If empty, roll over to the next file.
   /// \param response The service response to populate.
   void handle_timer_bag_split_request(std::optional<rclcpp::Time> split_time,
+                                      const std::string & output_uri,
                                       SplitBagFileCallbackResponse & response);
 
   /// \brief Handle a timestamp-based bag split request.
   /// \param split_time The time at which to split the bag file. If std::nullopt, split immediately.
   /// \param split_mode The mode to use for the split (publish time, receive time).
   /// \param topic_name The topic to track for the split. If empty, track all topics.
+  /// \param output_uri Directory to record the new bag into. If empty, roll over to the next file.
   /// \param response The service response to populate.
   void handle_timestamp_bag_split_request(const std::optional<rclcpp::Time> & split_time,
                                           SplitMode split_mode,
                                           const std::string & topic_name,
+                                          const std::string & output_uri,
                                           SplitBagFileCallbackResponse & response);
   // *INDENT-ON*
 
   /// \brief Attempt an immediate split of the bag file.
-  void attempt_immediate_bag_split(SplitBagFileCallbackResponse & response);
+  void attempt_immediate_bag_split(
+    const std::string & output_uri,
+    SplitBagFileCallbackResponse & response);
 
   rclcpp::Node * node;
   std::unique_ptr<TopicFilter> topic_filter_;
@@ -794,7 +803,7 @@ bool RecorderImpl::record(const std::string & uri)
   return true;
 }
 
-bool RecorderImpl::split_bagfile()
+bool RecorderImpl::split_bagfile(const std::string & output_uri)
 {
   std::lock_guard<std::mutex> state_lock(start_stop_transition_mutex_);
   if (!in_recording_.load()) {
@@ -803,7 +812,13 @@ bool RecorderImpl::split_bagfile()
     return false;
   }
 
-  writer_->split_bagfile();
+  if (output_uri.empty()) {
+    writer_->split_bagfile();
+  } else {
+    RCLCPP_INFO(node->get_logger(), "Splitting bag file to new output URI: '%s'.",
+                output_uri.c_str());
+    writer_->split_bagfile(output_uri);
+  }
   return true;
 }
 
@@ -853,7 +868,7 @@ void RecorderImpl::create_control_services()
         return;
       }
       if (split_mode.value() == SplitMode::NodeTime) {
-        handle_timer_bag_split_request(split_time, response);
+        handle_timer_bag_split_request(split_time, request->output_uri, response);
         return;
       }
       std::string split_tracking_topic_name;
@@ -874,6 +889,7 @@ void RecorderImpl::create_control_services()
       handle_timestamp_bag_split_request(split_time,
                                          split_mode.value(),
                                          split_tracking_topic_name,
+                                         request->output_uri,
                                          response);
     }
   );
@@ -1228,10 +1244,12 @@ void RecorderImpl::handle_timestamp_resume_request(
   set_service_success(response);
 }
 
-void RecorderImpl::attempt_immediate_bag_split(SplitBagFileCallbackResponse & response)
+void RecorderImpl::attempt_immediate_bag_split(
+  const std::string & output_uri,
+  SplitBagFileCallbackResponse & response)
 {
   try {
-    if (this->split_bagfile()) {
+    if (this->split_bagfile(output_uri)) {
       set_service_success(response);
     } else {
       set_service_error(response,
@@ -1246,14 +1264,15 @@ void RecorderImpl::attempt_immediate_bag_split(SplitBagFileCallbackResponse & re
 
 void RecorderImpl::handle_timer_bag_split_request(
   std::optional<rclcpp::Time> split_time,
+  const std::string & output_uri,
   SplitBagFileCallbackResponse & response)
 {
   if (should_execute_immediately(split_time)) {
-    attempt_immediate_bag_split(response);
+    attempt_immediate_bag_split(output_uri, response);
   } else {
-    auto action_task = [this]() {
+    auto action_task = [this, output_uri]() {
         try {
-          (void)this->split_bagfile();
+          (void)this->split_bagfile(output_uri);
         } catch (const std::exception & e) {
           RCLCPP_ERROR(node->get_logger(), "Error during 'SplitBagfile' request: %s", e.what());
         }
@@ -1267,10 +1286,11 @@ void RecorderImpl::handle_timestamp_bag_split_request(
   const std::optional<rclcpp::Time> & split_time,
   SplitMode split_mode,
   const std::string & topic_name,
+  const std::string & output_uri,
   SplitBagFileCallbackResponse & response)
 {
   if (!split_time.has_value()) {
-    attempt_immediate_bag_split(response);
+    attempt_immediate_bag_split(output_uri, response);
     return;
   }
 
@@ -1298,7 +1318,7 @@ void RecorderImpl::handle_timestamp_bag_split_request(
     RCLCPP_INFO(node->get_logger(),
                 "Timestamp-based split request%s already due (req=%.9f s). Splitting immediately.",
                 on_topic_str.c_str(), split_time->seconds());
-    attempt_immediate_bag_split(response);
+    attempt_immediate_bag_split(output_uri, response);
     return;
   }
 
@@ -1314,6 +1334,7 @@ void RecorderImpl::handle_timestamp_bag_split_request(
     pending_bag_split_request_->tracking_topic_name = topic_name;
     pending_bag_split_request_->mode = split_mode;
     pending_bag_split_request_->time_ns = split_req_ns;
+    pending_bag_split_request_->output_uri = output_uri;
   }
 
   RCLCPP_INFO(node->get_logger(),
@@ -1396,9 +1417,9 @@ void RecorderImpl::handle_pending_bag_split_request(
                    to_string(pending_bag_split_request_->mode),
                    message_time, pending_bag_split_request_->time_ns);
       auto action_task =
-        [this]() {
+        [this, output_uri = pending_bag_split_request_->output_uri]() {
           try {
-            (void)this->split_bagfile();
+            (void)this->split_bagfile(output_uri);
           } catch (const std::exception & e) {
             RCLCPP_ERROR(node->get_logger(), "Error during bag file split request: %s", e.what());
           }

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_writer.hpp
@@ -110,6 +110,30 @@ public:
     messages_per_file_ = 0;
   }
 
+  void split_bagfile(const std::string & new_uri) override
+  {
+    if (throw_on_split_to_new_uri_) {
+      throw std::runtime_error("Bag directory already exists (" + new_uri + ")");
+    }
+    split_uri_ = new_uri;
+    auto info = std::make_shared<rosbag2_cpp::bag_events::BagSplitInfo>();
+    info->closed_file = "BagFile" + std::to_string(file_number_);
+    file_number_ = 0;
+    info->opened_file = new_uri + "/BagFile0";
+    callback_manager_.execute_callbacks(rosbag2_cpp::bag_events::BagEvent::WRITE_SPLIT, info);
+    messages_per_file_ = 0;
+  }
+
+  std::string get_split_uri() const
+  {
+    return split_uri_;
+  }
+
+  void set_throw_on_split_to_new_uri(bool value)
+  {
+    throw_on_split_to_new_uri_ = value;
+  }
+
   void
   add_event_callbacks(const rosbag2_cpp::bag_events::WriterEventCallbacks & callbacks) override
   {
@@ -216,6 +240,8 @@ private:
   rosbag2_cpp::bag_events::EventCallbackManager callback_manager_;
   size_t file_number_ = 0;
   size_t max_messages_per_file_ = 0;
+  std::string split_uri_;
+  bool throw_on_split_to_new_uri_ = false;
   std::atomic<bool> writer_close_called_{false};
   rosbag2_storage::StorageOptions storage_options_;
 };

--- a/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_services.cpp
@@ -455,6 +455,73 @@ TEST_F(RecordSrvsTest, split_bagfile_with_default_parameters)
   EXPECT_EQ(opened_file, "BagFile1");
 }
 
+TEST_F(RecordSrvsTest, split_bagfile_with_output_uri)
+{
+  rosbag2_test_common::PublicationManager pub_manager;
+  auto string_message = get_messages_strings()[1];
+  pub_manager.setup_publisher(test_topic_, string_message, 1);
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
+  pub_manager.run_publishers();
+
+  auto & writer = recorder_->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  std::atomic<bool> split_called{false};
+  std::string closed_file, opened_file;
+  rosbag2_cpp::bag_events::WriterEventCallbacks callbacks;
+  callbacks.write_split_callback =
+    [&split_called, &closed_file, &opened_file](rosbag2_cpp::bag_events::BagSplitInfo & info) {
+      closed_file = info.closed_file;
+      opened_file = info.opened_file;
+      split_called.store(true);
+    };
+  mock_writer.add_event_callbacks(callbacks);
+
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 0;},
+      std::chrono::seconds(10))
+  ) << "Failed to capture message in time";
+
+  const std::string output_uri = "new_bag_dir";
+  auto request = std::make_shared<SplitBagfile::Request>();
+  request->output_uri = output_uri;
+  auto response = std::make_shared<SplitBagfile::Response>();
+  ASSERT_TRUE(successful_service_request<SplitBagfile>(cli_split_bagfile_, request, response));
+  EXPECT_EQ(SplitBagfile::Response::RETURN_CODE_SUCCESS, response->return_code);
+  EXPECT_TRUE(response->error_string.empty());
+
+  ASSERT_TRUE(split_called.load());
+  EXPECT_EQ(mock_writer.get_split_uri(), output_uri);
+  EXPECT_EQ(closed_file, "BagFile0");
+  EXPECT_EQ(opened_file, output_uri + "/BagFile0");
+}
+
+TEST_F(RecordSrvsTest, split_bagfile_reports_error_when_output_uri_is_rejected)
+{
+  rosbag2_test_common::PublicationManager pub_manager;
+  auto string_message = get_messages_strings()[1];
+  pub_manager.setup_publisher(test_topic_, string_message, 1);
+  ASSERT_TRUE(pub_manager.wait_for_matched(test_topic_.c_str()));
+  pub_manager.run_publishers();
+
+  auto & writer = recorder_->get_writer_handle();
+  auto & mock_writer = dynamic_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+  mock_writer.set_throw_on_split_to_new_uri(true);
+
+  ASSERT_TRUE(
+    rosbag2_test_common::wait_until_condition(
+      [&mock_writer]() {return mock_writer.get_number_of_recorded_messages() > 0;},
+      std::chrono::seconds(10))
+  ) << "Failed to capture message in time";
+
+  auto request = std::make_shared<SplitBagfile::Request>();
+  request->output_uri = "rejected_bag_dir";
+  auto response = std::make_shared<SplitBagfile::Response>();
+  ASSERT_TRUE(successful_service_request<SplitBagfile>(cli_split_bagfile_, request, response));
+  EXPECT_EQ(SplitBagfile::Response::RETURN_CODE_SPLIT_FAILED, response->return_code);
+  EXPECT_FALSE(response->error_string.empty());
+}
+
 TEST_F(RecordSrvsSimTimeTest, split_bagfile_by_receive_time_scheduled)
 {
   auto string_message = get_messages_strings()[1];


### PR DESCRIPTION
Splitting a bag file always rolls over to the next file inside the current bag directory. We record continuously on a vessel and want each mission to end up in its own directory, and today the only way to change the output directory is to stop the recorder and start a new one, which drops messages across the restart.

This adds an optional `output_uri` to the `SplitBagfile` request.

- `output_uri` empty keeps the current behavior: roll over to the next file in the current bag directory. Nothing changes unless you ask for it.
- `output_uri` set finalizes the current bag as if `close()` had been called on it, then continues recording in that directory. The new bag gets its own `metadata.yaml` and its file counter restarts at 0.
- It is honored for an immediate split and for both deferred forms (a future `split_time` with node time, and timestamp-based splits), so the requested directory is remembered until the split actually fires.
- The destination is validated before the current bag is finalized. A directory that already exists, or that cannot be created, throws and leaves the recorder still recording into the current bag, instead of leaving it with no storage to write to.
- A single `WRITE_SPLIT` event is emitted, naming the finalized file and the newly opened one, same as an ordinary split.

On the writer side, `rosbag2_cpp::Writer::split_bagfile(new_uri)` is the new entry point. The default implementation in `BaseWriterInterface` throws rather than ignoring `new_uri`, so a writer that does not implement it cannot silently keep recording into the old location. `SequentialWriter` implements it by reusing its own `close()` and `open()` paths, so all the per-bag state (metadata, file index, cache, topic registration) is reset the same way it is for a fresh recording.

`SequentialCompressionWriter` keeps working. Its `close()` override became a `close_impl(execute_split_callback)` override, so the compression-aware finalization (stopping the compressor threads and compressing the last file synchronously) still runs when splitting to a new URI. The closed file name is read after finalizing rather than before, so the event reports the compressed name, which is the same ordering its `close()` already relied on.

Tests:

- `test_sequential_writer.cpp`: the new bag being started, the file counter restarting at 0, the split event naming both files, an empty URI, and a rejected destination leaving the writer usable.
- `test_sequential_compression_writer.cpp`: the closed file is reported under its compressed name and the new bag starts in the requested directory.
- `test_record_services.cpp`: the service passes `output_uri` through to the writer and reports the new file names, and a destination the writer rejects comes back as `RETURN_CODE_SPLIT_FAILED` with an error string.
