### PR TITLE
Enhance action status topic handling and filtering logic

### DIFF
--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -432,12 +432,28 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
           }
         }
       }
+      if (real_root_type == "action_msgs/msg/GoalStatusArray") {
+        // The owning action type could not be determined (e.g. only the status topic of an
+        // action is recorded, so no other introspection topic has populated the cache).
+        // GoalStatusArray is an ordinary message type - fall back to its plain message
+        // definition instead of producing an "unknown" encoding with an empty definition.
+        format = Format::MSG;
+      } else if (real_root_type == "action_msgs/srv/CancelGoal_Event") {
+        // Same fallback for the cancel-goal service event type: use the plain service
+        // definition.
+        real_root_type = service_event_topic_type_to_service_type(real_root_type);
+        format = Format::SRV;
+      }
     }
     try {
       DefinitionIdentifier def_identifier{real_root_type, format};
       const MessageSpec & spec = load_message_spec(def_identifier);
       (void)seen_deps.insert(def_identifier).second;
-      result = delimiter(def_identifier);
+      if (format != Format::MSG) {
+        // By design the top-level message definition for MSG format is present first,
+        // with no delimiter.
+        result = delimiter(def_identifier);
+      }
       result += spec.text;
       for (const auto & dep_name : spec.dependencies) {
         DefinitionIdentifier dep(dep_name, Format::MSG);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -231,6 +231,41 @@ TEST(test_local_message_definition_source, can_find_action_deps_in_msg)
   }
 }
 
