### PR TITLE
Cleanup the tests

### DIFF
--- a/rosbag2_compression/CMakeLists.txt
+++ b/rosbag2_compression/CMakeLists.txt
@@ -70,33 +70,45 @@ if(BUILD_TESTING)
     test/rosbag2_compression/fake_compressor.cpp
     test/rosbag2_compression/fake_decompressor.cpp)
   target_link_libraries(fake_plugin ament_cmake_ros_core::ament_ros_defaults ${PROJECT_NAME})
-  install(
-    TARGETS fake_plugin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
-  pluginlib_export_plugin_description_file(
-    rosbag2_compression test/rosbag2_compression/fake_plugin.xml)
+  # Mock-install the fake compression plugin into the build folder rather
+  # than installing it, so that it never appears as a registered compression
+  # plugin outside of the tests that need it.
+  pluginlib_enable_plugin_testing(
+    CMAKE_TARGET_VAR fake_plugin_mock_install_target
+    AMENT_PREFIX_PATH_VAR fake_plugin_mock_install_path
+    PACKAGE_NAME "rosbag2_compression_test_plugins"
+    PACKAGE_XML "test/rosbag2_compression/test_package.xml"
+    PLUGIN_CATEGORY "rosbag2_compression"
+    PLUGIN_DESCRIPTIONS "test/rosbag2_compression/fake_plugin.xml"
+    PLUGIN_LIBRARIES fake_plugin)
 
   ament_add_gmock(test_compression_factory
-    test/rosbag2_compression/test_compression_factory.cpp)
+    test/rosbag2_compression/test_compression_factory.cpp
+    APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:fake_plugin>"
+    APPEND_ENV AMENT_PREFIX_PATH=${fake_plugin_mock_install_path})
   target_link_libraries(test_compression_factory ament_cmake_ros_core::ament_ros_defaults ${PROJECT_NAME})
+  add_dependencies(test_compression_factory "${fake_plugin_mock_install_target}")
 
   ament_add_gmock(test_compression_options
     test/rosbag2_compression/test_compression_options.cpp)
   target_link_libraries(test_compression_options ament_cmake_ros_core::ament_ros_defaults ${PROJECT_NAME})
 
   ament_add_gmock(test_sequential_compression_reader
-    test/rosbag2_compression/test_sequential_compression_reader.cpp)
+    test/rosbag2_compression/test_sequential_compression_reader.cpp
+    APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:fake_plugin>"
+    APPEND_ENV AMENT_PREFIX_PATH=${fake_plugin_mock_install_path})
   target_link_libraries(test_sequential_compression_reader
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
     rosbag2_cpp::rosbag2_cpp
     rosbag2_storage::rosbag2_storage
   )
+  add_dependencies(test_sequential_compression_reader "${fake_plugin_mock_install_target}")
 
   ament_add_gmock(test_sequential_compression_writer
-    test/rosbag2_compression/test_sequential_compression_writer.cpp)
+    test/rosbag2_compression/test_sequential_compression_writer.cpp
+    APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:fake_plugin>"
+    APPEND_ENV AMENT_PREFIX_PATH=${fake_plugin_mock_install_path})
   target_link_libraries(test_sequential_compression_writer
     ament_cmake_ros_core::ament_ros_defaults
     ${PROJECT_NAME}
@@ -104,6 +116,7 @@ if(BUILD_TESTING)
     rosbag2_cpp::rosbag2_cpp
     rosbag2_storage::rosbag2_storage
   )
+  add_dependencies(test_sequential_compression_writer "${fake_plugin_mock_install_target}")
 endif()
 
 ament_package()

--- a/rosbag2_compression/test/rosbag2_compression/test_package.xml
+++ b/rosbag2_compression/test/rosbag2_compression/test_package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbag2_compression_test_plugins</name>
+  <version>0.0.0</version>
+  <description>
+    Fake package used to mock-install the rosbag2_compression fake compression plugin for unit tests.
+    It is never installed.
+  </description>
+  <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
+  <license>Apache License 2.0</license>
+</package>

