### PR TITLE
Adds native per-topic frequency throttling to `ros2 bag record`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,39 @@ $ ros2 bag record -a --repeat-all-transient-local --repeat-transient-local /map=
 listed in `--repeat-transient-local`, the QoS override takes precedence. Ensure the override
 includes `transient_local` durability to receive latched messages.
 
+#### Throttling per-topic recording frequency
+
+High-frequency topics (IMUs, cameras, point clouds) can dominate bag size even when the recorded
+data is only needed at a lower rate. The `--topic-throttle-frequency` option sets a maximum
+recording frequency in Hz for individual topics. Messages arriving faster than the requested
+frequency are dropped inside the recorder at the subscription edge — before serialization
+buffering, compression, and disk I/O — so throttled data costs no write bandwidth.
+
+Format: `--topic-throttle-frequency <topic>=<frequency> [...]`
+
+Examples:
+
+```bash
+# Record everything, but limit the IMU to 10 Hz and the camera to 2 Hz
+$ ros2 bag record -a --topic-throttle-frequency /imu=10.0 /camera/image_raw=2.0
+
+# Record two topics, throttling only one of them
+$ ros2 bag record /odom /scan --topic-throttle-frequency /scan=5.0
+```
+
+Topics not listed are recorded at full frequency. Throttling compares message receive
+timestamps, so it follows the same time base as the timestamps recorded in the bag, including
+simulated time when recording with `use_sim_time`. The first message on a throttled topic is
+always recorded, and a backwards jump of the time base (e.g. a simulation reset) restarts the
+throttle window instead of stalling the topic.
+
+This option also works via node parameters as `record.topic_throttle_frequency`, accepting a
+list of strings in the same `<topic>=<frequency>` format.
+
+**Note**: Throttling drops messages deterministically by elapsed time, not by sampling. If you
+need every message during the live run and a smaller archive afterwards, record at full
+frequency and downsample in post-processing instead.
+
 #### Recording with compression
 
 By default Rosbag2 does not record with compression enabled. However, compression can be specified using the following CLI options.

