### PR TITLE
Stop fixed-frequency /clock publication after playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,10 @@ Options:
 
 For more options, run with `--help`.
 
+#### Publishing simulation time
+
+When fixed-frequency `/clock` publication is enabled with `--clock` or the `play.clock_publish_frequency` node parameter, `/clock` is published only while a playback session is active. If the Player node remains alive after playback finishes or is stopped, clock publication stops. Starting another playback session restarts it. Pausing playback does not end the session; fixed-frequency updates continue with the paused time.
+
 #### Playback action messages as action client
 
 If you want Rosbag2 to replay recorded action messages in the role of an action client, you need to specify the --send-actions-as-client parameter.

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -673,6 +673,10 @@ bool PlayerImpl::play()
         RCLCPP_ERROR(owner_->get_logger(), "Failed to play: %s", e.what());
       }
 
+      if (clock_publish_timer_ != nullptr) {
+        clock_publish_timer_->cancel();
+      }
+
       progress_bar_->update(clock_->is_paused() ? PlayerStatus::PAUSED : PlayerStatus::RUNNING);
 
       // Wait for all published messages to be acknowledged.

--- a/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <rclcpp/executors.hpp>
+#include "rcpputils/scope_exit.hpp"
 #include "rosbag2_transport/player.hpp"
 #include "rosgraph_msgs/msg/clock.hpp"
 #include "test_msgs/message_fixtures.hpp"
