### PR TITLE
Make the topic filter match the first message.

### DIFF
--- a/rosbag2_transport/include/rosbag2_transport/readers_manager.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/readers_manager.hpp
@@ -60,8 +60,10 @@ public:
 
   /// \brief Constructor which initializes the ReadersManager with multiple readers and their
   /// associated storage options.
-  /// \note The readers will be opened during construction and cache will be populated with the
-  /// first message from each reader (if available).
+  /// \note The readers will be opened during construction. The internal cache of next messages
+  /// is populated lazily on the first call to get_next_message_in_chronological_order() or
+  /// seek(), so that a filter set via set_filter() beforehand applies to all messages,
+  /// including the first one from each reader.
   /// \param reader_with_options Vector of pairs of unique pointer to the rosbag2_cpp::Reader class
   /// (which will be moved to the internal instance of the ReadersManager class during construction)
   /// and storage options (which will be applied to the rosbag2_cpp::reader when opening it).

--- a/rosbag2_transport/src/rosbag2_transport/readers_manager_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/readers_manager_impl.hpp
@@ -15,6 +15,7 @@
 #ifndef ROSBAG2_TRANSPORT__READERS_MANAGER_IMPL_HPP_
 #define ROSBAG2_TRANSPORT__READERS_MANAGER_IMPL_HPP_
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -46,14 +47,10 @@ public:
     if (readers_with_options_.empty()) {
       throw std::invalid_argument("At least one reader with storage options must be provided.");
     }
-    next_messages_cache_.reserve(readers_with_options_.size());
     earliest_timestamp_ = std::numeric_limits<rcutils_time_point_value_t>::max();
     latest_timestamp_ = std::numeric_limits<rcutils_time_point_value_t>::min();
     for (auto & [reader, options] : readers_with_options_) {
       reader->open(options, {rmw_get_serialization_format(), rmw_get_serialization_format()});
-      if (reader->has_next()) {
-        next_messages_cache_.emplace_back(reader->read_next());
-      }
       // Find the earliest starting time
       const auto metadata = reader->get_metadata();
       const auto metadata_starting_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -85,6 +82,15 @@ public:
   [[nodiscard]] bool has_next() const
   {
     rcpputils::unique_lock lk(reader_mutex_);
+    if (!next_messages_cache_initialized_) {
+      // Nothing has been consumed yet, so defer to the readers instead of filling the cache.
+      // This keeps this method from modifying any members.
+      return std::any_of(
+        readers_with_options_.cbegin(), readers_with_options_.cend(),
+        [](const auto & reader_with_options) {
+          return reader_with_options.first->has_next();
+        });
+    }
     return !std::all_of(
       next_messages_cache_.cbegin(),
       next_messages_cache_.cend(),
@@ -102,6 +108,9 @@ public:
     // queue, because that would require pushing all messages from all readers into the queue,
     // while this way we only keep one message per reader in memory at any time.
     rcpputils::unique_lock lk(reader_mutex_);
+    if (!next_messages_cache_initialized_) {
+      fill_next_messages_cache();
+    }
     std::shared_ptr<rosbag2_storage::SerializedBagMessage> earliest_msg = nullptr;
     size_t earliest_msg_index = 0;
     for (size_t i = 0; i < next_messages_cache_.size(); i++) {
@@ -131,17 +140,7 @@ public:
     for (auto & [reader, _] : readers_with_options_) {
       reader->seek(timestamp);
     }
-    // Clear and refill the next_messages_cache_
-    next_messages_cache_.clear();
-    next_messages_cache_.resize(readers_with_options_.size(), nullptr);
-    size_t i = 0;
-    for (const auto & [reader, _] : readers_with_options_) {
-      // Refill the next_messages_cache_
-      if (reader->has_next()) {
-        next_messages_cache_[i] = reader->read_next();
-      }
-      i++;
-    }
+    fill_next_messages_cache();
   }
 
   [[nodiscard]] rcutils_time_point_value_t get_earliest_timestamp() const
@@ -184,6 +183,27 @@ public:
   }
 
 private:
+  /// \brief Discard any cached messages and cache the next message from each reader.
+  /// \details The cache is filled lazily on first consumption rather than at construction time,
+  /// so that a filter set via set_filter() before the first read is applied to every message,
+  /// including the first one from each reader.
+  /// \note Shall be called with the reader_mutex_ held. The element at index i always
+  /// corresponds to the reader at index i in readers_with_options_; readers with no messages
+  /// get a nullptr placeholder.
+  void fill_next_messages_cache()
+  {
+    next_messages_cache_.clear();
+    next_messages_cache_.resize(readers_with_options_.size(), nullptr);
+    size_t i = 0;
+    for (const auto & [reader, _] : readers_with_options_) {
+      if (reader->has_next()) {
+        next_messages_cache_[i] = reader->read_next();
+      }
+      i++;
+    }
+    next_messages_cache_initialized_ = true;
+  }
+
   mutable std::mutex reader_mutex_;
 
   std::vector<reader_storage_options_pair_t>
@@ -191,6 +211,8 @@ private:
 
   std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
   next_messages_cache_ RCPPUTILS_TSA_GUARDED_BY(reader_mutex_);
+
+  bool next_messages_cache_initialized_ RCPPUTILS_TSA_GUARDED_BY(reader_mutex_) = false;
 
   rcutils_time_point_value_t earliest_timestamp_{0};
   rcutils_time_point_value_t latest_timestamp_{0};

--- a/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/mock_sequential_reader.hpp
@@ -150,10 +150,10 @@ public:
       const auto message_timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>(
         std::chrono::nanoseconds(messages[0]->recv_timestamp));
       metadata_.starting_time = message_timestamp;
+      metadata_.duration = std::chrono::nanoseconds(messages.back()->recv_timestamp -
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+          metadata_.starting_time.time_since_epoch()).count());
     }