--- a/docs/design/per_topic_frequency_throttling_during_recording.md
+++ b/docs/design/per_topic_frequency_throttling_during_recording.md
@@ -1,0 +1,102 @@
+# Design: Per-topic frequency throttling in the Rosbag2 recorder
+
+## Problem
+High-frequency topics (IMUs, cameras, point clouds) often dominate bag size even when the
+recorded data is only needed at a much lower rate for analysis or regression testing. Today the
+only options are:
+1) Run a `topic_tools throttle` proxy node and record the throttled copy. This costs an extra
+   node, an extra DDS publication of the (potentially large) payload, and renames the topic in
+   the bag.
+2) Record at full rate and downsample in post-processing. This preserves everything but pays the
+   full serialization, caching, compression, and disk I/O cost during the live run.
+
+Neither lets a user simply say "record `/imu` at 10 Hz" to the recorder itself.
+
+## Goals
+- Opt-in, per-topic maximum recording frequency, applied inside the recorder process.
+- Drop messages before they enter the writer pipeline, so throttled data costs no cache,
+  compression, or disk bandwidth.
+- Zero overhead and unchanged behavior for topics without a throttle entry.
+- Work identically from the `ros2 bag record` CLI, node parameters (composable recorder), and
+  the C++/Python `RecordOptions` APIs.
+
+## Non-goals
+- Throttling in the storage layer. A storage plugin receives messages after serialization,
+  caching, and compression, so filtering there would waste the exact work throttling is meant to
+  save, and every plugin would need its own implementation.
+- Throttling the direct `Recorder::write_message()` API. Programmatic writes are explicit;
+  callers who want fewer of them can simply call less often.
+- Bandwidth-based (bytes/sec) or count-based (every N-th message) policies. These can be added
+  later as separate options if needed.
+
+## User-facing interface
+
+```shell
+$ ros2 bag record -a --topic-throttle-frequency /imu=10.0 /camera/image_raw=2.0
+```
+
+Semantics:
+- Each entry `<topic>=<frequency>` sets a maximum recording frequency in Hz for that topic.
+- A message is written only if at least `1/frequency` seconds have elapsed since the last
+  written message on that topic; otherwise it is dropped at the subscription edge.
+- The first message on a throttled topic is always recorded.
+- Frequencies must be finite and greater than 0; the frequency is mandatory (there is no
+  sensible default, unlike `--repeat-transient-local` depths).
+- Topics are keyed by fully qualified name, matching how `--topics` entries are matched.
+- The same option is available as the `record.topic_throttle_frequency` node parameter (list of
+  `<topic>=<frequency>` strings) and as `RecordOptions::topic_throttle_frequencies`
+  (`std::unordered_map<std::string, double>`, exposed to Python via `rosbag2_py`).
+
+## Design overview
+
+### Where: the subscription callback in `rosbag2_transport`
+The recorder's generic subscription callback (created in `RecorderImpl::create_subscription`)
+is the earliest point the recorder owns the message. Dropping there skips
+`rosbag2_cpp::Writer::write()` entirely — no cache insertion, no compression, no storage I/O.
+The RMW layer has already delivered the serialized message, so the subscription cost itself is
+unavoidable without QoS/DDS-level filtering, which is not portable across RMW implementations.
+
+### Throttle state: owned by each subscription's closure
+The throttle period is resolved once per topic when the subscription is created, and the
+"last written receive timestamp" lives in the callback closure. This avoids a shared map lookup
+and locking on the hot path, and costs literally nothing (one integer compare against 0) for
+topics without a throttle entry. Recorder subscriptions use the node's default mutually
+exclusive callback group, so per-subscription state needs no synchronization.
+
+### Time base: the message receive timestamp
+The guard compares the same `recv_timestamp` that is written into the bag (the RMW receive
+timestamp, or the node clock when `use_sim_time` is set), rather than sampling
+`std::chrono::steady_clock` or calling `node->now()` again:
+- The message spacing in the recorded bag matches the requested frequency exactly, by
+  construction.
+- Under `use_sim_time` the throttle follows simulated time automatically, including paused and
+  accelerated clocks.
+- No extra clock query is added to the callback.
+
+If the time base jumps backwards (e.g. a simulation reset), the message is accepted and the
+throttle window restarts, so a throttled topic can never stall.
+
+### Interaction with pause/resume and split bookkeeping
+Dropped messages still update the recorder's last-seen timestamp bookkeeping, so
+timestamp-based resume and split requests observe the full message stream. The throttle guard
+runs inside the "not paused" branch, immediately before the writer call: pausing does not
+consume the throttle window, and the first message after resume follows the normal spacing
+rule.
+
+### Validation
+Frequencies are validated (finite, > 0) in three places: the `ros2 bag record` argument
+validation, the `record.topic_throttle_frequency` node-parameter parsing, and
+`Recorder::record()` itself (covering direct API users). Invalid values fail fast with
+`std::invalid_argument` before any bag is created.
+
+## Alternatives considered
+- **`topic_tools throttle` proxy (status quo):** works everywhere, but re-publishes the payload
+  over the middleware just to drop most of it, renames the topic in the bag, and adds an extra
+  process to launch and monitor.
+- **Storage plugin filter:** rejected; see Non-goals. Wrong layer — the savings happen before
+  the storage interface, and the feature would need reimplementing per plugin.
+- **QoS/DDS content or time-based filters:** `rmw` support is inconsistent across vendors, and
+  time-based filters change subscription QoS in ways that can affect publisher matching.
+- **Post-processing (`ros2 bag convert`-style downsampling):** complementary, not competing —
+  it preserves transients for later inspection but saves nothing at record time. The README
+  points users to it when they need every message during the live run.

--- a/ros2bag/CHANGELOG.rst
+++ b/ros2bag/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package ros2bag
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Unreleased
+----------
+* Add ``--topic-throttle-frequency Topic=Hz`` to ``ros2 bag record`` for per-topic max recording rate
+
 0.34.0 (2026-05-01)
 -------------------
 

--- a/ros2bag/ros2bag/verb/record.py
+++ b/ros2bag/ros2bag/verb/record.py
@@ -14,6 +14,7 @@
 
 from argparse import ArgumentParser, FileType
 import datetime
+import math
 import os
 import signal
 import threading
@@ -76,6 +77,38 @@ def parse_repeat_transient_local_topics(values):
         repeat_topics[topic] = depth
 
     return repeat_topics