--- a/rosbag2_cpp/CMakeLists.txt
+++ b/rosbag2_cpp/CMakeLists.txt
@@ -144,17 +144,25 @@ if(BUILD_TESTING)
     ${PROJECT_NAME}
     rosbag2_storage::rosbag2_storage
   )
-  install(
-    TARGETS converter_test_plugins
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
-  pluginlib_export_plugin_description_file(rosbag2_cpp test/rosbag2_cpp/converter_test_plugin.xml)
+  # Mock-install the test converter plugins into the build folder rather than
+  # installing them, so that they never appear as registered serialization
+  # format plugins outside of the tests that need them.
+  pluginlib_enable_plugin_testing(
+    CMAKE_TARGET_VAR converter_test_plugins_mock_install_target
+    AMENT_PREFIX_PATH_VAR converter_test_plugins_mock_install_path
+    PACKAGE_NAME "rosbag2_cpp_test_plugins"
+    PACKAGE_XML "test/rosbag2_cpp/test_package.xml"
+    PLUGIN_CATEGORY "rosbag2_cpp"
+    PLUGIN_DESCRIPTIONS "test/rosbag2_cpp/converter_test_plugin.xml"
+    PLUGIN_LIBRARIES converter_test_plugins)
 
   ament_add_gmock(test_converter_factory
-    test/rosbag2_cpp/test_converter_factory.cpp)
+    test/rosbag2_cpp/test_converter_factory.cpp
+    APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:converter_test_plugins>"
+    APPEND_ENV AMENT_PREFIX_PATH=${converter_test_plugins_mock_install_path})
   if(TARGET test_converter_factory)
     target_link_libraries(test_converter_factory ament_cmake_ros_core::ament_ros_defaults ${PROJECT_NAME})