+TEST(test_local_message_definition_source, action_status_and_cancel_goal_without_prior_lookup)
+{
+  // A fresh source has no cached action type for the topic: recording only the status or
+  // cancel_goal interface topic of an action must still yield a usable plain definition
+  // instead of an "unknown" encoding with an empty definition.
+  {
+    LocalMessageDefinitionSource source;
+    auto result = source.get_full_text_ext(
+      "action_msgs/msg/GoalStatusArray",
+      "/complex_action_msg/_action/status");
+    EXPECT_EQ(result.encoding, "ros2msg");
+    EXPECT_EQ(result.topic_type, "action_msgs/msg/GoalStatusArray");
+    EXPECT_THAT(
+      result.encoded_message_definition,
+      ::testing::HasSubstr("GoalStatus[] status_list"));
+    EXPECT_THAT(
+      result.encoded_message_definition,
+      ::testing::HasSubstr("MSG: action_msgs/GoalStatus"));
+    EXPECT_THAT(
+      result.encoded_message_definition,
+      ::testing::HasSubstr("MSG: unique_identifier_msgs/UUID"));
+  }
+  {
+    LocalMessageDefinitionSource source;
+    auto result = source.get_full_text_ext(
+      "action_msgs/srv/CancelGoal_Event",
+      "/complex_action_msg/_action/cancel_goal/_service_event");
+    EXPECT_EQ(result.encoding, "ros2msg");
+    EXPECT_EQ(result.topic_type, "action_msgs/srv/CancelGoal");
+    EXPECT_THAT(
+      result.encoded_message_definition,
+      ::testing::HasSubstr("SRV: action_msgs/srv/CancelGoal"));
+  }
+}
+
 TEST(test_local_message_definition_source, can_find_action_deps_in_idl)
 {
   auto check_result = [](const rosbag2_storage::MessageDefinition & result) {

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -279,17 +279,17 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
       if (include_action_interface_names_.find(topic_name) ==
         include_action_interface_names_.end())
       {
-        // An exact match in the topics list selects an individual action
-        // interface topic (e.g. only the status topic of an action).
-        selected_as_topic = topic_in_list(topic_name, record_options_.topics);
-        if (!selected_as_topic) {
-          // Not match include regex
-          if (!record_options_.regex.empty()) {
-            std::regex include_regex(record_options_.regex);
-            if (!std::regex_search(action_name, include_regex)) {
-              return false;
-            }
-          } else {
+        bool selected_by_regex = false;
+        if (!record_options_.regex.empty()) {
+          std::regex include_regex(record_options_.regex);
+          selected_by_regex = std::regex_search(action_name, include_regex);
+        }
+        if (!selected_by_regex) {
+          // An exact match in the topics list selects an individual action
+          // interface topic (e.g. only the status topic of an action). Whole-action
+          // selection takes precedence over this fallback.
+          selected_as_topic = topic_in_list(topic_name, record_options_.topics);
+          if (!selected_as_topic) {
             return false;
           }
         }
@@ -307,6 +307,14 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
       }
       if (topic_in_list(topic_name, record_options_.exclude_topics)) {
         return false;
+      }
+      // Apply exclude_regex against the topic name (not the action name) for
+      // parity with regular topic handling.
+      if (!record_options_.exclude_regex.empty()) {
+        std::regex exclude_regex(record_options_.exclude_regex);
+        if (std::regex_search(topic_name, exclude_regex)) {
+          return false;
+        }
       }
     }
 

--- a/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/topic_filter.cpp
@@ -262,6 +262,7 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
     if (!record_options_.all_actions &&
       static_topics_and_services_.empty() &&
       record_options_.actions.empty() &&
+      record_options_.topics.empty() &&
       record_options_.regex.empty())
     {
       return false;
@@ -270,6 +271,7 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
     // Convert topic name to action name
     auto action_name = rosbag2_cpp::action_interface_name_to_action_name(topic_name);
 
+    bool selected_as_topic = false;
     if (!record_options_.all_actions &&
       !topic_in_list(topic_name, static_topics_and_services_))
     {
@@ -277,15 +279,34 @@ bool TopicFilter::topic_selected_by_lists_or_regex(
       if (include_action_interface_names_.find(topic_name) ==
         include_action_interface_names_.end())
       {
-        // Not match include regex
-        if (!record_options_.regex.empty()) {
-          std::regex include_regex(record_options_.regex);
-          if (!std::regex_search(action_name, include_regex)) {
+        // An exact match in the topics list selects an individual action
+        // interface topic (e.g. only the status topic of an action).
+        selected_as_topic = topic_in_list(topic_name, record_options_.topics);
+        if (!selected_as_topic) {
+          // Not match include regex
+          if (!record_options_.regex.empty()) {
+            std::regex include_regex(record_options_.regex);
+            if (!std::regex_search(action_name, include_regex)) {
+              return false;
+            }
+          } else {
             return false;
           }
-        } else {
-          return false;
         }
+      }
+    }
+
+    if (selected_as_topic) {
+      // Keep parity with regular topic handling when selected via the topics
+      // list: honor hidden-topic gating and topic exclusions.
+      if (!record_options_.include_hidden_topics && topic_is_hidden(topic_name)) {
+        RCUTILS_LOG_WARN_ONCE_NAMED(
+          ROSBAG2_TRANSPORT_PACKAGE_NAME,
+          "Hidden topics are not recorded. Enable them with --include-hidden-topics");
+        return false;
+      }
+      if (topic_in_list(topic_name, record_options_.exclude_topics)) {
+        return false;
       }
     }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -353,6 +353,66 @@ TEST_F(TestTopicFilter, filter_actions) {
   }
 }
 
+TEST_F(TestTopicFilter, filter_individual_action_interface_topic_by_topics_list) {
+  std::map<std::string, std::vector<std::string>> topics_and_types{
+    {"topic/a", {"type_a"}},
+    // action/a
+    {"/action/a/_action/send_goal/_service_event", {"test_msgs/action/TypeA_SendGoal_Event"}},
+    {"/action/a/_action/get_result/_service_event", {"test_msgs/action/TypeA_GetResult_Event"}},
+    {"/action/a/_action/cancel_goal/_service_event", {"action_msgs/srv/CancelGoal_Event"}},
+    {"/action/a/_action/feedback", {"test_msgs/action/TypeA_FeedbackMessage"}},
+    {"/action/a/_action/status", {"action_msgs/msg/GoalStatusArray"}},
+  };
+
+  // An exact match in the topics list selects an individual action interface
+  // topic (e.g. only the status topic) without pulling in the whole action.
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"/action/a/_action/status"};
+    record_options.include_hidden_topics = true;
+    rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    ASSERT_EQ(1u, filtered_topics.size());
+    EXPECT_TRUE(
+      filtered_topics.find("/action/a/_action/status") != filtered_topics.end());
+  }
+
+  // A regular topic and an individual action interface topic can be mixed.
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"topic/a", "/action/a/_action/status"};
+    record_options.include_hidden_topics = true;
+    rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    ASSERT_EQ(2u, filtered_topics.size());
+    EXPECT_TRUE(filtered_topics.find("topic/a") != filtered_topics.end());
+    EXPECT_TRUE(
+      filtered_topics.find("/action/a/_action/status") != filtered_topics.end());
+  }
+
+  // Action interface topics are hidden: without --include-hidden-topics an
+  // exact topics-list match must not select them.
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"/action/a/_action/status"};
+    record_options.include_hidden_topics = false;
+    rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    EXPECT_TRUE(filtered_topics.empty());
+  }
+
+  // exclude_topics takes precedence over an exact topics-list match.
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"/action/a/_action/status"};
+    record_options.exclude_topics = {"/action/a/_action/status"};
+    record_options.include_hidden_topics = true;
+    rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    EXPECT_TRUE(filtered_topics.empty());
+  }
+}
+
 TEST_F(TestTopicFilter, all_topics_and_exclude_regex)
 {
   rosbag2_transport::RecordOptions record_options;

--- a/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_topic_filter.cpp
@@ -411,6 +411,33 @@ TEST_F(TestTopicFilter, filter_individual_action_interface_topic_by_topics_list)
     auto filtered_topics = filter.filter_topics(topics_and_types);
     EXPECT_TRUE(filtered_topics.empty());
   }