+
+
+def parse_topic_throttle_frequencies(values):
+    throttle_frequencies = {}
+    if not values:
+        return throttle_frequencies
+
+    for value in values:
+        topic, frequency_str = split_key_value(value)
+
+        if not topic:
+            raise ValueError(
+                f'Invalid value for --topic-throttle-frequency: "{value}". '
+                'Topic name must not be empty.')
+        if not frequency_str:
+            raise ValueError(
+                f'Invalid value for --topic-throttle-frequency: "{value}". '
+                'Expected format <topic>=<frequency>.')
+        try:
+            frequency = float(frequency_str)
+        except ValueError as exc:
+            raise ValueError(
+                f'Invalid frequency for --topic-throttle-frequency: "{value}". '
+                'Frequency must be a positive number.') from exc
+        if not math.isfinite(frequency) or frequency <= 0.0:
+            raise ValueError(
+                f'Invalid frequency for --topic-throttle-frequency: "{value}". '
+                'Frequency must be finite and greater than 0.')
+
+        throttle_frequencies[topic] = frequency
+
+    return throttle_frequencies
 
 
 def add_recorder_arguments(parser: ArgumentParser) -> None:
@@ -262,6 +295,12 @@ def add_recorder_arguments(parser: ArgumentParser) -> None:
              'Per-topic entries from --repeat-transient-local take precedence over this '
              'default depth. 0 disables (default).')
     parser.add_argument(
+        '--topic-throttle-frequency', type=str, default=[], metavar='Topic=Hz', nargs='+',
+        help='Space-delimited list of topics with a maximum recording frequency in Hz. '
+             'Messages arriving faster than the given frequency are dropped at the '
+             'subscription edge and not written to the bag. Format: <topic>=<frequency>. '
+             'Topics not listed are recorded at full frequency.')
+    parser.add_argument(
         '--log-level', type=str, default='info',
         choices=['debug', 'info', 'warn', 'error', 'fatal'],
         help='Logging level.')
@@ -408,6 +447,12 @@ def validate_parsed_arguments(args, uri) -> str:
     except ValueError as exc:
         return print_error(str(exc))
 
+    try:
+        args.topic_throttle_frequencies = parse_topic_throttle_frequencies(
+            args.topic_throttle_frequency)
+    except ValueError as exc:
+        return print_error(str(exc))
+
     return None
 
 
@@ -507,6 +552,7 @@ class RecordVerb(VerbExtension):
         record_options.statistics_max_publishing_rate = args.stats_max_publishing_rate
         record_options.repeat_transient_local_messages = args.repeat_transient_local_messages
         record_options.repeat_all_transient_local_depth = args.repeat_all_transient_local
+        record_options.topic_throttle_frequencies = args.topic_throttle_frequencies
 
         recorder = Recorder(storage_options, record_options, args.log_level, args.node_name)
 

--- a/ros2bag/test/test_recorder_args_parser.py
+++ b/ros2bag/test/test_recorder_args_parser.py
@@ -275,6 +275,54 @@ def test_recorder_repeat_all_transient_local_default(test_arguments_parser):
     assert 0 == args.repeat_all_transient_local
 
 
+def test_recorder_topic_throttle_frequency_argument(test_arguments_parser):
+    """Test recorder --topic-throttle-frequency list argument parser."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--topic-throttle-frequency', '/imu=10.0', '/camera/image_raw=2.5', '--all-topics',
+         '--output', output_path.as_posix()]
+    )
+    assert ['/imu=10.0', '/camera/image_raw=2.5'] == args.topic_throttle_frequency
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is None
+    assert {'/imu': 10.0, '/camera/image_raw': 2.5} == args.topic_throttle_frequencies
+
+
+def test_recorder_topic_throttle_frequency_missing_frequency(test_arguments_parser):
+    """Test recorder --topic-throttle-frequency without a frequency fails validation."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    args = test_arguments_parser.parse_args(
+        ['--topic-throttle-frequency', '/imu', '--all-topics',
+         '--output', output_path.as_posix()]
+    )
+
+    uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+    error_str = validate_parsed_arguments(args, uri)
+    assert error_str is not None
+    expected_output = 'Expected format <topic>=<frequency>'
+    matches = expected_output in error_str
+    assert matches, ERROR_STRING_MSG.format(expected_output, error_str)
+
+
+def test_recorder_topic_throttle_frequency_invalid_frequency(test_arguments_parser):
+    """Test recorder --topic-throttle-frequency with non-positive frequency fails validation."""
+    output_path = RESOURCES_PATH / 'ros2bag_tmp_file'
+    for bad_value in ['/imu=0', '/imu=-5.0', '/imu=inf', '/imu=not_a_number']:
+        args = test_arguments_parser.parse_args(
+            ['--topic-throttle-frequency', bad_value, '--all-topics',
+             '--output', output_path.as_posix()]
+        )
+
+        uri = args.output or datetime.datetime.now().strftime('rosbag2_%Y_%m_%d-%H_%M_%S')
+        error_str = validate_parsed_arguments(args, uri)
+        assert error_str is not None, f'expected validation error for {bad_value}'
+        expected_output = 'Frequency must be'
+        matches = expected_output in error_str
+        assert matches, ERROR_STRING_MSG.format(expected_output, error_str)
+
+
 def test_recorder_validate_exclude_regex_needs_inclusive_args(test_arguments_parser):
     """Test that --exclude-regex needs inclusive arguments."""
     output_path = RESOURCES_PATH / 'ros2bag_tmp_file'