+    add_dependencies(test_converter_factory "${converter_test_plugins_mock_install_target}")
   endif()
 
   ament_add_gmock(test_info

--- a/rosbag2_cpp/test/rosbag2_cpp/test_package.xml
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbag2_cpp_test_plugins</name>
+  <version>0.0.0</version>
+  <description>
+    Fake package used to mock-install the rosbag2_cpp test converter plugins for unit tests.
+    It is never installed.
+  </description>
+  <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
+  <license>Apache License 2.0</license>
+</package>

--- a/rosbag2_py/test/test_sequential_reader.py
+++ b/rosbag2_py/test/test_sequential_reader.py
@@ -169,4 +169,4 @@ def test_sequential_reader_seek(storage_id):
 
 def test_plugin_list():
     reader_plugins = rosbag2_py.get_registered_readers()
-    assert 'my_read_only_test_plugin' in reader_plugins
+    assert {'mcap', 'sqlite3'} <= reader_plugins

--- a/rosbag2_py/test/test_sequential_writer.py
+++ b/rosbag2_py/test/test_sequential_writer.py
@@ -98,7 +98,7 @@ def test_sequential_writer(tmp_path, storage_id):
 
 def test_plugin_list():
     writer_plugins = rosbag2_py.get_registered_writers()
-    assert 'my_test_plugin' in writer_plugins
+    assert {'mcap', 'sqlite3'} <= writer_plugins
 
 
 def test_compression_plugin_list():
@@ -108,17 +108,17 @@ def test_compression_plugin_list():
     :return:
     """
     compression_formats = rosbag2_py.get_registered_compressors()
-    assert 'fake_comp' in compression_formats
+    assert 'zstd' in compression_formats
 
 
 def test_serialization_plugin_list():
     """
     Testing retrieval of available serialization format plugins.
 
+    No serialization format plugins ship with the core distribution, so only
+    check that the query itself succeeds.
+
     :return:
     """
     serialization_formats = rosbag2_py.get_registered_serializers()
-    assert 's_converter' in serialization_formats, \
-        'get_registered_serializers should return SerializationFormatSerializer plugins'
-    assert 'a_converter' in serialization_formats, \
-        'get_registered_serializers should also return SerializationFormatConverter plugins'
+    assert isinstance(serialization_formats, set)

--- a/rosbag2_storage/CMakeLists.txt
+++ b/rosbag2_storage/CMakeLists.txt
@@ -82,17 +82,25 @@ if(BUILD_TESTING)
     test/rosbag2_storage/test_plugin.cpp
     test/rosbag2_storage/test_read_only_plugin.cpp)
   target_link_libraries(test_plugin ament_cmake_ros_core::ament_ros_defaults ${PROJECT_NAME} pluginlib::pluginlib)
-  install(
-    TARGETS test_plugin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
-  pluginlib_export_plugin_description_file(rosbag2_storage test/rosbag2_storage/test_plugin.xml)
+  # Mock-install the test plugin into the build folder rather than installing
+  # it, so that it never appears as a registered storage plugin outside of the
+  # tests that need it.
+  pluginlib_enable_plugin_testing(
+    CMAKE_TARGET_VAR test_plugin_mock_install_target
+    AMENT_PREFIX_PATH_VAR test_plugin_mock_install_path
+    PACKAGE_NAME "rosbag2_storage_test_plugins"
+    PACKAGE_XML "test/rosbag2_storage/test_package.xml"
+    PLUGIN_CATEGORY "rosbag2_storage"
+    PLUGIN_DESCRIPTIONS "test/rosbag2_storage/test_plugin.xml"
+    PLUGIN_LIBRARIES test_plugin)
 
   ament_add_gmock(test_storage_factory
-    test/rosbag2_storage/test_storage_factory.cpp)
+    test/rosbag2_storage/test_storage_factory.cpp
+    APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:test_plugin>"
+    APPEND_ENV AMENT_PREFIX_PATH=${test_plugin_mock_install_path})
   if(TARGET test_storage_factory)
     target_link_libraries(test_storage_factory ament_cmake_ros_core::ament_ros_defaults ${PROJECT_NAME})
+    add_dependencies(test_storage_factory "${test_plugin_mock_install_target}")
   endif()
 
   ament_add_gmock(test_ros_helper

--- a/rosbag2_storage/test/rosbag2_storage/test_package.xml
+++ b/rosbag2_storage/test/rosbag2_storage/test_package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbag2_storage_test_plugins</name>
+  <version>0.0.0</version>
+  <description>
+    Fake package used to mock-install the rosbag2_storage test plugins for unit tests.
+    It is never installed.
+  </description>
+  <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
+  <license>Apache License 2.0</license>
+</package>

--- a/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_plugin.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -27,34 +26,23 @@
 
 TestPlugin::~TestPlugin()
 {
-  std::cout << "\nclosing.\n";
 }
 
 void TestPlugin::open(
   const rosbag2_storage::StorageOptions & storage_options,
-  rosbag2_storage::storage_interfaces::IOFlag flag)
+  rosbag2_storage::storage_interfaces::IOFlag /*flag*/)
 {
   if (storage_options.storage_id != test_constants::READ_WRITE_PLUGIN_IDENTIFIER) {
-    throw std::runtime_error{"storage_id did not match. TestReadOnlyPlugin won't open."};
+    throw std::runtime_error{"storage_id did not match. TestPlugin won't open."};
   }
-  if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
-    std::cout << "opening testplugin read only: ";
-  } else if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) {
-    std::cout << "opening testplugin read write: ";
-  }
-  std::cout << "storage uri: " << storage_options.uri << ".\n";
-  std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
-void TestPlugin::update_metadata(const rosbag2_storage::BagMetadata & metadata)
+void TestPlugin::update_metadata(const rosbag2_storage::BagMetadata & /*metadata*/)
 {
-  std::cout << "Set metadata" << std::endl;
-  (void)metadata;
 }
 
-bool TestPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
+bool TestPlugin::set_read_order(const rosbag2_storage::ReadOrder & /*order*/)
 {
-  std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
   return true;
 }
 
@@ -65,41 +53,34 @@ bool TestPlugin::has_next()
 
 std::shared_ptr<rosbag2_storage::SerializedBagMessage> TestPlugin::read_next()
 {
-  std::cout << "\nreading\n";
   return std::shared_ptr<rosbag2_storage::SerializedBagMessage>();
 }
 
 void TestPlugin::create_topic(
-  const rosbag2_storage::TopicMetadata & topic,
-  const rosbag2_storage::MessageDefinition & message_definition)
+  const rosbag2_storage::TopicMetadata & /*topic*/,
+  const rosbag2_storage::MessageDefinition & /*message_definition*/)
 {
-  std::cout << "Created topic with name =" << topic.name << ", type =" << topic.type <<
-    "and message definition encoding " << message_definition.encoding << ".\n";
 }
 
-void TestPlugin::remove_topic(const rosbag2_storage::TopicMetadata & topic)
+void TestPlugin::remove_topic(const rosbag2_storage::TopicMetadata & /*topic*/)
 {
-  std::cout << "Removed topic with name =" << topic.name << " and type =" << topic.type << ".\n";
 }
 
 void TestPlugin::write(const std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
   (void) msg;
-  std::cout << "\nwriting\n";
 }
 
 void TestPlugin::write(
   const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msg)
 {
   (void) msg;
-  std::cout << "\nwriting multiple\n";
 }
 
 bool TestPlugin::write_message(
   const std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
 {
   (void) msg;
-  std::cout << "\nwriting message\n";
   return true;
 }
 
@@ -107,14 +88,12 @@ std::vector<size_t>
 TestPlugin::write_messages(const rosbag2_storage::SerializedBagMessages & messages)
 {
   (void)messages;
-  std::cout << "\nwriting multiple messages\n";
   std::vector<size_t> ret_value;
   return ret_value;
 }
 
 std::vector<rosbag2_storage::TopicMetadata> TestPlugin::get_all_topics_and_types()
 {
-  std::cout << "\nreading topics and types\n";
   return std::vector<rosbag2_storage::TopicMetadata>();
 }
 
@@ -122,48 +101,40 @@ void TestPlugin::get_all_message_definitions(std::vector<rosbag2_storage::Messag
 
 rosbag2_storage::BagMetadata TestPlugin::get_metadata()
 {
-  std::cout << "\nreturning metadata\n";
   return rosbag2_storage::BagMetadata();
 }
 
 std::string TestPlugin::get_relative_file_path() const
 {
-  std::cout << "\nreturning relative path\n";
   return test_constants::DUMMY_FILEPATH;
 }
 
 uint64_t TestPlugin::get_bagfile_size() const
 {
-  std::cout << "\nreturning bagfile size\n";
   return test_constants::MAX_BAGFILE_SIZE;
 }
 
 std::string TestPlugin::get_storage_identifier() const
 {
-  std::cout << "\nreturning storage identifier\n";
   return test_constants::READ_WRITE_PLUGIN_IDENTIFIER;
 }
 
 uint64_t TestPlugin::get_minimum_split_file_size() const
 {
-  std::cout << "\nreturning minimum split file size\n";
   return test_constants::MIN_SPLIT_FILE_SIZE;
 }
 
 void TestPlugin::set_filter(
   const rosbag2_storage::StorageFilter & /*storage_filter*/)
 {
-  std::cout << "\nsetting storage filter\n";
 }
 
 void TestPlugin::reset_filter()
 {
-  std::cout << "\nresetting storage filter\n";
 }
 
 void TestPlugin::seek(const rcutils_time_point_value_t & /*timestamp*/)
 {
-  std::cout << "\nseeking\n";
 }
 
 PLUGINLIB_EXPORT_CLASS(TestPlugin, rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
+++ b/rosbag2_storage/test/rosbag2_storage/test_read_only_plugin.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,28 +23,19 @@
 
 TestReadOnlyPlugin::~TestReadOnlyPlugin()
 {
-  std::cout << "\nclosing.\n";
 }
 
 void TestReadOnlyPlugin::open(
   const rosbag2_storage::StorageOptions & storage_options,
-  rosbag2_storage::storage_interfaces::IOFlag flag)
+  rosbag2_storage::storage_interfaces::IOFlag /*flag*/)
 {
   if (storage_options.storage_id != test_constants::READ_ONLY_PLUGIN_IDENTIFIER) {
     throw std::runtime_error{"storage_id did not match. TestReadOnlyPlugin won't open."};
   }
-  if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
-    std::cout << "opening testplugin read only: ";
-  } else if (flag == rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) {
-    std::cout << "opening testplugin read write: ";
-  }
-  std::cout << "storage uri: " << storage_options.uri << ".\n";
-  std::cout << "config file uri: " << storage_options.storage_config_uri << ".\n";
 }
 
-bool TestReadOnlyPlugin::set_read_order(const rosbag2_storage::ReadOrder & order)
+bool TestReadOnlyPlugin::set_read_order(const rosbag2_storage::ReadOrder & /*order*/)
 {
-  std::cout << "Set read order " << order.sort_by << " " << order.reverse << std::endl;
   return true;
 }
 
@@ -56,13 +46,11 @@ bool TestReadOnlyPlugin::has_next()
 
 std::shared_ptr<rosbag2_storage::SerializedBagMessage> TestReadOnlyPlugin::read_next()
 {
-  std::cout << "\nreading\n";
   return std::shared_ptr<rosbag2_storage::SerializedBagMessage>();
 }
 
 std::vector<rosbag2_storage::TopicMetadata> TestReadOnlyPlugin::get_all_topics_and_types()
 {
-  std::cout << "\nreading topics and types\n";
   return std::vector<rosbag2_storage::TopicMetadata>();
 }
 
@@ -71,42 +59,35 @@ void TestReadOnlyPlugin::get_all_message_definitions(
 
 std::string TestReadOnlyPlugin::get_relative_file_path() const
 {
-  std::cout << "\nreturning relative path\n";
   return test_constants::DUMMY_FILEPATH;
 }
 
 rosbag2_storage::BagMetadata TestReadOnlyPlugin::get_metadata()
 {
-  std::cout << "\nreturning bag metadata\n";
   return rosbag2_storage::BagMetadata();
 }
 
 uint64_t TestReadOnlyPlugin::get_bagfile_size() const
 {
-  std::cout << "\nreturning bagfile size\n";
   return test_constants::MAX_BAGFILE_SIZE;
 }
 
 std::string TestReadOnlyPlugin::get_storage_identifier() const
 {
-  std::cout << "\nreturning storage identifier\n";
   return test_constants::READ_ONLY_PLUGIN_IDENTIFIER;
 }
 
 void TestReadOnlyPlugin::set_filter(
   const rosbag2_storage::StorageFilter & /*storage_filter*/)
 {
-  std::cout << "\nsetting storage filter\n";
 }
 
 void TestReadOnlyPlugin::reset_filter()
 {
-  std::cout << "\nresetting storage filter\n";
 }
 
 void TestReadOnlyPlugin::seek(const rcutils_time_point_value_t & /*timestamp*/)
 {
-  std::cout << "\nseeking\n";
 }
 
 PLUGINLIB_EXPORT_CLASS(TestReadOnlyPlugin, rosbag2_storage::storage_interfaces::ReadOnlyInterface)


### PR DESCRIPTION
## Description

There are two changes in here to make the test situation a bit nicer:

1.  Remove printouts from the test plugin.
    
    The main reason to do this is that, during development,
    the test plugin gets installed as a "regular" plugin.
    Thus when you run any "ros2 bag" commands, the plugin
    gets loaded and prints out spurious messages.
    There is really no need for the plugin to print out, so just make it silent.
    
2.  Don't install test plugins into the "production" location.
    
    Instead utilize pluginlib_enable_plugin_testing() to install
    to the build directory, and then inject the path into the
    tests so they get found properly.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes, Claude Fable 5

### Additional Information

Strictly speaking, patch 1 is not required if we just take patch 2.  But it still seems like unnecessary printouts to me, so I left it in.