### PR TITLE
Replace the `rosbag2_py` recorder executor with the `EventsCBGExecutor`

### DIFF
--- a/rosbag2_performance/rosbag2_performance_benchmarking/config/benchmarks/dispatch_latency.yaml
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/config/benchmarks/dispatch_latency.yaml
@@ -1,0 +1,21 @@
+rosbag2_performance_benchmarking:
+  benchmark_node:
+    ros__parameters:
+      benchmark:
+        summary_result_file:  "results.csv"
+        bag_root_folder:      "/tmp/rosbag2_dispatch_latency"
+        repeat_each:          1
+        no_transport:         False
+        # Required: extract_latency.py reads recv/send timestamps back out of the bags.
+        preserve_bags:        True
+        # On an 8-core host, disjoint sets so producers cannot steal cycles from the recorder.
+        producers_cpu_affinity: [0, 1, 2]
+        recorder_cpu_affinity:  [3, 4, 5, 6, 7]
+        parameters:
+          storage_id:             ["mcap"]
+          max_cache_size:         [100000000]
+          max_bag_size:           [0]
+          compression:            [""]
+          compression_queue_size: [1]
+          compression_threads:    [0]
+          storage_config_file:    [""]

--- a/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_1000hz.yaml
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_1000hz.yaml
@@ -1,0 +1,16 @@
+rosbag2_performance_benchmarking_node:
+  ros__parameters:
+    publishers:
+      publisher_groups: [ "many_small" ]
+      wait_for_subscriptions: True
+      # Saturation ladder rung: 200 topics x 1000 Hz = 200000 msg/s at 128 B.
+      many_small:
+        publishers_count:   200
+        topic_root:         "benchmarking_small"
+        msg_size_bytes:     128
+        msg_count_each:     5000
+        rate_hz:            1000
+        qos:
+          qos_depth:          10
+          qos_reliability:    "reliable"
+          qos_durability:     "volatile"

--- a/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_200hz.yaml
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_200hz.yaml
@@ -1,0 +1,16 @@
+rosbag2_performance_benchmarking_node:
+  ros__parameters:
+    publishers:
+      publisher_groups: [ "many_small" ]
+      wait_for_subscriptions: True
+      # Saturation ladder rung: 200 topics x 200 Hz = 40000 msg/s at 128 B.
+      many_small:
+        publishers_count:   200
+        topic_root:         "benchmarking_small"
+        msg_size_bytes:     128
+        msg_count_each:     1000
+        rate_hz:            200
+        qos:
+          qos_depth:          10
+          qos_reliability:    "reliable"
+          qos_durability:     "volatile"

--- a/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_400hz.yaml
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_400hz.yaml
@@ -1,0 +1,16 @@
+rosbag2_performance_benchmarking_node:
+  ros__parameters:
+    publishers:
+      publisher_groups: [ "many_small" ]
+      wait_for_subscriptions: True
+      # Saturation ladder rung: 200 topics x 400 Hz = 80000 msg/s at 128 B.
+      many_small:
+        publishers_count:   200
+        topic_root:         "benchmarking_small"
+        msg_size_bytes:     128
+        msg_count_each:     2000
+        rate_hz:            400
+        qos:
+          qos_depth:          10
+          qos_reliability:    "reliable"
+          qos_durability:     "volatile"

--- a/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_600hz.yaml
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_600hz.yaml
@@ -1,0 +1,16 @@
+rosbag2_performance_benchmarking_node:
+  ros__parameters:
+    publishers:
+      publisher_groups: [ "many_small" ]
+      wait_for_subscriptions: True
+      # Saturation ladder rung: 200 topics x 600 Hz = 120000 msg/s at 128 B.
+      many_small:
+        publishers_count:   200
+        topic_root:         "benchmarking_small"
+        msg_size_bytes:     128
+        msg_count_each:     3000
+        rate_hz:            600
+        qos:
+          qos_depth:          10
+          qos_reliability:    "reliable"
+          qos_durability:     "volatile"