--- a/rosbag2_py/CHANGELOG.rst
+++ b/rosbag2_py/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rosbag2_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Unreleased
+----------
+* Expose ``RecordOptions.topic_throttle_frequencies`` in Python bindings
+
 0.34.0 (2026-05-01)
 -------------------
 

--- a/rosbag2_py/rosbag2_py/_transport.pyi
+++ b/rosbag2_py/rosbag2_py/_transport.pyi
@@ -130,6 +130,7 @@ class RecordOptions:
     statistics_max_publishing_rate: float
     topic_polling_interval: datetime.timedelta
     topic_qos_profile_overrides: dict
+    topic_throttle_frequencies: Dict[str, float]
     topic_types: List[str]
     topics: List[str]
     use_sim_time: bool

--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -1013,6 +1013,7 @@ PYBIND11_MODULE(_transport, m) {
   .def_readwrite("repeat_transient_local_messages", &RecordOptions::repeat_transient_local_messages)
   .def_readwrite("repeat_all_transient_local_depth",
                  &RecordOptions::repeat_all_transient_local_depth)
+  .def_readwrite("topic_throttle_frequencies", &RecordOptions::topic_throttle_frequencies)
   ;
 
   py::class_<rosbag2_py::Player>(m, "Player")

--- a/rosbag2_storage/CHANGELOG.rst
+++ b/rosbag2_storage/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rosbag2_storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Unreleased
+----------
+* Add YAML converter for ``std::unordered_map<std::string, double>`` (topic throttle frequencies)
+
 0.34.0 (2026-05-01)
 -------------------
 

--- a/rosbag2_storage/include/rosbag2_storage/yaml.hpp
+++ b/rosbag2_storage/include/rosbag2_storage/yaml.hpp
@@ -100,6 +100,27 @@ struct convert<std::unordered_map<std::string, size_t>>
 };
 
 template<>