-    metadata_.duration = std::chrono::nanoseconds(messages.back()->recv_timestamp -
-      std::chrono::duration_cast<std::chrono::nanoseconds>(
-        metadata_.starting_time.time_since_epoch()).count());
 
     messages_ = std::move(messages);
     topics_ = std::move(topics);

--- a/rosbag2_transport/test/rosbag2_transport/test_readers_manager.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_readers_manager.cpp
@@ -255,3 +255,55 @@ TEST_F(Rosbag2ReadersWrapperTestFixture, get_all_topics_and_types_from_multiple_
     EXPECT_EQ(topics[1].type, "test_msgs/msg/BasicTypes");
   }
 }
+
+TEST_F(Rosbag2ReadersWrapperTestFixture, set_filter_applies_to_first_message)
+{
+  ReadersManager readers_manager(std::move(readers_with_options_));
+
+  // Filter out topic1 entirely before reading anything. The filter must apply to every
+  // message, including the very first one from each reader.
+  rosbag2_storage::StorageFilter filter;
+  filter.topics = {"topic2"};
+  readers_manager.set_filter(filter);
+
+  size_t num_messages = 0;
+  while (auto message = readers_manager.get_next_message_in_chronological_order()) {
+    EXPECT_EQ(message->topic_name, "topic2");
+    num_messages++;
+  }
+  EXPECT_EQ(num_messages, static_cast<size_t>(kNumMessagesPerBag));
+}
+
+TEST_F(Rosbag2ReadersWrapperTestFixture, reader_without_messages_does_not_break_cache_alignment)
+{
+  // First reader has no messages at all
+  auto empty_reader = std::make_unique<MockSequentialReader>();
+  empty_reader->prepare({}, {{1u, "topic1", "test_msgs/msg/BasicTypes", "", {}, ""}});
+  auto cpp_reader1 = std::make_unique<rosbag2_cpp::Reader>(std::move(empty_reader));
+
+  auto basic_message = get_messages_basic_types()[0];
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages;
+  std::vector<rosbag2_storage::TopicMetadata> topics{
+    {2u, "topic2", "test_msgs/msg/BasicTypes", "", {}, ""}
+  };
+  for (int32_t i = 0; i < kNumMessagesPerBag; i++) {
+    messages.push_back(serialize_test_message("topic2", i * 10, basic_message));
+  }
+  auto mock_reader2 = std::make_unique<MockSequentialReader>();
+  mock_reader2->prepare(messages, topics);
+  auto cpp_reader2 = std::make_unique<rosbag2_cpp::Reader>(std::move(mock_reader2));
+
+  std::vector<ReadersManager::reader_storage_options_pair_t> readers_with_options;
+  readers_with_options.emplace_back(std::move(cpp_reader1), storage_options_);
+  readers_with_options.emplace_back(std::move(cpp_reader2), storage_options_);
+
+  ReadersManager readers_manager(std::move(readers_with_options));
+
+  // All messages from the second reader must be returned despite the first reader being empty.
+  size_t num_messages = 0;
+  while (auto message = readers_manager.get_next_message_in_chronological_order()) {
+    EXPECT_EQ(message->topic_name, "topic2");
+    num_messages++;
+  }
+  EXPECT_EQ(num_messages, static_cast<size_t>(kNumMessagesPerBag));
+}


### PR DESCRIPTION
## Description

Previously the ReadersManager pre-read one message from each reader in its constructor.  There are 2 problems with that:

1.  This happens before any filter could be set via set_filter(), so the first message from each bag bypassed the topic filter.  The problem was latent because the player always did a seek back to the beginning before playback, but a naive user of the API could run into it.

2.  The pre-read could misalign the next-message cache with the reader indices when a reader had no messages, silently dropping messages from other bags.

Fix both of these issues by filling the cache lazily on first access instead, with one index-aligned slot per reader.

(this fix is a prerequisite to a follow-up patch that I'm going to open for mixed serialization formats)

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes, Claude Fable 5.

### Additional Information

N/A