--- a/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_800hz.yaml
+++ b/rosbag2_performance/rosbag2_performance_benchmarking/config/producers/many_small_800hz.yaml
@@ -1,0 +1,16 @@
+rosbag2_performance_benchmarking_node:
+  ros__parameters:
+    publishers:
+      publisher_groups: [ "many_small" ]
+      wait_for_subscriptions: True
+      # Saturation ladder rung: 200 topics x 800 Hz = 160000 msg/s at 128 B.
+      many_small:
+        publishers_count:   200
+        topic_root:         "benchmarking_small"
+        msg_size_bytes:     128
+        msg_count_each:     4000
+        rate_hz:            800
+        qos:
+          qos_depth:          10
+          qos_reliability:    "reliable"
+          qos_durability:     "volatile"

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -32,6 +32,8 @@
 #include "rosbag2_transport/record_options.hpp"
 #include "rosbag2_transport/recorder.hpp"
 
+#include "rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp"
+
 #include "./pybind11.hpp"
 
 namespace py = pybind11;
@@ -635,7 +637,8 @@ public:
       // We already have an executor spinning
       return;
     }
-    exec_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+    exec_ = std::make_unique<rclcpp::executors::EventsCBGExecutor>(
+      rclcpp::ExecutorOptions(), 1);
     exec_->add_node(recorder_);
     spin_thread_ = std::thread(
       [this]() {
@@ -825,7 +828,7 @@ protected:
 
   std::shared_ptr<rosbag2_transport::Recorder> recorder_;
   std::mutex spin_thread_mutex_;
-  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> exec_{nullptr};
+  std::unique_ptr<rclcpp::executors::EventsCBGExecutor> exec_{nullptr};
   std::thread spin_thread_;
 };
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
This PR swaps the `SingleThreadedExecutor` used in the `rosbag2_py` `recorder` class with the `EventsCBGExecutor`, resulting in on average 15 - 23% less CPU with the existing benchmark (each publisher publishing at the same time in a loop), and up to **_43% less CPU with staggered publishing._**

This PR also adds a few more benchmark configs to `rosbag2_performance_benchmarking` which are more focused on benchmarking the message rate rather than bandwidth / IO.

See more extensive benchmarks below in **Additional Information**

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Follow-up to the discussion in https://github.com/ros2/rosbag2/pull/743

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Not really. Functionality is preserved, but with less CPU usage

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
Claude Opus 5 was used to generate the benchmarking harnesses and new topologies, with a lot of paring down by me.


### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
- All benchmarks were done on my [x86 lenovo developer laptop](https://gist.github.com/skyegalaxy/26fb1d31809c3021b0d1225b515bc165).

- FastDDS was used for all these runs. Note, that at 1000hz, I was able to reproduce the already documented deadlock issues that [this PR](https://github.com/ros2/rmw_fastrtps/pull/890) addresses. All runs were done with this PR cherry-picked into my workspace.

- All CPU values are expressed as % of a core.

Pre-existing rosbag benchmarks (3 runs each):
```
┌─────────────────────────────┬─────────┬──────┬────────┬─────────┬────────┬─────────┬─────────┐
│       Producer config       │  msg/s  │ MB/s │ Stock  │ Patched │ Change │ t value │ p value │
├─────────────────────────────┼─────────┼──────┼────────┼─────────┼────────┼─────────┼─────────┤
│ mixed_110Mbs                │ 100,010 │ 60   │ 159.8% │ 121.8%  │ −23.8% │ 41.5    │ 0.0006  │
├─────────────────────────────┼─────────┼──────┼────────┼─────────┼────────┼─────────┼─────────┤
│ mixed_110Mbs_low_pubs_count │ 20,010  │ 110  │ 33.3%  │ 30.9%   │ −7.2%  │ 6.7     │ 0.0218  │
├─────────────────────────────┼─────────┼──────┼────────┼─────────┼────────┼─────────┼─────────┤
│ automotive                  │ 1,124   │ 573  │ 58.3%  │ 59.2%   │ +1.6%  │ −0.3    │ 0.8245  │
├─────────────────────────────┼─────────┼──────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 100MBs_raw                  │ 500     │ 100  │ 15.9%  │ 15.4%   │ −2.9%  │ 1.8     │ 0.2149  │
├─────────────────────────────┼─────────┼──────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 200MBs_raw                  │ 500     │ 200  │ 27.3%  │ 26.8%   │ −2.0%  │ 3.7     │ 0.0669  │
├─────────────────────────────┼─────────┼──────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 300MBs_raw                  │ 500     │ 300  │ 35.3%  │ 35.8%   │ +1.2%  │ −0.3    │ 0.7685  │
└─────────────────────────────┴─────────┴──────┴────────┴─────────┴────────┴─────────┴─────────┘
```
many_small saturation ladder (20 runs each):
```
┌───────────────────┬─────────┬────────┬─────────┬────────┬─────────┬─────────┐
│ Publish frequency │  msg/s  │ Stock  │ Patched │ Change │ t value │ p value │
├───────────────────┼─────────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 200 Hz            │ 40,000  │ 50.4%  │ 42.6%   │ −15.5% │ 21.6    │ 8e−15   │
├───────────────────┼─────────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 400 Hz            │ 80,000  │ 88.3%  │ 74.6%   │ −15.6% │ 38.2    │ 2e−19   │
├───────────────────┼─────────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 600 Hz            │ 120,000 │ 129.4% │ 102.5%  │ −20.8% │ 65.1    │ 9e−24   │
├───────────────────┼─────────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 800 Hz            │ 160,000 │ 163.8% │ 147.5%  │ −9.9%  │ 15.8    │ 2e−12   │
├───────────────────┼─────────┼────────┼─────────┼────────┼─────────┼─────────┤
│ 1000 Hz           │ 200,000 │ 175.0% │ 162.2%  │ −7.3%  │ 5.7     │ 2e−05   │
└───────────────────┴─────────┴────────┴─────────┴────────┴─────────┴─────────┘
```
<img width="1200" height="720" alt="2_ladder_cpu" src="https://github.com/user-attachments/assets/b29d9f5d-0826-4832-9fd7-41be3b2028b7" />

CPU Usage by Thread was also inferred (according to the thread name and usage) across these runs, by sampling every thread under `/proc/<pid>/task` every 0.5 seconds. 

<img width="1425" height="840" alt="4_thread_breakdown" src="https://github.com/user-attachments/assets/e1a419a1-b6bf-4383-ae20-e6cdfb8c8b66" />

The effects on latency were benchmarked by computing the `recv_timestamp` - `send_timestamp` in a utility script. In exchange for lower CPU, it's worth noting there is around a ~30 microsecond per message increase in latency, on average.
```
┌───────────────────┬───────────┬─────────────┬──────────────────┬─────────┐
│ Publish frequency │ Stock p50 │ Patched p50 │    Difference    │ t value │
├───────────────────┼───────────┼─────────────┼──────────────────┼─────────┤
│ 200 Hz            │ 633 µs    │ 660 µs      │ +27 µs (+4.3%)   │ 3.0     │
├───────────────────┼───────────┼─────────────┼──────────────────┼─────────┤
│ 400 Hz            │ 577 µs    │ 610 µs      │ +32 µs (+5.6%)   │ 3.6     │
├───────────────────┼───────────┼─────────────┼──────────────────┼─────────┤
│ 600 Hz            │ 632 µs    │ 615 µs      │ −17 µs (−2.7%)   │ −2.7    │
├───────────────────┼───────────┼─────────────┼──────────────────┼─────────┤
│ 800 Hz †          │ 427 µs    │ 473 µs      │ +46 µs (+10.8%)  │ 2.4     │
├───────────────────┼───────────┼─────────────┼──────────────────┼─────────┤
│ 1000 Hz †         │ 296 µs    │ 464 µs      │ +168 µs (+56.9%) │ 2.7     │
└───────────────────┴───────────┴─────────────┴──────────────────┴─────────┘
```

As a footnote, the use of multiple recording threads was experimented with, but this only increased the CPU usage without any real benefits to latency at any message publication frequency. Therefore, this PR simply replaces a single-threaded wait set executor with a single threaded events queue based one.