+struct convert<std::unordered_map<std::string, double>>
+{
+  static Node encode(const std::unordered_map<std::string, double> & map)
+  {
+    Node node;
+    for (const auto & it : map) {
+      node[it.first] = it.second;
+    }
+    return node;
+  }
+
+  static bool decode(const Node & node, std::unordered_map<std::string, double> & map)
+  {
+    for (YAML::const_iterator it = node.begin(); it != node.end(); ++it) {
+      map.emplace(it->first.as<std::string>(), it->second.as<double>());
+    }
+    return true;
+  }
+};
+
+template<>
 struct convert<rclcpp::Duration>
 {
   static Node encode(const rclcpp::Duration & duration)

--- a/rosbag2_transport/CHANGELOG.rst
+++ b/rosbag2_transport/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rosbag2_transport
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Unreleased
+----------
+* Add per-topic frequency throttling for recording via ``RecordOptions::topic_throttle_frequencies``,
+  ``record.topic_throttle_frequency`` node parameter, and subscription-edge drop before writer I/O
+
 0.34.0 (2026-05-01)
 -------------------
 * Fixed compile errors in rosbag2_transport for MSVC 2022 and C++20 (`#2407 <https://github.com/ros2/rosbag2/issues/2407>`_)

--- a/rosbag2_transport/include/rosbag2_transport/record_options.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/record_options.hpp
@@ -102,6 +102,15 @@ public:
   /// repeat_transient_local_messages. 0 disables the feature.
   uint32_t repeat_all_transient_local_depth = 0;
 
+  /// \brief Per-topic maximum recording frequency in Hz, keyed by fully qualified topic name.
+  /// Messages arriving on a listed topic are dropped at the subscription edge if less than
+  /// 1/frequency seconds have elapsed, in the receive timestamp time base, since the last
+  /// message written for that topic. Topics without an entry are recorded at full frequency.
+  /// Values must be finite and greater than 0. Empty map disables the feature.
+  /// \note Throttling applies only to messages received via subscriptions. Messages written
+  /// through the direct Recorder::write_message() API are not throttled.
+  std::unordered_map<std::string, double> topic_throttle_frequencies{};
+
   /// Note: Please don't forget to update the YAML serialization and deserialization logic in
   /// `record_options.cpp` and the test case `test_yaml_serialization_deserialization`
   /// in `test_record_options.cpp` when updating the fields in RecordOptions.

--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <string>
 #include <vector>
 
@@ -426,6 +427,32 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
   }
   record_options.repeat_all_transient_local_depth =
     static_cast<uint32_t>(repeat_all_transient_local_depth);
+
+  auto topic_throttle_frequency = node.declare_parameter<std::vector<std::string>>(
+    "record.topic_throttle_frequency", std::vector<std::string>());
+  for (const auto & entry : topic_throttle_frequency) {
+    auto [topic_name, frequency_str] = param_utils::split_key_value(entry, "");
+    if (topic_name.empty()) {
+      throw std::invalid_argument(
+              "record.topic_throttle_frequency topic name cannot be empty.");
+    }
+    if (frequency_str.empty()) {
+      throw std::invalid_argument(
+              "record.topic_throttle_frequency expects entries in <topic>=<frequency> format.");
+    }
+    double frequency = 0.0;
+    try {
+      frequency = std::stod(frequency_str);
+    } catch (const std::exception &) {
+      throw std::invalid_argument(
+              "record.topic_throttle_frequency frequency must be a positive number.");
+    }
+    if (!std::isfinite(frequency) || frequency <= 0.0) {
+      throw std::invalid_argument(
+              "record.topic_throttle_frequency frequency must be finite and greater than 0.");
+    }
+    record_options.topic_throttle_frequencies[topic_name] = frequency;
+  }
 
   record_options.use_sim_time = node.get_parameter("use_sim_time").get_value<bool>();
 

--- a/rosbag2_transport/src/rosbag2_transport/record_options.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/record_options.cpp
@@ -40,7 +40,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
     include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
     start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
     statistics_max_publishing_rate, repeat_transient_local_messages,
-    repeat_all_transient_local_depth] = record_options;
+    repeat_all_transient_local_depth, topic_throttle_frequencies] = record_options;
   Node node;
   node["all_topics"] = all_topics;
   node["all_services"] = all_services;
@@ -78,6 +78,7 @@ Node convert<rosbag2_transport::RecordOptions>::encode(
   node["statistics_max_publishing_rate"] = statistics_max_publishing_rate;
   node["repeat_transient_local_messages"] = repeat_transient_local_messages;
   node["repeat_all_transient_local_depth"] = repeat_all_transient_local_depth;
+  node["topic_throttle_frequencies"] = topic_throttle_frequencies;
   return node;
 }
 
@@ -98,7 +99,7 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
     include_hidden_topics, include_unpublished_topics, ignore_leaf_topics,
     start_paused, use_sim_time, static_topics_uri, disable_keyboard_controls,
     statistics_max_publishing_rate, repeat_transient_local_messages,
-    repeat_all_transient_local_depth] = record_options;
+    repeat_all_transient_local_depth, topic_throttle_frequencies] = record_options;
 
   optional_assign<bool>(node, "all_topics", all_topics);
   optional_assign<bool>(node, "all_services", all_services);
@@ -160,6 +161,8 @@ bool convert<rosbag2_transport::RecordOptions>::decode(
     node, "repeat_transient_local_messages", repeat_transient_local_messages);
   optional_assign<uint32_t>(node, "repeat_all_transient_local_depth",
     repeat_all_transient_local_depth);