+
+  // exclude_regex is matched against the topic name (parity with regular
+  // topic handling) and takes precedence over an exact topics-list match.
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"/action/a/_action/status"};
+    record_options.exclude_regex = ".*/_action/status";
+    record_options.include_hidden_topics = true;
+    rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    EXPECT_TRUE(filtered_topics.empty());
+  }
+
+  // Whole-action selection via the include regex takes precedence over an
+  // exact topics-list match: the topic keeps action semantics (no hidden-topic
+  // gating) even though it is also listed in topics.
+  {
+    rosbag2_transport::RecordOptions record_options;
+    record_options.topics = {"/action/a/_action/status"};
+    record_options.regex = "/action/a";
+    record_options.include_hidden_topics = false;
+    rosbag2_transport::TopicFilter filter{record_options, nullptr, true};
+    auto filtered_topics = filter.filter_topics(topics_and_types);
+    ASSERT_EQ(5u, filtered_topics.size());
+    EXPECT_TRUE(
+      filtered_topics.find("/action/a/_action/status") != filtered_topics.end());
+  }
 }
 
 TEST_F(TestTopicFilter, all_topics_and_exclude_regex)


### PR DESCRIPTION
## Description

Enables recording a **single action interface topic** (most notably an action's `status` topic) by name, without pulling in the entire action, and ensures such recordings get a proper, self-contained message/service definition in the bag.

Previously, selecting just one action sub-topic (e.g. `.../_action/status`) was not possible via the `--topics` list, and even when recorded the message definition came out as an "unknown" encoding with an empty definition because the owning action type could not be resolved.

**Changes:**

- **Topic filtering** (`rosbag2_transport/topic_filter.cpp`): an exact match in the `topics` list now selects an individual action interface topic on its own. When selected this way it keeps parity with regular topic handling — honoring hidden-topic gating (`--include-hidden-topics` required, since these topics are hidden) and `exclude_topics` precedence.
- **Message definitions** (`rosbag2_cpp/local_message_definition_source.cpp`): adds fallbacks in `get_full_text_ext` when the owning action type is unknown — `action_msgs/msg/GoalStatusArray` emits its plain message definition (`MSG`) and `action_msgs/srv/CancelGoal_Event` emits the plain service definition (`SRV`). Also fixes delimiter handling so the top-level `MSG` definition is emitted first with no delimiter.
- **Tests**: coverage for both the filter behavior and the definition fallbacks.

### Fixes # (issue)

### Is this user-facing behavior change?

Yes. Users can now record an individual action interface topic by listing its exact name (e.g. `ros2 bag record /my_action/_action/status --include-hidden-topics`) instead of being forced to record the whole action. Such recordings now also contain a valid `ros2msg` message/service definition rather than an empty/unknown one. Existing behavior for whole-action, regex, and `--all-actions` selection is unchanged, and action interface topics remain hidden by default.

### Did you use Generative AI?

yes Opus 4.8

### Additional Information