### PR TITLE
fix SQLite::SQLite3  deprecation

### DIFF
--- a/rosbag2_storage_sqlite3/CMakeLists.txt
+++ b/rosbag2_storage_sqlite3/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   rosbag2_storage::rosbag2_storage
   rcpputils::rcpputils
   rcutils::rcutils
-  SQLite::SQLite3
+  SQLite3::SQLite3
 )
 target_link_libraries(${PROJECT_NAME} PRIVATE
   ament_cmake_ros_core::ament_ros_defaults


### PR DESCRIPTION
## Description

The target name SQLite::SQLite3 is deprecated

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