+  optional_assign<std::unordered_map<std::string, double>>(
+    node, "topic_throttle_frequencies", topic_throttle_frequencies);
   return true;
 }
 

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -16,8 +16,10 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <functional>
 #include <future>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -715,6 +717,14 @@ bool RecorderImpl::record(const std::string & uri)
     RCLCPP_WARN(node->get_logger(),
       "No output serialization format specified, using rmw serialization format. '%s'.",
       record_options_.output_serialization_format.c_str());
+  }
+
+  for (const auto & [topic_name, frequency] : record_options_.topic_throttle_frequencies) {
+    if (!std::isfinite(frequency) || frequency <= 0.0) {
+      throw std::invalid_argument(
+              "Invalid throttle frequency " + std::to_string(frequency) + " for topic '" +
+              topic_name + "'. Frequencies must be finite and greater than 0.");
+    }
   }
 
   event_notifier_->reset_total_num_messages_lost_in_transport();
@@ -1807,8 +1817,25 @@ RecorderImpl::create_subscription(
       on_messages_lost_in_transport(topic_name, msgs_lost_info);
     };
 
+  // Per-topic throttle state, owned by the subscription callback. Throttling compares receive
+  // timestamps so that the message spacing in the bag matches the requested frequency and
+  // follows the same time base as the recorded timestamps (including sim time).
+  rcutils_duration_value_t throttle_period_ns = 0;
+  auto throttle_it = record_options_.topic_throttle_frequencies.find(topic_name);
+  if (throttle_it != record_options_.topic_throttle_frequencies.end()) {
+    constexpr auto kMaxPeriodNs = std::numeric_limits<rcutils_duration_value_t>::max();
+    const double period_ns = 1e9 / throttle_it->second;
+    throttle_period_ns = period_ns < static_cast<double>(kMaxPeriodNs) ?
+      static_cast<rcutils_duration_value_t>(period_ns) : kMaxPeriodNs;
+    RCLCPP_INFO(node->get_logger(),
+      "Throttling topic '%s' to %.3f Hz for recording.", topic_name.c_str(), throttle_it->second);
+  }
+  auto last_written_recv_timestamp = std::make_shared<rcutils_time_point_value_t>(
+    std::numeric_limits<rcutils_time_point_value_t>::min());
+
   auto subscription_callback =