@@ -178,6 +179,12 @@ TEST_F(ClockPublishFixture, clock_stops_after_playback_and_restarts_on_next_play
   exec.add_node(player);
   exec.add_node(clock_subscriber);
   auto spin_thread = std::thread([&exec]() {exec.spin();});
+  auto cleanup_spin_thread = rcpputils::make_scope_exit([&]() {
+        exec.cancel();
+        if (spin_thread.joinable()) {
+          spin_thread.join();
+        }
+    });
 
   const auto discovery_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
   while ((*clock_publisher)->get_subscription_count() == 0 &&
@@ -186,10 +193,6 @@ TEST_F(ClockPublishFixture, clock_stops_after_playback_and_restarts_on_next_play
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   const bool clock_subscription_matched = (*clock_publisher)->get_subscription_count() > 0;
-  if (!clock_subscription_matched) {
-    exec.cancel();
-    spin_thread.join();
-  }
   ASSERT_TRUE(clock_subscription_matched);
 
   ASSERT_TRUE(player->play());
@@ -206,15 +209,8 @@ TEST_F(ClockPublishFixture, clock_stops_after_playback_and_restarts_on_next_play
     received_clock_messages.load(std::memory_order_relaxed),
     clock_messages_after_playback);
 
-  const bool second_play_started = player->play();
-  if (second_play_started) {
-    player->wait_for_playback_to_finish(std::chrono::seconds(30));
-  }
-
-  exec.cancel();
-  spin_thread.join();
-
-  EXPECT_TRUE(second_play_started);
+  ASSERT_TRUE(player->play());
+  ASSERT_TRUE(player->wait_for_playback_to_finish(std::chrono::seconds(30)));
   EXPECT_GT(
     received_clock_messages.load(std::memory_order_relaxed),
     clock_messages_after_playback);

--- a/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
@@ -14,7 +14,11 @@
 
 #include <gmock/gmock.h>
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -129,6 +133,91 @@ TEST_F(ClockPublishFixture, clock_respects_playback_rate)
   play_options_.rate = 0.5;
   messages_to_play_ = 5;
   run_test();
+}
+
+TEST_F(ClockPublishFixture, clock_stops_after_playback_and_restarts_on_next_play)
+{
+  constexpr double clock_publish_frequency = 20.0;
+  const auto clock_publish_period = std::chrono::milliseconds(50);
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {1u, "topic1", "test_msgs/BasicTypes", "", {}, ""},
+  };
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages;
+  for (size_t i = 0; i < messages_to_play_; i++) {
+    auto message = get_messages_basic_types()[0];
+    message->int32_value = static_cast<int32_t>(i);
+    messages.push_back(
+      serialize_test_message("topic1", milliseconds_between_messages_ * i, message));
+  }
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  play_options_.clock_publish_frequency = clock_publish_frequency;
+  play_options_.playback_duration = rclcpp::Duration(0, 250000000);
+  auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+  std::atomic<size_t> received_clock_messages{0};
+  auto clock_subscriber = std::make_shared<rclcpp::Node>("clock_after_playback_subscriber");
+  auto clock_subscription = clock_subscriber->create_subscription<rosgraph_msgs::msg::Clock>(
+    "/clock", rclcpp::ClockQoS(),
+    [&received_clock_messages](rosgraph_msgs::msg::Clock::ConstSharedPtr) {
+      received_clock_messages.fetch_add(1, std::memory_order_relaxed);
+    });
+
+  auto publishers = player->get_list_of_publishers();
+  auto clock_publisher = std::find_if(
+    publishers.begin(), publishers.end(),
+    [](const auto * publisher) {return publisher->get_topic_name() == std::string("/clock");});
+  ASSERT_NE(clock_publisher, publishers.end());
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(player);
+  exec.add_node(clock_subscriber);
+  auto spin_thread = std::thread([&exec]() {exec.spin();});
+
+  const auto discovery_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  while ((*clock_publisher)->get_subscription_count() == 0 &&
+    std::chrono::steady_clock::now() < discovery_deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  const bool clock_subscription_matched = (*clock_publisher)->get_subscription_count() > 0;
+  if (!clock_subscription_matched) {
+    exec.cancel();
+    spin_thread.join();
+  }
+  ASSERT_TRUE(clock_subscription_matched);
+
+  ASSERT_TRUE(player->play());
+  ASSERT_TRUE(player->wait_for_playback_to_finish(std::chrono::seconds(30)));
+
+  // Allow an in-flight timer callback or DDS sample to arrive before taking the snapshot.
+  std::this_thread::sleep_for(clock_publish_period * 2);
+  const auto clock_messages_after_playback =
+    received_clock_messages.load(std::memory_order_relaxed);
+  EXPECT_GT(clock_messages_after_playback, 0u);
+
+  std::this_thread::sleep_for(clock_publish_period * 5);
+  EXPECT_EQ(
+    received_clock_messages.load(std::memory_order_relaxed),
+    clock_messages_after_playback);
+
+  const bool second_play_started = player->play();
+  if (second_play_started) {
+    player->wait_for_playback_to_finish(std::chrono::seconds(30));
+  }
+
+  exec.cancel();
+  spin_thread.join();
+
+  EXPECT_TRUE(second_play_started);
+  EXPECT_GT(
+    received_clock_messages.load(std::memory_order_relaxed),
+    clock_messages_after_playback);
 }
 
 TEST_F(ClockPublishFixture, clock_is_published_from_topic_trigger)


### PR DESCRIPTION
## Summary

A Player configured for fixed-frequency clock publication leaves its wall timer active after playback finishes. When the Player node remains alive, this causes `/clock` to continue advancing after message playback has stopped, including when playback reaches a configured duration or timestamp boundary.

This change cancels the fixed-frequency clock timer when the playback session finishes. The existing reset at the beginning of `play()` restarts the canceled timer for subsequent playback sessions.

The Player node and its executor remain alive. This is intentional because Player can be loaded as a component in a shared process, where shutting down the ROS context would also affect unrelated nodes.

Addresses the `/clock` behavior reported in #2383.

## Testing

- Added a regression test that keeps the executor running after playback finishes, verifies that fixed-frequency `/clock` publication stops, and verifies that a subsequent playback restarts clock publication.
- Built `rosbag2_transport` and its dependencies with `BUILD_TESTING=ON` and `-Werror` in a ROS Rolling container.
- Ran the `test_play_publish_clock` target together with `cpplint` and `uncrustify`: 3/3 passed.
- Ran the complete `rosbag2_transport` package test suite: 39/39 CTest targets passed; 612 tests, 0 errors, 0 failures, 79 skipped.
- Repeated the complete `test_play_publish_clock` target 10 times with no failures.
