### PR TITLE
Fix missing lib : Add iomanip lib

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/player_progress_bar_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player_progress_bar_impl.hpp
@@ -18,16 +18,16 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <iomanip>
+#include <iostream>
 #include <limits>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
-#include <sstream>
 
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
-#include <iomanip>
 #include "rcutils/time.h"
 #include "rosbag2_transport/player_progress_bar.hpp"
 

--- a/rosbag2_transport/src/rosbag2_transport/player_progress_bar_impl.hpp
+++ b/rosbag2_transport/src/rosbag2_transport/player_progress_bar_impl.hpp
@@ -27,6 +27,7 @@
 
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
+#include <iomanip>
 #include "rcutils/time.h"
 #include "rosbag2_transport/player_progress_bar.hpp"
 


### PR DESCRIPTION
## Description
fix missing include:
 error: ‘setprecision’ is not a member of ‘std’
  149 |       "[" << std::fixed << std::setprecision(9) << progress_current_time_secs <<

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