-    [this, topic_name, topic_type](std::shared_ptr<const rclcpp::SerializedMessage> message,
+    [this, topic_name, topic_type, throttle_period_ns, last_written_recv_timestamp](
+    std::shared_ptr<const rclcpp::SerializedMessage> message,
     const rclcpp::MessageInfo & mi)
     {
       rcutils_time_point_value_t recv_timestamp{0};
@@ -1838,6 +1865,20 @@ RecorderImpl::create_subscription(
       handle_pending_resume_request(topic_name, send_timestamp, recv_timestamp);
 
       if (!paused_.load()) {
+        if (throttle_period_ns > 0) {
+          constexpr auto kNoMessageWrittenYet =
+            std::numeric_limits<rcutils_time_point_value_t>::min();
+          if (*last_written_recv_timestamp != kNoMessageWrittenYet) {
+            const rcutils_duration_value_t elapsed_ns =
+              recv_timestamp - *last_written_recv_timestamp;
+            // A negative elapsed time means the time base jumped backwards (e.g. a sim time
+            // reset); accept the message and restart the throttle window instead of stalling.
+            if (elapsed_ns >= 0 && elapsed_ns < throttle_period_ns) {
+              return;
+            }
+          }
+          *last_written_recv_timestamp = recv_timestamp;
+        }
         writer_->write(std::move(message), topic_name, topic_type, recv_timestamp, send_timestamp);
         // Handle pending bag split request if it is existing
         handle_pending_bag_split_request(topic_name, send_timestamp, recv_timestamp);

--- a/rosbag2_transport/test/resources/recorder_node_params.yaml
+++ b/rosbag2_transport/test/resources/recorder_node_params.yaml
@@ -36,6 +36,7 @@ recorder_params_node:
       start_paused: false
       disable_keyboard_controls: true
       statistics_max_publishing_rate: 0.5
+      topic_throttle_frequency: ["/imu=10.0", "/camera/image_raw=2.5"]
 
     storage:
       uri: "path/to/some_bag"

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <regex>
 #include <sstream>
+#include <string>
+#include <unordered_map>
 
 #include "composition_manager_test_fixture.hpp"
 #include "rosbag2_cpp/reader.hpp"
@@ -255,6 +257,11 @@ TEST_P(ComposableRecorderTests, recorder_can_parse_parameters_from_file) {
   EXPECT_EQ(record_options.disable_keyboard_controls, true);
   EXPECT_EQ(record_options.statistics_max_publishing_rate, 0.5);
   EXPECT_EQ(record_options.use_sim_time, false);
+  std::unordered_map<std::string, double> topic_throttle_frequencies{
+    {"/imu", 10.0},
+    {"/camera/image_raw", 2.5}
+  };
+  EXPECT_EQ(record_options.topic_throttle_frequencies, topic_throttle_frequencies);
 
   EXPECT_EQ(storage_options.uri, root_bag_path_.generic_string());
   EXPECT_EQ(storage_options.storage_id, GetParam());

--- a/rosbag2_transport/test/rosbag2_transport/test_record.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <atomic>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -424,6 +425,77 @@ TEST_F(RecordIntegrationTestFixture, receives_latched_messages)
   EXPECT_THAT(recorded_messages, SizeIs(expected_messages));
   EXPECT_EQ(recorded_topics.size(), 1u);
   EXPECT_FALSE(recorded_messages.empty());
+}
+
+TEST_F(RecordIntegrationTestFixture, topic_throttle_frequency_drops_messages_at_subscription)
+{
+  auto string_message = get_messages_strings()[1];
+  const std::string throttled_topic = "/throttled_string_topic";
+  const std::string full_rate_topic = "/full_rate_string_topic";
+  constexpr size_t num_published_messages = 5;
+
+  rosbag2_test_common::PublicationManager pub_manager;
+  pub_manager.setup_publisher(throttled_topic, string_message, num_published_messages);
+  pub_manager.setup_publisher(full_rate_topic, string_message, num_published_messages);
+
+  rosbag2_transport::RecordOptions record_options;
+  record_options.topics = {throttled_topic, full_rate_topic};
+  record_options.rmw_serialization_format = "rmw_format";
+  record_options.topic_polling_interval = 100ms;
+  // One message per 1000 seconds. Everything published by the test after the first message
+  // arrives well within the throttle period and must be dropped.
+  record_options.topic_throttle_frequencies[throttled_topic] = 0.001;
+
+  auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+    std::move(writer_), storage_options_, record_options);
+  recorder->record();
+
+  start_async_spin(recorder);
+  auto cleanup_process_handle = rcpputils::make_scope_exit([&]() {stop_spinning();});
+
+  ASSERT_TRUE(pub_manager.wait_for_matched(throttled_topic.c_str()));
+  ASSERT_TRUE(pub_manager.wait_for_matched(full_rate_topic.c_str()));
+
+  pub_manager.run_publishers();
+
+  auto & writer = recorder->get_writer_handle();
+  MockSequentialWriter & mock_writer =
+    static_cast<MockSequentialWriter &>(writer.get_implementation_handle());
+
+  // Expect all messages from the full rate topic and exactly one from the throttled topic.
+  constexpr size_t expected_messages = num_published_messages + 1;
+  auto ret = rosbag2_test_common::wait_until_condition(
+    [ =, &mock_writer]() {
+      return mock_writer.get_number_of_recorded_messages() >= expected_messages;
+    },
+    std::chrono::seconds(5));
+  EXPECT_TRUE(ret) << "failed to capture expected messages in time";
+
+  auto recorded_messages = mock_writer.get_messages();
+  auto throttled_messages = filter_messages<test_msgs::msg::Strings>(
+    recorded_messages, throttled_topic);
+  auto full_rate_messages = filter_messages<test_msgs::msg::Strings>(
+    recorded_messages, full_rate_topic);
+  EXPECT_THAT(full_rate_messages, SizeIs(num_published_messages));
+  EXPECT_THAT(throttled_messages, SizeIs(1));
+}
+
+TEST_F(RecordIntegrationTestFixture, record_throws_on_invalid_topic_throttle_frequency)
+{
+  // Cover the same rejection set as the CLI/node-param validators: non-positive and non-finite.
+  for (const double bad_frequency : {0.0, -5.0, std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::quiet_NaN()})
+  {
+    auto writer = std::make_shared<rosbag2_cpp::Writer>(std::make_unique<MockSequentialWriter>());
+    rosbag2_transport::RecordOptions record_options;
+    record_options.is_discovery_disabled = true;
+    record_options.rmw_serialization_format = "rmw_format";
+    record_options.topic_throttle_frequencies["/some_topic"] = bad_frequency;
+
+    auto recorder = std::make_shared<rosbag2_transport::Recorder>(
+      std::move(writer), storage_options_, record_options);
+    EXPECT_THROW(recorder->record(), std::invalid_argument) << "frequency=" << bad_frequency;
+  }
 }
 
 TEST_F(RecordIntegrationTestFixture, repeat_transient_local_topics_register_requested_depth)

--- a/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_record_options.cpp
@@ -58,6 +58,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   original.statistics_max_publishing_rate = 5.0f;
   original.repeat_transient_local_messages = {{"/map", 1}, {"/tf_static", 5}};
   original.repeat_all_transient_local_depth = 3;
+  original.topic_throttle_frequencies = {{"/imu", 10.0}, {"/camera/image_raw", 2.5}};
 
   auto node = YAML::convert<rosbag2_transport::RecordOptions>::encode(original);
 
@@ -101,6 +102,7 @@ TEST(record_options, test_yaml_serialization_deserialization)
   CHECK(disable_keyboard_controls);
   CHECK(repeat_transient_local_messages);
   CHECK(repeat_all_transient_local_depth);
+  CHECK(topic_throttle_frequencies);
   #undef CHECK
   ASSERT_FLOAT_EQ(original.statistics_max_publishing_rate,
                   reconstructed.statistics_max_publishing_rate);


### PR DESCRIPTION
## Description

Adds native per-topic frequency throttling to `ros2 bag record` so high-rate topics (IMUs, cameras, point clouds) can be recorded at a lower Hz without paying writer cache / compression / disk I/O for dropped messages.

## Fixes

- https://github.com/ros2/rosbag2/issues/2211
- https://github.com/ros2/rosbag2/issues/682

```bash
ros2 bag record -a --topic-throttle-frequency /imu=10.0 /camera/image_raw=2.0
```

Plumbing mirrors the existing `--repeat-transient-local` pattern end-to-end:

- `RecordOptions::topic_throttle_frequencies` (+ YAML round-trip via `unordered_map<string, double>`)
- `record.topic_throttle_frequency` composable-recorder node parameter
- `rosbag2_py` binding + stub
- `ros2bag` CLI flag with validation
- Design doc under `docs/design/per_topic_frequency_throttling_during_recording.md`

### Is this user-facing behavior change?

No, everything happen in a new RecordOptions

### Behavior

- Drop happens in the recorder subscription callback (transport edge), before `Writer::write()`
- Throttle compares the same receive timestamp written into the bag (honors `use_sim_time`); a backwards time jump restarts the window instead of stalling
- First message on a throttled topic is always recorded; unlisted topics are untouched
- Direct `Recorder::write_message()` is intentionally not throttled
- Invalid frequencies (non-finite / ≤ 0) fail fast in CLI, node params, and `record()`

## Did you use Generative AI?

Yes

## Test plan

- [x] `colcon build --parallel-workers 2 --packages-up-to rosbag2_transport rosbag2_py ros2bag` (Rolling Docker `ros:rolling-ros-base-resolute`)
- [x] `colcon test --packages-select rosbag2_storage rosbag2_transport rosbag2_py ros2bag` — **1097 tests, 0 failures**
- [x] Integration: throttled topic records 1 of 5 burst messages; unthrottled records all 5
- [x] `record()` rejects 0 / negative / inf / NaN frequencies
- [x] YAML round-trip of `topic_throttle_frequencies`
- [x] Composable recorder parses `record.topic_throttle_frequency` from params file
- [x] CLI parser accepts valid entries; rejects missing / non-positive / non-finite frequencies
- [x] Manual smoke: `ros2 topic pub -r 100 /chatter std_msgs/msg/String "{data: hi}"` + `ros2 bag record /chatter --topic-throttle-frequency /chatter=5.0` → ~5 Hz in bag info

## Additional Information

Design discussions started in https://github.com/ros2/rosbag2/issues/2211